### PR TITLE
Prevent tour window from appearing in incorrect position

### DIFF
--- a/web/js/tour.js
+++ b/web/js/tour.js
@@ -236,7 +236,7 @@ export default function (models, ui, config) {
       .width();
     var viewHeight = $(window)
       .height();
-    return viewWidth >= 768 && viewHeight >= 680;
+    return viewWidth > 800 && viewHeight > 680;
   };
 
   init();


### PR DESCRIPTION
Fixes a bug found during testing where some devices with 768px widths (iPad, Galaxy Tab) were still showing the tour. Because the tour could not fit properly at this size, the first tour step was dropping below the timeline. This PR increases the width detection to `> 800`

Changes in this pull request:

- Increase validScreenSize width detection to prevent the tour window from appearing on devices with too small of an area for the window to fit correctly.