### PR TITLE
Move `fetch` task to after `update-packages`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -795,8 +795,8 @@ module.exports = function(grunt) {
   grunt.registerTask("e2e", ["firefox-tests", "chrome-tests"]);
 
   grunt.registerTask("default", [
-    "fetch",
     "update-packages",
+    "fetch",
     "update",
     "build",
     "config",


### PR DESCRIPTION
`fetch` sometimes failed if not all packages had been installed first.