### PR TITLE
Enable arctic projection change

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -224,7 +224,7 @@ window.onload = () => {
     models.link.load(state); // needs to be loaded twice
 
     if (config.features.arcticProjectionChange) {
-      // models.proj.change = projectionChange(models, config);
+      models.proj.change = projectionChange(models, config);
     }
 
     elapsed('ui');


### PR DESCRIPTION
Based on `update-build-scripts` (#647)

Enables arctic projection change. Not much to do here, since projection change itself is already enabled.
  