### PR TITLE
Orbit description fix

### DIFF
--- a/web/js/layers/wv.layers.modal.js
+++ b/web/js/layers/wv.layers.modal.js
@@ -508,8 +508,23 @@ wv.layers.modal = wv.layers.modal || function(models, ui, config) {
             .append($label);
 
           // If this is an orbit track.... put it in the orbit track list
-          if (layer.title.indexOf("Orbital Track") !== -1) {
+          if (layer.layergroup && layer.layergroup.indexOf("reference_orbits") !== -1) {
             var orbitTitle;
+
+            if (layer.time && layer.track) {
+              orbitTitle = wv.util.capitalizeFirstLetter(layer.time) + "/" + wv.util.capitalizeFirstLetter(layer.track);
+            }
+
+            $label.empty()
+              .text(orbitTitle);
+            $sourceOrbits.append($wrapper);
+
+          /**
+           * @deprecated since version 1.8.0 If the data set is old and doesn't have
+           * layergroup's set then we will need to track the layer title to determine
+           * if it is a Orbital Track
+           */
+          } else if (layer.title.indexOf("Orbital Track") !== -1) {
 
             // The following complex if statement is a placeholder
             // for truncating the layer names, until the rest of

--- a/web/js/layers/wv.layers.modal.js
+++ b/web/js/layers/wv.layers.modal.js
@@ -510,9 +510,8 @@ wv.layers.modal = wv.layers.modal || function(models, ui, config) {
           // If this is an orbit track.... put it in the orbit track list
           if (layer.layergroup && layer.layergroup.indexOf("reference_orbits") !== -1) {
             var orbitTitle;
-
-            if (layer.time && layer.track) {
-              orbitTitle = wv.util.capitalizeFirstLetter(layer.time) + "/" + wv.util.capitalizeFirstLetter(layer.track);
+            if (layer.daynight && layer.track) {
+              orbitTitle = wv.util.capitalizeFirstLetter(layer.daynight) + "/" + wv.util.capitalizeFirstLetter(layer.track);
             }
 
             $label.empty()

--- a/web/js/layers/wv.layers.model.js
+++ b/web/js/layers/wv.layers.model.js
@@ -50,7 +50,15 @@ wv.layers.model = wv.layers.model || function(models, config) {
           thisSetting = setting;
           description = source.description;
           _.each(config.layers, function(layer, layerKey) {
-            if (layer.id == thisSetting) {
+            // If a layer is an orbit track (based on layer title)
+            if (layer.title.indexOf("Orbital Track") !== -1) {
+              // And if a source is a
+              if (source.title.indexOf("Space-Track.org") !== -1) {
+                if (layer.id == thisSetting) {
+                  layer.description = description || "";
+                }
+              }
+            } else if (layer.id == thisSetting) {
               layer.description = description || "";
             }
           });

--- a/web/js/layers/wv.layers.model.js
+++ b/web/js/layers/wv.layers.model.js
@@ -41,29 +41,59 @@ wv.layers.model = wv.layers.model || function(models, config) {
     }
   };
 
+
+  /**
+   * Map source descriptions to the layer objects based on their measurement relationship.
+   * There is a special check for Orbit Tracks since these layers are attached
+   * to sources in multiple measurment files.
+   * @deprecated since version 1.8.0 - Add a description flag to individual layer option files
+   *
+   * @return {type}
+   */
   self.addDescriptions = function() {
     var thisSetting;
     var description;
     _.each(config.measurements, function(measurement, measurementKey) {
-      _.each(measurement.sources, function(source, sourceKey) {
-        _.each(source.settings, function(setting, settingKey) {
-          thisSetting = setting;
-          description = source.description;
-          _.each(config.layers, function(layer, layerKey) {
-            // If a layer is an orbit track (based on layer title)
-            if (layer.title.indexOf("Orbital Track") !== -1) {
-              // And if a source is a
-              if (source.title.indexOf("Space-Track.org") !== -1) {
+      if(measurementKey == "Orbital Track") {
+        _.each(measurement.sources, function(source, sourceKey) {
+          _.each(source.settings, function(setting, settingKey) {
+            thisSetting = setting;
+            description = source.description;
+            _.each(config.layers, function(layer, layerKey) {
+              // If a layer is an orbit track
+              if (layer.layergroup && layer.layergroup.indexOf("reference_orbits") !== -1) {
+                // Set the description
                 if (layer.id == thisSetting) {
-                  layer.description = description || "";
+                  // If there has not been a layer description set in the file, then set it based on measurement description.
+                  if(!layer.description) {
+                    layer.description = description || "";
+                  }
                 }
               }
-            } else if (layer.id == thisSetting) {
-              layer.description = description || "";
-            }
+            });
           });
         });
-      });
+      } else {
+        _.each(measurement.sources, function(source, sourceKey) {
+          _.each(source.settings, function(setting, settingKey) {
+            thisSetting = setting;
+            description = source.description;
+            _.each(config.layers, function(layer, layerKey) {
+              if (layer.layergroup && layer.layergroup.indexOf("reference_orbits") !== -1) {
+                // Do nothing
+              } else {
+                // If a layer is not an orbit track
+                if (layer.id == thisSetting) {
+                  // If there has not been a layer description set in the file, then set it based on measurement description.
+                  if(!layer.description) {
+                    layer.description = description || "";
+                  }
+                }
+              }
+            });
+          });
+        });
+      }
     });
   };
 

--- a/web/js/util/wv.util.js
+++ b/web/js/util/wv.util.js
@@ -807,6 +807,11 @@ wv.util = (function(self) {
     return value;
   };
 
+
+  self.capitalizeFirstLetter = function(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
   return self;
 
 })(wv.util || {});


### PR DESCRIPTION
Fixes the issue of orbit tracks displaying the wrong measurement descriptions.

I would recommend merging this after merging the [orbit-track-references](https://github.com/nasa-gibs/worldview-options-eosdis/pull/109) PR  in the options repo since some of the code references new parameters; though everything should gracefully fallback regardless.

self.addDescriptions is a big, not so nice looking function providing a lot of fallbacks at the moment. Eventually it can be removed once we have individual layer descriptions in place. Right now it specifically filters out Orbital Tracks to get the right measurement descriptions associated with the orbit layers, then it is also is providing a check to see if a description field is set in the layer file, if not then associate it with the measurement description.
Connects to #477