### PR TITLE
Fix sidebar row spacing issue in Chrome 62

### DIFF
--- a/web/css/bank.css
+++ b/web/css/bank.css
@@ -134,7 +134,6 @@ h4 {
 
 .bank li.item {
   padding: 0;
-  overflow: hidden;
   cursor: move;
   margin: 0 auto;
 }


### PR DESCRIPTION
- Removes `overflow: hidden` from bank li.item