### PR TITLE
E2e description test

### DIFF
--- a/e2e/tests/layer-descriptions/search.js
+++ b/e2e/tests/layer-descriptions/search.js
@@ -1,0 +1,14 @@
+module.exports = {
+    'Layer Descriptions - Layer search ("Add Layers" Search: "Corrected Reflectance (True Color)"' : function (browser) {
+        browser
+            .url(browser.globals.url)
+            .pause(1000);
+        browser.waitForElementVisible('#skipTour', 10000, function (el) {
+            browser.click('#skipTour');
+
+            // Check the 'Add Layers' search layer for a description
+
+        });
+        browser.end();
+    }
+};

--- a/e2e/tests/layer-descriptions/search.js
+++ b/e2e/tests/layer-descriptions/search.js
@@ -4,9 +4,7 @@ module.exports = {
     browser.waitForElementVisible('#skipTour', 10000, function(el) {
       browser.click('#skipTour');
 
-      /*
-       * Check to see if 'Add Layers' Butto is present and click to open it
-       */
+      // Check to see if 'Add Layers' Button is present and click to open it
       browser.expect.element('#layers-add').to.be.present;
       browser.click('#layers-add').pause(500);
       browser.waitForElementVisible('#layers-search-input', 5000, function(el) {
@@ -15,15 +13,15 @@ module.exports = {
         browser.waitForElementVisible('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor', 5000, function(el) {
           browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor').to.be.present;
 
-          // Click the description icon and check if css hidden class has been removed (to expose description).
+          // Click the info icon and check if css hidden class has been removed (to expose description).
           browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
           browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
 
-          // Click the description icon and check if css hidden class has been added (to hide description).
+          // Click the info icon and check if css hidden class has been added (to hide description).
           browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
           browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
 
-          // Click the description icon, check if no hidden class is present and element is visible.
+          // Click the info icon, check if no hidden class is present and element is visible.
           browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
           browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
           browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.be.visible;

--- a/e2e/tests/layer-descriptions/search.js
+++ b/e2e/tests/layer-descriptions/search.js
@@ -6,7 +6,15 @@ module.exports = {
         browser.waitForElementVisible('#skipTour', 10000, function (el) {
             browser.click('#skipTour');
 
-            // Check the 'Add Layers' search layer for a description
+            /*
+             * Check to see if 'Add Layers' Butto is present and click
+             */
+            browser.expect.element('#layers-add').to.be.present;
+            browser.click('#layers-add').pause(1000);
+            // Corrected Reflectance (True Color) should have descrition
+            browser.setValue('#layers-search-input', 'Corrected Reflectance (True Color)').pause(5000);
+            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor').to.be.present;
+            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
 
         });
         browser.end();

--- a/e2e/tests/layer-descriptions/search.js
+++ b/e2e/tests/layer-descriptions/search.js
@@ -1,41 +1,41 @@
 module.exports = {
-    'Layer Descriptions - Layer search ("Add Layers" Search: "Corrected Reflectance (True Color)"' : function (browser) {
-        browser
-            .url(browser.globals.url)
-            .pause(1000);
-        browser.waitForElementVisible('#skipTour', 10000, function (el) {
-            browser.click('#skipTour');
+  'Layer Descriptions - Layer search ("Add Layers" Search: "Corrected Reflectance (True Color)"': function(browser) {
+    browser.url(browser.globals.url).pause(1000);
+    browser.waitForElementVisible('#skipTour', 10000, function(el) {
+      browser.click('#skipTour');
 
-            /*
-             * Check to see if 'Add Layers' Butto is present and click to open it
-             */
-            browser.expect.element('#layers-add').to.be.present;
-            browser.click('#layers-add').pause(1000);
+      /*
+       * Check to see if 'Add Layers' Butto is present and click to open it
+       */
+      browser.expect.element('#layers-add').to.be.present;
+      browser.click('#layers-add').pause(500);
+      browser.waitForElementVisible('#layers-search-input', 5000, function(el) {
+        // Search for Corrected Reflectance (True Color) as this should have a descrition.
+        browser.setValue('#layers-search-input', 'Corrected Reflectance (True Color)');
+        browser.waitForElementVisible('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor', 5000, function(el) {
+          browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor').to.be.present;
 
-            // Search for Corrected Reflectance (True Color) as this should have a descrition.
-            browser.setValue('#layers-search-input', 'Corrected Reflectance (True Color)').pause(3000);
-            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor').to.be.present;
+          // Click the description icon and check if css hidden class has been removed (to expose description).
+          browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
+          browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
 
-            // Click the description icon and check if css hidden class has been removed (to expose description).
-            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
-            browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+          // Click the description icon and check if css hidden class has been added (to hide description).
+          browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
+          browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
 
-            // Click the description icon and check if css hidden class has been added (to hide description).
-            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
-            browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+          // Click the description icon, check if no hidden class is present and element is visible.
+          browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(500);
+          browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+          browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.be.visible;
 
-            // Click the description icon, check if no hidden class is present and element is visible.
-            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
-            browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
-            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.be.visible;
-
-            // Scroll to close arrow at bottom of description, click close arrow, check hidden class, check if element is not visible.
-            browser.moveToElement('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more', 10, 10).pause(1000);
-            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more').pause(1000);
-            browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
-            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.not.be.visible;
-
+          // Scroll to close arrow at bottom of description, click close arrow, check hidden class, check if element is not visible.
+          browser.moveToElement('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more', 10, 10).pause(500);
+          browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more').pause(500);
+          browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+          browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.not.be.visible;
         });
-        browser.end();
-    }
+      });
+    });
+    browser.end();
+  }
 };

--- a/e2e/tests/layer-descriptions/search.js
+++ b/e2e/tests/layer-descriptions/search.js
@@ -7,14 +7,33 @@ module.exports = {
             browser.click('#skipTour');
 
             /*
-             * Check to see if 'Add Layers' Butto is present and click
+             * Check to see if 'Add Layers' Butto is present and click to open it
              */
             browser.expect.element('#layers-add').to.be.present;
             browser.click('#layers-add').pause(1000);
-            // Corrected Reflectance (True Color) should have descrition
-            browser.setValue('#layers-search-input', 'Corrected Reflectance (True Color)').pause(5000);
+
+            // Search for Corrected Reflectance (True Color) as this should have a descrition.
+            browser.setValue('#layers-search-input', 'Corrected Reflectance (True Color)').pause(3000);
             browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor').to.be.present;
+
+            // Click the description icon and check if css hidden class has been removed (to expose description).
             browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
+            browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+
+            // Click the description icon and check if css hidden class has been added (to hide description).
+            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
+            browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+
+            // Click the description icon, check if no hidden class is present and element is visible.
+            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .fa-info-circle').pause(1000);
+            browser.assert.cssClassNotPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.be.visible;
+
+            // Scroll to close arrow at bottom of description, click close arrow, check hidden class, check if element is not visible.
+            browser.moveToElement('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more', 10, 10).pause(1000);
+            browser.click('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata .metadata-more').pause(1000);
+            browser.assert.cssClassPresent('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata', 'hidden');
+            browser.expect.element('#layer-flat-VIIRS_SNPP_CorrectedReflectance_TrueColor .source-metadata').to.not.be.visible;
 
         });
         browser.end();

--- a/e2e/tests/layer-descriptions/sidebar.js
+++ b/e2e/tests/layer-descriptions/sidebar.js
@@ -1,33 +1,30 @@
 module.exports = {
-    'Layer Descriptions - Sidebar' : function (browser) {
-        browser
-            .url(browser.globals.url)
-            .pause(1000);
-        browser.waitForElementVisible('#skipTour', 10000, function (el) {
-            browser.click('#skipTour');
-            /*
-             * Check to see if info dialog widget is present after info icon is clicked
-             */
-            browser.expect.element('#overlays li:first-child .wv-layers-info').to.be.present;
+  'Layer Descriptions - Sidebar': function(browser) {
+    browser.url(browser.globals.url).pause(1000);
+    browser.waitForElementVisible('#skipTour', 10000, function(el) {
+      browser.click('#skipTour');
 
-            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
-            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
+      // Check to see if info link is present
+      browser.expect.element('#overlays li:first-child .wv-layers-info').to.be.present;
 
-            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
-            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
+      // Check if info dialog has opened after icon is clicked.
+      browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+      browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
 
-            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
-            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
+      // Check if info dialog has closed after icon is clicked again.
+      browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+      browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
 
-            /*
-             * Check to see if info dialog widget is closedafter options icon is clicked
-             * Check ton see if options dialog widget is present after options icon is clicked
-             */
-            browser.click('#overlays li:first-child .wv-layers-options').pause(1000);
-            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
-            browser.expect.element('.ui-widget-content #wv-layers-options-dialog').to.be.present;
+      // Check if info dialog has opened after icon is clicked.
+      browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+      browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
 
-        });
-        browser.end();
-    }
+      // Check to see if info dialog widget is closed after options icon is clicked
+      // Check to see if options dialog widget is present after options icon is clicked
+      browser.click('#overlays li:first-child .wv-layers-options').pause(1000);
+      browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
+      browser.expect.element('.ui-widget-content #wv-layers-options-dialog').to.be.present;
+    });
+    browser.end();
+  }
 };

--- a/e2e/tests/layer-descriptions/sidebar.js
+++ b/e2e/tests/layer-descriptions/sidebar.js
@@ -6,8 +6,7 @@ module.exports = {
         browser.waitForElementVisible('#skipTour', 10000, function (el) {
             browser.click('#skipTour');
             /*
-             * check to see if info dialog widget is present
-             * after info icon is clicked
+             * Check to see if info dialog widget is present after info icon is clicked
              */
             browser.expect.element('#overlays li:first-child .wv-layers-info').to.be.present;
 
@@ -21,11 +20,8 @@ module.exports = {
             browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
 
             /*
-             * check to see if info dialog widget is closed
-             * after options icon is clicked
-             *
-             * check ton see if options dialog widget is present
-             * after options icon is clicked
+             * Check to see if info dialog widget is closedafter options icon is clicked
+             * Check ton see if options dialog widget is present after options icon is clicked
              */
             browser.click('#overlays li:first-child .wv-layers-options').pause(1000);
             browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;

--- a/e2e/tests/layer-descriptions/sidebar.js
+++ b/e2e/tests/layer-descriptions/sidebar.js
@@ -1,0 +1,37 @@
+module.exports = {
+    'Layer Descriptions - Sidebar' : function (browser) {
+        browser
+            .url(browser.globals.url)
+            .pause(1000);
+        browser.waitForElementVisible('#skipTour', 10000, function (el) {
+            browser.click('#skipTour');
+            /*
+             * check to see if info dialog widget is present
+             * after info icon is clicked
+             */
+            browser.expect.element('#overlays li:first-child .wv-layers-info').to.be.present;
+
+            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
+
+            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
+
+            browser.click('#overlays li:first-child .wv-layers-info').pause(1000);
+            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.be.present;
+
+            /*
+             * check to see if info dialog widget is closed
+             * after options icon is clicked
+             *
+             * check ton see if options dialog widget is present
+             * after options icon is clicked
+             */
+            browser.click('#overlays li:first-child .wv-layers-options').pause(1000);
+            browser.expect.element('.ui-widget-content #wv-layers-info-dialog').to.not.be.present;
+            browser.expect.element('.ui-widget-content #wv-layers-options-dialog').to.be.present;
+
+        });
+        browser.end();
+    }
+};

--- a/e2e/tests/layer-descriptions/source.js
+++ b/e2e/tests/layer-descriptions/source.js
@@ -1,0 +1,15 @@
+module.exports = {
+    'Layer Descriptions - Measurment source ("Add Layers" Categories / All / Aerosol Optical Depth / Terra/MODIS)' : function (browser) {
+        browser
+            .url(browser.globals.url)
+            .pause(1000);
+        browser.waitForElementVisible('#skipTour', 10000, function (el) {
+            browser.click('#skipTour');
+
+            // Check the 'Add Layers' Categories / All / Aerosol Optical Depth / Terra/MODIS
+            // for the presence of a description box.
+
+        });
+        browser.end();
+    }
+};

--- a/e2e/tests/layer-descriptions/source.js
+++ b/e2e/tests/layer-descriptions/source.js
@@ -1,15 +1,13 @@
 module.exports = {
-    'Layer Descriptions - Measurment source ("Add Layers" Categories / All / Aerosol Optical Depth / Terra/MODIS)' : function (browser) {
-        browser
-            .url(browser.globals.url)
-            .pause(1000);
-        browser.waitForElementVisible('#skipTour', 10000, function (el) {
-            browser.click('#skipTour');
+  'Layer Descriptions - Measurment source ("Add Layers" Categories / All / Aerosol Optical Depth / Terra/MODIS)' : function (browser) {
+    browser.url(browser.globals.url).pause(1000);
+    browser.waitForElementVisible('#skipTour', 10000, function (el) {
+      browser.click('#skipTour');
 
-            // Check the 'Add Layers' Categories / All / Aerosol Optical Depth / Terra/MODIS
-            // for the presence of a description box.
+      // Check the 'Add Layers' Categories / All / Aerosol Optical Depth / Terra/MODIS
+      // for the presence of a description box.
 
-        });
-        browser.end();
-    }
+    });
+    browser.end();
+  }
 };

--- a/e2e/tests/layer-descriptions/source.js
+++ b/e2e/tests/layer-descriptions/source.js
@@ -13,6 +13,12 @@ module.exports = {
         // TODO: Change to explicitly click the Aerosol Optical Layers
         browser.click('#layer-categories #air-quality .layer-category-item:first-child').pause(500);
 
+        // In Aerosol Optical Depth measurement view, click "Terra/MODIS" source, check if visible &
+        // has a meta description.
+        browser.click('xpath', "//a[contains(@class, 'ui-tabs-anchor') and text()='Terra/MODIS']")
+        browser.expect.element('#aerosol-optical-depth-terra-modis').to.be.visible;
+        browser.expect.element('#aerosol-optical-depth-terra-modis .source-metadata').to.be.present;
+
       });
     });
     browser.end();

--- a/e2e/tests/layer-descriptions/source.js
+++ b/e2e/tests/layer-descriptions/source.js
@@ -4,9 +4,16 @@ module.exports = {
     browser.waitForElementVisible('#skipTour', 10000, function (el) {
       browser.click('#skipTour');
 
-      // Check the 'Add Layers' Categories / All / Aerosol Optical Depth / Terra/MODIS
-      // for the presence of a description box.
+      // Check to see if 'Add Layers' Button is present and click to open it
+      browser.expect.element('#layers-add').to.be.present;
+      browser.click('#layers-add').pause(500);
+      browser.waitForElementVisible('#layer-modal-main', 5000, function(el) {
 
+        // Click the first layer category under Air Quality category.
+        // TODO: Change to explicitly click the Aerosol Optical Layers
+        browser.click('#layer-categories #air-quality .layer-category-item:first-child').pause(500);
+
+      });
     });
     browser.end();
   }


### PR DESCRIPTION
Connects to #400
Added an end to end test for layer descriptions. This test will open the description boxes in the sidebar active layer list, perform a search in the 'Add Layer' modal and ensure a descriptions are available and open/close buttons are clickable, Ensure descriptions are showing within the measurements. 