### PR TITLE
Fix metadata preload

### DIFF
--- a/web/js/layers/wv.layers.modal.js
+++ b/web/js/layers/wv.layers.modal.js
@@ -55,17 +55,18 @@ wv.layers.modal = wv.layers.modal || function(models, ui, config) {
   self.loadMetadata = function() {
     if(isMetadataLoaded) return;
     var layersProcessed = 0;
-    var layersWithMetadata = Object.values(config.layers).filter(function(layer){
+    var layersMissingMetadata = Object.values(config.layers).filter(function(layer){
       visible[layer.id] = true; // What does this line do?
-      return layer.description;
+      // We only want to request metadata for layers with a description but no metadata
+      return layer.description && !self.metadata[layer.id];
     });
-    layersWithMetadata.forEach(function(layer) {
+    layersMissingMetadata.forEach(function(layer) {
       if(layer.description){
         $.get('config/metadata/' + layer.description + '.html').always(function(){
           layersProcessed++;
         }).success(function(data) {
           self.metadata[layer.id] = data;
-          if (layersProcessed === layersWithMetadata.length) {
+          if (layersProcessed === layersMissingMetadata.length) {
             isMetadataLoaded = true;
             // add metadata if component is already rendered
             if(self.reactList) {

--- a/web/js/wv.main.js
+++ b/web/js/wv.main.js
@@ -268,7 +268,6 @@ $(function() {
     $(document).click(function(e) {
       if (e.target.id == "wv-logo") resetWorldview(e);
     });
-    ui.addModal.loadMetadata(); // start loading metaData for layer search
   };
 
   var resetWorldview = function(e){
@@ -332,4 +331,25 @@ $(function() {
 
   wv.util.wrap(main)();
 
+});
+
+/**
+ * Waits for ui.addModal.loadMetadata to be defined, then calls it
+ *
+ * @method loadSearchMetadata
+ * @return {void}
+ */
+function loadSearchMetadata() {
+  var ui = wvx.ui || false;
+  if (ui && ui.addModal && ui.addModal.loadMetadata) {
+    ui.addModal.loadMetadata();
+  } else {
+    window.setTimeout(loadSearchMetadata,200);
+  }
+}
+
+// Load layer descriptions for search after all other resources have finished downloading
+// Doing this here prevents it from blocking images from being loaded
+$(window).on('load', function(){
+  loadSearchMetadata();
 });


### PR DESCRIPTION
Fix metadata preload

Because of the limit of parallel requests in browsers (6 in Chrome) there are still some situations on slow connections where the loading of metadata files might be blocking the loading of other resources like images.

This change waits to start loading metadata until all of the initially displayed resources (images, icons, etc) are downloaded, but still blocks some resources that are loaded later like CSS background images on elements that are not initially visible.