### PR TITLE
Fix console error thrown when switching projections

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -854,6 +854,7 @@ export function mapui(models, config) {
       }
       pixels = map.getEventPixel(e.originalEvent);
       coords = map.getCoordinateFromPixel(pixels);
+      if (!coords) return;
       if (!olExtent.containsCoordinate(extent, coords)) {
         outside = true;
       }


### PR DESCRIPTION
Fixes #723

Changes in this pull request:

- Set the coords variable to [0,0] by default so that it is not null.

@nasa-gibs/worldview
