### PR TITLE
Pass filetype to react component when updated 

### DIFF
--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -144,7 +144,8 @@ export function imagePanel (models, ui, config, dialogConfig) {
       imgHeight: imgHeight,
       imgWidth: imgWidth,
       resolutions: resolutions,
-      fileTypes: fileTypes
+      fileTypes: fileTypes,
+      fileType: imgFormat
     };
   };
   var renderPanel = function(options, mountEl) {


### PR DESCRIPTION
Fixes #851 .
* Bug was likely introduced by an update to react

Changes in this pull request:
- [x] Pass filetype to react component when updated 

@nasa-gibs/worldview
