### PR TITLE
Update RPM to build on el7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -238,9 +238,6 @@ module.exports = function(grunt) {
             from: '@BUILD_VERSION@',
             to: '<%=pkg.version%>'
           }, {
-            from: '@BUILD_RELEASE@',
-            to: '<%=pkg.release%>'
-          }, {
             from: '@BUILD_NUMBER@',
             to: buildNumber
           }

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,15 +1,8 @@
-Alias /labs/@WORLDVIEW@/var /var/lib/@WORLDVIEW@
-Alias /labs/@WORLDVIEW@ /usr/share/@WORLDVIEW@/web
-
-AddHandler cgi-script .cgi
+Alias /@WORLDVIEW@ /usr/share/@WORLDVIEW@/web
 
 <Directory /usr/share/@WORLDVIEW@/web>
-    AllowOverride All
-    Order allow,deny
-    Allow from all
+    Require all granted
 </Directory>
 
-<Directory /usr/share/@WORLDVIEW@/web/service>
-    Options ExecCGI
-</Directory>
+
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "scripts": {
     "browserstack": "node e2e/browserstack.js -c e2e/browserstack.conf.js -e browserstack --skiptags wip",
     "build": "rm -rf build && run-s \"getcapabilities -- {1}\" \"build:config -- {1}\" --",
-    "postbuild": "run-p build:css build:js build:tests && grunt build site",
+    "postbuild": "run-p build:css build:js build:tests && npx grunt build site",
     "build:css": "node ./tasks/buildCSS",
     "build:config": "bash -c 'tasks/buildOptions.sh ${1}' 0",
-    "postbuild:config": "grunt config",
+    "postbuild:config": "npx grunt config",
     "build:js": "node ./tasks/buildJS",
     "build:tests": "node ./tasks/buildJS --tests",
     "e2e": "run-s --continue-on-error --silent e2e:*",

--- a/tasks/buildAll.sh
+++ b/tasks/buildAll.sh
@@ -8,14 +8,5 @@ rm -rf build dist node_modules .python web/build
 npm install --production=false # Install dependencies, set production false so devDependencies are installed even though NODE_ENV is set to production
 npm run build # Build the app
 
-# Prepare rpm sources
-mkdir -p build/rpm/{SOURCES,SPECS}
-cp worldview.spec build/rpm/SPECS
-cp dist/*.tar.bz2 build/rpm/SOURCES
-cp *.conf build/rpm/SOURCES
+tasks/buildRPM.sh
 
-# Replace placeholders in rpm spec
-grunt rpm-placeholders
-
-# Build rpm
-rpmbuild --define "_topdir $PWD/build/rpm" -ba build/rpm/SPECS/worldview.spec

--- a/tasks/buildRPM.sh
+++ b/tasks/buildRPM.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Prepare rpm sources
+mkdir -p build/rpm/{SOURCES,SPECS}
+cp worldview.spec build/rpm/SPECS
+cp dist/*.tar.bz2 build/rpm/SOURCES
+cp *.conf build/rpm/SOURCES
+
+# Replace placeholders in rpm spec
+npx grunt rpm-placeholders
+
+# Build rpm
+rpmbuild --define "_topdir $PWD/build/rpm" -ba build/rpm/SPECS/worldview.spec

--- a/worldview.spec
+++ b/worldview.spec
@@ -1,6 +1,6 @@
 Name: @WORLDVIEW@
 Version: @BUILD_VERSION@
-Release: 0.@BUILD_NUMBER@%{?dist}
+Release: 1.@BUILD_NUMBER@%{?dist}
 Summary: Browse full-resolution, near real-time satellite imagery.
 License: NASA-1.3
 URL: http://earthdata.nasa.gov

--- a/worldview.spec
+++ b/worldview.spec
@@ -1,6 +1,6 @@
 Name: @WORLDVIEW@
 Version: @BUILD_VERSION@
-Release: @BUILD_RELEASE@.@BUILD_NUMBER@%{?dist}
+Release: 0.@BUILD_NUMBER@%{?dist}
 Summary: Browse full-resolution, near real-time satellite imagery.
 License: NASA-1.3
 URL: http://earthdata.nasa.gov
@@ -68,28 +68,29 @@ rm -rf %{buildroot}
 
 %post
 if [ $1 -gt 0 ] ; then
-   if /sbin/service httpd status >/dev/null ; then
-      /sbin/service httpd reload
+   if /bin/systemctl show httpd.service | grep ActiveState=active >/dev/null ; then
+      /bin/systemctl reload httpd.service
    fi
 fi
 
 %post debug
 if [ $1 -gt 0 ] ; then
-   if /sbin/service httpd status >/dev/null ; then
-       /sbin/service httpd reload
+   if /bin/systemctl show httpd.service | grep ActiveState=active >/dev/null ; then
+      /bin/systemctl reload httpd.service
    fi
 fi
 
 %postun
-if [ $1 -eq 0 ] ; then
-   if /sbin/service httpd status >/dev/null ; then
-       /sbin/service httpd reload
+if [ $1 -gt 0 ] ; then
+   if /bin/systemctl show httpd.service | grep ActiveState=active >/dev/null ; then
+      /bin/systemctl reload httpd.service
    fi
 fi
 
 %postun debug
-if [ $1 -eq 0 ] ; then
-   if /sbin/service httpd status >/dev/null ; then
-       /sbin/service httpd reload
+if [ $1 -gt 0 ] ; then
+   if /bin/systemctl show httpd.service | grep ActiveState=active >/dev/null ; then
+      /bin/systemctl reload httpd.service
    fi
 fi
+


### PR DESCRIPTION
## Description

Fixes #883.

Update RPM build to build on Red Hat Enterprise Linux 7 and CentOS 7.

- Use systemctl instead of service
- Fix bug where release was not being filled in. Set to zero. 
- Split out buildRPM.sh from buildAll.sh 
- Use npx for grunt instead of using a global version 
- Root Worldview at /worldview instead of /labs/worldview
- Remove CGI handler
- Update apache config to use "Require all granted" syntax

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
