### PR TITLE
Margin on subheading in layer list

### DIFF
--- a/web/css/layers.modal.css
+++ b/web/css/layers.modal.css
@@ -393,6 +393,7 @@
   line-height: 100%;
   font-weight: 400;
   margin-top: 3px;
+  margin-right: 50px;
   font-style: italic;
 }
 


### PR DESCRIPTION
Fixes #888.

Changes in this pull request:

- Placed margin on subheading in layer list to prevent overflow with the button

@nasa-gibs/worldview
