### PR TITLE
Ignore offline granules in data download

### DIFF
--- a/doc/data_download.md
+++ b/doc/data_download.md
@@ -167,6 +167,10 @@ Creates a index value by combining the MODIS H and V tile numbers.
 
 Creates a label for this granule based on the MODIS H and V tile numbers.
 
+### OfflineFilter
+
+Filters out granules that are not available for download.
+
 ### OrbitFilter
 
 Filter by ascending or descending orbit. Configure with `orbit` with the

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -31,7 +31,8 @@ import {
   dataResultsGeometryFromMODISGrid,
   dataResultsModisGridLabel,
   dataResultsOrbitFilter,
-  dataResultsDividePolygon
+  dataResultsDividePolygon,
+  dataResultsOfflineFilter
 } from './results';
 
 export function dataHandlerGetByName(name) {
@@ -156,6 +157,7 @@ export function dataHandlerModisSwathMultiDay(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagNRT(productConfig.nrt),
       dataResultsTagURS(productConfig.urs),
@@ -230,6 +232,7 @@ export function dataHandlerCollectionList(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagList(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagURS(productConfig.urs),
@@ -334,6 +337,7 @@ export function dataHandlerList(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagList(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagNRT(productConfig.nrt),
@@ -391,6 +395,7 @@ export function dataHandlerDailyAMSRE(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagList(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagURS(productConfig.urs),
@@ -446,6 +451,7 @@ export function dataHandlerModisGrid(config, model, spec) {
 
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagVersion(),
       dataResultsTagURS(productConfig.urs),
@@ -568,6 +574,7 @@ export function dataHandlerModisSwath(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagNRT(productConfig.nrt),
       dataResultsTagURS(productConfig.urs),
@@ -617,6 +624,7 @@ export function dataHandlerHalfOrbit(config, model, spec) {
     var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
+      dataResultsOfflineFilter(),
       dataResultsOrbitFilter(productConfig.orbit),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagNRT(productConfig.nrt),

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -456,6 +456,21 @@ export function dataResultsGeometryFromMODISGrid(projection) {
   return self;
 };
 
+export function dataResultsOfflineFilter() {
+  var self = {};
+
+  self.name = 'OfflineFilter';
+
+  self.process = function (meta, granule) {
+    if (granule.online_access_flag === false) {
+      return null;
+    }
+    return granule;
+  };
+
+  return self;
+};
+
 export function dataResultsModisGridIndex() {
   var self = {};
 


### PR DESCRIPTION
Fixes #898.

Changes in this pull request:

- Granules that are not available for download are no longer displayed in data download. 

@nasa-gibs/worldview
