### PR TITLE
Fix babel polyfills not working in IE and older browsers

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'; // Needed for worldview-components in IE and older browsers
 import $ from 'jquery';
 import lodashEach from 'lodash/each';
 import { GA as googleAnalytics } from 'worldview-components';


### PR DESCRIPTION
- Add babel-polyfill import to main.js