### PR TITLE
Allow subdaily max date to extend to "now" local time

### DIFF
--- a/web/js/date/model.js
+++ b/web/js/date/model.js
@@ -11,7 +11,7 @@ export function dateModel(config, spec) {
     'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
 
   var init = function () {
-    var initial = spec.initial || util.today();
+    var initial = spec.initial || util.now();
     self.select(initial);
   };
 
@@ -35,8 +35,14 @@ export function dateModel(config, spec) {
   };
 
   self.clamp = function (date) {
-    if (date > util.today()) {
-      date = util.today();
+    if (self.maxZoom > 3) {
+      if (date > util.now()) {
+        date = util.now();
+      }
+    } else {
+      if (date > util.today()) {
+        date = util.today();
+      }
     }
     if (config.startDate) {
       let startDate = util.parseDateUTC(config.startDate);
@@ -48,8 +54,14 @@ export function dateModel(config, spec) {
   };
 
   self.isValid = function (date) {
-    if (date > util.today()) {
-      return false;
+    if (self.maxZoom > 3) {
+      if (date > util.now()) {
+        return false;
+      }
+    } else {
+      if (date > util.today()) {
+        return false;
+      }
     }
     if (config.startDate) {
       let startDate = util.parseDateUTC(config.startDate);
@@ -68,7 +80,7 @@ export function dateModel(config, spec) {
   };
 
   self.maxDate = function () {
-    return util.today();
+    return util.now();
   };
 
   self.maxZoom = null;

--- a/web/js/date/timeline-data.js
+++ b/web/js/date/timeline-data.js
@@ -13,8 +13,8 @@ export function timelineData(models, config, ui) {
 
   self.end = function () {
     return new Date(
-      new Date(util.today())
-        .setUTCDate(util.today()
+      new Date(util.now())
+        .setUTCDate(util.now()
           .getUTCDate()));
   };
 

--- a/web/js/date/timeline-input.js
+++ b/web/js/date/timeline-input.js
@@ -37,7 +37,7 @@ export function timelineInput(models, config, ui) {
     self.delta = 1;
     var nextDay = new Date(new Date(model.selected)
       .setUTCDate(model.selected.getUTCDate() + 1));
-    if (nextDay <= util.today()) {
+    if (nextDay <= util.now()) {
       animateForward('day', 1);
     } else {
       self.stop();
@@ -48,7 +48,7 @@ export function timelineInput(models, config, ui) {
     self.delta = 1;
     var nextMonth = new Date(new Date(model.selected)
       .setUTCMonth(model.selected.getUTCMonth() + 1));
-    if (nextMonth <= util.today()) {
+    if (nextMonth <= util.now()) {
       animateForward('month', 1);
     } else {
       self.stop();
@@ -59,7 +59,7 @@ export function timelineInput(models, config, ui) {
     self.delta = 1;
     var nextYear = new Date(new Date(model.selected)
       .setUTCFullYear(model.selected.getUTCFullYear() + 1));
-    if (nextYear <= util.today()) {
+    if (nextYear <= util.now()) {
       animateForward('year', 1);
     } else {
       self.stop();
@@ -281,7 +281,7 @@ export function timelineInput(models, config, ui) {
           break;
       }
       if ((selectedDateObj > tl.data.start()) &&
-        (selectedDateObj <= util.today())) {
+        (selectedDateObj <= util.now())) {
         var parent = selected.parent();
         var sib = parent.next('div.input-wrapper.selectable')
           .find('input.button-input-group');
@@ -384,9 +384,9 @@ export function timelineInput(models, config, ui) {
     }
 
     // Disable arrows if nothing before/after selection
-    if ((model.selectedZoom === 4) && ms >= util.today()) {
+    if ((model.selectedZoom === 4) && ms >= util.now()) {
       $incrementBtn.addClass('button-disabled');
-    } else if ((model.selectedZoom !== 4) && nd > util.today()) {
+    } else if ((model.selectedZoom !== 4) && nd > util.now()) {
       $incrementBtn.addClass('button-disabled');
     } else {
       $incrementBtn.removeClass('button-disabled');

--- a/web/js/date/wheels.js
+++ b/web/js/date/wheels.js
@@ -116,7 +116,7 @@ var dateWheels = function(models, config) {
 
   var updateRange = function () {
     var startDate = util.parseDateUTC(config.startDate);
-    var endDate = util.today();
+    var endDate = util.now();
     $('#linkmode')
       .mobiscroll('option', 'disabled', false);
     $('#linkmode')

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -107,7 +107,7 @@ export function layersModel(models, config) {
     if (ignoreRange) {
       return {
         start: new Date(Date.UTC(1970, 0, 1)),
-        end: util.today()
+        end: util.now()
       };
     }
     var min = Number.MAX_VALUE;
@@ -129,20 +129,20 @@ export function layersModel(models, config) {
         max = Math.max(max, end);
       } else if (def.endDate) {
         range = true;
-        max = util.today()
+        max = util.now()
           .getTime();
       }
       // If there is a start date but no end date, this is a
       // product that is currently being created each day, set
       // the max day to today.
       if (def.startDate && !def.endDate) {
-        max = util.today()
+        max = util.now()
           .getTime();
       }
     });
     if (range) {
       if (max === 0) {
-        max = util.today()
+        max = util.now()
           .getTime();
       }
       return {


### PR DESCRIPTION
## Description

Fixes #924

This pull request allows subdaily layers to be viewed up until the current local time rather than to today at 00:00.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

@nasa-gibs/worldview
