### PR TITLE
Ignore d3 global variables

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,10 @@
         "standard/computed-property-even-spacing": "warn",
         "wrap-iife": "warn",
         "new-cap": "warn"
-      }
+      },
+      "globals": {
+        "d3": true,
+      },
     }
   ]
 }


### PR DESCRIPTION
Add d3 to the globals key in `.eslintrc` so the linter doesn't complain about us using the global version.