### PR TITLE
Add a Worldview client identifier in CMR requests

### DIFF
--- a/web/js/data/cmr.js
+++ b/web/js/data/cmr.js
@@ -15,6 +15,9 @@ export function dataCmrClient(spec) {
 
   var ajaxOptions = {
     url: 'https://cmr.earthdata.nasa.gov/search/',
+    headers: {
+      'Client-Id': 'Worldview'
+    },
     traditional: true,
     dataType: 'json',
     timeout: QUERY_TIMEOUT


### PR DESCRIPTION
Fixes #880.

Changes in this pull request:

- "Client-Id: Worldview" now added to CMR requests.

@nasa-gibs/worldview
