### PR TITLE
fix vertical align for list items in data download - fixes #864

### DIFF
--- a/web/css/dataDownload.css
+++ b/web/css/dataDownload.css
@@ -62,6 +62,7 @@
 
 #wv-data-selection td {
   border-bottom: 1px solid #404040;
+  vertical-align: middle;
   padding: 5px;
 }
 


### PR DESCRIPTION
## Description

Fixes #864  .

- List items in unordered list not vertically aligned in ie11/edge (see images below)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I wanted to show some before/after screenshots:

**BEFORE:**
![before-a](https://user-images.githubusercontent.com/24417194/39487210-6c35ba70-4d4c-11e8-9b32-c152f0d1b999.png)
**AFTER:**
![after-a](https://user-images.githubusercontent.com/24417194/39487218-70c72d12-4d4c-11e8-8d37-b65faf2f0e83.png)

With multi-item lists, the middle alignment is more obvious:

**BEFORE:**
![before-b](https://user-images.githubusercontent.com/24417194/39487272-a5cb67bc-4d4c-11e8-9281-9e7bc5a39fac.png)
**AFTER:**
![after-b](https://user-images.githubusercontent.com/24417194/39487279-a9de071a-4d4c-11e8-95b3-f2d3ff629329.png)

@nasa-gibs/worldview
