### PR TITLE
Modularize mobile timeline wheel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8970,14 +8970,6 @@
       "integrity": "sha1-67Opd+evHGg65v2hK1Raa6bFhT0=",
       "dev": true
     },
-    "mobiscroll-jquery": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/mobiscroll-jquery/-/mobiscroll-jquery-3.2.6.tgz",
-      "integrity": "sha512-dBszOkH6K5YfKqCVE+Z4GA5ZPfH9ZH97FIrhoXExLkIan7FUXeGIA/fn9DBnzGwr830ozsA313JrrLhFyLNQgw==",
-      "requires": {
-        "jquery": "2.2.4"
-      }
-    },
     "mocha-nightwatch": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/mocha-nightwatch/-/mocha-nightwatch-3.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "jquery.joyride": "git+https://git@github.com/nasa-gibs/joyride.git",
     "jscrollpane": "^2.0.22",
     "lodash": "4.15.0",
-    "mobiscroll-jquery": "^3.2.6",
     "nouislider": "7.0.10",
     "ol": "^4.4.2",
     "perfect-scrollbar": "^0.8.1",
@@ -130,11 +129,13 @@
   },
   "browser": {
     "d3": "./web/ext/d3/d3.js",
+    "mobiscroll": "./web/ext/mobiscroll-2.6.0/mobiscroll.js",
     "isotope-layout": "./node_modules/isotope-layout/dist/isotope.pkgd.js",
     "jquery-jcrop": "./node_modules/jquery-jcrop/js/jquery.Jcrop.js",
     "jquery": "./node_modules/jquery/dist/jquery.js"
   },
   "browserify-shim": {
+    "mobiscroll": "mobiscroll",
     "isotope-layout": "isotope",
     "jquery-jcrop": "Jcrop",
     "jquery": "$"

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -7,7 +7,7 @@
 @import url("../../node_modules/icheck/skins/line/red.css");
 @import url("../../node_modules/jscrollpane/style/jquery.jscrollpane.css");
 @import url("../../node_modules/perfect-scrollbar/dist/css/perfect-scrollbar.css");
-@import url("../../node_modules/mobiscroll-jquery/dist/css/mobiscroll.css");
+@import url("../ext/mobiscroll-2.6.0/mobiscroll.css");
 @import url("../../node_modules/jquery.joyride/jquery.joyride.css");
 @import url("../../node_modules/jquery-jcrop/css/jquery.Jcrop.css");
 @import url("../../node_modules/ol/ol.css");

--- a/web/ext/mobiscroll-2.6.0/mobiscroll.css
+++ b/web/ext/mobiscroll-2.6.0/mobiscroll.css
@@ -1,0 +1,2082 @@
+/* Datewheel overlay */
+.dw {
+    position: absolute;
+    top: 5%;
+    left: 0;
+    z-index: 1001;
+    color: #fff;
+    font-family: arial, verdana, sans-serif;
+    font-size: 12px;
+    text-shadow: none;
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -ms-touch-action: none;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-backface-visibility: hidden;
+}
+.dwi {
+    position: static;
+    display: inline-block;
+}
+.dwwr {
+    min-width: 170px;
+    zoom: 1;
+    padding: 0 10px;
+    text-align: center;
+}
+/* Datewheel overlay background */
+.dw-persp, .dwo {
+    width: 100%;
+    height: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1001;
+}
+.dwo {
+    background: #000;
+    opacity: .7;
+    filter: Alpha(Opacity=70);
+    display:none;
+}
+/* Bubble positionings */
+.dw-bubble .dw {
+    margin: 20px 0;
+}
+.dw-bubble .dw-arrw {
+    position: absolute;
+    left: 0;
+    width: 100%;
+}
+.dw-bubble-top .dw-arrw {
+    bottom: -36px;
+}
+.dw-bubble-bottom .dw-arrw {
+    top: -36px;
+}
+.dw-bubble .dw-arrw-i {
+    margin: 0 30px;
+    position: relative;
+    height: 36px;
+}
+.dw-bubble .dw-arr {
+    display: block;
+}
+.dw-arr {
+    display: none;
+    position: absolute;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-width: 18px 18px;
+    border-style: solid;
+    margin-left: -18px;
+}
+.dw-bubble-bottom .dw-arr {
+    top: 0;
+    border-color: transparent transparent #fff transparent;
+}
+.dw-bubble-top .dw-arr {
+    bottom: 0;
+    border-color: #fff transparent transparent transparent;
+}
+/* Datewheel wheel container wrapper */
+.dwc {
+    padding: 30px 2px 5px 2px;
+    display: inline-block;
+}
+/* Datewheel label */
+.dwl {
+    text-align: center;
+    line-height: 30px;
+    height: 30px;
+    white-space: nowrap;
+    position: absolute;
+    top: -30px;
+    width: 100%;
+}
+/* Datewheel value */
+.dwv {
+    padding: 10px 0;
+    border-bottom: 1px solid #000;
+}
+/* Datewheel wheel container */
+.dwrc {
+    -webkit-border-radius: 3px;
+    border-radius: 3px;
+}
+.dwwc {
+    margin: 0;
+    padding: 0 2px;
+    position: relative;
+    background: #000;
+    zoom: 1;
+}
+/* Datewheel wheels */
+.dwwl {
+    margin: 4px 2px;
+    padding: 0 2px;
+    position: relative;
+    z-index: 5;
+}
+.dwww {
+    position: relative;
+    padding: 1px;
+}
+.dww {
+    overflow: hidden;
+    position: relative;
+    z-index: 2;
+}
+.dw-moz .dww {
+    opacity: .99; /* Fixes Firefox translate overflow bug */
+}
+.dwsc .dwwl {
+    background: #888;
+    background: linear-gradient(#000 0%,#333 35%, #888 50%,#333 65%,#000 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#000),color-stop(0.35, #333),color-stop(0.50, #888),color-stop(0.65, #333),to(#000));
+    background: -webkit-linear-gradient(#000 0%,#333 35%, #888 50%,#333 65%,#000 100%);
+    background: -moz-linear-gradient(#000 0%,#333 35%, #888 50%,#333 65%,#000 100%);
+}
+.dwsc .dww {
+    color: #fff;
+    background: #444;
+    background: linear-gradient(#000 0%,#444 45%, #444 55%, #000 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#000),color-stop(0.45, #444),color-stop(0.55, #444),to(#000));
+    background: -webkit-linear-gradient(#000 0%,#444 45%, #444 55%, #000 100%);
+    background: -moz-linear-gradient(#000 0%,#444 45%, #444 55%, #000 100%);
+}
+.dw-bf {
+    -webkit-perspective: 1000;
+    -webkit-backface-visibility: hidden;
+}
+.dw-ul {
+    position: relative;
+    z-index: 2;
+}
+.dw-li {
+    padding: 0 5px;
+    display: block;
+    text-align: center;
+    line-height: 40px;
+    font-size: 26px;
+    white-space: nowrap;
+    text-shadow: 0 1px 1px #000;
+    vertical-align: bottom;
+    opacity: .3;
+    filter: Alpha(Opacity=30);
+}
+/* Higlighted */
+.dw-li.dw-hl {
+    background: #fff;
+    background: rgba(255,255,255,.3);
+}
+/* Valid entry */
+.dw-li.dw-v {
+    opacity: 1;
+    filter: Alpha(Opacity=100);
+}
+/* Hidden entry */
+.dw-li.dw-h {
+    visibility: hidden;
+}
+.dw-i {
+    position: relative;
+    height: 100%;
+}
+/* Wheel +/- buttons */
+.dwwb {
+    position: absolute;
+    z-index: 4;
+    left: 0;
+    cursor: pointer;
+    width: 100%;
+    height: 40px;
+    text-align: center;
+    opacity: 1;
+    transition: opacity .2s linear;
+    -webkit-transition: opacity .2s linear;
+}
+.dwa .dwwb {
+    opacity: 0;
+}
+.dwwbp {
+    top: 0;
+    -webkit-border-radius: 3px 3px 0 0;
+    border-radius: 3px 3px 0 0;
+    font-size: 40px;
+}
+.dwwbm {
+    bottom: 0;
+    -webkit-border-radius: 0 0 3px 3px;
+    border-radius: 0 0 3px 3px;
+    font-size: 32px;
+    font-weight: bold;
+}
+.dwpm .dwwc {
+    background: transparent;
+}
+.dwpm .dwwl {
+    padding: 0;
+}
+.dwpm .dw-li {
+    text-shadow: none;
+}
+.dwpm .dwwol {
+    display: none;
+}
+/* Datewheel wheel overlay */
+.dwwo {
+    position: absolute;
+    z-index: 3;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(#000 0%,rgba(44,44,44,0) 52%, rgba(44,44,44,0) 48%, #000 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#000),color-stop(0.52, rgba(44,44,44,0)),color-stop(0.48, rgba(44,44,44,0)),to(#000));
+    background: -webkit-linear-gradient(#000 0%,rgba(44,44,44,0) 52%, rgba(44,44,44,0) 48%, #000 100%);
+    background: -moz-linear-gradient(#000 0%,rgba(44,44,44,0) 52%, rgba(44,44,44,0) 48%, #000 100%);
+}
+/* Background line */
+.dwwol {
+    position: absolute;
+    z-index: 1;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 0;
+    margin-top: -1px;
+    border-top: 1px solid #333;
+    border-bottom: 1px solid #555;
+}
+/* Datewheel button */
+.dwbg .dwb {
+    cursor: pointer;
+    overflow: hidden;
+    display: block;
+    height: 40px;
+    line-height: 40px;
+    padding: 0 15px;
+    margin: 0 2px;
+    font-size: 14px;
+    font-weight: bold;
+    text-decoration: none;
+    text-shadow: 0 -1px 1px #000;
+    border-radius: 5px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    color: #fff;
+    background: #000;
+    background: linear-gradient(#6e6e6e 50%,#000 50%);
+    background: -webkit-gradient(linear,left bottom,left top,color-stop(0.5, #000),color-stop(0.5, #6e6e6e));
+    background: -webkit-linear-gradient(#6e6e6e 50%,#000 50%);
+    background: -moz-linear-gradient(#6e6e6e 50%,#000 50%);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    -webkit-box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    -webkit-border-radius: 5px;
+    -webkit-backface-visibility: hidden;
+}
+/* Datewheel button container */
+.dwbc {
+    padding: 5px 0;
+    text-align: center;
+}
+/* Datewheel button wrapper */
+.dwbw {
+    display: inline-block;
+    width: 50%;
+    position: relative;
+    z-index: 5;
+}
+.dwbc-p .dwbw {
+    width: 33.33%;
+}
+/* Hidden label */
+.dwhl {
+    padding-top: 10px;
+}
+.dwhl .dwl {
+    display: none;
+}
+/* Multiple selection */
+.dwms .dwwms .dw-li {
+    padding: 0 40px;
+    position: relative;
+}
+.dwms .dw-msel:after {
+    width: 40px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    content: '✔';
+}
+/* Backgrounds */
+.dwbg {
+	background: rgba(38,43,49,0.85);
+	border-radius: 3px;
+    -webkit-border-radius: 3px;
+}
+.dwbg .dwpm .dwwl {
+    border: 1px solid #aaa;
+}
+.dwbg .dwpm .dww {
+    color: #000;
+    background: #fff;
+    -webkit-border-radius: 3px;
+}
+.dwbg .dwwb {
+    background: #ccc;
+    color: #888;
+    text-shadow: 0 -1px 1px #333;
+    box-shadow: 0 0 5px #333;
+    -webkit-box-shadow: 0 0 5px #333;
+}
+.dwbg .dwwbp {
+    background: linear-gradient(#f7f7f7,#bdbdbd);
+    background: -webkit-gradient(linear,left bottom,left top,from(#bdbdbd),to(#f7f7f7));
+    background: -webkit-linear-gradient(#f7f7f7,#bdbdbd);
+    background: -moz-linear-gradient(#f7f7f7,#bdbdbd);
+}
+.dwbg .dwwbm {
+    background: linear-gradient(#bdbdbd,#f7f7f7);
+    background: -webkit-gradient(linear,left bottom,left top,from(#f7f7f7),to(#bdbdbd));
+    background: -webkit-linear-gradient(#bdbdbd,#f7f7f7);
+    background: -moz-linear-gradient(#bdbdbd,#f7f7f7);
+}
+.dwbg .dwb-a {
+    background: #3c7500;
+    background: linear-gradient(#94c840 50%,#3c7500 50%);
+    background: -webkit-gradient(linear,left bottom,left top,color-stop(0.5, #3c7500),color-stop(0.5, #94c840));
+    background: -webkit-linear-gradient(#94c840 50%,#3c7500 50%);
+    background: -moz-linear-gradient(#94c840 50%,#3c7500 50%);
+}
+.dwbg .dwwl .dwb-a {
+    background: #3c7500;
+    background: linear-gradient(#94c840,#3c7500);
+    background: -webkit-gradient(linear,left bottom,left top,from(#3c7500),to(#94c840));
+    background: -webkit-linear-gradient(#94c840,#3c7500);
+    background: -moz-linear-gradient(#94c840,#3c7500);
+}
+
+/* jQuery Mobile Theme */
+.jqm .dwo {
+    background: none;
+}
+.jqm .dw {
+    padding: 6px;
+    z-index: 1003;
+}
+.jqm .dwv {
+    position: static;
+    width: auto;
+    padding: .7em 15px .7em 15px;
+    border: 0;
+}
+.jqm .dwwr {
+    border: 0;
+    padding: 0;
+}
+.jqm .dwpm .dwwo {
+    background: none;
+}
+.jqm .dwc {
+    padding: 30px 5px 5px 5px;
+ }
+.jqm .dwhl {
+    padding: 5px;
+}
+.jqm .dwwb {
+    margin: 0;
+    border: 0;
+}
+.jqm .dwwb span {
+    padding: 0;
+}
+.jqm .dwwbp .ui-btn-inner {
+    font-size: 40px;
+    border-radius: 3px 3px 0 0;
+    -webkit-border-radius: 3px 3px 0 0;
+    -moz-border-radius: 3px 3px 0 0;
+}
+.jqm .dwwbm .ui-btn-inner {
+    font-size: 32px;
+    border-radius: 0 0 3px 3px;
+    -webkit-border-radius: 0 0 3px 3px;
+    -moz-border-radius: 0 0 3px 3px;
+}
+.jqm .dwwbp span {
+    font-weight: normal;
+}
+.jqm .dwbc {
+    padding: 0;
+}
+.jqm .dwbc .ui-btn {
+    margin: .5em 5px;
+}
+.jqm .dwbc .ui-btn-inner {
+    font-size: 12px;
+}
+.jqm .dwpm .dwl {
+    border: 0;
+    background: none;
+}
+/* Bubble positioning */
+.jqm .dw-bubble-bottom .dw-arr
+{
+    border-color: transparent transparent #444 transparent;
+}
+.jqm .dw-bubble-top .dw-arr
+{
+    border-color: #222 transparent transparent transparent;
+}
+/* Docked */
+.jqm.dw-bottom .dw, .jqm.dw-top .dw {
+    padding: 0;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+}
+.jqm.dw-top .dw {
+    border-right: 0;
+    border-top: 0;
+    border-left: 0;
+}
+.jqm.dw-bottom .dw {
+    border-bottom: 0;
+    border-right: 0;
+    border-left: 0;
+}
+
+/* Android Skin */
+.android .dw {
+    padding: 0;
+    background: #000;
+    border: 2px solid #555;
+    color: #fff;
+}
+.android .dwv {
+    padding: 10px;
+    border-bottom: 1px solid #333;
+}
+.android .dwwr {
+    padding: 0;
+}
+.android .dww {
+    top: 0;
+}
+.android .dwwc {
+    background: #000;
+}
+.android .dw .dwpm .dww,
+.android .dw .dwpm .dwwl {
+    border: 0;
+    background: #fff;
+}
+.android .dw .dwpm .dww {
+    margin: 0;
+}
+.android .dwpm .dww .dw-li {
+    color: #000;
+    text-shadow: none;
+}
+.android .dwbc {
+    padding: 5px 1px;
+    background: #9c9c9c;
+}
+.android .dw .dwb {
+    margin: 0 5px;
+    background: #ccc;
+    background: linear-gradient(#eee,#ccc);
+    background: -webkit-gradient(linear,left bottom,left top,from(#ccc),to(#eee));
+    background: -moz-linear-gradient(#eee,#ccc);
+    background: -o-linear-gradient(#eee,#ccc);
+    color: #000;
+    font-weight: normal;
+    text-shadow: none;
+    border-radius: 0;
+    -moz-border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.android .dw .dwb-a, .android .dw .dwwl .dwb-a {
+    background: #ffb25a;
+    background: linear-gradient(#ffb25a,#ef6100);
+    background: -webkit-gradient(linear,left bottom,left top,from(#ef6100),to(#ffb25a));
+    background: -moz-linear-gradient(#ffb25a,#ef6100);
+    background: -o-linear-gradient(#ffb25a,#ef6100);
+}
+/* Bubble positioning */
+.android .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #000 transparent;
+}
+.android .dw-bubble-top .dw-arr {
+    border-color: #9c9c9c transparent transparent transparent;
+}
+/* Docked */
+.android.dw-top .dw,
+.android.dw-bottom .dw {
+    border-right: 0;
+    border-left: 0;
+}
+.android.dw-top .dw {
+    border-top: 0;
+}
+.android.dw-bottom .dw {
+    border-bottom: 0;
+}
+
+/* Android ICS skin */
+.android-ics .dw {
+    padding: 0;
+    color: #31b6e7;
+    background: #292829;
+}
+.android-ics .dw .dwwc,
+.android-ics .dw .dwwl,
+.android-ics .dw .dww,
+.android-ics .dw .dwb,
+.android-ics .dw .dwpm .dww {
+    background: none;
+}
+.android-ics .dwwr {
+    padding: 0;
+}
+.android-ics .dwc {
+    padding: 30px 10px 1px 10px;
+}
+.android-ics .dwhl {
+    padding: 1px 10px;
+}
+.android-ics .dwv {
+    height: 36px;
+    line-height: 36px;
+    padding: 0;
+    border-bottom: 2px solid #31b6e7;
+    font-size: 18px;
+}
+.android-ics .dwwl {
+    margin: 0 2px;
+}
+.android-ics .dww,
+.android-ics .dw .dwpm .dwwl,
+.android-ics .dw .dwpm .dww {
+    border: 0;
+}
+.android-ics .dww .dw-li {
+    color: #fff;
+    font-size: 18px;
+    text-shadow: none;
+}
+.android-ics .dww .dw-li.dw-hl {
+    background: #31b6e7;
+    background: rgba(49,182,231,.5);
+}
+.android-ics .dwwo {
+    background: linear-gradient(#282828 0%,rgba(40,40,40,0) 52%, rgba(40,40,40,0) 48%, #282828 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#282828),color-stop(0.52, rgba(40,40,40,0)),color-stop(0.48, rgba(40,40,40,0)),to(#282828));
+    background: -moz-linear-gradient(#282828 0%,rgba(40,40,40,0) 52%, rgba(40,40,40,0) 48%, #282828 100%);
+    background: -o-linear-gradient(#282828 0%,rgba(40,40,40,0) 52%, rgba(40,40,40,0) 48%, #282828 100%);
+}
+.android-ics .dw .dwwb {
+    background: #292829;
+    box-shadow: none;
+    -webkit-box-shadow: none;
+}
+.android-ics .dwwb span {
+    display: none;
+}
+.android-ics .dwwb:after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -8px;
+    margin-left: -8px;
+    color: #7e7e7e;
+    width: 0;
+    height: 0;
+    border-width: 8px;
+    border-style: solid;
+    content: '';
+}
+.android-ics .dwwbm {
+    top: 0;
+    bottom: auto;
+}
+.android-ics .dwwbp {
+    bottom: 0;
+    top: auto;
+}
+.android-ics .dwwbm:after {
+    border-color: transparent transparent #7e7e7e transparent;
+}
+.android-ics .dwwbp:after {
+    border-color: #7e7e7e transparent transparent transparent;
+}
+.android-ics .dw .dwwl .dwb-a {
+    background: #292829;
+}
+.android-ics .dwwbm.dwb-a:after {
+    border-color: transparent transparent #319abd transparent;
+}
+.android-ics .dwwbp.dwb-a:after {
+    border-color: #319abd transparent transparent transparent;
+}
+.android-ics .dw .dwwol {
+    width: 60%;
+    left: 20%;
+    height: 36px;
+    border-top: 2px solid #31b6e7;
+    border-bottom: 2px solid #31b6e7;
+    margin-top: -20px;
+    display: block;
+}
+.android-ics .dwbc {
+    border-top: 1px solid #424542;
+    padding: 0;
+}
+.android-ics .dw .dwb {
+    height: 36px;
+    line-height: 36px;
+    padding: 0;
+    margin: 0;
+    font-weight: normal;
+    text-shadow: none;
+    box-shadow: none;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+    -webkit-box-shadow: none;
+}
+.android-ics .dw .dwb-a {
+    background: #29799c;
+}
+.android-ics .dwb-s .dwb, .android-ics .dwb-n .dwb {
+    border-right: 1px solid #424542;
+}
+/* Docked */
+.android-ics.dw-bottom .dw, .android-ics.dw-top .dw {
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+/* Multiple select */
+.android-ics .dwwms .dwwol {
+    display: none;
+}
+.android-ics .dwwms .dw-li {
+    padding-left: 5px;
+    padding-right: 36px;
+}
+.android-ics .dwwms .dw-li:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: auto;
+    right: 10px;
+    width: 14px;
+    height: 14px;
+    margin-top: -9px;
+    color: #31b6e7;
+    line-height: 14px;
+    border: 1px solid #424542;
+    text-shadow: 0 0 5px #29799c;
+}
+.android-ics .dwwms .dw-msel:after {
+    content: '✔';
+}
+/* Light version */
+.android-ics.light .dw {
+    background: #f5f5f5;
+}
+.android-ics.light .dww .dw-li {
+    color: #000;
+}
+.android-ics.light .dwwo {
+    background: linear-gradient(#f5f5f5 0%,rgba(245,245,245,0) 52%, rgba(245,245,245,0) 48%, #f5f5f5 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#f5f5f5),color-stop(0.52, rgba(245,245,245,0)),color-stop(0.48, rgba(245,245,245,0)),to(#f5f5f5));
+    background: -moz-linear-gradient(#f5f5f5 0%,rgba(245,245,245,0) 52%, rgba(245,245,245,0) 48%, #f5f5f5 100%);
+    background: -o-linear-gradient(#f5f5f5 0%,rgba(245,245,245,0) 52%, rgba(245,245,245,0) 48%, #f5f5f5 100%);
+}
+.android-ics.light .dw .dwwb {
+    background: #f5f5f5;
+    color: #f5f5f5;
+}
+.android-ics.light .dwbc {
+    border-top: 1px solid #dbdbdb;
+}
+.android-ics.light .dwb {
+    color: #000;
+}
+.android-ics.light .dwb-a {
+    color: #fff;
+}
+.android-ics.light .dwb-s .dwb, .android-ics.light .dwb-n .dwb {
+    border-right: 1px solid #dbdbdb;
+}
+/* Bubble positioning */
+.android-ics .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #292829 transparent;
+}
+.android-ics .dw-bubble-top .dw-arr {
+    border-color: #292829 transparent transparent transparent;
+}
+/* Bubble positioning */
+.android-ics.light .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #f5f5f5 transparent;
+}
+.android-ics.light .dw-bubble-top .dw-arr {
+    border-color: #f5f5f5 transparent transparent transparent;
+}
+/* Multiple select */
+.android-ics.light .dwwms .dw-li:after {
+    text-shadow: 0 0 5px #31b6e7;
+}
+
+/* iOS Skin */
+.ios .dw {
+    min-width: 134px;
+    padding: 0;
+    border: 1px solid #2d3034;
+    background: none;
+    color: #fff;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.ios .dwo {
+    background: none;
+}
+.ios .dwwr {
+    position: relative;
+    margin-top: 40px;
+    background: #50515d;
+    background: linear-gradient(#9f9fa6,#484a55 50%,#272836 50%,#282a39);
+    background: -webkit-gradient(linear,left top,left bottom,from(#9f9fa6),color-stop(0.5, #484a55),color-stop(0.5, #272836),to(#282a39));
+    background: -webkit-linear-gradient(#9f9fa6,#484a55 50%,#272836 50%,#282a39);
+    background: -moz-linear-gradient(#9f9fa6,#484a55 50%,#272836 50%,#282a39);
+}
+.ios .dwi .dwwr {
+    margin-top: 0;
+}
+.ios .dwv {
+    display: none;
+}
+.ios .dwc {
+    padding: 30px 2px;
+    margin: 0;
+}
+.ios .dwhl {
+    padding: 10px 2px;
+}
+.ios .dwwc {
+    background: transparent;
+}
+.ios .dwwl {
+    margin: 4px 0;
+    border-left: 1px solid #000;
+    border-right: 1px solid #000;
+    background: #cbcce0;
+    background: linear-gradient(#2c2c38 0%,#cbcce0 35%, #cbcce0 65%,#2c2c38 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#2c2c38),color-stop(0.35, #cbcce0),color-stop(0.65, #cbcce0),to(#2c2c38));
+    background: -webkit-linear-gradient(#2c2c38 0%,#cbcce0 35%, #cbcce0 65%,#2c2c38 100%);
+    background: -moz-linear-gradient(#2c2c38 0%,#cbcce0 35%, #cbcce0 65%,#2c2c38 100%);
+    box-shadow: 0 1px 1px rgba(255,255,255,0.3);
+    -webkit-box-shadow: 0 1px 1px rgba(255,255,255,0.3);
+}
+.ios td:first-child .dwwl {
+    border-top-left-radius: 3px;
+    border-bottom-left-radius: 3px;
+    -webkit-border-top-left-radius: 3px;
+    -webkit-border-bottom-left-radius: 3px;
+}
+.ios td:last-child .dwwl {
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+    -webkit-border-top-right-radius: 3px;
+    -webkit-border-bottom-right-radius: 3px;
+}
+.ios .dwsc .dwwl {
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.ios .dwsc .dww {
+    background: #fff;
+    background: linear-gradient(#333 0%,#999 10%,#fff 30%,#fff 70%,#999 90%,#333 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#333),color-stop(0.10, #999),color-stop(0.30, #fff),color-stop(0.70, #fff),color-stop(0.90, #999),to(#333));
+    background: -webkit-linear-gradient(#333 0%,#999 10%,#fff 30%,#fff 70%,#999 90%,#333 100%);
+    background: -moz-linear-gradient(#333 0%,#999 10%,#fff 30%,#fff 70%,#999 90%,#333 100%);
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.ios .dw .dwpm .dww {
+    background: linear-gradient(#333,#fff 48%,#fff 52%,#333);
+    background: -webkit-gradient(linear,left bottom,left top,from(#333),color-stop(0.48, #fff),color-stop(0.52, #fff),to(#333));
+    background: -webkit-linear-gradient(#333 0%,#fff 48%,#fff 52%,#333 100%);
+    background: -moz-linear-gradient(#333 0%,#fff 48%,#fff 52%,#333 100%);
+}
+.ios .dw .dwpm .dwwl {
+    margin: 4px 2px;
+    border: 1px solid #000;
+}
+.ios .dw .dwpm .dww {
+    margin: 0;
+    border: 0;
+}
+.ios .dww .dw-li {
+    color: #000;
+    font-size: 20px;
+    font-weight: bold;
+    text-align: right;
+    text-shadow: none;
+}
+.ios .dww .dw-li.dw-hl {
+    background: linear-gradient(#0288f3,#005de6);
+    background: -webkit-gradient(linear,left bottom,left top,from(#0288f3),to(#005de6));
+    background: -webkit-linear-gradient(#0288f3,#005de6);
+    background: -moz-linear-gradient(#0288f3,#005de6);
+    color: #fff;
+}
+.ios .dwwo {
+    background: linear-gradient(#333 0%,rgba(153,153,153,0) 10%, rgba(153,153,153,0) 90%, #333 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#333),color-stop(0.1, rgba(153,153,153,0)),color-stop(0.9, rgba(153,153,153,0)),to(#333));
+    background: -webkit-linear-gradient(#333 0%,rgba(153,153,153,0) 10%, rgba(153,153,153,0) 90%, #333 100%);
+    background: -moz-linear-gradient(#333 0%,rgba(153,153,153,0) 10%, rgba(153,153,153,0) 90%, #333 100%);
+}
+.ios .dwwol {
+    height: 28px;
+    padding: 1px;
+    margin-top: -16px;
+    border-color: #7b8699;
+    background: #6f75b0;
+    background: linear-gradient(rgba(151, 157, 197, 0.5) 50%,rgba(111, 117, 176, 0.5) 50%);
+    background: -webkit-gradient(linear,left bottom,left top,color-stop(0.5, rgba(111, 117, 176, 0.5)),color-stop(0.5, rgba(151, 157, 197, 0.5)));
+    background: -webkit-linear-gradient(rgba(151, 157, 197, 0.5) 50%,rgba(111, 117, 176, 0.5) 50%);
+    background: -moz-linear-gradient(rgba(151, 157, 197, 0.5) 50%,rgba(111, 117, 176, 0.5) 50%);
+    z-index: 10;
+    left: -1px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    -webkit-box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+    filter: alpha(opacity=50);
+}
+.ios .dww .dwwol {
+    display: none;
+}
+.ios .dw .dwbc {
+    position: absolute;
+    top: -40px;
+    left: 0;
+    width: 100%;
+    height: 28px;
+    padding: 5px 0;
+    background: #454545;
+    background: linear-gradient(rgba(69,69,69,0.7),rgba(37,37,37,0.7) 50%,rgba(16,16,16,0.7) 50%,rgba(0,0,0,0.7));
+    background: -webkit-gradient(linear,left top,left bottom,from(rgba(69,69,69,0.7)),color-stop(0.5, rgba(37,37,37,0.7)),color-stop(0.5, rgba(16,16,16,0.7)),to(rgba(0,0,0,0.7)));
+    background: -webkit-linear-gradient(rgba(69,69,69,0.7),rgba(37,37,37,0.7) 50%,rgba(16,16,16,0.7) 50%,rgba(0,0,0,0.7));
+    background: -moz-linear-gradient(rgba(69,69,69,0.7),rgba(37,37,37,0.7) 50%,rgba(16,16,16,0.7) 50%,rgba(0,0,0,0.7));
+    border-bottom: 1px solid #888;
+    border-bottom: 1px solid rgba(255,255,255,0.5);
+    border-top: 1px solid #888;
+    border-top: 1px solid rgba(255,255,255,0.5);
+}
+.ios .dw .dwb {
+    margin: 0 5px;
+    padding: 0 10px;
+    display: inline-block;
+    font-size: 12px;
+    height: 26px;
+    line-height: 26px;
+    border: 1px solid #1f1f1f;
+    background: #1a1a1a;
+    background: linear-gradient(#7b7b7b,#1a1a1a 50%,#000 50%);
+    background: -webkit-gradient(linear,left top,left bottom,from(#7b7b7b),color-stop(0.5, #1a1a1a),color-stop(0.5, #000));
+    background: -webkit-linear-gradient(#7b7b7b,#1a1a1a 50%,#000 50%);
+    background: -moz-linear-gradient(#7b7b7b,#1a1a1a 50%,#000 50%);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.3);
+    -webkit-box-shadow: 0 1px 0 rgba(255,255,255,0.3);
+}
+.ios .dwb-s .dwb {
+    border: 1px solid #194aab;
+    background: #194aab;
+    background: linear-gradient(#82aaff,#3162c4 50%,#194aab 50%);
+    background: -webkit-gradient(linear,left top,left bottom,from(#82aaff),color-stop(0.5,#3162c4),color-stop(0.5,#194aab));
+    background: -webkit-linear-gradient(#82aaff,#3162c4 50%,#194aab 50%);
+    background: -moz-linear-gradient(#82aaff,#3162c4 50%,#194aab 50%);
+}
+.ios .dwb-a {
+    opacity: .8;
+    filter: alpha(opacity=80);
+}
+.ios .dw .dwwb {
+    color: #fff;
+    border: 0;
+    background: #3f4e68;
+    background: linear-gradient(#c7d1e2 0%,#808ea6 50%,#75859f 50%,#3f4e68 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#3f4e68),color-stop(0.5, #75859f),color-stop(0.5, #808ea6),to(#c7d1e2));
+    background: -webkit-linear-gradient(#c7d1e2 0%,#808ea6 50%,#75859f 50%,#3f4e68 100%);
+    background: -moz-linear-gradient(#c7d1e2 0%,#808ea6 50%,#75859f 50%,#3f4e68 100%);
+}
+.ios .dw .dwwl .dwb-a {
+    background: #252c36;
+    background: linear-gradient(#6b6e75 0%,#272e38 50%,#171e28 50%,#252c36 100%);
+    background: -webkit-gradient(linear,left bottom,left top,from(#252c36),color-stop(0.5, #171e28),color-stop(0.5, #272e38),to(#6b6e75));
+    background: -webkit-linear-gradient(#6b6e75 0%,#272e38 50%,#171e28 50%,#252c36 100%);
+    background: -moz-linear-gradient(#6b6e75 0%,#272e38 50%,#171e28 50%,#252c36 100%);
+}
+.ios .dwb-s, .ios .dwb-n {
+    width: auto;
+    float: right;
+    text-align: right;
+}
+.ios .dwb-c {
+    width: auto;
+    float: left;
+    text-align: left;
+}
+/* Bubble positioning */
+.ios.dw-bubble .dw {
+    padding: 6px;
+    background: #afafaf;
+    background: linear-gradient(#afafaf, #1b2530 30%);
+    background: -webkit-gradient(linear,left top,left bottom,from(#afafaf),color-stop(0.3, #1b2530));
+    background: -webkit-linear-gradient(#afafaf, #1b2530 30%);
+    background: -moz-linear-gradient(#afafaf, #1b2530 30%);
+    box-shadow: 0 0 25px rgba(0,0,0,0.7);
+    border-radius: 5px;
+    -webkit-border-radius: 5px;
+    -webkit-box-shadow: 0 0 25px rgba(0,0,0,0.7);
+}
+.ios .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #2d3034 transparent;
+}
+.ios .dw-bubble-bottom .dw-arr:after {
+    content: '';
+    position: absolute;
+    top: -16px;
+    left: -17px;
+    border: 17px solid #afafaf;
+    border-color: transparent transparent #afafaf transparent;
+}
+.ios .dw-bubble-top .dw-arr {
+    border-color: #1b2530 transparent transparent transparent;
+}
+/* Multiple select */
+.ios .dwwms .dwwol {
+    display: none;
+}
+.ios .dwwms .dw-li {
+    padding: 0 5px 0 30px;
+    text-align: left;
+}
+.ios .dw-msel:after {
+    width: 30px;
+}
+.ios .dww .dw-msel {
+    color: #215085;
+}
+
+/* Sense UI Skin */
+.sense-ui .dw {
+    padding: 0;
+    background: #333;
+    border: 2px solid #fff;
+    color: #fff;
+}
+.sense-ui .dwwr {
+    padding: 0;
+}
+.sense-ui .dwv {
+    padding: 5px 10px;
+    border-bottom: 1px solid #666;
+    text-align: left;
+}
+.sense-ui .dwwc {
+    background: #333;
+}
+.sense-ui .dw .dwpm .dwwl,
+.sense-ui .dw .dwpm .dww {
+    background: #fff;
+    border: 0;
+    padding: 0;
+}
+.sense-ui .dwbc {
+    padding: 5px 1px;
+    background: #000;
+    background: linear-gradient(#666 50%,#000 50%);
+    background: -webkit-gradient(linear,left bottom,left top,color-stop(0.5, #000),color-stop(0.5, #666));
+    background: -moz-linear-gradient(#666 50%,#000 50%);
+    background: -o-linear-gradient(#666 50%,#000 50%);
+}
+.sense-ui .dw .dwb {
+    margin: 0 5px;
+    border: 1px solid #333;
+    background: #222;
+    background: linear-gradient(#444,#000);
+    background: -webkit-gradient(linear,left bottom,left top,from(#000),to(#444));
+    background: -moz-linear-gradient(#444,#000);
+    background: -o-linear-gradient(#444,#000);
+    box-shadow: inset 0 0 5px #000;
+}
+.sense-ui .dw .dwb-a {
+    background: #3c7500;
+    background: linear-gradient(#94c840,#3c7500);
+    background: -webkit-gradient(linear,left bottom,left top,from(#3c7500),to(#94c840));
+    background: -moz-linear-gradient(#94c840,#3c7500);
+    background: -o-linear-gradient(#94c840,#3c7500);
+}
+/* Docked */
+.sense-ui.dw-top .dw {
+    border: 0;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.sense-ui.dw-bottom .dw {
+    border: 0;
+    border-top: 1px solid #666;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+
+.wp .dw {
+    background: #1f1f1f;
+    border-radius: 0;
+    -webkit-border-radius: 0;
+}
+.wp .dwwr {
+    padding: 10px;
+}
+.wp .dwv {
+    display: none;
+}
+.wp .dwc {
+    padding: 30px 0 0 0;
+    vertical-align: middle;
+}
+.wp .dwhl {
+    padding: 0;
+}
+.wp .dwwc {
+    padding: 3px;
+    background: none;
+}
+.wp .dwwl {
+    margin: 0;
+    padding: 0 2px;
+    background: none;
+}
+.wp .dwl {
+    color: #fff;
+}
+.wp .dw .dwwl .dww {
+    background: none;
+    border: 0;
+    color: #fff;
+}
+.wp .dw-li {
+    position: relative;
+    padding: 0;
+    font-size: 26px;
+    letter-spacing: -1px;
+    text-align: left;
+    text-shadow: none;
+    opacity: 0;
+    box-sizing: border-box;
+    filter: Alpha(Opacity=0);
+    /*transition: opacity .3s linear;*/
+    -webkit-box-sizing: border-box;
+    /*-webkit-transition: opacity .3s linear;*/
+    -moz-box-sizing: border-box;
+    /*-moz-transition: opacity .3s linear;*/
+}
+.wp .dw-i {
+    position: relative;
+    top: 4%;
+    height: 92%;
+    padding: 0 5px;
+    border: 1px solid #4c4c4c;
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    filter: inherit;
+}
+.wp .wpa .dw-li, .wp .dwa .dw-li {
+    opacity: .3;
+    filter: Alpha(Opacity=30);
+}
+.wp .wpa .dw-v, .wp .dwa .dw-v, .wp .wpam .dw-v {
+    opacity: 1;
+    filter: Alpha(Opacity=100);
+}
+.wp .dw-day, .wp .dw-mon {
+    display: block;
+    color: #a9a9a9;
+    line-height: 18px;
+    font-size: 11px;
+    letter-spacing: normal;
+    position: absolute;
+    bottom: 0;
+    filter: inherit;
+}
+.wp .dw-sel {
+    opacity: 1;
+    filter: Alpha(Opacity=100);
+}
+.wp .dw .dw-sel .dw-i {
+    color: #fff;
+    background: #4c4c4c;
+    /*transition: all .1s linear;
+    -webkit-transition: all .1s linear;
+    -moz-transition: all .1s linear;*/
+}
+.wp .dw-sel .dw-day, .wp .dw-sel .dw-mon {
+    color: #fff;
+}
+.wp .dw-hl {
+    background: none;
+}
+.wp .dw-hl .dw-i {
+    background: #4c4c4c;
+}
+.wp .dwa .dww .dw-sel .dw-i {
+    border: 1px solid #4c4c4c;
+    background-color: transparent;
+}
+.wp .dwa .dw-day, .wp .dwa .dw-month {
+    color: #a9a9a9;
+}
+.wp .dwwo {
+    display: none;
+}
+.wp .dwwol {
+    display: none;
+}
+.wp .dwbc {
+    padding: 0;
+}
+.wp .dwbw {
+    float: none;
+    width: auto;
+}
+.wp .dw .dwb {
+    position: relative;
+    top: 0;
+    min-width: 32px;
+    display: inline-block;
+    height: 20px;
+    padding: 29px 5px 0 5px;
+    background: none;
+    box-shadow: none;
+    line-height: 20px;
+    font-size: 11px;
+    font-weight: normal;
+    text-transform: lowercase;
+    text-shadow: none;
+    transition: top .1s linear;
+    -webkit-box-shadow: none;
+    -webkit-transition: top .1s linear;
+    -moz-transition: top .1s linear;
+}
+.wp .dwb:after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 50%;
+    width: 26px;
+    height: 26px;
+    margin: 0 -13px;
+    background: url(wp_icons.png) center center no-repeat;
+}
+.wp .dwb-s .dwb:after {
+    background-position: 0 0;
+}
+.wp .dwb-c .dwb:after {
+    background-position: -26px 0;
+}
+.wp .dwb-n .dwb:after {
+    background-position: -52px 0;
+}
+.wp .dwb-s .dwb-a:after {
+    background-position: 0 -26px;
+}
+.wp .dwb-c .dwb-a:after {
+    background-position: -26px -26px;
+}
+.wp .dwb-n .dwb-a:after {
+    background-position: -52px -26px;
+}
+.wp .dwb.dwb-a {
+    top: -3px;
+}
+/* +/- buttons */
+.wp .dw .dwwl .dwb-a {
+    background: #1f1f1f;
+}
+.wp .dw .dwpm .dwwl {
+    border: 0;
+}
+.wp .dw .dwwb {
+    background: #1f1f1f;
+    border-radius: 0;
+    box-shadow: none;
+    box-sizing: border-box;
+    color: #a9a9a9;
+    -webkit-box-shadow: none;
+    -webkit-border-radius: 0;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+}
+.wp .dwwb span {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 26px;
+    height: 0;
+    padding-top: 26px;
+    overflow: hidden;
+    margin: -13px;
+    display: block;
+    background: url(wp_icons.png) center center no-repeat;
+}
+.wp .dwwbp span {
+    background-position: -78px 0;
+}
+.wp .dwwbp.dwb-a span {
+    background-position: -78px -26px;
+}
+.wp .dwwbm span {
+    background-position: -104px 0;
+}
+.wp .dwwbm.dwb-a span {
+    background-position: -104px -26px;
+}
+/* Bubble positioning */
+.wp .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #1f1f1f transparent;
+}
+.wp .dw-bubble-top .dw-arr {
+    border-color: #1f1f1f transparent transparent transparent;
+}
+/* Multiple select */
+.wp .dwwms .dw-li {
+    opacity: .3;
+    filter: Alpha(Opacity=30);
+    padding: 0 0 0 30px;
+}
+.wp .dwwms .dw-v {
+    opacity: 1;
+    filter: Alpha(Opacity=100);
+}
+.wp .dwc .dwwms .dw-i,
+.wp .dwc .dwwms .dw-sel .dw-i,
+.wp .dwc .dwwms .dw-hl .dw-i,
+.wp .dwc .dwwms.dwa .dw-sel .dw-i {
+    border: 0;
+    background: none;
+}
+.wp .dwwms .dw-li:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 5px;
+    width: 20px;
+    height: 20px;
+    margin-top: -10px;
+    font-size: 18px;
+    line-height: 20px;
+    background: #4c4c4c;
+    color: #fff;
+}
+.wp .dwwms .dw-msel:after {
+    content: '✔';
+}
+/* Light version */
+.wp.light .dw {
+    background: #dedede;
+}
+.wp.light .dwv,
+.wp.light .dwl,
+.wp.light .dwb {
+    color: #000;
+}
+.wp.light .dw-li {
+    color: #6b6b6b;
+}
+.wp.light .dw-i {
+    border-color: #b5b5b5;
+}
+.wp.light .dw-sel .dw-i {
+    background: #b5b5b5;
+}
+.wp.light .dw-hl .dw-i {
+    color: #fff;
+    background: #b5b5b5;
+}
+.wp.light .dw-day, .wp.light .dw-mon {
+    color: #6b6b6b;
+}
+.wp.light .dw-sel .dw-day, .wp.light .dw-sel .dw-mon {
+    color: #fff;
+}
+.wp.light .dw .dwa .dw-sel .dw-i {
+    color: #6b6b6b;
+    border: 1px solid #b5b5b5;
+    background-color: transparent;
+}
+.wp.light .dw .dwc .dwa .dw-day, .wp.light .dw .dwc .dwa .dw-mon {
+    color: #6b6b6b;
+}
+.wp.light .dwb:after {
+    background-image: url(wp_icons_light.png);
+}
+.wp.light .dw .dwwb {
+    background: #dedede;
+}
+.wp.light .dwwb span {
+    background-image: url(wp_icons_light.png);
+}
+/* Bubble positioning */
+.wp.light .dw-bubble-bottom .dw-arr {
+    border-color: transparent transparent #dedede transparent;
+}
+.wp.light .dw-bubble-top .dw-arr {
+    border-color: #dedede transparent transparent transparent;
+}
+/* Multiple select */
+.wp.light .dwc .dwwms .dw-i,
+.wp.light .dwwms.dwa .dw-sel .dw-i {
+    border: 0;
+    background: none;
+    color: #000;
+}
+.wp.light .dwwms .dw-li:after {
+    background: #b5b5b5;
+}
+.wp.light .wp-none .dwwms .dw-li:after {
+    color: #000;
+}
+/* Accents */
+.wp.light .wp-none .dw-sel .dw-i, .wp.light .wp-none .dw-hl .dw-i {
+    color: #000;
+}
+.wp.light .wp-none .dw-day, .wp.light .wp-none .dw-mon {
+    color: #6b6b6b;
+}
+.wp .wp-lime .dw-sel .dw-i, .wp .wp-lime .dw-hl .dw-i, .wp .wp-lime .dwwms .dw-li:after {
+    background: #a4c400;
+    border-color: #a4c400;
+}
+.wp .wp-green .dw-sel .dw-i, .wp .wp-green .dw-hl .dw-i, .wp .wp-green .dwwms .dw-li:after {
+    background: #60a917;
+    border-color: #60a917;
+}
+.wp .wp-emerald .dw-sel .dw-i, .wp .wp-emerald .dw-hl .dw-i, .wp .wp-emerald .dwwms .dw-li:after {
+    background: #008a00;
+    border-color: #008a00;
+}
+.wp .wp-teal .dw-sel .dw-i, .wp .wp-teal .dw-hl .dw-i, .wp .wp-teal .dwwms .dw-li:after {
+    background: #00aba9;
+    border-color: #00aba9;
+}
+.wp .wp-cyan .dw-sel .dw-i, .wp .wp-cyan .dw-hl .dw-i, .wp .wp-cyan .dwwms .dw-li:after {
+    background: #1ba1e2;
+    border-color: #1ba1e2;
+}
+.wp .wp-cobalt .dw-sel .dw-i, .wp .wp-cobalt .dw-hl .dw-i, .wp .wp-cobalt .dwwms .dw-li:after {
+    background: #0050ef;
+    border-color: #0050ef;
+}
+.wp .wp-indigo .dw-sel .dw-i, .wp .wp-indigo .dw-hl .dw-i, .wp .wp-indigo .dwwms .dw-li:after {
+    background: #6a00ff;
+    border-color: #6a00ff;
+}
+.wp .wp-violet .dw-sel .dw-i, .wp .wp-violet .dw-hl .dw-i, .wp .wp-violet .dwwms .dw-li:after {
+    background: #aa00ff;
+    border-color: #aa00ff;
+}
+.wp .wp-pink .dw-sel .dw-i, .wp .wp-pink .dw-hl .dw-i, .wp .wp-pink .dwwms .dw-li:after {
+    background: #f472d0;
+    border-color: #f472d0;
+}
+.wp .wp-magenta .dw-sel .dw-i, .wp .wp-magenta .dw-hl .dw-i, .wp .wp-magenta .dwwms .dw-li:after {
+    background: #d80073;
+    border-color: #d80073;
+}
+.wp .wp-crimson .dw-sel .dw-i, .wp .wp-crimson .dw-hl .dw-i, .wp .wp-crimson .dwwms .dw-li:after {
+    background: #a20025;
+    border-color: #a20025;
+}
+.wp .wp-red .dw-sel .dw-i, .wp .wp-red .dw-hl .dw-i, .wp .wp-red .dwwms .dw-li:after {
+    background: #e51400;
+    border-color: #e51400;
+}
+.wp .wp-orange .dw-sel .dw-i, .wp .wp-orange .dw-hl .dw-i, .wp .wp-orange .dwwms .dw-li:after {
+    background: #fa6800;
+    border-color: #fa6800;
+}
+.wp .wp-amber .dw-sel .dw-i, .wp .wp-amber .dw-hl .dw-i, .wp .wp-amber .dwwms .dw-li:after {
+    background: #f0a30a;
+    border-color: #f0a30a;
+}
+.wp .wp-yellow .dw-sel .dw-i, .wp .wp-yellow .dw-hl .dw-i, .wp .wp-yellow .dwwms .dw-li:after {
+    background: #d8c100;
+    border-color: #d8c100;
+}
+.wp .wp-brown .dw-sel .dw-i, .wp .wp-brown .dw-hl .dw-i, .wp .wp-brown .dwwms .dw-li:after {
+    background: #825a2c;
+    border-color: #825a2c;
+}
+.wp .wp-olive .dw-sel .dw-i, .wp .wp-olive .dw-hl .dw-i, .wp .wp-olive .dwwms .dw-li:after {
+    background: #6d8764;
+    border-color: #6d8764;
+}
+.wp .wp-steel .dw-sel .dw-i, .wp .wp-steel .dw-hl .dw-i, .wp .wp-steel .dwwms .dw-li:after {
+    background: #647687;
+    border-color: #647687;
+}
+.wp .wp-mauve .dw-sel .dw-i, .wp .wp-mauve .dw-hl .dw-i, .wp .wp-mauve .dwwms .dw-li:after {
+    background: #76608a;
+    border-color: #76608a;
+}
+.wp .wp-sienna .dw-sel .dw-i, .wp .wp-sienna .dw-hl .dw-i, .wp .wp-sienna .dwwms .dw-li:after {
+    background: #7a3b3f;
+    border-color: #7a3b3f;
+}
+
+.dw-trans .dw-persp {
+    overflow: hidden;
+    perspective: 1000px;
+    -webkit-perspective: 1000px;
+    -moz-perspective: 1000px;
+}
+.dw-trans .dwwb,
+.dw-trans .dwwo {
+    -webkit-backface-visibility: hidden;
+}
+.dw-in,
+.dw-out {
+     animation-duration: 350ms;
+     -webkit-animation-duration: 350ms;
+     -moz-animation-duration: 350ms;
+}
+.dw-in {
+    animation-timing-function: ease-out;
+    -webkit-animation-timing-function: ease-out;
+    -moz-animation-timing-function: ease-out;
+}
+.dw-out {
+    animation-timing-function: ease-in;
+    -webkit-animation-timing-function: ease-in;
+    -moz-animation-timing-function: ease-in;
+}
+.dw-flip,
+.dw-swing,
+.dw-slidehorizontal,
+.dw-slidevertical,
+.dw-slidedown,
+.dw-slideup,
+.dw-fade {
+    backface-visibility: hidden;
+    transform: translateX(0);
+    -webkit-backface-visibility: hidden;
+    -webkit-transform: translateX(0);
+    -moz-backface-visibility: hidden;
+    -moz-transform: translateX(0);
+}
+.dw-swing,
+.dw-slidehorizontal,
+.dw-slidevertical,
+.dw-slidedown,
+.dw-slideup,
+.dw-fade {
+    transform-origin: 0 0;
+    -webkit-transform-origin: 0 0;
+    -moz-transform-origin: 0 0;
+}
+.dw-flip,
+.dw-pop {
+    transform-origin: 50% 50%;
+    -webkit-transform-origin: 50% 50%;
+    -moz-transform-origin: 50% 50%;
+}
+.dw-pop.dw-in {
+    opacity: 1;
+    transform: scale(1);
+    animation-name: dw-p-in;
+    -webkit-animation-name: dw-p-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-p-in;
+    -moz-transform: scale(1);
+}
+.dw-pop.dw-out {
+    opacity: 0;
+    animation-name: dw-p-out;
+    -webkit-animation-name: dw-p-out;
+    -moz-animation-name: dw-p-out;
+}
+.dw-flip.dw-in {
+    opacity: 1;
+    transform: scale(1);
+    animation-name: dw-fl-in;
+    -webkit-animation-name: dw-fl-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-fl-in;
+    -moz-transform: scale(1);
+}
+.dw-flip.dw-out {
+    opacity: 0;
+    animation-name: dw-fl-out;
+    -webkit-animation-name: dw-fl-out;
+    -moz-animation-name: dw-fl-out;
+}
+.dw-swing.dw-in {
+    opacity: 1;
+    transform: scale(1);
+    animation-name: dw-sw-in;
+    -webkit-animation-name: dw-sw-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-sw-in;
+    -moz-transform: scale(1);
+}
+.dw-swing.dw-out {
+    opacity: 0;
+    animation-name: dw-sw-out;
+    -webkit-animation-name: dw-sw-out;
+    -moz-animation-name: dw-sw-out;
+}
+.dw-slidehorizontal.dw-in {
+    opacity: 1;
+    transform: scale(1);
+    animation-name: dw-sh-in;
+    -webkit-animation-name: dw-sh-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-sh-in;
+    -moz-transform: scale(1);
+}
+.dw-slidehorizontal.dw-out {
+    opacity: 0;
+    animation-name: dw-sh-out;
+    -webkit-animation-name: dw-sh-out;
+    -moz-animation-name: dw-sh-out;
+}
+.dw-slidevertical.dw-in {
+    opacity: 1;
+    animation-name: dw-dw-sv-in;
+    transform: scale(1);
+    -webkit-animation-name: dw-dw-sv-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-dw-sv-in;
+    -moz-transform: scale(1);
+}
+.dw-slidevertical.dw-out {
+    opacity: 0;
+    animation-name: dw-sv-out;
+    -webkit-animation-name: dw-sv-out;
+    -moz-animation-name: dw-sv-out;
+}
+.dw-slidedown.dw-in {
+    animation-name: dw-sd-in;
+    transform: scale(1);
+    -webkit-animation-name: dw-sd-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-sd-in;
+    -moz-transform: scale(1);
+}
+.dw-slidedown.dw-out {
+    animation-name: dw-sd-out;
+    -webkit-animation-name: dw-sd-out;
+    -moz-animation-name: dw-sd-out;
+}
+.dw-slideup.dw-in {
+    transform: scale(1);
+    animation-name: dw-su-in;
+    -webkit-animation-name: dw-su-in;
+    -webkit-transform: scale(1);
+    -moz-animation-name: dw-su-in;
+    -moz-transform: scale(1);
+}
+.dw-slideup.dw-out {
+    animation-name: dw-su-out;
+    -webkit-animation-name: dw-su-out;
+    -moz-animation-name: dw-su-out;
+}
+.dw-fade.dw-in {
+    opacity: 1;
+    animation-name: dw-f-in;
+    -webkit-animation-name: dw-f-in;
+    -moz-animation-name: dw-f-in;
+}
+.dw-fade.dw-out {
+    opacity: 0;
+    animation-name: dw-f-out;
+    -webkit-animation-name: dw-f-out;
+    -moz-animation-name: dw-f-out;
+}
+/* Fade in */
+@keyframes dw-f-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+@-webkit-keyframes dw-f-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+@-moz-keyframes dw-f-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+/* Fade out */
+@keyframes dw-f-out {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+@-webkit-keyframes dw-f-out {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+@-moz-keyframes dw-f-out {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+/* Pop in */
+@keyframes dw-p-in {
+    from {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+@-webkit-keyframes dw-p-in {
+    from {
+        opacity: 0;
+        -webkit-transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: scale(1);
+    }
+}
+@-moz-keyframes dw-p-in {
+    from {
+        opacity: 0;
+        -moz-transform: scale(0.8);
+    }
+    to {
+        opacity: 1;
+        -moz-transform: scale(1);
+    }
+}
+/* Pop out */
+@keyframes dw-p-out {
+    from {
+        opacity: 1;
+        transform: scale(1);
+    }
+    to {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+}
+@-webkit-keyframes dw-p-out {
+    from {
+        opacity: 1;
+        -webkit-transform: scale(1);
+    }
+    to {
+        opacity: 0;
+        -webkit-transform: scale(0.8);
+    }
+}
+@-moz-keyframes dw-p-out {
+    from {
+        opacity: 1;
+        -moz-transform: scale(1);
+    }
+    to {
+        opacity: 0;
+        -moz-transform: scale(0.8);
+    }
+}
+/* Flip in */
+@keyframes dw-fl-in {
+    from {
+        opacity: 0;
+        transform: rotateY(90deg);
+    }
+    to {
+        opacity: 1;
+        transform: rotateY(0);
+    }
+}
+@-webkit-keyframes dw-fl-in {
+    from {
+        opacity: 0;
+        -webkit-transform: rotateY(90deg);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: rotateY(0);
+    }
+}
+@-moz-keyframes dw-fl-in {
+    from {
+        opacity: 0;
+        -moz-transform: rotateY(90deg);
+    }
+    to {
+        opacity: 1;
+        -moz-transform: rotateY(0);
+    }
+}
+/* Flip out */
+@keyframes dw-fl-out {
+    from {
+        opacity: 1;
+        transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        transform: rotateY(-90deg);
+    }
+}
+@-webkit-keyframes dw-fl-out {
+    from {
+        opacity: 1;
+        -webkit-transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        -webkit-transform: rotateY(-90deg);
+    }
+}
+@-moz-keyframes dw-fl-out {
+    from {
+        opacity: 1;
+        -moz-transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        -moz-transform: rotateY(-90deg);
+    }
+}
+/* Swing in */
+@keyframes dw-sw-in {
+    from {
+        opacity: 0;
+        transform: rotateY(-90deg);
+    }
+    to {
+        opacity: 1;
+        transform: rotateY(0deg);
+    }
+}
+@-webkit-keyframes dw-sw-in {
+    from {
+        opacity: 0;
+        -webkit-transform: rotateY(-90deg);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: rotateY(0deg);
+    }
+}
+@-moz-keyframes dw-sw-in {
+    from {
+        opacity: 0;
+        -moz-transform: rotateY(-90deg);
+    }
+    to {
+        opacity: 1;
+        -moz-transform: rotateY(0deg);
+    }
+}
+/* Swing out */
+@keyframes dw-sw-out {
+    from {
+        opacity: 1;
+        transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        transform: rotateY(-90deg);
+    }
+}
+@-webkit-keyframes dw-sw-out {
+    from {
+        opacity: 1;
+        -webkit-transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        -webkit-transform: rotateY(-90deg);
+    }
+}
+@-moz-keyframes dw-sw-out {
+    from {
+        opacity: 1;
+        -moz-transform: rotateY(0deg);
+    }
+    to {
+        opacity: 0;
+        -moz-transform: rotateY(-90deg);
+    }
+}
+/* Slide horizontal in */
+@keyframes dw-sh-in {
+    from {
+        opacity: 0;
+        transform: translateX(-100%);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+@-webkit-keyframes dw-sh-in {
+    from {
+        opacity: 0;
+        -webkit-transform: translateX(-100%);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateX(0);
+    }
+}
+@-moz-keyframes dw-sh-in {
+    from {
+        opacity: 0;
+        -moz-transform: translateX(-100%);
+    }
+    to {
+        opacity: 1;
+        -moz-transform: translateX(0);
+    }
+}
+/* Slide horizontal out */
+@keyframes dw-sh-out {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(100%);
+    }
+}
+@-webkit-keyframes dw-sh-out {
+    from {
+        opacity: 1;
+        -webkit-transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        -webkit-transform: translateX(100%);
+    }
+}
+@-moz-keyframes dw-sh-out {
+    from {
+        opacity: 1;
+        -moz-transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        -moz-transform: translateX(100%);
+    }
+}
+/* Slide vertical in */
+@keyframes dw-dw-sv-in {
+    from {
+        opacity: 0;
+        transform: translateY(-100%);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+@-webkit-keyframes dw-dw-sv-in {
+    from {
+        opacity: 0;
+        -webkit-transform: translateY(-100%);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+}
+@-moz-keyframes dw-dw-sv-in {
+    from {
+        opacity: 0;
+        -moz-transform: translateY(-100%);
+    }
+    to {
+        opacity: 1;
+        -moz-transform: translateY(0);
+    }
+}
+/* Slide vertical out */
+@keyframes dw-sv-out {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(100%);
+    }
+}
+@-webkit-keyframes dw-sv-out {
+    from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        -webkit-transform: translateY(100%);
+    }
+}
+@-moz-keyframes dw-sv-out {
+    from {
+        opacity: 1;
+        -moz-transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        -moz-transform: translateY(100%);
+    }
+}
+/* Slide Down In */
+@keyframes dw-sd-in {
+    from {
+        transform: translateY(-100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}
+@-webkit-keyframes dw-sd-in {
+    from {
+        opacity: 1;
+        -webkit-transform: translateY(-100%);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+}
+@-moz-keyframes dw-sd-in {
+    from {
+        -moz-transform: translateY(-100%);
+    }
+    to {
+        -moz-transform: translateY(0);
+    }
+}
+/* Slide down out */
+@keyframes dw-sd-out {
+    from {
+        transform: translateY(0);
+    }
+    to {
+        transform: translateY(-100%);
+    }
+}
+@-webkit-keyframes dw-sd-out {
+    from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateY(-100%);
+    }
+}
+@-moz-keyframes dw-sd-out {
+    from {
+        -moz-transform: translateY(0);
+    }
+    to {
+        -moz-transform: translateY(-100%);
+    }
+}
+/* Slide Up In */
+@keyframes dw-su-in {
+    from {
+        transform: translateY(100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}
+@-webkit-keyframes dw-su-in {
+    from {
+        opacity: 1;
+        -webkit-transform: translateY(100%);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+}
+@-moz-keyframes dw-su-in {
+    from {
+        -moz-transform: translateY(100%);
+    }
+    to {
+        -moz-transform: translateY(0);
+    }
+}
+/* Slide up out */
+@keyframes dw-su-out {
+    from {
+        transform: translateY(0);
+    }
+    to {
+        transform: translateY(100%);
+    }
+}
+@-webkit-keyframes dw-su-out {
+    from {
+        opacity: 1;
+        -webkit-transform: translateY(0);
+    }
+    to {
+        opacity: 1;
+        -webkit-transform: translateY(100%);
+    }
+}
+@-moz-keyframes dw-su-out {
+    from {
+        -moz-transform: translateY(0);
+    }
+    to {
+        -moz-transform: translateY(100%);
+    }
+}

--- a/web/ext/mobiscroll-2.6.0/mobiscroll.js
+++ b/web/ext/mobiscroll-2.6.0/mobiscroll.js
@@ -1,0 +1,2236 @@
+/*jslint eqeq: true, plusplus: true, undef: true, sloppy: true, vars: true, forin: true, nomen: true */
+/*!
+ * jQuery MobiScroll v2.6.0
+ * http://mobiscroll.com
+ *
+ * Copyright 2010-2013, Acid Media
+ * Licensed under the MIT license.
+ *
+ */
+(function ($) {
+
+    function Scroller(elem, settings) {
+        var m,
+            hi,
+            v,
+            dw,
+            ww, // Window width
+            wh, // Window height
+            rwh,
+            mw, // Modal width
+            mh, // Modal height
+            anim,
+            debounce,
+            theme,
+            lang,
+            click,
+            scrollable,
+            moved,
+            start,
+            startTime,
+            stop,
+            p,
+            min,
+            max,
+            target,
+            index,
+            timer,
+            readOnly,
+            that = this,
+            ms = $.mobiscroll,
+            e = elem,
+            elm = $(e),
+            s = extend({}, defaults),
+            pres = {},
+            iv = {},
+            pos = {},
+            pixels = {},
+            wheels = [],
+            input = elm.is('input'),
+            visible = false,
+            onStart = function (e) {
+                // Scroll start
+                if (testTouch(e) && !move && !isReadOnly(this) && !click) {
+                    // Prevent scroll
+                    e.preventDefault();
+
+                    move = true;
+                    scrollable = s.mode != 'clickpick';
+                    target = $('.dw-ul', this);
+                    setGlobals(target);
+                    moved = iv[index] !== undefined; // Don't allow tap, if still moving
+                    p = moved ? getCurrentPosition(target) : pos[index];
+                    start = getCoord(e, 'Y');
+                    startTime = new Date();
+                    stop = start;
+                    scroll(target, index, p, 0.001);
+
+                    if (scrollable) {
+                        target.closest('.dwwl').addClass('dwa');
+                    }
+
+                    $(document).bind(MOVE_EVENT, onMove).bind(END_EVENT, onEnd);
+                }
+            },
+            onMove = function (e) {
+                if (scrollable) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    stop = getCoord(e, 'Y');
+                    scroll(target, index, constrain(p + (start - stop) / hi, min - 1, max + 1));
+                }
+                moved = true;
+            },
+            onEnd = function (e) {
+                var time = new Date() - startTime,
+                    val = constrain(p + (start - stop) / hi, min - 1, max + 1),
+                    speed,
+                    dist,
+                    tindex,
+                    ttop = target.offset().top;
+
+                if (time < 300) {
+                    speed = (stop - start) / time;
+                    dist = (speed * speed) / s.speedUnit;
+                    if (stop - start < 0) {
+                        dist = -dist;
+                    }
+                } else {
+                    dist = stop - start;
+                }
+
+                tindex = Math.round(p - dist / hi);
+
+                if (!dist && !moved) { // this is a "tap"
+                    var idx = Math.floor((stop - ttop) / hi),
+                        li = $('.dw-li', target).eq(idx),
+                        hl = scrollable;
+
+                    if (event('onValueTap', [li]) !== false) {
+                        tindex = idx;
+                    } else {
+                        hl = true;
+                    }
+
+                    if (hl) {
+                        li.addClass('dw-hl'); // Highlight
+                        setTimeout(function () {
+                            li.removeClass('dw-hl');
+                        }, 200);
+                    }
+                }
+
+                if (scrollable) {
+                    calc(target, tindex, 0, true, Math.round(val));
+                }
+
+                move = false;
+                target = null;
+
+                $(document).unbind(MOVE_EVENT, onMove).unbind(END_EVENT, onEnd);
+            },
+            onBtnStart = function (e) {
+                $(document).bind(END_EVENT, onBtnEnd);
+                // Active button
+                if (!$(this).hasClass('dwb-d')) {
+                    $(this).addClass('dwb-a');
+                }
+                // +/- buttons
+                if ($(this).hasClass('dwwb')) {
+                    var w = $(this).closest('.dwwl');
+                    if (testTouch(e) && !isReadOnly(w) && !w.hasClass('dwa')) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        click = true;
+                        // + Button
+                        var t = w.find('.dw-ul'),
+                            func = $(this).hasClass('dwwbp') ? plus : minus;
+
+                        setGlobals(t);
+                        clearInterval(timer);
+                        timer = setInterval(function () { func(t); }, s.delay);
+                        func(t);
+                    }
+                }
+            },
+            onBtnEnd = function (e) {
+                if (click) {
+                    clearInterval(timer);
+                    click = false;
+                }
+                $(document).unbind(END_EVENT, onBtnEnd);
+                $('.dwb-a', dw).removeClass('dwb-a');
+            },
+            onScroll = function (e) {
+                if (!isReadOnly(this)) {
+                    e.preventDefault();
+                    e = e.originalEvent;
+                    var delta = e.wheelDelta ? (e.wheelDelta / 120) : (e.detail ? (-e.detail / 3) : 0),
+                        t = $('.dw-ul', this);
+
+                    setGlobals(t);
+                    calc(t, Math.round(pos[index] - delta), delta < 0 ? 1 : 2);
+                }
+            };
+
+        // Private functions
+
+        function isReadOnly(wh) {
+            if ($.isArray(s.readonly)) {
+                var i = $('.dwwl', dw).index(wh);
+                return s.readonly[i];
+            }
+            return s.readonly;
+        }
+
+        function generateWheelItems(i) {
+            var html = '<div class="dw-bf">',
+                ww = wheels[i],
+                w = ww.values ? ww : convert(ww),
+                l = 1,
+                values = w.values,
+                keys = w.keys || values;
+
+            $.each(values, function (j, v) {
+                if (l % 20 == 0) {
+                    html += '</div><div class="dw-bf">';
+                }
+                html += '<div class="dw-li dw-v" data-val="' + keys[j] + '" style="height:' + hi + 'px;line-height:' + hi + 'px;"><div class="dw-i">' + v + '</div></div>';
+                l++;
+            });
+
+            html += '</div>';
+            return html;
+        }
+
+        function setGlobals(t) {
+            min = $('.dw-li', t).index($('.dw-v', t).eq(0));
+            max = $('.dw-li', t).index($('.dw-v', t).eq(-1));
+            index = $('.dw-ul', dw).index(t);
+        }
+
+        function formatHeader(v) {
+            var t = s.headerText;
+            return t ? (typeof t === 'function' ? t.call(e, v) : t.replace(/\{value\}/i, v)) : '';
+        }
+
+        function read() {
+            that.temp = ((input && that.val !== null && that.val != elm.val()) || that.values === null) ? s.parseValue(elm.val() || '', that) : that.values.slice(0);
+            setVal();
+        }
+
+        function getCurrentPosition(t) {
+            var style = window.getComputedStyle ? getComputedStyle(t[0]) : t[0].style,
+                matrix,
+                px;
+
+            if (has3d) {
+                $.each(['t', 'webkitT', 'MozT', 'OT', 'msT'], function (i, v) {
+                    if (style[v + 'ransform'] !== undefined) {
+                        matrix = style[v + 'ransform'];
+                        return false;
+                    }
+                });
+                matrix = matrix.split(')')[0].split(', ');
+                px = matrix[13] || matrix[5];
+            } else {
+                px = style.top.replace('px', '');
+            }
+
+            return Math.round(m - (px / hi));
+        }
+
+        function ready(t, i) {
+            clearTimeout(iv[i]);
+            delete iv[i];
+            t.closest('.dwwl').removeClass('dwa');
+        }
+
+        function scroll(t, index, val, time, active) {
+
+            var px = (m - val) * hi,
+                style = t[0].style,
+                i;
+
+            if (px == pixels[index] && iv[index]) {
+                return;
+            }
+
+            if (time && px != pixels[index]) {
+                // Trigger animation start event
+                event('onAnimStart', [dw, index, time]);
+            }
+
+            pixels[index] = px;
+
+            style[pr + 'Transition'] = 'all ' + (time ? time.toFixed(3) : 0) + 's ease-out';
+
+            if (has3d) {
+                style[pr + 'Transform'] = 'translate3d(0,' + px + 'px,0)';
+            } else {
+                style.top = px + 'px';
+            }
+
+            if (iv[index]) {
+                ready(t, index);
+            }
+
+            if (time && active !== undefined) {
+                t.closest('.dwwl').addClass('dwa');
+                iv[index] = setTimeout(function () {
+                    ready(t, index);
+                }, time * 1000);
+            }
+
+            pos[index] = val;
+        }
+
+        function scrollToPos(time, index, manual, dir, active) {
+
+            // Call validation event
+            if (event('validate', [dw, index, time]) !== false) {
+
+                // Set scrollers to position
+                $('.dw-ul', dw).each(function (i) {
+                    var t = $(this),
+                        cell = $('.dw-li[data-val="' + that.temp[i] + '"]', t),
+                        cells = $('.dw-li', t),
+                        v = cells.index(cell),
+                        l = cells.length,
+                        sc = i == index || index === undefined;
+
+                    // Scroll to a valid cell
+                    if (!cell.hasClass('dw-v')) {
+                        var cell1 = cell,
+                            cell2 = cell,
+                            dist1 = 0,
+                            dist2 = 0;
+
+                        while (v - dist1 >= 0 && !cell1.hasClass('dw-v')) {
+                            dist1++;
+                            cell1 = cells.eq(v - dist1);
+                        }
+
+                        while (v + dist2 < l && !cell2.hasClass('dw-v')) {
+                            dist2++;
+                            cell2 = cells.eq(v + dist2);
+                        }
+
+                        // If we have direction (+/- or mouse wheel), the distance does not count
+                        if (((dist2 < dist1 && dist2 && dir !== 2) || !dist1 || (v - dist1 < 0) || dir == 1) && cell2.hasClass('dw-v')) {
+                            cell = cell2;
+                            v = v + dist2;
+                        } else {
+                            cell = cell1;
+                            v = v - dist1;
+                        }
+                    }
+
+                    if (!(cell.hasClass('dw-sel')) || sc) {
+                        // Set valid value
+                        that.temp[i] = cell.attr('data-val');
+
+                        // Add selected class to cell
+                        $('.dw-sel', t).removeClass('dw-sel');
+                        cell.addClass('dw-sel');
+
+                        // Scroll to position
+                        scroll(t, i, v, sc ? time : 0.1, sc ? active : false);
+                    }
+                });
+
+                // Reformat value if validation changed something
+                v = s.formatResult(that.temp);
+                if (s.display == 'inline') {
+                    setVal(manual, 0, true);
+                } else {
+                    $('.dwv', dw).html(formatHeader(v));
+                }
+
+                if (manual) {
+                    event('onChange', [v]);
+                }
+            }
+
+        }
+
+        function event(name, args) {
+            var ret;
+            args.push(that);
+            $.each([theme.defaults, pres, settings], function (i, v) {
+                if (v[name]) { // Call preset event
+                    ret = v[name].apply(e, args);
+                }
+            });
+            return ret;
+        }
+
+        function calc(t, val, dir, anim, orig) {
+            val = constrain(val, min, max);
+
+            var cell = $('.dw-li', t).eq(val),
+                o = orig === undefined ? val : orig,
+                idx = index,
+                time = anim ? (val == o ? 0.1 : Math.abs((val - o) * s.timeUnit)) : 0;
+
+            // Set selected scroller value
+            that.temp[idx] = cell.attr('data-val');
+
+            scroll(t, idx, val, time, orig);
+
+            setTimeout(function () {
+                // Validate
+                scrollToPos(time, idx, true, dir, orig);
+            }, 10);
+        }
+
+        function plus(t) {
+            var val = pos[index] + 1;
+            calc(t, val > max ? min : val, 1, true);
+        }
+
+        function minus(t) {
+            var val = pos[index] - 1;
+            calc(t, val < min ? max : val, 2, true);
+        }
+
+        function setVal(fill, time, noscroll, temp) {
+
+            if (visible && !noscroll) {
+                scrollToPos(time);
+            }
+
+            v = s.formatResult(that.temp);
+
+            if (!temp) {
+                that.values = that.temp.slice(0);
+                that.val = v;
+            }
+
+            if (fill) {
+                if (input) {
+                    elm.val(v).trigger('change');
+                }
+            }
+        }
+
+        // Public functions
+
+        that.position = function (check) {
+
+            if (s.display == 'inline' || (ww === $(window).width() && rwh === $(window).height() && check) || (event('onPosition', [dw]) === false)) {
+                return;
+            }
+
+            var w,
+                l,
+                t,
+                aw, // anchor width
+                ah, // anchor height
+                ap, // anchor position
+                at, // anchor top
+                al, // anchor left
+                arr, // arrow
+                arrw, // arrow width
+                arrl, // arrow left
+                scroll,
+                totalw = 0,
+                minw = 0,
+                st = $(window).scrollTop(),
+                wr = $('.dwwr', dw),
+                d = $('.dw', dw),
+                css = {},
+                anchor = s.anchor === undefined ? elm : s.anchor;
+
+            ww = $(window).width();
+            rwh = $(window).height();
+            wh = window.innerHeight; // on iOS we need innerHeight
+            wh = wh || rwh;
+
+            if (/modal|bubble/.test(s.display)) {
+                $('.dwc', dw).each(function () {
+                    w = $(this).outerWidth(true);
+                    totalw += w;
+                    minw = (w > minw) ? w : minw;
+                });
+                w = totalw > ww ? minw : totalw;
+                wr.width(w).css('white-space', totalw > ww ? '' : 'nowrap');
+            }
+
+            mw = d.outerWidth();
+            mh = d.outerHeight(true);
+
+            if (s.display == 'modal') {
+                l = (ww - mw) / 2;
+                t = st + (wh - mh) / 2;
+            } else if (s.display == 'bubble') {
+                scroll = true;
+                arr = $('.dw-arrw-i', dw);
+                ap = anchor.offset();
+                at = ap.top;
+                al = ap.left;
+
+                // horizontal positioning
+                aw = anchor.outerWidth();
+                ah = anchor.outerHeight();
+                l = al - (d.outerWidth(true) - aw) / 2;
+                l = l > (ww - mw) ? (ww - (mw + 20)) : l;
+                l = l >= 0 ? l : 20;
+
+                // vertical positioning
+                t = at - mh; // above the input
+                if ((t < st) || (at > st + wh)) { // if doesn't fit above or the input is out of the screen
+                    d.removeClass('dw-bubble-top').addClass('dw-bubble-bottom');
+                    t = at + ah; // below the input
+                } else {
+                    d.removeClass('dw-bubble-bottom').addClass('dw-bubble-top');
+                }
+
+                // Calculate Arrow position
+                arrw = arr.outerWidth();
+                arrl = al + aw / 2 - (l + (mw - arrw) / 2);
+
+                // Limit Arrow position
+                $('.dw-arr', dw).css({ left: constrain(arrl, 0, arrw) });
+            } else {
+                css.width = '100%';
+                if (s.display == 'top') {
+                    t = st;
+                } else if (s.display == 'bottom') {
+                    t = st + wh - mh;
+                }
+            }
+
+            css.top = t < 0 ? 0 : t;
+            css.left = l;
+            d.css(css);
+
+            // If top + modal height > doc height, increase doc height
+            $('.dw-persp', dw).height(0).height(t + mh > $(document).height() ? t + mh : $(document).height());
+
+            // Scroll needed
+            if (scroll && ((t + mh > st + wh) || (at > st + wh))) {
+                $(window).scrollTop(t + mh - wh);
+            }
+        };
+
+        /**
+        * Enables the scroller and the associated input.
+        */
+        that.enable = function () {
+            s.disabled = false;
+            if (input) {
+                elm.prop('disabled', false);
+            }
+        };
+
+        /**
+        * Disables the scroller and the associated input.
+        */
+        that.disable = function () {
+            s.disabled = true;
+            if (input) {
+                elm.prop('disabled', true);
+            }
+        };
+
+        /**
+        * Gets the selected wheel values, formats it, and set the value of the scroller instance.
+        * If input parameter is true, populates the associated input element.
+        * @param {Array} values - Wheel values.
+        * @param {Boolean} [fill=false] - Also set the value of the associated input element.
+        * @param {Number} [time=0] - Animation time
+        * @param {Boolean} [temp=false] - If true, then only set the temporary value.(only scroll there but not set the value)
+        */
+        that.setValue = function (values, fill, time, temp) {
+            that.temp = $.isArray(values) ? values.slice(0) : s.parseValue.call(e, values + '', that);
+            setVal(fill, time, false, temp);
+        };
+
+        that.getValue = function () {
+            return that.values;
+        };
+
+        that.getValues = function () {
+            var ret = [],
+                i;
+
+            for (i in that._selectedValues) {
+                ret.push(that._selectedValues[i]);
+            }
+            return ret;
+        };
+
+        /**
+        * Changes the values of a wheel, and scrolls to the correct position
+        */
+        that.changeWheel = function (idx, time) {
+            if (dw) {
+                var i = 0,
+                    nr = idx.length;
+
+                $.each(s.wheels, function (j, wg) {
+                    $.each(wg, function (k, w) {
+                        if ($.inArray(i, idx) > -1) {
+                            wheels[i] = w;
+                            $('.dw-ul', dw).eq(i).html(generateWheelItems(i));
+                            nr--;
+                            if (!nr) {
+                                that.position();
+                                scrollToPos(time, undefined, true);
+                                return false;
+                            }
+                        }
+                        i++;
+                    });
+                    if (!nr) {
+                        return false;
+                    }
+                });
+            }
+        };
+
+        /**
+        * Return true if the scroller is currently visible.
+        */
+        that.isVisible = function () {
+            return visible;
+        };
+
+        that.tap = function (el, handler) {
+            var startX,
+                startY;
+
+            if (s.tap) {
+                el.bind('touchstart', function (e) {
+                    e.preventDefault();
+                    startX = getCoord(e, 'X');
+                    startY = getCoord(e, 'Y');
+                }).bind('touchend', function (e) {
+                    // If movement is less than 20px, fire the click event handler
+                    if (Math.abs(getCoord(e, 'X') - startX) < 20 && Math.abs(getCoord(e, 'Y') - startY) < 20) {
+                        handler.call(this, e);
+                    }
+                    tap = true;
+                    setTimeout(function () {
+                        tap = false;
+                    }, 300);
+                });
+            }
+
+            el.bind('click', function (e) {
+                if (!tap) {
+                    // If handler was not called on touchend, call it on click;
+                    handler.call(this, e);
+                }
+            });
+
+        };
+
+        /**
+        * Shows the scroller instance.
+        * @param {Boolean} prevAnim - Prevent animation if true
+        */
+        that.show = function (prevAnim) {
+            if (s.disabled || visible) {
+                return false;
+            }
+
+            if (s.display == 'top') {
+                anim = 'slidedown';
+            }
+
+            if (s.display == 'bottom') {
+                anim = 'slideup';
+            }
+
+            // Parse value from input
+            read();
+
+            event('onBeforeShow', []);
+
+            // Create wheels
+            var l = 0,
+                mAnim = '';
+
+            if (anim && !prevAnim) {
+                mAnim = 'dw-' + anim + ' dw-in';
+            }
+            // Create wheels containers
+            var html = '<div class="' + s.theme + ' dw-' + s.display + (prefix ? ' dw' + prefix : '') + '">' + (s.display == 'inline' ? '<div class="dw dwbg dwi"><div class="dwwr">' : '<div class="dw-persp">' + '<div class="dwo"></div><div class="dw dwbg ' + mAnim + '"><div class="dw-arrw"><div class="dw-arrw-i"><div class="dw-arr"></div></div></div><div class="dwwr">' + (s.headerText ? '<div class="dwv"></div>' : '')) + '<div class="dwcc">';
+
+            $.each(s.wheels, function (i, wg) { // Wheel groups
+                html += '<div class="dwc' + (s.mode != 'scroller' ? ' dwpm' : ' dwsc') + (s.showLabel ? '' : ' dwhl') + '"><div class="dwwc dwrc"><table cellpadding="0" cellspacing="0"><tr>';
+                $.each(wg, function (j, w) { // Wheels
+                    wheels[l] = w;
+                    html += '<td><div class="dwwl dwrc dwwl' + l + '">' + (s.mode != 'scroller' ? '<div class="dwb-e dwwb dwwbp" style="height:' + hi + 'px;line-height:' + hi + 'px;"><span>+</span></div><div class="dwb-e dwwb dwwbm" style="height:' + hi + 'px;line-height:' + hi + 'px;"><span>&ndash;</span></div>' : '') + '<div class="dwl">' + (w.label || j) + '</div><div class="dwww"><div class="dww" style="height:' + (s.rows * hi) + 'px;min-width:' + s.width + 'px;"><div class="dw-ul">';
+                    // Create wheel values
+                    html += generateWheelItems(l);
+                    html += '</div><div class="dwwol"></div></div><div class="dwwo"></div></div><div class="dwwol"></div></div></td>';
+                    l++;
+                });
+
+                html += '</tr></table></div></div>';
+            });
+
+            html += '</div>' + (s.display != 'inline' ? '<div class="dwbc' + (s.button3 ? ' dwbc-p' : '') + '"><span class="dwbw dwb-s"><span class="dwb dwb-e">' + s.setText + '</span></span>' + (s.button3 ? '<span class="dwbw dwb-n"><span class="dwb dwb-e">' + s.button3Text + '</span></span>' : '') + '<span class="dwbw dwb-c"><span class="dwb dwb-e">' + s.cancelText + '</span></span></div></div>' : '') + '</div></div></div>';
+            dw = $(html);
+
+            scrollToPos();
+
+            event('onMarkupReady', [dw]);
+
+            // Show
+            if (s.display != 'inline') {
+                dw.appendTo('body');
+                if (anim && !prevAnim) {
+                    dw.addClass('dw-trans');
+                    // Remove animation class
+                    setTimeout(function () {
+                        dw.removeClass('dw-trans').find('.dw').removeClass(mAnim);
+                    }, 350);
+                }
+            } else if (elm.is('div')) {
+                elm.html(dw);
+            } else {
+                dw.insertAfter(elm);
+            }
+
+            event('onMarkupInserted', [dw]);
+
+            visible = true;
+
+            // Theme init
+            theme.init(dw, that);
+
+            if (s.display != 'inline') {
+                // Init buttons
+                that.tap($('.dwb-s span', dw), function () {
+                    if (that.hide(false, 'set') !== false) {
+                        setVal(true, 0, true);
+                        event('onSelect', [that.val]);
+                    }
+                });
+
+                that.tap($('.dwb-c span', dw), function () {
+                    that.cancel();
+                });
+
+                if (s.button3) {
+                    that.tap($('.dwb-n span', dw), s.button3);
+                }
+
+                // prevent scrolling if not specified otherwise
+                if (s.scrollLock) {
+                    dw.bind('touchmove', function (e) {
+                        if (mh <= wh && mw <= ww) {
+                            e.preventDefault();
+                        }
+                    });
+                }
+
+                // Disable inputs to prevent bleed through (Android bug) and set autocomplete to off (for Firefox)
+                /*$('input,select,button').each(function () {
+                    if (!this.disabled) {
+                        $(this).addClass('dwtd').prop('disabled', true).data('autocomplete', $(this).attr('autocomplete')).attr('autocomplete', 'off');
+                    }
+                });*/
+
+                // Set position
+                that.position();
+                $(window).bind('orientationchange.dw resize.dw', function () {
+                    // Sometimes scrollTop is not correctly set, so we wait a little
+                    clearTimeout(debounce);
+                    debounce = setTimeout(function () {
+                        that.position(true);
+                    }, 100);
+                });
+            }
+
+            // Events
+            dw.delegate('.dwwl', 'DOMMouseScroll mousewheel', onScroll).delegate('.dwb-e', START_EVENT, onBtnStart).delegate('.dwwl', START_EVENT, onStart);
+
+            event('onShow', [dw, v]);
+        };
+
+        /**
+        * Hides the scroller instance.
+        */
+        that.hide = function (prevAnim, btn) {
+            // If onClose handler returns false, prevent hide
+            if (!visible || event('onClose', [v, btn]) === false) {
+                return false;
+            }
+
+            // Re-enable temporary disabled fields
+            $('.dwtd').each(function () {
+                $(this).prop('disabled', false).removeClass('dwtd');
+                if ($(this).data('autocomplete')) {
+                    $(this).attr('autocomplete', $(this).data('autocomplete'));
+                } else {
+                    $(this).removeAttr('autocomplete');
+                }
+            });
+            elm.blur();
+
+            // Hide wheels and overlay
+            if (dw) {
+                if (s.display != 'inline' && anim && !prevAnim) {
+                    dw.addClass('dw-trans').find('.dw').addClass('dw-' + anim + ' dw-out');
+                    setTimeout(function () {
+                        dw.remove();
+                        dw = null;
+                    }, 350);
+                } else {
+                    dw.remove();
+                    dw = null;
+                }
+                visible = false;
+                pixels = {};
+                // Stop positioning on window resize
+                $(window).unbind('.dw');
+            }
+        };
+
+        /**
+        * Cancel and hide the scroller instance.
+        */
+        that.cancel = function () {
+            if (that.hide(false, 'cancel') !== false) {
+                event('onCancel', [that.val]);
+            }
+        };
+
+        /**
+        * Scroller initialization.
+        */
+        that.init = function (ss) {
+            // Get theme defaults
+            theme = extend({ defaults: {}, init: empty }, ms.themes[ss.theme || s.theme]);
+
+            // Get language defaults
+            lang = ms.i18n[ss.lang || s.lang];
+
+            extend(settings, ss); // Update original user settings
+            extend(s, theme.defaults, lang, settings);
+
+            that.settings = s;
+
+            // Unbind all events (if re-init)
+            elm.unbind('.dw');
+
+            var preset = ms.presets[s.preset];
+
+            if (preset) {
+                pres = preset.call(e, that);
+                extend(s, pres, settings); // Load preset settings
+            }
+
+            // Set private members
+            m = Math.floor(s.rows / 2);
+            hi = s.height;
+            anim = s.animate;
+
+            if (visible) {
+                that.hide();
+            }
+
+            if (s.display == 'inline') {
+                that.show();
+            } else {
+                read();
+                if (input && s.showOnFocus) {
+                    // Set element readonly, save original state
+                    if (readOnly === undefined) {
+                        readOnly = e.readOnly;
+                    }
+                    e.readOnly = true;
+                    // Init show datewheel
+                    elm.bind('focus.dw', function () { that.show(); });
+                }
+            }
+        };
+
+        that.trigger = function (name, params) {
+            return event(name, params);
+        };
+
+        that.option = function (opt, value) {
+            var obj = {};
+            if (typeof opt === 'object') {
+                obj = opt;
+            } else {
+                obj[opt] = value;
+            }
+            that.init(obj);
+        };
+
+        that.destroy = function () {
+            that.hide();
+            elm.unbind('.dw');
+            delete scrollers[e.id];
+            if (input) {
+                e.readOnly = readOnly;
+            }
+        };
+
+        that.getInst = function () {
+            return that;
+        };
+
+        that.values = null;
+        that.val = null;
+        that.temp = null;
+        that._selectedValues = {};
+
+        that.init(settings);
+    }
+
+    function testProps(props) {
+        var i;
+        for (i in props) {
+            if (mod[props[i]] !== undefined) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function testPrefix() {
+        var prefixes = ['Webkit', 'Moz', 'O', 'ms'],
+            p;
+
+        for (p in prefixes) {
+            if (testProps([prefixes[p] + 'Transform'])) {
+                return '-' + prefixes[p].toLowerCase();
+            }
+        }
+        return '';
+    }
+
+    function testTouch(e) {
+        if (e.type === 'touchstart') {
+            touch = true;
+            /*setTimeout(function () {
+                touch = false; // Reset if mouse event was not fired
+            }, 500);*/
+        } else if (touch) {
+            touch = false;
+            return false;
+        }
+        return true;
+    }
+
+    function getCoord(e, c) {
+        var org = e.originalEvent,
+            ct = e.changedTouches;
+        return ct || (org && org.changedTouches) ? (org ? org.changedTouches[0]['page' + c] : ct[0]['page' + c]) : e['page' + c];
+
+    }
+
+    function constrain(val, min, max) {
+        return Math.max(min, Math.min(val, max));
+    }
+
+    function convert(w) {
+        var ret = {
+            values: [],
+            keys: []
+        };
+        $.each(w, function (k, v) {
+            ret.keys.push(k);
+            ret.values.push(v);
+        });
+        return ret;
+    }
+
+    function init(that, options, args) {
+        var ret = that;
+
+        // Init
+        if (typeof options === 'object') {
+            return that.each(function () {
+                if (!this.id) {
+                    uuid += 1;
+                    this.id = 'mobiscroll' + uuid;
+                }
+                scrollers[this.id] = new Scroller(this, options);
+            });
+        }
+
+        // Method call
+        if (typeof options === 'string') {
+            that.each(function () {
+                var r,
+                    inst = scrollers[this.id];
+
+                if (inst && inst[options]) {
+                    r = inst[options].apply(this, Array.prototype.slice.call(args, 1));
+                    if (r !== undefined) {
+                        ret = r;
+                        return false;
+                    }
+                }
+            });
+        }
+
+        return ret;
+    }
+
+    var move,
+        tap,
+        touch,
+        date = new Date(),
+        uuid = date.getTime(),
+        scrollers = {},
+        empty = function () {},
+        mod = document.createElement('modernizr').style,
+        has3d = testProps(['perspectiveProperty', 'WebkitPerspective', 'MozPerspective', 'OPerspective', 'msPerspective']),
+        prefix = testPrefix(),
+        pr = prefix.replace(/^\-/, '').replace('moz', 'Moz'),
+        extend = $.extend,
+        START_EVENT = 'touchstart mousedown',
+        MOVE_EVENT = 'touchmove mousemove',
+        END_EVENT = 'touchend mouseup',
+        defaults = {
+            // Options
+            width: 70,
+            height: 40,
+            rows: 3,
+            delay: 300,
+            disabled: false,
+            readonly: false,
+            showOnFocus: true,
+            showLabel: true,
+            wheels: [],
+            theme: '',
+            headerText: '{value}',
+            display: 'modal',
+            mode: 'scroller',
+            preset: '',
+            lang: 'en-US',
+            setText: 'Set',
+            cancelText: 'Cancel',
+            scrollLock: true,
+            tap: true,
+            speedUnit: 0.0012,
+            timeUnit: 0.1,
+            formatResult: function (d) {
+                return d.join(' ');
+            },
+            parseValue: function (value, inst) {
+                var val = value.split(' '),
+                    ret = [],
+                    i = 0,
+                    keys;
+
+                $.each(inst.settings.wheels, function (j, wg) {
+                    $.each(wg, function (k, w) {
+                        w = w.values ? w : convert(w);
+                        keys = w.keys || w.values;
+                        if ($.inArray(val[i], keys) !== -1) {
+                            ret.push(val[i]);
+                        } else {
+                            ret.push(keys[0]);
+                        }
+                        i++;
+                    });
+                });
+                return ret;
+            }
+        };
+
+    $(document).bind('mouseover mouseup mousedown click', function (e) { // Prevent standard behaviour on body click
+        if (tap) {
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+        }
+    });
+
+    $.fn.mobiscroll = function (method) {
+        extend(this, $.mobiscroll.shorts);
+        return init(this, method, arguments);
+    };
+
+    $.mobiscroll = $.mobiscroll || {
+        /**
+        * Set settings for all instances.
+        * @param {Object} o - New default settings.
+        */
+        setDefaults: function (o) {
+            extend(defaults, o);
+        },
+        presetShort: function (name) {
+            this.shorts[name] = function (method) {
+                return init(this, extend(method, { preset: name }), arguments);
+            };
+        },
+        shorts: {},
+        presets: {},
+        themes: {},
+        i18n: {}
+    };
+
+    $.scroller = $.scroller || $.mobiscroll;
+    $.fn.scroller = $.fn.scroller || $.fn.mobiscroll;
+
+})(jQuery);
+
+/*jslint eqeq: true, plusplus: true, undef: true, sloppy: true, vars: true, forin: true */
+(function ($) {
+
+    var ms = $.mobiscroll,
+        date = new Date(),
+        defaults = {
+            dateFormat: 'mm/dd/yy',
+            dateOrder: 'mmddy',
+            timeWheels: 'hhiiA',
+            timeFormat: 'hh:ii A',
+            startYear: date.getFullYear() - 100,
+            endYear: date.getFullYear() + 1,
+            monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+            monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+            dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+            shortYearCutoff: '+10',
+            monthText: 'Month',
+            dayText: 'Day',
+            yearText: 'Year',
+            hourText: 'Hours',
+            minuteText: 'Minutes',
+            secText: 'Seconds',
+            ampmText: '&nbsp;',
+            nowText: 'Now',
+            showNow: false,
+            stepHour: 1,
+            stepMinute: 1,
+            stepSecond: 1,
+            separator: ' '
+        },
+        preset = function (inst) {
+            var that = $(this),
+                html5def = {},
+                format;
+            // Force format for html5 date inputs (experimental)
+            if (that.is('input')) {
+                switch (that.attr('type')) {
+                case 'date':
+                    format = 'yy-mm-dd';
+                    break;
+                case 'datetime':
+                    format = 'yy-mm-ddTHH:ii:ssZ';
+                    break;
+                case 'datetime-local':
+                    format = 'yy-mm-ddTHH:ii:ss';
+                    break;
+                case 'month':
+                    format = 'yy-mm';
+                    html5def.dateOrder = 'mmyy';
+                    break;
+                case 'time':
+                    format = 'HH:ii:ss';
+                    break;
+                }
+                // Check for min/max attributes
+                var min = that.attr('min'),
+                    max = that.attr('max');
+                if (min) {
+                    html5def.minDate = ms.parseDate(format, min);
+                }
+                if (max) {
+                    html5def.maxDate = ms.parseDate(format, max);
+                }
+            }
+
+            // Set year-month-day order
+            var i,
+                k,
+                keys,
+                values,
+                wg,
+                start,
+                end,
+                orig = $.extend({}, inst.settings),
+                s = $.extend(inst.settings, defaults, html5def, orig),
+                offset = 0,
+                wheels = [],
+                ord = [],
+                o = {},
+                f = { y: 'getFullYear', m: 'getMonth', d: 'getDate', h: getHour, i: getMinute, s: getSecond, a: getAmPm },
+                p = s.preset,
+                dord = s.dateOrder,
+                tord = s.timeWheels,
+                regen = dord.match(/D/),
+                ampm = tord.match(/a/i),
+                hampm = tord.match(/h/),
+                hformat = p == 'datetime' ? s.dateFormat + s.separator + s.timeFormat : p == 'time' ? s.timeFormat : s.dateFormat,
+                defd = new Date(),
+                stepH = s.stepHour,
+                stepM = s.stepMinute,
+                stepS = s.stepSecond,
+                mind = s.minDate || new Date(s.startYear, 0, 1),
+                maxd = s.maxDate || new Date(s.endYear, 11, 31, 23, 59, 59);
+
+            format = format || hformat;
+
+            if (p.match(/date/i)) {
+
+                // Determine the order of year, month, day wheels
+                $.each(['y', 'm', 'd'], function (j, v) {
+                    i = dord.search(new RegExp(v, 'i'));
+                    if (i > -1) {
+                        ord.push({ o: i, v: v });
+                    }
+                });
+                ord.sort(function (a, b) { return a.o > b.o ? 1 : -1; });
+                $.each(ord, function (i, v) {
+                    o[v.v] = i;
+                });
+
+                wg = [];
+                for (k = 0; k < 3; k++) {
+                    if (k == o.y) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        start = mind.getFullYear();
+                        end = maxd.getFullYear();
+                        for (i = start; i <= end; i++) {
+                            keys.push(i);
+                            values.push(dord.match(/yy/i) ? i : (i + '').substr(2, 2));
+                        }
+                        addWheel(wg, keys, values, s.yearText);
+                    } else if (k == o.m) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        for (i = 0; i < 12; i++) {
+                            var str = dord.replace(/[dy]/gi, '').replace(/mm/, i < 9 ? '0' + (i + 1) : i + 1).replace(/m/, (i + 1));
+                            keys.push(i);
+                            values.push(str.match(/MM/) ? str.replace(/MM/, '<span class="dw-mon">' + s.monthNames[i] + '</span>') : str.replace(/M/, '<span class="dw-mon">' + s.monthNamesShort[i] + '</span>'));
+                        }
+                        addWheel(wg, keys, values, s.monthText);
+                    } else if (k == o.d) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        for (i = 1; i < 32; i++) {
+                            keys.push(i);
+                            values.push(dord.match(/dd/i) && i < 10 ? '0' + i : i);
+                        }
+                        addWheel(wg, keys, values, s.dayText);
+                    }
+                }
+                wheels.push(wg);
+            }
+
+            if (p.match(/time/i)) {
+
+                // Determine the order of hours, minutes, seconds wheels
+                ord = [];
+                $.each(['h', 'i', 's', 'a'], function (i, v) {
+                    i = tord.search(new RegExp(v, 'i'));
+                    if (i > -1) {
+                        ord.push({ o: i, v: v });
+                    }
+                });
+                ord.sort(function (a, b) {
+                    return a.o > b.o ? 1 : -1;
+                });
+                $.each(ord, function (i, v) {
+                    o[v.v] = offset + i;
+                });
+
+                wg = [];
+                for (k = offset; k < offset + 4; k++) {
+                    if (k == o.h) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        for (i = 0; i < (hampm ? 12 : 24); i += stepH) {
+                            keys.push(i);
+                            values.push(hampm && i == 0 ? 12 : tord.match(/hh/i) && i < 10 ? '0' + i : i);
+                        }
+                        addWheel(wg, keys, values, s.hourText);
+                    } else if (k == o.i) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        for (i = 0; i < 60; i += stepM) {
+                            keys.push(i);
+                            values.push(tord.match(/ii/) && i < 10 ? '0' + i : i);
+                        }
+                        addWheel(wg, keys, values, s.minuteText);
+                    } else if (k == o.s) {
+                        offset++;
+                        values = [];
+                        keys = [];
+                        for (i = 0; i < 60; i += stepS) {
+                            keys.push(i);
+                            values.push(tord.match(/ss/) && i < 10 ? '0' + i : i);
+                        }
+                        addWheel(wg, keys, values, s.secText);
+                    } else if (k == o.a) {
+                        offset++;
+                        var upper = tord.match(/A/);
+                        addWheel(wg, [0, 1], upper ? ['AM', 'PM'] : ['am', 'pm'], s.ampmText);
+                    }
+                }
+
+                wheels.push(wg);
+            }
+
+            function get(d, i, def) {
+                if (o[i] !== undefined) {
+                    return +d[o[i]];
+                }
+                if (def !== undefined) {
+                    return def;
+                }
+                return defd[f[i]] ? defd[f[i]]() : f[i](defd);
+            }
+
+            function addWheel(wg, k, v, lbl) {
+                wg.push({
+                    values: v,
+                    keys: k,
+                    label: lbl
+                });
+            }
+
+            function step(v, st) {
+                return Math.floor(v / st) * st;
+            }
+
+            function getHour(d) {
+                var hour = d.getHours();
+                hour = hampm && hour >= 12 ? hour - 12 : hour;
+                return step(hour, stepH);
+            }
+
+            function getMinute(d) {
+                return step(d.getMinutes(), stepM);
+            }
+
+            function getSecond(d) {
+                return step(d.getSeconds(), stepS);
+            }
+
+            function getAmPm(d) {
+                return ampm && d.getHours() > 11 ? 1 : 0;
+            }
+
+            function getDate(d) {
+                var hour = get(d, 'h', 0);
+                return new Date(get(d, 'y'), get(d, 'm'), get(d, 'd', 1), get(d, 'a') ? hour + 12 : hour, get(d, 'i', 0), get(d, 's', 0));
+            }
+
+            // Extended methods
+            // ---
+
+            /**
+             * Sets the selected date
+             *
+             * @param {Date} d Date to select.
+             * @param {Boolean} [fill=false] Also set the value of the associated input element. Default is true.
+             * @return {Object} jQuery object to maintain chainability
+             */
+            inst.setDate = function (d, fill, time, temp) {
+                var i;
+
+                // Set wheels
+                for (i in o) {
+                    inst.temp[o[i]] = d[f[i]] ? d[f[i]]() : f[i](d);
+                }
+                inst.setValue(inst.temp, fill, time, temp);
+            };
+
+            /**
+             * Returns the currently selected date.
+             *
+             * @param {Boolean} [temp=false] If true, return the currently shown date on the picker, otherwise the last selected one
+             * @return {Date}
+             */
+            inst.getDate = function (temp) {
+                return getDate(temp ? inst.temp : inst.values);
+            };
+
+            // ---
+
+            return {
+                button3Text: s.showNow ? s.nowText : undefined,
+                button3: s.showNow ? function () { inst.setDate(new Date(), false, 0.3, true); } : undefined,
+                wheels: wheels,
+                headerText: function (v) {
+                    return ms.formatDate(hformat, getDate(inst.temp), s);
+                },
+                /**
+                * Builds a date object from the wheel selections and formats it to the given date/time format
+                * @param {Array} d - An array containing the selected wheel values
+                * @return {String} - The formatted date string
+                */
+                formatResult: function (d) {
+                    return ms.formatDate(format, getDate(d), s);
+                },
+                /**
+                * Builds a date object from the input value and returns an array to set wheel values
+                * @return {Array} - An array containing the wheel values to set
+                */
+                parseValue: function (val) {
+                    var d = new Date(),
+                        i,
+                        result = [];
+                    try {
+                        d = ms.parseDate(format, val, s);
+                    } catch (e) {
+                    }
+                    // Set wheels
+                    for (i in o) {
+                        result[o[i]] = d[f[i]] ? d[f[i]]() : f[i](d);
+                    }
+                    return result;
+                },
+                /**
+                * Validates the selected date to be in the minDate / maxDate range and sets unselectable values to disabled
+                * @param {Object} dw - jQuery object containing the generated html
+                * @param {Integer} [i] - Index of the changed wheel, not set for initial validation
+                */
+                validate: function (dw, i) {
+                    var temp = inst.temp, //.slice(0),
+                        mins = { y: mind.getFullYear(), m: 0, d: 1, h: 0, i: 0, s: 0, a: 0 },
+                        maxs = { y: maxd.getFullYear(), m: 11, d: 31, h: step(hampm ? 11 : 23, stepH), i: step(59, stepM), s: step(59, stepS), a: 1 },
+                        minprop = true,
+                        maxprop = true;
+                    $.each(['y', 'm', 'd', 'a', 'h', 'i', 's'], function (x, i) {
+                        if (o[i] !== undefined) {
+                            var min = mins[i],
+                                max = maxs[i],
+                                maxdays = 31,
+                                val = get(temp, i),
+                                t = $('.dw-ul', dw).eq(o[i]),
+                                y,
+                                m;
+                            if (i == 'd') {
+                                y = get(temp, 'y');
+                                m = get(temp, 'm');
+                                maxdays = 32 - new Date(y, m, 32).getDate();
+                                max = maxdays;
+                                if (regen) {
+                                    $('.dw-li', t).each(function () {
+                                        var that = $(this),
+                                            d = that.data('val'),
+                                            w = new Date(y, m, d).getDay(),
+                                            str = dord.replace(/[my]/gi, '').replace(/dd/, d < 10 ? '0' + d : d).replace(/d/, d);
+                                        $('.dw-i', that).html(str.match(/DD/) ? str.replace(/DD/, '<span class="dw-day">' + s.dayNames[w] + '</span>') : str.replace(/D/, '<span class="dw-day">' + s.dayNamesShort[w] + '</span>'));
+                                    });
+                                }
+                            }
+                            if (minprop && mind) {
+                                min = mind[f[i]] ? mind[f[i]]() : f[i](mind);
+                            }
+                            if (maxprop && maxd) {
+                                max = maxd[f[i]] ? maxd[f[i]]() : f[i](maxd);
+                            }
+                            if (i != 'y') {
+                                var i1 = $('.dw-li', t).index($('.dw-li[data-val="' + min + '"]', t)),
+                                    i2 = $('.dw-li', t).index($('.dw-li[data-val="' + max + '"]', t));
+                                $('.dw-li', t).removeClass('dw-v').slice(i1, i2 + 1).addClass('dw-v');
+                                if (i == 'd') { // Hide days not in month
+                                    $('.dw-li', t).removeClass('dw-h').slice(maxdays).addClass('dw-h');
+                                }
+                            }
+                            if (val < min) {
+                                val = min;
+                            }
+                            if (val > max) {
+                                val = max;
+                            }
+                            if (minprop) {
+                                minprop = val == min;
+                            }
+                            if (maxprop) {
+                                maxprop = val == max;
+                            }
+                            // Disable some days
+                            if (s.invalid && i == 'd') {
+                                var idx = [];
+                                // Disable exact dates
+                                if (s.invalid.dates) {
+                                    $.each(s.invalid.dates, function (i, v) {
+                                        if (v.getFullYear() == y && v.getMonth() == m) {
+                                            idx.push(v.getDate() - 1);
+                                        }
+                                    });
+                                }
+                                // Disable days of week
+                                if (s.invalid.daysOfWeek) {
+                                    var first = new Date(y, m, 1).getDay(),
+                                        j;
+                                    $.each(s.invalid.daysOfWeek, function (i, v) {
+                                        for (j = v - first; j < maxdays; j += 7) {
+                                            if (j >= 0) {
+                                                idx.push(j);
+                                            }
+                                        }
+                                    });
+                                }
+                                // Disable days of month
+                                if (s.invalid.daysOfMonth) {
+                                    $.each(s.invalid.daysOfMonth, function (i, v) {
+                                        v = (v + '').split('/');
+                                        if (v[1]) {
+                                            if (v[0] - 1 == m) {
+                                                idx.push(v[1] - 1);
+                                            }
+                                        } else {
+                                            idx.push(v[0] - 1);
+                                        }
+                                    });
+                                }
+                                $.each(idx, function (i, v) {
+                                    $('.dw-li', t).eq(v).removeClass('dw-v');
+                                });
+                            }
+
+                            // Set modified value
+                            temp[o[i]] = val;
+                        }
+                    });
+                }
+            };
+        };
+
+    $.each(['date', 'time', 'datetime'], function (i, v) {
+        ms.presets[v] = preset;
+        ms.presetShort(v);
+    });
+
+    /**
+    * Format a date into a string value with a specified format.
+    * @param {String} format - Output format.
+    * @param {Date} date - Date to format.
+    * @param {Object} settings - Settings.
+    * @return {String} - Returns the formatted date string.
+    */
+    ms.formatDate = function (format, date, settings) {
+        if (!date) {
+            return null;
+        }
+        var s = $.extend({}, defaults, settings),
+            look = function (m) { // Check whether a format character is doubled
+                var n = 0;
+                while (i + 1 < format.length && format.charAt(i + 1) == m) {
+                    n++;
+                    i++;
+                }
+                return n;
+            },
+            f1 = function (m, val, len) { // Format a number, with leading zero if necessary
+                var n = '' + val;
+                if (look(m)) {
+                    while (n.length < len) {
+                        n = '0' + n;
+                    }
+                }
+                return n;
+            },
+            f2 = function (m, val, s, l) { // Format a name, short or long as requested
+                return (look(m) ? l[val] : s[val]);
+            },
+            i,
+            output = '',
+            literal = false;
+
+        for (i = 0; i < format.length; i++) {
+            if (literal) {
+                if (format.charAt(i) == "'" && !look("'")) {
+                    literal = false;
+                } else {
+                    output += format.charAt(i);
+                }
+            } else {
+                switch (format.charAt(i)) {
+                case 'd':
+                    output += f1('d', date.getDate(), 2);
+                    break;
+                case 'D':
+                    output += f2('D', date.getDay(), s.dayNamesShort, s.dayNames);
+                    break;
+                case 'o':
+                    output += f1('o', (date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000, 3);
+                    break;
+                case 'm':
+                    output += f1('m', date.getMonth() + 1, 2);
+                    break;
+                case 'M':
+                    output += f2('M', date.getMonth(), s.monthNamesShort, s.monthNames);
+                    break;
+                case 'y':
+                    output += (look('y') ? date.getFullYear() : (date.getYear() % 100 < 10 ? '0' : '') + date.getYear() % 100);
+                    break;
+                case 'h':
+                    var h = date.getHours();
+                    output += f1('h', (h > 12 ? (h - 12) : (h == 0 ? 12 : h)), 2);
+                    break;
+                case 'H':
+                    output += f1('H', date.getHours(), 2);
+                    break;
+                case 'i':
+                    output += f1('i', date.getMinutes(), 2);
+                    break;
+                case 's':
+                    output += f1('s', date.getSeconds(), 2);
+                    break;
+                case 'a':
+                    output += date.getHours() > 11 ? 'pm' : 'am';
+                    break;
+                case 'A':
+                    output += date.getHours() > 11 ? 'PM' : 'AM';
+                    break;
+                case "'":
+                    if (look("'")) {
+                        output += "'";
+                    } else {
+                        literal = true;
+                    }
+                    break;
+                default:
+                    output += format.charAt(i);
+                }
+            }
+        }
+        return output;
+    };
+
+    /**
+    * Extract a date from a string value with a specified format.
+    * @param {String} format - Input format.
+    * @param {String} value - String to parse.
+    * @param {Object} settings - Settings.
+    * @return {Date} - Returns the extracted date.
+    */
+    ms.parseDate = function (format, value, settings) {
+        var def = new Date();
+
+        if (!format || !value) {
+            return def;
+        }
+
+        value = (typeof value == 'object' ? value.toString() : value + '');
+
+        var s = $.extend({}, defaults, settings),
+            shortYearCutoff = s.shortYearCutoff,
+            year = def.getFullYear(),
+            month = def.getMonth() + 1,
+            day = def.getDate(),
+            doy = -1,
+            hours = def.getHours(),
+            minutes = def.getMinutes(),
+            seconds = 0, //def.getSeconds(),
+            ampm = -1,
+            literal = false, // Check whether a format character is doubled
+            lookAhead = function (match) {
+                var matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) == match);
+                if (matches) {
+                    iFormat++;
+                }
+                return matches;
+            },
+            getNumber = function (match) { // Extract a number from the string value
+                lookAhead(match);
+                var size = (match == '@' ? 14 : (match == '!' ? 20 : (match == 'y' ? 4 : (match == 'o' ? 3 : 2)))),
+                    digits = new RegExp('^\\d{1,' + size + '}'),
+                    num = value.substr(iValue).match(digits);
+
+                if (!num) {
+                    return 0;
+                }
+                //throw 'Missing number at position ' + iValue;
+                iValue += num[0].length;
+                return parseInt(num[0], 10);
+            },
+            getName = function (match, s, l) { // Extract a name from the string value and convert to an index
+                var names = (lookAhead(match) ? l : s),
+                    i;
+
+                for (i = 0; i < names.length; i++) {
+                    if (value.substr(iValue, names[i].length).toLowerCase() == names[i].toLowerCase()) {
+                        iValue += names[i].length;
+                        return i + 1;
+                    }
+                }
+                return 0;
+                //throw 'Unknown name at position ' + iValue;
+            },
+            checkLiteral = function () {
+                //if (value.charAt(iValue) != format.charAt(iFormat))
+                //throw 'Unexpected literal at position ' + iValue;
+                iValue++;
+            },
+            iValue = 0,
+            iFormat;
+
+        for (iFormat = 0; iFormat < format.length; iFormat++) {
+            if (literal) {
+                if (format.charAt(iFormat) == "'" && !lookAhead("'")) {
+                    literal = false;
+                } else {
+                    checkLiteral();
+                }
+            } else {
+                switch (format.charAt(iFormat)) {
+                case 'd':
+                    day = getNumber('d');
+                    break;
+                case 'D':
+                    getName('D', s.dayNamesShort, s.dayNames);
+                    break;
+                case 'o':
+                    doy = getNumber('o');
+                    break;
+                case 'm':
+                    month = getNumber('m');
+                    break;
+                case 'M':
+                    month = getName('M', s.monthNamesShort, s.monthNames);
+                    break;
+                case 'y':
+                    year = getNumber('y');
+                    break;
+                case 'H':
+                    hours = getNumber('H');
+                    break;
+                case 'h':
+                    hours = getNumber('h');
+                    break;
+                case 'i':
+                    minutes = getNumber('i');
+                    break;
+                case 's':
+                    seconds = getNumber('s');
+                    break;
+                case 'a':
+                    ampm = getName('a', ['am', 'pm'], ['am', 'pm']) - 1;
+                    break;
+                case 'A':
+                    ampm = getName('A', ['am', 'pm'], ['am', 'pm']) - 1;
+                    break;
+                case "'":
+                    if (lookAhead("'")) {
+                        checkLiteral();
+                    } else {
+                        literal = true;
+                    }
+                    break;
+                default:
+                    checkLiteral();
+                }
+            }
+        }
+        if (year < 100) {
+            year += new Date().getFullYear() - new Date().getFullYear() % 100 +
+                (year <= (typeof shortYearCutoff != 'string' ? shortYearCutoff : new Date().getFullYear() % 100 + parseInt(shortYearCutoff, 10)) ? 0 : -100);
+        }
+        if (doy > -1) {
+            month = 1;
+            day = doy;
+            do {
+                var dim = 32 - new Date(year, month - 1, 32).getDate();
+                if (day <= dim) {
+                    break;
+                }
+                month++;
+                day -= dim;
+            } while (true);
+        }
+        hours = (ampm == -1) ? hours : ((ampm && hours < 12) ? (hours + 12) : (!ampm && hours == 12 ? 0 : hours));
+        var date = new Date(year, month - 1, day, hours, minutes, seconds);
+        if (date.getFullYear() != year || date.getMonth() + 1 != month || date.getDate() != day) {
+            throw 'Invalid date';
+        }
+        return date;
+    };
+
+})(jQuery);
+
+/*jslint eqeq: true, plusplus: true, undef: true, sloppy: true, vars: true, forin: true */
+(function ($) {
+
+    var defaults = {
+        inputClass: '',
+        invalid: [],
+        rtl: false,
+        group: false,
+        groupLabel: 'Groups'
+    };
+
+    $.mobiscroll.presetShort('select');
+
+    $.mobiscroll.presets.select = function (inst) {
+        var orig = $.extend({}, inst.settings),
+            s = $.extend(inst.settings, defaults, orig),
+            elm = $(this),
+            multiple = elm.prop('multiple'),
+            id = this.id + '_dummy',
+            option = multiple ? (elm.val() ? elm.val()[0] : $('option', elm).attr('value')) : elm.val(),
+            group = elm.find('option[value="' + option + '"]').parent(),
+            prev = group.index() + '',
+            gr = prev,
+            prevent,
+            l1 = $('label[for="' + this.id + '"]').attr('for', id),
+            l2 = $('label[for="' + id + '"]'),
+            label = s.label !== undefined ? s.label : (l2.length ? l2.text() : elm.attr('name')),
+            invalid = [],
+            origValues = [],
+            main = {},
+            grIdx,
+            optIdx,
+            timer,
+            input,
+            roPre = s.readonly,
+            w;
+
+        function genWheels() {
+            var cont,
+                wg = 0,
+                values = [],
+                keys = [],
+                w = [[]];
+
+            if (s.group) {
+                if (s.rtl) {
+                    wg = 1;
+                }
+
+                $('optgroup', elm).each(function (i) {
+                    values.push($(this).attr('label'));
+                    keys.push(i);
+                });
+
+                w[wg] = [{
+                    values: values,
+                    keys: keys,
+                    label: label
+                }];
+
+                cont = group;
+                wg += (s.rtl ? -1 : 1);
+
+            } else {
+                cont = elm;
+            }
+
+            values = [];
+            keys = [];
+
+            $('option', cont).each(function () {
+                var v = $(this).attr('value');
+                values.push($(this).text());
+                keys.push(v);
+                if ($(this).prop('disabled')) {
+                    invalid.push(v);
+                }
+            });
+
+            w[wg] = [{
+                values: values,
+                keys: keys,
+                label: label
+            }];
+
+            return w;
+        }
+
+        function setVal(v, fill) {
+            var value = [];
+
+            if (multiple) {
+                var sel = [],
+                    i = 0;
+
+                for (i in inst._selectedValues) {
+                    sel.push(main[i]);
+                    value.push(i);
+                }
+                input.val(sel.join(', '));
+            } else {
+                input.val(v);
+                value = fill ? inst.values[optIdx] : null;
+            }
+
+            if (fill) {
+                prevent = true;
+                elm.val(value).trigger('change');
+            }
+        }
+
+        // if groups is true and there are no groups fall back to no grouping
+        if (s.group && !$('optgroup', elm).length) {
+            s.group = false;
+        }
+
+        if (!s.invalid.length) {
+            s.invalid = invalid;
+        }
+
+        if (s.group) {
+            if (s.rtl) {
+                grIdx = 1;
+                optIdx = 0;
+            } else {
+                grIdx = 0;
+                optIdx = 1;
+            }
+        } else {
+            grIdx = -1;
+            optIdx = 0;
+        }
+
+        $('#' + id).remove();
+
+        input = $('<input type="text" id="' + id + '" class="' + s.inputClass + '" readonly />').insertBefore(elm),
+
+        $('option', elm).each(function () {
+            main[$(this).attr('value')] = $(this).text();
+        });
+
+        if (s.showOnFocus) {
+            input.focus(function () {
+                inst.show();
+            });
+        }
+
+        var v = elm.val() || [],
+            i = 0;
+
+        for (i; i < v.length; i++) {
+            inst._selectedValues[v[i]] = v[i];
+        }
+
+        setVal(main[option]);
+
+        elm.unbind('.dwsel').bind('change.dwsel', function () {
+            if (!prevent) {
+                inst.setValue(multiple ? elm.val() || [] : [elm.val()], true);
+            }
+            prevent = false;
+        }).hide().closest('.ui-field-contain').trigger('create');
+
+        // Extended methods
+        // ---
+
+        if (!inst._setValue) {
+            inst._setValue = inst.setValue;
+        }
+
+        inst.setValue = function (d, fill, time, noscroll, temp) {
+            var value,
+                v = $.isArray(d) ? d[0] : d;
+
+            option = v !== undefined ? v : $('option', elm).attr('value');
+
+            if (multiple) {
+                inst._selectedValues = {};
+                var i = 0;
+                for (i; i < d.length; i++) {
+                    inst._selectedValues[d[i]] = d[i];
+                }
+            }
+
+            if (s.group) {
+                group = elm.find('option[value="' + option + '"]').parent();
+                gr = group.index();
+                value = s.rtl ? [option, group.index()] : [group.index(), option];
+                if (gr !== prev) { // Need to regenerate wheels, if group changed
+                    s.wheels = genWheels();
+                    inst.changeWheel([optIdx]);
+                    prev = gr + '';
+                }
+            } else {
+                value = [option];
+            }
+
+            inst._setValue(value, fill, time, noscroll, temp);
+
+            // Set input/select values
+            if (fill) {
+                var changed = multiple ? true : option !== elm.val();
+                setVal(main[option], changed);
+            }
+        };
+
+        inst.getValue = function (temp) {
+            var val = temp ? inst.temp : inst.values;
+            return val[optIdx];
+        };
+
+        // ---
+
+        return {
+            width: 50,
+            wheels: w,
+            headerText: false,
+            multiple: multiple,
+            anchor: input,
+            formatResult: function (d) {
+                return main[d[optIdx]];
+            },
+            parseValue: function () {
+                var v = elm.val() || [],
+                    i = 0;
+
+                if (multiple) {
+                    inst._selectedValues = {};
+                    for (i; i < v.length; i++) {
+                        inst._selectedValues[v[i]] = v[i];
+                    }
+                }
+
+                option = multiple ? (elm.val() ? elm.val()[0] : $('option', elm).attr('value')) : elm.val();
+
+                group = elm.find('option[value="' + option + '"]').parent();
+                gr = group.index();
+                prev = gr + '';
+                return s.group && s.rtl ? [option, gr] : s.group ? [gr, option] : [option];
+            },
+            validate: function (dw, i, time) {
+                if (i === undefined && multiple) {
+                    var v = inst._selectedValues,
+                        j = 0;
+
+                    $('.dwwl' + optIdx + ' .dw-li', dw).removeClass('dw-msel');
+
+                    for (j in v) {
+                        $('.dwwl' + optIdx + ' .dw-li[data-val="' + v[j] + '"]', dw).addClass('dw-msel');
+                    }
+                }
+
+                if (i === grIdx) {
+                    gr = inst.temp[grIdx];
+                    if (gr !== prev) {
+                        group = elm.find('optgroup').eq(gr);
+                        gr = group.index();
+                        option = group.find('option').eq(0).val();
+                        option = option || elm.val();
+                        s.wheels = genWheels();
+                        if (s.group) {
+                            inst.temp = s.rtl ? [option, gr] : [gr, option];
+                            s.readonly = [s.rtl, !s.rtl];
+                            clearTimeout(timer);
+                            timer = setTimeout(function () {
+                                inst.changeWheel([optIdx]);
+                                s.readonly = roPre;
+                                prev = gr + '';
+                            }, time * 1000);
+                            return false;
+                        }
+                    } else {
+                        s.readonly = roPre;
+                    }
+                } else {
+                    option = inst.temp[optIdx];
+                }
+
+                var t = $('.dw-ul', dw).eq(optIdx);
+                $.each(s.invalid, function (i, v) {
+                    $('.dw-li[data-val="' + v + '"]', t).removeClass('dw-v');
+                });
+            },
+            onBeforeShow: function (dw) {
+                s.wheels = genWheels();
+                if (s.group) {
+                    inst.temp = s.rtl ? [option, group.index()] : [group.index(), option];
+                }
+            },
+            onMarkupReady: function (dw) {
+                $('.dwwl' + grIdx, dw).bind('mousedown touchstart', function () {
+                    clearTimeout(timer);
+                });
+                if (multiple) {
+                    dw.addClass('dwms');
+                    $('.dwwl', dw).eq(optIdx).addClass('dwwms');
+                    origValues = {};
+                    var i;
+                    for (i in inst._selectedValues) {
+                        origValues[i] = inst._selectedValues[i];
+                    }
+                }
+            },
+            onValueTap: function (li) {
+                if (multiple && li.hasClass('dw-v') && li.closest('.dw').find('.dw-ul').index(li.closest('.dw-ul')) == optIdx) {
+                    var val = li.attr('data-val');
+                    if (li.hasClass('dw-msel')) {
+                        delete inst._selectedValues[val];
+                    } else {
+                        inst._selectedValues[val] = val;
+                    }
+                    li.toggleClass('dw-msel');
+
+                    if (s.display == 'inline') {
+                        setVal(val, true);
+                    }
+                    return false;
+                }
+            },
+            onSelect: function (v) {
+                setVal(v, true);
+                if (s.group) {
+                    inst.values = null;
+                }
+            },
+            onCancel: function () {
+                if (s.group) {
+                    inst.values = null;
+                }
+                if (multiple) {
+                    inst._selectedValues = {};
+                    var i;
+                    for (i in origValues) {
+                        inst._selectedValues[i] = origValues[i];
+                    }
+                }
+            },
+            onChange: function (v) {
+                if (s.display == 'inline' && !multiple) {
+                    input.val(v);
+                    prevent = true;
+                    elm.val(inst.temp[optIdx]).trigger('change');
+                }
+            },
+            onClose: function () {
+                input.blur();
+            }
+        };
+    };
+
+})(jQuery);
+
+(function ($) {
+
+    $.mobiscroll.themes.jqm = {
+        defaults: {
+            jqmBorder: 'a',
+            jqmBody: 'c',
+            jqmHeader: 'b',
+            jqmWheel: 'd',
+            jqmClickPick: 'c',
+            jqmSet: 'b',
+            jqmCancel: 'c'
+        },
+        init: function (elm, inst) {
+            var s = inst.settings;
+            $('.dw', elm).removeClass('dwbg').addClass('ui-overlay-shadow ui-corner-all ui-body-' + s.jqmBorder);
+            $('.dwb-s span', elm).attr('data-role', 'button').attr('data-theme', s.jqmSet);
+            $('.dwb-n span', elm).attr('data-role', 'button').attr('data-theme', s.jqmCancel);
+            $('.dwb-c span', elm).attr('data-role', 'button').attr('data-theme', s.jqmCancel);
+            $('.dwwb', elm).attr('data-role', 'button').attr('data-theme', s.jqmClickPick);
+            $('.dwv', elm).addClass('ui-header ui-bar-' + s.jqmHeader);
+            $('.dwwr', elm).addClass('ui-body-' + s.jqmBody);
+            $('.dwpm .dwwl', elm).addClass('ui-body-' + s.jqmWheel);
+            $('.dwpm .dwl', elm).addClass('ui-body-' + s.jqmBody);
+            elm.trigger('create');
+            // Hide on overlay click
+            $('.dwo', elm).click(function () { inst.cancel(); });
+        }
+    };
+
+})(jQuery);
+
+(function ($) {
+
+    $.mobiscroll.themes.ios = {
+        defaults: {
+            dateOrder: 'MMdyy',
+            rows: 5,
+            height: 30,
+            width: 55,
+            headerText: false,
+            showLabel: false,
+            useShortLabels: true
+        }
+    }
+
+})(jQuery);
+
+(function ($) {
+
+    $.mobiscroll.themes.android = {
+        defaults: {
+            dateOrder: 'Mddyy',
+            mode: 'clickpick',
+            height: 50,
+            showLabel: false
+        }
+    }
+
+})(jQuery);
+
+
+(function ($) {
+    var theme = {
+        defaults: {
+            dateOrder: 'Mddyy',
+            mode: 'mixed',
+            rows: 5,
+            width: 70,
+            height: 36,
+            showLabel: false,
+            useShortLabels: true
+        }
+    };
+
+    $.mobiscroll.themes['android-ics'] = theme;
+    $.mobiscroll.themes['android-ics light'] = theme;
+
+})(jQuery);
+
+
+(function ($) {
+    
+    var anim;
+    
+    $.mobiscroll.themes.wp = {
+        defaults: {
+            width: 70,
+            height: 76,
+            accent: 'none',
+            dateOrder: 'mmMMddDDyy',
+            showLabel: false,
+            onAnimStart: function (dw, i, time) {
+                $('.dwwl' + i, dw).addClass('wpam');
+                clearTimeout(anim[i]);
+                anim[i] = setTimeout(function () {
+                    $('.dwwl' + i, dw).removeClass('wpam');
+                }, time * 1000 + 100);
+            }
+        },
+        init: function (elm, inst) {
+            var click,
+                active;
+            
+            anim = {};
+            
+            $('.dw', elm).addClass('wp-' + inst.settings.accent);
+
+            //$('.dwwl', elm).bind('touchstart mousedown DOMMouseScroll mousewheel', function () {
+            $('.dwwl', elm).delegate('.dw-sel', 'touchstart mousedown DOMMouseScroll mousewheel', function () {
+                click = true;
+                active = $(this).closest('.dwwl').hasClass('wpa');
+                $('.dwwl', elm).removeClass('wpa');
+                $(this).closest('.dwwl').addClass('wpa');
+            }).bind('touchmove mousemove', function () {
+                click = false;
+            }).bind('touchend mouseup', function () {
+                if (click && active) {
+                    $(this).closest('.dwwl').removeClass('wpa');
+                }
+            });
+        }
+    };
+
+    $.mobiscroll.themes['wp light'] = $.mobiscroll.themes.wp;
+
+})(jQuery);
+
+

--- a/web/js/date/wheels.js
+++ b/web/js/date/wheels.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import 'mobiscroll-jquery';
+import 'mobiscroll';
 import util from '../util/util';
 
 export function dateWheels(models, config) {

--- a/web/js/date/wheels.js
+++ b/web/js/date/wheels.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import 'mobiscroll';
 import util from '../util/util';
 
-export function dateWheels(models, config) {
+var dateWheels = function(models, config) {
   var id = 'timewheels';
   var $container = $('#' + id);
   var MSEC_TO_MIN = 1000 * 60;
@@ -89,3 +89,5 @@ export function dateWheels(models, config) {
   init();
   return self;
 };
+
+export default dateWheels;

--- a/web/js/layers/modal.js
+++ b/web/js/layers/modal.js
@@ -9,11 +9,11 @@ import 'perfect-scrollbar/jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {LayerList} from 'worldview-components';
-import loFind from 'lodash/find';
-import loIndexOf from 'lodash/indexOf';
-import loSortBy from 'lodash/sortBy';
-import loStartCase from 'lodash/startCase';
-import loValues from 'lodash/values';
+import lodashFind from 'lodash/find';
+import lodashIndexOf from 'lodash/indexOf';
+import lodashSortBy from 'lodash/sortBy';
+import lodashStartCase from 'lodash/startCase';
+import lodashValues from 'lodash/values';
 import util from '../util/util';
 
 export function layersModal(models, ui, config) {
@@ -36,7 +36,7 @@ export function layersModal(models, ui, config) {
   var hasMeasurement;
 
   var getLayersForProjection = function (projection) {
-    var filteredLayers = loValues(config.layers).filter(function (layer) {
+    var filteredLayers = lodashValues(config.layers).filter(function (layer) {
       // Only use the layers for the active projection
       return layer.projections[projection];
     }).map(function (layer) {
@@ -48,8 +48,8 @@ export function layersModal(models, ui, config) {
       if (layer.subtitle) layer.subtitle = decodeHtml(layer.subtitle);
       return layer;
     });
-    return loSortBy(filteredLayers, function (layer) {
-      return loIndexOf(config.layerOrder, layer.id);
+    return lodashSortBy(filteredLayers, function (layer) {
+      return lodashIndexOf(config.layerOrder, layer.id);
     });
   };
 
@@ -98,7 +98,7 @@ export function layersModal(models, ui, config) {
   var hasMeasurementSetting = function (current, source) {
     var projection = models.proj.selected.id;
     var hasSetting;
-    loValues(source.settings).forEach(function (setting) {
+    lodashValues(source.settings).forEach(function (setting) {
       var layer = config.layers[setting];
       if (layer) {
         var proj = layer.projections;
@@ -129,7 +129,7 @@ export function layersModal(models, ui, config) {
 
   var hasMeasurementSource = function (current) {
     var hasSource;
-    loValues(current.sources).forEach(function (source) {
+    lodashValues(current.sources).forEach(function (source) {
       if (hasMeasurementSetting(current, source)) {
         hasSource = true;
         hasMeasurement = true;
@@ -276,13 +276,13 @@ export function layersModal(models, ui, config) {
     $nav.empty();
 
     Object.keys(config.categories).forEach(function (metaCategoryName) {
-      loValues(config.categories[metaCategoryName]).forEach(function (category) {
+      lodashValues(config.categories[metaCategoryName]).forEach(function (category) {
         var sortNumber = 2;
         var $i = 0;
 
         // Check if categories have settings with the same projection.
         hasMeasurement = false;
-        loValues(category.measurements).forEach(function (measurement) {
+        lodashValues(category.measurements).forEach(function (measurement) {
           hasMeasurementSource(config.measurements[measurement]);
         });
 
@@ -324,7 +324,7 @@ export function layersModal(models, ui, config) {
 
           var $measurements = $('<ul />');
 
-          loValues(category.measurements).forEach(function (measurement, index) {
+          lodashValues(category.measurements).forEach(function (measurement, index) {
             var current = config.measurements[measurement];
             // Check if measurements have settings with the same projection.
             if (hasMeasurementSource(current)) {
@@ -439,7 +439,7 @@ export function layersModal(models, ui, config) {
       id: category.id + '-list'
     });
     // Begin Measurement Level
-    loValues(category.measurements).forEach(function (measurement) {
+    lodashValues(category.measurements).forEach(function (measurement) {
       var current = config.measurements[measurement];
       // Check if measurements have settings with the same projection.
       if (hasMeasurementSource(current)) {
@@ -467,7 +467,7 @@ export function layersModal(models, ui, config) {
         $measurementContent.append($sourceTabs);
 
         // Begin source level
-        loValues(current.sources).forEach(function (source) {
+        lodashValues(current.sources).forEach(function (source) {
           var isExpanded;
           // Check if sources have settings with the same projection.
           if (hasMeasurementSetting(current, source)) {
@@ -537,7 +537,7 @@ export function layersModal(models, ui, config) {
               'class': 'source-orbit-tracks'
             });
 
-            loValues(source.settings).forEach(function (setting) {
+            lodashValues(source.settings).forEach(function (setting) {
               var layer = config.layers[setting];
               // If a setting matches the current projection, then output it.
               if (layer && layer.id === setting && Object.keys(layer.projections).indexOf(projection) > -1) {
@@ -556,7 +556,7 @@ export function layersModal(models, ui, config) {
                 }).on('ifChecked', addLayer)
                   .on('ifUnchecked', removeLayer);
 
-                if (loFind(model.active, {id: layer.id})) {
+                if (lodashFind(model.active, {id: layer.id})) {
                   $setting.attr('checked', 'checked');
                 }
 
@@ -571,7 +571,7 @@ export function layersModal(models, ui, config) {
                 if (layer.layergroup && layer.layergroup.indexOf('reference_orbits') !== -1) {
                   var orbitTitle;
                   if (layer.daynight && layer.track) {
-                    orbitTitle = loStartCase(layer.track) + '/' + loStartCase(layer.daynight);
+                    orbitTitle = lodashStartCase(layer.track) + '/' + lodashStartCase(layer.daynight);
                   }
 
                   $label.empty()
@@ -684,7 +684,7 @@ export function layersModal(models, ui, config) {
    */
   var drawAllMeasurements = function () {
     Object.keys(config.categories).forEach(function (metaCategoryName) {
-      loValues(config.categories[metaCategoryName]).forEach(function (category) {
+      lodashValues(config.categories[metaCategoryName]).forEach(function (category) {
         if (category.id === 'legacy-all') {
           drawMeasurements(category);
         }

--- a/web/js/layers/modal.js
+++ b/web/js/layers/modal.js
@@ -13,6 +13,7 @@ import loFind from 'lodash/find';
 import loIndexOf from 'lodash/indexOf';
 import loSortBy from 'lodash/sortBy';
 import loStartCase from 'lodash/startCase';
+import loValues from 'lodash/values';
 import util from '../util/util';
 
 export function layersModal(models, ui, config) {
@@ -35,7 +36,7 @@ export function layersModal(models, ui, config) {
   var hasMeasurement;
 
   var getLayersForProjection = function (projection) {
-    var filteredLayers = Object.values(config.layers).filter(function (layer) {
+    var filteredLayers = loValues(config.layers).filter(function (layer) {
       // Only use the layers for the active projection
       return layer.projections[projection];
     }).map(function (layer) {
@@ -97,11 +98,11 @@ export function layersModal(models, ui, config) {
   var hasMeasurementSetting = function (current, source) {
     var projection = models.proj.selected.id;
     var hasSetting;
-    Object.values(source.settings).forEach(function (setting) {
+    loValues(source.settings).forEach(function (setting) {
       var layer = config.layers[setting];
       if (layer) {
         var proj = layer.projections;
-        if (layer.id == setting && Object.keys(proj).indexOf(projection) > -1) {
+        if (layer.id === setting && Object.keys(proj).indexOf(projection) > -1) {
           if (layer.layergroup && layer.layergroup.indexOf('reference_orbits') !== -1) {
             if (current.id === 'orbital-track') {
               hasSetting = true;
@@ -128,7 +129,7 @@ export function layersModal(models, ui, config) {
 
   var hasMeasurementSource = function (current) {
     var hasSource;
-    Object.values(current.sources).forEach(function (source) {
+    loValues(current.sources).forEach(function (source) {
       if (hasMeasurementSetting(current, source)) {
         hasSource = true;
         hasMeasurement = true;
@@ -242,7 +243,7 @@ export function layersModal(models, ui, config) {
         break;
       case undefined:
         // Set the default views per projection if modalView is not defined.
-        if (projection == 'geographic') {
+        if (projection === 'geographic') {
           crumbText = 'Categories';
           drawCategories();
         } else {
@@ -275,13 +276,13 @@ export function layersModal(models, ui, config) {
     $nav.empty();
 
     Object.keys(config.categories).forEach(function (metaCategoryName) {
-      Object.values(config.categories[metaCategoryName]).forEach(function (category) {
+      loValues(config.categories[metaCategoryName]).forEach(function (category) {
         var sortNumber = 2;
         var $i = 0;
 
         // Check if categories have settings with the same projection.
         hasMeasurement = false;
-        Object.values(category.measurements).forEach(function (measurement) {
+        loValues(category.measurements).forEach(function (measurement) {
           hasMeasurementSource(config.measurements[measurement]);
         });
 
@@ -323,7 +324,7 @@ export function layersModal(models, ui, config) {
 
           var $measurements = $('<ul />');
 
-          Object.values(category.measurements).forEach(function (measurement, index) {
+          loValues(category.measurements).forEach(function (measurement, index) {
             var current = config.measurements[measurement];
             // Check if measurements have settings with the same projection.
             if (hasMeasurementSource(current)) {
@@ -438,12 +439,12 @@ export function layersModal(models, ui, config) {
       id: category.id + '-list'
     });
     // Begin Measurement Level
-    Object.values(category.measurements).forEach(function (measurement) {
+    loValues(category.measurements).forEach(function (measurement) {
       var current = config.measurements[measurement];
       // Check if measurements have settings with the same projection.
       if (hasMeasurementSource(current)) {
         currentTab++;
-        if (selectedMeasurement == current.id) {
+        if (selectedMeasurement === current.id) {
           tabIndex = currentTab;
         }
 
@@ -466,7 +467,7 @@ export function layersModal(models, ui, config) {
         $measurementContent.append($sourceTabs);
 
         // Begin source level
-        Object.values(current.sources).forEach(function (source) {
+        loValues(current.sources).forEach(function (source) {
           var isExpanded;
           // Check if sources have settings with the same projection.
           if (hasMeasurementSetting(current, source)) {
@@ -536,10 +537,10 @@ export function layersModal(models, ui, config) {
               'class': 'source-orbit-tracks'
             });
 
-            Object.values(source.settings).forEach(function (setting) {
+            loValues(source.settings).forEach(function (setting) {
               var layer = config.layers[setting];
               // If a setting matches the current projection, then output it.
-              if (layer && layer.id == setting && Object.keys(layer.projections).indexOf(projection) > -1) {
+              if (layer && layer.id === setting && Object.keys(layer.projections).indexOf(projection) > -1) {
                 var $wrapper = $('<li />', {
                   'class': 'measurement-settings-item',
                   'data-layer': encodeURIComponent(layer.id),
@@ -683,8 +684,8 @@ export function layersModal(models, ui, config) {
    */
   var drawAllMeasurements = function () {
     Object.keys(config.categories).forEach(function (metaCategoryName) {
-      Object.values(config.categories[metaCategoryName]).forEach(function (category) {
-        if (category.id == 'legacy-all') {
+      loValues(config.categories[metaCategoryName]).forEach(function (category) {
+        if (category.id === 'legacy-all') {
           drawMeasurements(category);
         }
       });

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -9,7 +9,7 @@ import util from './util/util'; // Maybe this is the time to remove the util fil
 import {parse as dateParser} from './date/date'; // export default function parse!!!
 import {dateModel} from './date/model';
 import {dateLabel} from './date/label';
-import {dateWheels} from './date/wheels';
+import dateWheels from './date/wheels';
 // Timeline
 import {timeline} from './date/timeline';
 import {timelineData} from './date/timeline-data';
@@ -257,7 +257,7 @@ window.onload = () => {
       if (!util.browser.small) { // If mobile device, do not build timeline
         timelineInit();
       }
-      //ui.dateWheels = dateWheels(models, config);
+      ui.dateWheels = dateWheels(models, config);
     }
 
     ui.rubberband = imageRubberband(models, ui, config);

--- a/web/js/polyfill.js
+++ b/web/js/polyfill.js
@@ -86,20 +86,20 @@ export function polyfill () {
    */
   if (util.browser.ie && util.browser.version <= 9) {
     (function () {
-      var __nativeST__ = window.setTimeout,
-        __nativeSI__ = window.setInterval;
+      var __nativeST__ = window.setTimeout;
+      var __nativeSI__ = window.setInterval;
 
       window.setTimeout = function (vCallback, nDelay /*, argumentToPass1, argumentToPass2, etc. */) {
-        var oThis = this,
-          aArgs = Array.prototype.slice.call(arguments, 2);
+        var oThis = this;
+        var aArgs = Array.prototype.slice.call(arguments, 2);
         return __nativeST__(vCallback instanceof Function ? function () {
           vCallback.apply(oThis, aArgs);
         } : vCallback, nDelay);
       };
 
       window.setInterval = function (vCallback, nDelay /*, argumentToPass1, argumentToPass2, etc. */) {
-        var oThis = this,
-          aArgs = Array.prototype.slice.call(arguments, 2);
+        var oThis = this;
+        var aArgs = Array.prototype.slice.call(arguments, 2);
         return __nativeSI__(vCallback instanceof Function ? function () {
           vCallback.apply(oThis, aArgs);
         } : vCallback, nDelay);
@@ -173,17 +173,17 @@ export function polyfill () {
       navigator.userAgent.match(/BlackBerry/i) ||
       navigator.userAgent.match(/Windows Phone/i)
     ) {
-      mobile = true;
-      if (!(window.orientation == 90 || window.orientation == -90)) {
-        portrait = true;
+      var mobile = true;
+      if (!(window.orientation === 90 || window.orientation === -90)) {
+        var portrait = true;
       }
     }
 
-    if (navigator.userAgent.indexOf('iPhone') != -1 || navigator.userAgent.indexOf('Android') != -1) {
+    if (navigator.userAgent.indexOf('iPhone') !== -1 || navigator.userAgent.indexOf('Android') !== -1) {
       // In Safari, the true version is after "Safari"
-      if (navigator.userAgent.indexOf('Safari') != -1) {
+      if (navigator.userAgent.indexOf('Safari') !== -1) {
         // Set a variable to use later
-        mobileSafari = true;
+        var mobileSafari = true;
       }
       addEventListener('load', function () {
         if (mobile) {
@@ -204,13 +204,13 @@ export function polyfill () {
     // Set the div height
     function setHeight ($body) {
       if (navigator.userAgent.match(/(iPad|iPhone|iPod touch);.*CPU.*OS 6_\d/i)) {
-        var new_height = $(window)
+        var newHeight = $(window)
           .height();
         // if mobileSafari 6 add +60px
-        new_height += 60;
+        newHeight += 60;
         $('#app')
           .css('min-height', 0)
-          .css('height', new_height);
+          .css('height', newHeight);
       } else {
         $('#app, .ui-mobile, .ui-mobile .ui-page')
           .css('min-height', 0);


### PR DESCRIPTION
Based on `update-build-scripts` (#647) 

Modularizes mobile timeline wheel. Had to revert `mobiscroll` to 2.6.x and put it back in the `/web/ext` directory. The newer version of mobiscroll requires a license to access full functionality, so we need to stick with the old version until we can replace this dependency.

This PR also fixes various mobile bugs.
  