### PR TITLE
Travis builds no longer hang and timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ node_js:
 before_install: npm install -g grunt-cli
 install: npm install
 before_script: npm run build:tests
+cache:
+  directories:
+    - node_modules
+    - .python

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:server": "buster-server -c",
     "test:run": "sleep 2 && buster-test && npm run test:end",
     "test:end": "run-script-os",
-    "test:end:darwin:linux": "pkill -f buster-server",
+    "test:end:darwin:linux": "pkill -f run-p",
     "test:end:win32": "tskill node",
     "updateconfig": "run-s getcapabilities build:config",
     "watch": "bash -c 'WORLDVIEW_WATCH='active' npm-watch'"


### PR DESCRIPTION
## Description

Fixes #1002 and #1001.

pkill was not killing buster-server and because of this run-p was never exiting causing the build to hang. While pkill will not kill itself, it was wrapped in another process and its parent was being killed which then kills itself before killing buster-server. This change kills run-p instead. 

To speed up testing, caching of node_modules and .python was added. Seems to work well. 

- pkill run-p instead of buster-server
- cache node_modules and .python between builds

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
