### PR TITLE
Change phantomjs to phantomjs-prebuilt and fix lint errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -231,9 +231,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-gray": {
@@ -570,13 +570,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "atob": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
-      "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
     },
     "autobind-decorator": {
       "version": "1.4.3",
@@ -590,10 +589,10 @@
       "dev": true,
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000815",
+        "caniuse-lite": "1.0.30000821",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "postcss-value-parser": "3.3.0"
       }
     },
@@ -601,15 +600,13 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1226,14 +1223,14 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
           "dev": true
         },
         "regenerator-runtime": {
@@ -1350,7 +1347,7 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
@@ -1358,9 +1355,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
           "dev": true
         },
         "lodash": {
@@ -1376,14 +1373,14 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+          "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
         }
       }
     },
@@ -1556,43 +1553,6 @@
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
       "dev": true
     },
-    "bl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
-      "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
-        }
-      }
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -1635,7 +1595,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -1814,8 +1773,8 @@
         "htmlescape": "1.1.1",
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
-        "insert-module-globals": "7.0.2",
-        "labeled-stream-splicer": "2.0.0",
+        "insert-module-globals": "7.0.5",
+        "labeled-stream-splicer": "2.0.1",
         "module-deps": "4.1.1",
         "os-browserify": "0.3.0",
         "parents": "1.0.1",
@@ -1825,7 +1784,7 @@
         "querystring-es3": "0.2.1",
         "read-only-stream": "2.0.0",
         "readable-stream": "2.3.5",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "shasum": "1.0.2",
         "shell-quote": "1.6.1",
         "stream-browserify": "2.0.1",
@@ -1938,7 +1897,7 @@
       "dev": true,
       "requires": {
         "clean-css": "4.1.11",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "css": "2.2.1",
         "find-node-modules": "1.0.4",
         "lodash": "4.17.5",
@@ -1947,11 +1906,12 @@
       },
       "dependencies": {
         "concat-stream": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-          "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
@@ -2067,8 +2027,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000815",
-        "electron-to-chromium": "1.3.38"
+        "caniuse-lite": "1.0.30000821",
+        "electron-to-chromium": "1.3.41"
       }
     },
     "browserstack-capabilities": {
@@ -2108,13 +2068,19 @@
       "dev": true,
       "requires": {
         "base64-js": "1.2.3",
-        "ieee754": "1.1.8"
+        "ieee754": "1.1.11"
       }
     },
     "buffer-crc32": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz",
       "integrity": "sha1-fhENyZU5CKt8MqzccMn5RbHLxSY=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "buffer-xor": {
@@ -2286,7 +2252,7 @@
       "dev": true,
       "requires": {
         "buster-cli": "0.8.0",
-        "ejs": "2.5.7",
+        "ejs": "2.5.8",
         "finalhandler": "0.4.1",
         "phantom-proxy": "0.1.792",
         "platform": "1.3.5",
@@ -2389,7 +2355,7 @@
         "buster-analyzer": "0.6.0",
         "buster-cli": "0.8.0",
         "buster-test": "0.8.0",
-        "ejs": "2.5.7",
+        "ejs": "2.5.8",
         "lodash": "3.10.1",
         "platform": "1.3.5",
         "ramp": "2.0.2",
@@ -2473,7 +2439,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000815",
+        "caniuse-db": "1.0.30000821",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2484,8 +2450,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "lodash.memoize": {
@@ -2497,15 +2463,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000815",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000815.tgz",
-      "integrity": "sha1-DiGPoTPQ0HHIhqoEG0NSWMx0aJE=",
+      "version": "1.0.30000821",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000821.tgz",
+      "integrity": "sha1-P83GfERqlKnN2Egkik4+VLLadBk=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000815",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz",
-      "integrity": "sha512-PGSOPK6gFe5fWd+eD0u2bG0aOsN1qC4B1E66tl3jOsIoKkTIcBYAc2+O6AeNzKW8RsFykWgnhkTlfOyuTzgI9A==",
+      "version": "1.0.30000821",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000821.tgz",
+      "integrity": "sha512-qyYay02wr/5k7PO86W+LKFaEUZfWIvT65PaXuPP16jkSpgZGIsSstHKiYAPVLjTj98j2WnWwZg8CjXPx7UIPYg==",
       "dev": true
     },
     "canvg-browser": {
@@ -2651,6 +2617,12 @@
         "npmconf": "2.1.2",
         "rimraf": "2.6.2"
       }
+    },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -2875,18 +2847,18 @@
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.0.tgz",
-      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "dev": true,
       "requires": {
         "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.0"
+        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-stats": {
@@ -2950,7 +2922,7 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
+        "clone": "1.0.4",
         "color-convert": "1.9.1",
         "color-string": "0.3.0"
       }
@@ -3203,9 +3175,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -3410,7 +3382,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -3424,7 +3396,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "create-react-class": {
@@ -3472,7 +3444,6 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -3482,7 +3453,6 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "4.2.1"
           }
@@ -3686,7 +3656,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000815",
+            "caniuse-db": "1.0.30000821",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3699,8 +3669,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "object-assign": {
@@ -3783,7 +3753,7 @@
         "bluebird": "3.4.6",
         "cli-table": "0.3.1",
         "colors": "1.2.1",
-        "commander": "2.15.0",
+        "commander": "2.15.1",
         "cucumber-expressions": "5.0.13",
         "cucumber-tag-expressions": "1.1.1",
         "duration": "0.2.0",
@@ -3797,7 +3767,7 @@
         "lodash": "4.15.0",
         "mz": "2.7.0",
         "progress": "2.0.0",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "stack-chain": "2.0.0",
         "stacktrace-js": "2.0.0",
         "string-argv": "0.0.2",
@@ -3813,9 +3783,9 @@
           "dev": true
         },
         "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "glob": {
@@ -3912,7 +3882,7 @@
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.40"
+        "es5-ext": "0.10.42"
       }
     },
     "d3": {
@@ -4252,7 +4222,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
-        "clone": "1.0.3"
+        "clone": "1.0.4"
       }
     },
     "define-properties": {
@@ -4315,7 +4285,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -4480,7 +4450,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000815",
+        "caniuse-db": "1.0.30000821",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4499,8 +4469,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "postcss": {
@@ -4656,7 +4626,7 @@
       "dev": true,
       "requires": {
         "d": "0.1.1",
-        "es5-ext": "0.10.40"
+        "es5-ext": "0.10.42"
       }
     },
     "ecc-jsbn": {
@@ -4676,16 +4646,16 @@
       "dev": true,
       "requires": {
         "bluebird": "3.4.6",
-        "commander": "2.15.0",
+        "commander": "2.15.1",
         "lru-cache": "3.2.0",
         "semver": "5.5.0",
         "sigmund": "1.0.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "lru-cache": {
@@ -4711,15 +4681,15 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
+      "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ==",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.38",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.38.tgz",
-      "integrity": "sha1-SSNLAMBZL2KSH5QmvM7+4j3ghrs=",
+      "version": "1.3.41",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz",
+      "integrity": "sha1-fjNkPgDNhe39F+BBlPbQDnNzcjU=",
       "dev": true
     },
     "elliptic": {
@@ -4781,9 +4751,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -4805,13 +4775,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.40",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.40.tgz",
-      "integrity": "sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -4821,7 +4792,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.40",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       },
       "dependencies": {
@@ -4831,10 +4802,16 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.40"
+            "es5-ext": "0.10.42"
           }
         }
       }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -4843,7 +4820,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.40"
+        "es5-ext": "0.10.42"
       },
       "dependencies": {
         "d": {
@@ -4852,7 +4829,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.40"
+            "es5-ext": "0.10.42"
           }
         }
       }
@@ -4892,15 +4869,15 @@
       }
     },
     "eslint": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.2",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
@@ -4912,7 +4889,7 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.3.0",
+        "globals": "11.4.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
@@ -4928,6 +4905,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.0.1",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -4963,11 +4941,12 @@
           }
         },
         "concat-stream": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-          "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
@@ -4997,9 +4976,9 @@
           }
         },
         "globals": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
           "dev": true
         },
         "has-flag": {
@@ -5098,7 +5077,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "eslint-module-utils": {
@@ -5233,7 +5212,7 @@
       "requires": {
         "ignore": "3.3.7",
         "minimatch": "3.0.4",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "semver": "5.3.0"
       },
       "dependencies": {
@@ -5443,7 +5422,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "1.0.0"
+        "clone-regexp": "1.0.1"
       }
     },
     "exit": {
@@ -5884,33 +5863,27 @@
       }
     },
     "extract-zip": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
-      "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.5.0",
-        "debug": "0.7.4",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
         "concat-stream": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
-          "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
+            "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
           }
-        },
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
@@ -5933,24 +5906,28 @@
             "minimist": "0.0.8"
           }
         },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
         "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -6049,7 +6026,7 @@
       "requires": {
         "bindings": "1.2.1",
         "debug": "2.6.9",
-        "nan": "2.9.2",
+        "nan": "2.10.0",
         "ref": "1.3.5",
         "ref-struct": "1.1.0"
       }
@@ -6362,7 +6339,7 @@
       "requires": {
         "detect-file": "1.0.0",
         "is-glob": "3.1.0",
-        "micromatch": "3.1.9",
+        "micromatch": "3.1.10",
         "resolve-dir": "1.0.1"
       }
     },
@@ -6612,21 +6589,6 @@
         "bluebird": "3.4.6",
         "got": "5.6.0",
         "tar.gz": "1.0.5"
-      }
-    },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
       }
     },
     "get-caller-file": {
@@ -7096,7 +7058,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "node-status-codes": "1.0.0",
         "object-assign": "4.1.1",
         "parse-json": "2.2.0",
@@ -7483,7 +7445,7 @@
       "requires": {
         "highlight.js": "8.4.0",
         "lodash": "2.4.2",
-        "marked": "0.3.17"
+        "marked": "0.3.19"
       },
       "dependencies": {
         "lodash": {
@@ -7942,15 +7904,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -8058,7 +8018,6 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -8210,7 +8169,6 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -8245,9 +8203,9 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
     },
     "ignore": {
       "version": "3.3.7",
@@ -8335,7 +8293,7 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
+        "ansi-escapes": "3.1.0",
         "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
@@ -8404,14 +8362,14 @@
       }
     },
     "insert-module-globals": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.2.tgz",
-      "integrity": "sha512-p3s7g96Nm62MbHRuj9ZXab0DuJNWD7qcmdUXCOQ/ZZn42DtDXfsLill7bq19lDCx3K3StypqUnuE3H2VmIJFUw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.5.tgz",
+      "integrity": "sha512-wgRtrCpMm0ruH2hgLUIx+9YfJsgJQmU1KkPUzTuatW9dbH19yPRqAQhFX1HJU6zbmg2IMmt80BgSE5MWuksw3Q==",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
-        "combine-source-map": "0.7.2",
-        "concat-stream": "1.5.2",
+        "combine-source-map": "0.8.0",
+        "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
@@ -8419,29 +8377,47 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
-        "combine-source-map": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-          "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.6.2",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.5.7"
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.5",
+            "typedarray": "0.0.6"
           }
         },
-        "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+        "readable-stream": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
         }
       }
     },
@@ -8559,6 +8535,15 @@
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -8670,25 +8655,6 @@
         "is-path-inside": "1.0.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -8741,9 +8707,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -8788,12 +8754,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-redirect": {
@@ -8849,9 +8809,9 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-supported-regexp-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
-      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-svg": {
@@ -9165,7 +9125,7 @@
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
         "escodegen": "1.9.1",
-        "nwmatcher": "1.4.3",
+        "nwmatcher": "1.4.4",
         "parse5": "1.5.1",
         "request": "2.85.0",
         "sax": "1.2.4",
@@ -9363,12 +9323,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -9417,14 +9371,22 @@
       "dev": true
     },
     "labeled-stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "isarray": "0.0.1",
+        "isarray": "2.0.4",
         "stream-splicer": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
+          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
+          "dev": true
+        }
       }
     },
     "latest-version": {
@@ -9514,7 +9476,7 @@
         "is-plain-object": "2.0.4",
         "object.map": "1.0.1",
         "rechoir": "0.6.2",
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "load-json-file": {
@@ -10061,9 +10023,9 @@
       "dev": true
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
     "lru-cache": {
@@ -10149,9 +10111,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
-      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "masonry-layout": {
@@ -10273,9 +10235,9 @@
       "integrity": "sha1-qqK0gpMXv4ERipYNMlbgbdlnS40="
     },
     "micromatch": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
-      "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
         "arr-diff": "4.0.0",
         "array-unique": "0.3.2",
@@ -10578,7 +10540,7 @@
         "inherits": "2.0.3",
         "parents": "1.0.1",
         "readable-stream": "2.3.5",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "stream-combiner2": "1.1.1",
         "subarg": "1.0.0",
         "through2": "2.0.3",
@@ -10747,9 +10709,9 @@
       }
     },
     "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true
     },
     "nanomatch": {
@@ -10793,6 +10755,12 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
     "nightwatch": {
       "version": "0.9.20",
       "resolved": "https://registry.npmjs.org/nightwatch/-/nightwatch-0.9.20.tgz",
@@ -10811,6 +10779,12 @@
         "q": "1.4.1"
       },
       "dependencies": {
+        "ejs": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+          "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
+          "dev": true
+        },
         "minimatch": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
@@ -10910,7 +10884,7 @@
       "integrity": "sha512-v1fVfgaZanBHP/ZOc9V72uKKIF4dcRfZV7GISNVi/w/g5pwB7nIvOK+RGULjrzhs97cwUX41cM4+dlw+bg2igw==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.2",
+        "chokidar": "2.0.3",
         "debug": "3.1.0",
         "ignore-by-default": "1.0.1",
         "minimatch": "3.0.4",
@@ -10919,7 +10893,7 @@
         "supports-color": "5.3.0",
         "touch": "3.1.0",
         "undefsafe": "2.0.2",
-        "update-notifier": "2.3.0"
+        "update-notifier": "2.4.0"
       },
       "dependencies": {
         "anymatch": {
@@ -10928,14 +10902,14 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "3.1.9",
+            "micromatch": "3.1.10",
             "normalize-path": "2.1.1"
           }
         },
         "chokidar": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
-          "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
@@ -11258,9 +11232,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true,
       "optional": true
     },
@@ -11698,7 +11672,7 @@
             "is-redirect": "1.0.0",
             "is-retry-allowed": "1.1.0",
             "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
+            "lowercase-keys": "1.0.1",
             "safe-buffer": "5.1.1",
             "timed-out": "4.0.1",
             "unzip-response": "2.0.1",
@@ -11963,7 +11937,7 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "requires": {
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.11",
         "resolve-protobuf-schema": "2.0.0"
       }
     },
@@ -11977,7 +11951,7 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -11995,8 +11969,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "phantom-proxy": {
       "version": "0.1.792",
@@ -12109,104 +12082,32 @@
         }
       }
     },
-    "phantomjs": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-2.1.7.tgz",
-      "integrity": "sha1-xpEPZ5NcNyhbYRQyn8LyfV8+MTQ=",
+    "phantomjs-prebuilt": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "extract-zip": "1.5.0",
-        "fs-extra": "0.26.7",
+        "es6-promise": "4.2.4",
+        "extract-zip": "1.6.6",
+        "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
-        "request": "2.67.0",
+        "request": "2.85.0",
         "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "which": "1.3.0"
       },
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.15.0"
-          }
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
-          "dev": true,
-          "requires": {
-            "async": "2.6.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
         "fs-extra": {
-          "version": "0.26.7",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "klaw": "1.3.1"
           }
         },
         "graceful-fs": {
@@ -12214,47 +12115,6 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.0",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
         },
         "jsonfile": {
           "version": "2.4.0",
@@ -12276,70 +12136,6 @@
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
-        },
-        "qs": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
-          "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.67.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "bl": "1.0.3",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.1",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "5.2.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.2",
-            "tunnel-agent": "0.4.3"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
         }
       }
     },
@@ -12427,9 +12223,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "6.0.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-      "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+      "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -12527,7 +12323,7 @@
         "get-stdin": "5.0.1",
         "globby": "6.1.0",
         "ora": "1.4.0",
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "postcss-load-config": "1.2.0",
         "postcss-reporter": "5.0.0",
         "pretty-hrtime": "1.0.3",
@@ -13141,10 +12937,10 @@
       "integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "postcss-value-parser": "3.3.0",
         "read-cache": "1.0.0",
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "postcss-less": {
@@ -13344,8 +13140,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "postcss": {
@@ -13794,7 +13590,7 @@
         "chalk": "2.3.2",
         "lodash": "4.17.5",
         "log-symbols": "2.2.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13852,7 +13648,7 @@
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.21"
       }
     },
     "postcss-sass": {
@@ -13862,7 +13658,7 @@
       "dev": true,
       "requires": {
         "gonzales-pe": "4.2.3",
-        "postcss": "6.0.19"
+        "postcss": "6.0.21"
       }
     },
     "postcss-scss": {
@@ -13871,7 +13667,7 @@
       "integrity": "sha512-IFj42Hz2cBHHFvZTqkJqU08JCCM/MZU5/uNkTUZBaBFP2d4C5unw4HyCL52RfCwJb6KoVUD3eoepxMh1dfBFCQ==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.21"
       }
     },
     "postcss-selector-parser": {
@@ -14020,7 +13816,7 @@
         "mime": "1.4.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "xxhashjs": "0.2.2"
       },
       "dependencies": {
@@ -14340,7 +14136,7 @@
       "integrity": "sha1-5069y/PnhpjNSlAz9b5vN+9cNVw=",
       "dev": true,
       "requires": {
-        "ejs": "2.5.7",
+        "ejs": "2.5.8",
         "faye": "1.1.2",
         "mori": "0.3.2",
         "node-uuid": "1.4.8",
@@ -14764,7 +14560,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "redent": {
@@ -14827,7 +14623,7 @@
       "requires": {
         "bindings": "1.2.1",
         "debug": "2.6.9",
-        "nan": "2.9.2"
+        "nan": "2.10.0"
       }
     },
     "ref-struct": {
@@ -14903,6 +14699,12 @@
         "extend-shallow": "3.0.2",
         "safe-regex": "1.1.0"
       }
+    },
+    "regexpp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
+      "integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
+      "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
@@ -15117,7 +14919,6 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -15147,8 +14948,7 @@
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.6",
@@ -15170,7 +14970,6 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
@@ -15181,8 +14980,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -15229,9 +15027,9 @@
       "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw=="
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -15518,9 +15316,9 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -15534,7 +15332,7 @@
       "dev": true,
       "requires": {
         "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "shebang-command": {
@@ -15744,7 +15542,6 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -15835,7 +15632,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
       "requires": {
-        "atob": "2.0.3",
+        "atob": "2.1.0",
         "decode-uri-component": "0.2.0",
         "resolve-url": "0.2.1",
         "source-map-url": "0.4.0",
@@ -16403,7 +16200,7 @@
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
+        "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
       }
     },
@@ -16484,7 +16281,7 @@
         "editorconfig": "0.13.3",
         "globby": "6.1.0",
         "minimist": "1.2.0",
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "postcss-scss": "1.0.4",
         "postcss-sorting": "2.1.0",
         "postcss-value-parser": "3.3.0",
@@ -16524,7 +16321,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000815",
+            "caniuse-db": "1.0.30000821",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -16568,8 +16365,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "diff": {
@@ -16918,8 +16715,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "log-symbols": {
@@ -16999,9 +16796,9 @@
         "micromatch": "2.3.11",
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
-        "postcss": "6.0.19",
+        "postcss": "6.0.21",
         "postcss-html": "0.12.0",
-        "postcss-less": "1.1.3",
+        "postcss-less": "1.1.5",
         "postcss-media-query-parser": "0.2.3",
         "postcss-reporter": "5.0.0",
         "postcss-resolve-nested-selector": "0.1.1",
@@ -17050,10 +16847,10 @@
           "dev": true,
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000815",
+            "caniuse-lite": "1.0.30000821",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.19",
+            "postcss": "6.0.21",
             "postcss-value-parser": "3.3.0"
           }
         },
@@ -17334,9 +17131,9 @@
           "dev": true
         },
         "postcss-less": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
-          "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.5.tgz",
+          "integrity": "sha512-QQIiIqgEjNnquc0d4b6HDOSFZxbFQoy4MPpli2lSLpKhMyBkKwwca2HFqu4xzxlKID/F2fxSOowwtKpgczhF7A==",
           "dev": true,
           "requires": {
             "postcss": "5.2.18"
@@ -17476,7 +17273,7 @@
           "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
           "dev": true,
           "requires": {
-            "postcss": "6.0.19"
+            "postcss": "6.0.21"
           }
         },
         "supports-color": {
@@ -17538,7 +17335,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000815",
+            "caniuse-db": "1.0.30000821",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -17568,8 +17365,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000815",
-            "electron-to-chromium": "1.3.38"
+            "caniuse-db": "1.0.30000821",
+            "electron-to-chromium": "1.3.41"
           }
         },
         "expand-brackets": {
@@ -17940,18 +17737,19 @@
       "dev": true,
       "requires": {
         "command-exists": "1.2.2",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "get-port": "3.2.0",
         "http-response-object": "1.1.0",
         "then-request": "2.2.0"
       },
       "dependencies": {
         "concat-stream": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-          "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
@@ -18090,7 +17888,7 @@
       "dev": true,
       "requires": {
         "bluebird": "2.11.0",
-        "commander": "2.15.0",
+        "commander": "2.15.1",
         "fstream": "1.0.11",
         "mout": "0.11.1",
         "tar": "2.2.1"
@@ -18103,9 +17901,9 @@
           "dev": true
         },
         "commander": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-          "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         }
       }
@@ -18820,15 +18618,16 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
@@ -19036,7 +18835,7 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "requires": {
-        "clone": "1.0.3",
+        "clone": "1.0.4",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
@@ -19129,7 +18928,7 @@
             "browserify-zlib": "0.2.0",
             "buffer": "5.1.0",
             "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.1",
+            "concat-stream": "1.6.2",
             "console-browserify": "1.1.0",
             "constants-browserify": "1.0.0",
             "crypto-browserify": "3.12.0",
@@ -19143,10 +18942,10 @@
             "htmlescape": "1.1.1",
             "https-browserify": "1.0.0",
             "inherits": "2.0.3",
-            "insert-module-globals": "7.0.2",
-            "labeled-stream-splicer": "2.0.0",
+            "insert-module-globals": "7.0.5",
+            "labeled-stream-splicer": "2.0.1",
             "mkdirp": "0.5.1",
-            "module-deps": "6.0.0",
+            "module-deps": "6.0.2",
             "os-browserify": "0.3.0",
             "parents": "1.0.1",
             "path-browserify": "0.0.0",
@@ -19155,7 +18954,7 @@
             "querystring-es3": "0.2.1",
             "read-only-stream": "2.0.0",
             "readable-stream": "2.3.5",
-            "resolve": "1.5.0",
+            "resolve": "1.6.0",
             "shasum": "1.0.2",
             "shell-quote": "1.6.1",
             "stream-browserify": "2.0.1",
@@ -19173,11 +18972,12 @@
           }
         },
         "concat-stream": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-          "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
+            "buffer-from": "1.0.0",
             "inherits": "2.0.3",
             "readable-stream": "2.3.5",
             "typedarray": "0.0.6"
@@ -19245,22 +19045,22 @@
           }
         },
         "module-deps": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.0.tgz",
-          "integrity": "sha512-BKsMhJJENEM4dTgqq2MDTTHXRHcNUFegoAwlG4HO4VMdUyMcJDKgfgI+MOv6tR5Iv8G3MKZFgsSiyP3ZoosRMw==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.0.2.tgz",
+          "integrity": "sha512-KWBI3009iRnHjRlxRhe8nJ6kdeBTg4sMi5N6AZgg5f1/v5S7EBCRBOY854I4P5Anl4kx6AJH+4bBBC2Gi3nkvg==",
           "dev": true,
           "requires": {
             "JSONStream": "1.3.2",
             "browser-resolve": "1.11.2",
             "cached-path-relative": "1.0.1",
-            "concat-stream": "1.6.1",
+            "concat-stream": "1.6.2",
             "defined": "1.0.0",
             "detective": "5.1.0",
             "duplexer2": "0.1.4",
             "inherits": "2.0.3",
             "parents": "1.0.1",
             "readable-stream": "2.3.5",
-            "resolve": "1.5.0",
+            "resolve": "1.6.0",
             "stream-combiner2": "1.1.1",
             "subarg": "1.0.0",
             "through2": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "nightwatch-cucumber": "^8.2.10",
     "npm-run-all": "^4.1.1",
     "npm-watch": "^0.3.0",
-    "phantomjs": "2.1.x",
+    "phantomjs-prebuilt": "2.1.x",
     "postcss-cli": "^4.1.1",
     "postcss-import": "^11.0.0",
     "postcss-url": "^7.2.1",

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -37,7 +37,7 @@ export function timelineConfig(models, config, ui) {
         dateInterval = d3.time.year.utc;
         tickCount = tl.data.end()
           .getUTCFullYear() - tl.data.start()
-            .getUTCFullYear();
+          .getUTCFullYear();
         tickWidth = 15;
         tickCountMax = Math.ceil(tl.width / tickWidth);
 

--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -370,7 +370,7 @@ export function imagePanel (models, ui, config, dialogConfig) {
       .offset();
     var left = offset.left + parseInt($('#' + alignTo.id)
       .css('width')) - parseInt($('#' + id)
-        .css('width'));
+      .css('width'));
     $('#' + id)
       .css('left', left + 'px');
   };


### PR DESCRIPTION
Fixes #828

Changes in this pull request:

- Changes `phantomjs` depreciated package to `phantomjs-prebuilt`
- Fixes lint errors

@nasa-gibs/worldview
