### PR TITLE
Fix sortable overriding layer controls on Android tablets

### DIFF
--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -88,6 +88,7 @@ export function layersActive(models, ui, config) {
     $('.layer-container ul.category')
       .sortable({
         items: 'li:not(.head)',
+        cancel: 'a',
         axis: 'y',
         containment: 'parent',
         tolerance: 'pointer',


### PR DESCRIPTION
Changes in this pull request:

 - Target `a` elements with sortable's cancel attribute within the layer `li`. 