### PR TITLE
Changed title to inline to allow icon to wrap; added padding for icon

### DIFF
--- a/web/css/wv.layers.modal.css
+++ b/web/css/wv.layers.modal.css
@@ -275,7 +275,8 @@
 #layers-all .layers-all-title-wrap {
     position: relative;
     display: block;
-    margin-right: 50px;
+    margin-right: 66px;
+    padding-top: .5em;
 }
 #selected-category .ui-accordion-header,
 #layers-all .layers-all-layer {
@@ -325,8 +326,7 @@
     font-size:20px;
     line-height:100%;
     position: relative;
-    padding-top: .3em;
-    display: inline-block;
+    display: inline;
 }
 @media (min-width:753px) {
   #selected-category .ui-accordion-header h3,
@@ -436,9 +436,9 @@
 @media (min-width: 753px) {
   .layers-all-layer .layers-all-header .fa {
     padding: 10px 18px 16px;
-    top: 0;
+    top: auto;
     right: 0;
-    margin-top: 0;
+    margin-top: -6px;
     margin-left: 0;
   }
 }

--- a/web/js/layers/wv.layers.info.js
+++ b/web/js/layers/wv.layers.info.js
@@ -37,6 +37,8 @@ wv.layers.info = wv.layers.info || function(config, models, layer) {
             show: { effect: "slide", direction: "left" },
             width: 450,
             height: 300,
+            resizable: false,
+            draggable: false,
             position: {
                 my: "left top",
                 at: "right+5 top",
@@ -50,6 +52,7 @@ wv.layers.info = wv.layers.info || function(config, models, layer) {
             },
             close: dispose
         });
+        $("#wv-layers-info-dialog").perfectScrollbar();
     };
 
     var dispose = function() {

--- a/web/js/layers/wv.layers.options.js
+++ b/web/js/layers/wv.layers.options.js
@@ -67,6 +67,8 @@ wv.layers.options = wv.layers.options || function(config, models, layer) {
             show: { effect: "slide", direction: "left" },
             width: 300,
             height: "auto",
+            resizable: false,
+            draggable: false,
             position: {
                 my: "left top",
                 at: "right+5 top",


### PR DESCRIPTION
- Changed the title from inline-block to inline to prevent absolutely
positioned icon from hanging right when title wrapped to 2 lines.
- Added padding on rows so that "i" icon did not overlay checkbox in
some situations on mobile/tablet views
- Added perfect scrollbar to jQuery info dialog. Removed draggable & resizeable as these can conflict with touch scrolling.