### PR TITLE
Fix debug -/+ buttons not working

### DIFF
--- a/web/js/debug.js
+++ b/web/js/debug.js
@@ -268,14 +268,14 @@ export function debugLayers(ui, models, config) {
   var nextLayer = function () {
     $('.wv-debug-gibs-layerlist option:selected')
       .next()
-      .attr('selected', 'selected');
+      .prop('selected', 'selected');
     updateLayers.apply($('.wv-debug-gibs-layerlist'));
   };
 
   var previousLayer = function () {
     $('.wv-debug-gibs-layerlist option:selected')
       .prev()
-      .attr('selected', 'selected');
+      .prop('selected', 'selected');
     updateLayers.apply($('.wv-debug-gibs-layerlist'));
   };
 


### PR DESCRIPTION
Fixes #681

Changes in this pull request:

- Change jQuery's `.attr` to `.prop`