### PR TITLE
Update image download parameters on projection change

### DIFF
--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -109,6 +109,7 @@ export function imagePanel (models, ui, config, dialogConfig) {
     };
 
     self.reactComponent = renderPanel(options, htmlElements);
+    models.proj.events.on('select', setProjectionGlobals);
   };
   var setProjectionGlobals = function() {
     if (models.proj.selected.id === 'geographic') {


### PR DESCRIPTION
## Description

Fixes #957.

In image download, projection dependent information was only been set during initialization. Update it when the projection changes. 

- Update image download parameters on projection change. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Lint and unit tests pass locally with my changes (`npm run test`)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
