### PR TITLE
WV-1095: _.each changed to _.forOwn when creating maps. 

### DIFF
--- a/web/js/map/wv.map.ui.js
+++ b/web/js/map/wv.map.ui.js
@@ -39,7 +39,9 @@ wv.map.ui = wv.map.ui || function(models, config) {
         if ( config.parameters.mockMap ) {
             return;
         }
-        _.each(config.projections, function(proj) {
+        // NOTE: iOS sometimes bombs if this is _.each instead. In that case,
+        // it is possible that config.projections somehow becomes array-like.
+        _.forOwn(config.projections, function(proj) {
             var map = createMap(proj);
             self.proj[proj.id] = map;
         });


### PR DESCRIPTION
Fixes occasional crashes on iOS? 

At first, I thought this was a network latency issue because I could easily (but not always) reproduce this problem on slow networks but that ended up being a red herring. After a painful debugging session only using alert() functions, the problem was narrowed down to the code that initializes the map. Occasionally, the _.each loop was not being called and all maps were null. Research into that lodash function seems to indicate this behavior is expected when the iterating object appears to look like an array. Without proper debugging tools, it cannot be confirmed, but changing it to _.forOwn seems to work. Somewhere else in the code must be accidentally mutating the config object.
