### PR TITLE
Fix drag and drop to change layer order not working on desktop

### DIFF
--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -88,7 +88,8 @@ export function layersActive(models, ui, config) {
         axis: 'y',
         containment: 'parent',
         tolerance: 'pointer',
-        placeholder: 'state-saver'
+        placeholder: 'state-saver',
+        cursorAt: { bottom: 20 }
       });
     $('.layer-container ul.category li')
       .disableSelection();


### PR DESCRIPTION
Fixes #680

Changes in this pull request:
- Add `cursorAt` parameter, with a value of `bottom: 20` to jQuery sortable.

Note: `20` is half of the pixel value of the layer's min-height (40px) ensuring it always can be dragged below the smallest layer.
