### PR TITLE
Set font-family fallback for GIFs

### DIFF
--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -237,7 +237,7 @@ export function animationGif(models, config, ui) {
         'textBaseline': 'top', // If textYCoordinate is null this takes precedence
         'fontColor': '#fff',
         'fontWeight': '300',
-        'fontFamily': 'Helvetica Neue',
+        'fontFamily': 'Open Sans, sans-serif',
         'interval': 1 / interval,
         'progressCallback': onGifProgress,
         'showFrameText': stampHeight > 20,


### PR DESCRIPTION
Fixes #810 .

Changes in this pull request:

- [x] Set fallback for devices without `Helvetica Neue`

@nasa-gibs/worldview
