### PR TITLE
Top half of the animation picker is now selectable

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -389,8 +389,6 @@ g.plot rect.data-bar-invisible {
 
 #timeline-footer > svg {
   overflow-y: hidden;
-  margin-top: -32px;
-  padding-top: 16px;
 }
 
 #wv-rangeselector-case > .wv-timeline-range-selector {


### PR DESCRIPTION
## Description

Fixes #972.

- Top half of the animation picker is now selectable

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

I'm not sure why that styling was there to begin with. Does this break something else? 

@nasa-gibs/worldview
