### PR TITLE
WELD data download handler

### DIFF
--- a/doc/data_download.md
+++ b/doc/data_download.md
@@ -66,6 +66,7 @@ grid tiles.
 on the map.
 * `TerraSwathMultiDay`: Use for Terra 5-minute data granules where today,
 yesterday, and tomorrow appear together on the same map.
+* `WELDGranuleFootprints`: Use for the WELD product.
 
 ## Query Parameters
 
@@ -205,6 +206,12 @@ otherwise keeps science-quality granules if `science`.
 
 Sets the label of the granule to the `name` provided in the constructor.
 
+### TagButtonScale
+
+Sets a scale value for the granule selection buttons. Useful for making the
+buttons smaller for dense datasets. For example, WELD uses a value of
+0.35.
+
 ### TagList
 
 Forces the results to display in a dialog box list instead of on the map.
@@ -267,6 +274,10 @@ in degrees, is considered to have crossed the anti-meridian.
 
 Creates a label for this granule based on its acquisition time only. Times
 that are not from the selected day are indicated with + or - day indicators.
+
+### TitleLabel
+
+Use the provided title in the metadata as the granule label.
 
 ### Transform
 

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -793,10 +793,9 @@ export function dataHandlerWeldGranuleFootprints(config, model, spec) {
       granules: data
     };
 
-    // var productConfig = config.products[model.selectedProduct];
     var chain = dataResultsChain();
     chain.processes = [
-      dataResultsTagButtonScale(0.35),
+      dataResultsTagButtonScale(0.35), // standard button size is too big
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagVersion(),
       dataResultsGeometryFromCMR(),

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -7,6 +7,7 @@ import brand from '../brand';
 import { CRS_WGS_84_QUERY_EXTENT, CRS_WGS_84 } from '../map/map';
 import {
   dataResultsChain,
+  dataResultsTagButtonScale,
   dataResultsTagProduct,
   dataResultsTagNRT,
   dataResultsTagURS,
@@ -49,7 +50,8 @@ export function dataHandlerGetByName(name) {
     'TerraSwathMultiDay': dataHandlerTerraSwathMultiDay,
     'HalfOrbit': dataHandlerHalfOrbit,
     'VIIRSSwathDay': dataHandlerVIIRSSwathDay,
-    'VIIRSSwathNight': dataHandlerVIIRSSwathNight
+    'VIIRSSwathNight': dataHandlerVIIRSSwathNight,
+    'WELDGranuleFootprints': dataHandlerWELDGranuleFootprints
   };
   var handler = map[name];
   if (!handler) {
@@ -769,5 +771,40 @@ export function dataHandlerVIIRSSwathNight(config, model) {
   };
 
   init();
+  return self;
+};
+
+export function dataHandlerWELDGranuleFootprints(config, model, spec) {
+  var self = dataHandlerBase(config, model);
+
+  self._submit = function (queryData) {
+    var queryOptions = {
+      time: model.time,
+      data: queryData
+    };
+
+    return self.cmr.submit(queryOptions);
+  };
+
+  self._processResults = function (data) {
+    var results = {
+      meta: {},
+      granules: data
+    };
+
+    // var productConfig = config.products[model.selectedProduct];
+    var chain = dataResultsChain();
+    chain.processes = [
+      dataResultsTagButtonScale(0.35),
+      dataResultsTagProduct(model.selectedProduct),
+      dataResultsTagVersion(),
+      dataResultsGeometryFromCMR(),
+      dataResultsDensify(),
+      dataResultsTransform(model.crs),
+      dataResultsExtentFilter(model.crs, self.extents[model.crs])
+    ];
+    return chain.process(results);
+  };
+
   return self;
 };

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -33,7 +33,8 @@ import {
   dataResultsModisGridLabel,
   dataResultsOrbitFilter,
   dataResultsDividePolygon,
-  dataResultsOfflineFilter
+  dataResultsOfflineFilter,
+  dataResultsTitleLabel
 } from './results';
 
 export function dataHandlerGetByName(name) {
@@ -801,7 +802,8 @@ export function dataHandlerWELDGranuleFootprints(config, model, spec) {
       dataResultsGeometryFromCMR(),
       dataResultsDensify(),
       dataResultsTransform(model.crs),
-      dataResultsExtentFilter(model.crs, self.extents[model.crs])
+      dataResultsExtentFilter(model.crs, self.extents[model.crs]),
+      dataResultsTitleLabel()
     ];
     return chain.process(results);
   };

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -52,7 +52,7 @@ export function dataHandlerGetByName(name) {
     'HalfOrbit': dataHandlerHalfOrbit,
     'VIIRSSwathDay': dataHandlerVIIRSSwathDay,
     'VIIRSSwathNight': dataHandlerVIIRSSwathNight,
-    'WELDGranuleFootprints': dataHandlerWELDGranuleFootprints
+    'WELDGranuleFootprints': dataHandlerWeldGranuleFootprints
   };
   var handler = map[name];
   if (!handler) {
@@ -775,7 +775,7 @@ export function dataHandlerVIIRSSwathNight(config, model) {
   return self;
 };
 
-export function dataHandlerWELDGranuleFootprints(config, model, spec) {
+export function dataHandlerWeldGranuleFootprints(config, model, spec) {
   var self = dataHandlerBase(config, model);
 
   self._submit = function (queryData) {

--- a/web/js/data/map.js
+++ b/web/js/data/map.js
@@ -39,7 +39,7 @@ export function dataMap(model, maps, config) {
   };
 
   var buttonStyle = function (feature) {
-    var dimensions = getButtonDimensions();
+    var dimensions = getButtonDimensions(feature);
     var image;
     if (model.isSelected(feature.granule)) {
       image = 'images/data.minus-button.png';
@@ -56,7 +56,7 @@ export function dataMap(model, maps, config) {
   };
 
   var hoverStyle = function (feature) {
-    var dimensions = getButtonDimensions();
+    var dimensions = getButtonDimensions(feature);
     var offset = -(dimensions.size / 2.0 + 14);
     var textStyle = new OlStyleText({
       exceedLength: true,
@@ -385,7 +385,7 @@ export function dataMap(model, maps, config) {
       .clear();
   };
 
-  var getButtonDimensions = function () {
+  var getButtonDimensions = function (feature) {
     var zoom = map.getView()
       .getZoom();
     // Minimum size of the button is 15 pixels
@@ -393,7 +393,9 @@ export function dataMap(model, maps, config) {
     // Double the size for each zoom level
     var add = Math.pow(2, zoom);
     // But 47 pixels is the maximum size
-    var size = Math.min(base + add, base + 32);
+    var buttonScale = feature.granule.buttonScale || 1;
+    var size = (base + add) * buttonScale;
+    size = Math.min(size, base + 32);
     return {
       scale: size / 48,
       size: size

--- a/web/js/data/map.js
+++ b/web/js/data/map.js
@@ -392,9 +392,10 @@ export function dataMap(model, maps, config) {
     var base = 12;
     // Double the size for each zoom level
     var add = Math.pow(2, zoom);
-    // But 47 pixels is the maximum size
+    // Apply size adjustment to the button if specified by TagButtonScale
     var buttonScale = feature.granule.buttonScale || 1;
     var size = (base + add) * buttonScale;
+    // But 44 pixels is the maximum size
     size = Math.min(size, base + 32);
     return {
       scale: size / 48,

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -578,6 +578,19 @@ export function dataResultsProductLabel(name) {
   return self;
 };
 
+export function dataResultsTagButtonScale(scale) {
+  var self = {};
+
+  self.name = 'TagButtonScale';
+
+  self.process = function (meta, granule) {
+    granule.buttonScale = scale;
+    return granule;
+  };
+
+  return self;
+};
+
 export function dataResultsTagList(spec) {
   var self = {};
 

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -799,6 +799,19 @@ export function dataResultsTimeLabel(time) {
   return self;
 };
 
+export function dataResultsTitleLabel() {
+  var self = {};
+
+  self.name = 'TitleLabel';
+
+  self.process = function (meta, granule) {
+    granule.label = granule.title || '';
+    return granule;
+  };
+
+  return self;
+};
+
 export function dataResultsTransform(projection) {
   var self = {};
 
@@ -861,3 +874,4 @@ export function dataResultsVersionFilterExact(version) {
 
   return self;
 };
+

--- a/web/js/data/ui.js
+++ b/web/js/data/ui.js
@@ -522,7 +522,7 @@ var dataUiDownloadListPanel = function (config, model) {
 
     $dialog.dialog({
       title: 'Download Links',
-      width: 600,
+      width: 650,
       height: 500,
       autoOpen: false
     });


### PR DESCRIPTION
## Description

Fixes #132.

- Update the data download handler for the following products:
  - Landsat_WELD_CONUS_5_Year_Tree_Cover: C1000000340-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Annual: C1000000080-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Monthly: C1000000082-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_Alaska_Seasonal: C1000000100-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Annual: C1000000081-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Monthly: C1000000085-LPDAAC_ECS
  - Landsat_WELD_CorrectedReflectance_TrueColor_CONUS_Seasonal: C1000000083-LPDAAC_ECS
- Add scale factor handler to change the size of data download buttons
- Add handler to label granules by metadata title
- Widen download dialog box
 
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
