### PR TITLE
Data download: Version number by regular expression

### DIFF
--- a/doc/data_download.md
+++ b/doc/data_download.md
@@ -258,6 +258,20 @@ configuration parameters.
 Parse out the version field into a numeric value that can used for comparison
 operations.
 
+### TagVersionRegex
+
+Use a regular expression to parse out a version into a numeric value that can
+used for comparison operations. Parameters:
+
+* `field`: The name of the field that contains the version
+* `namedRegex`: Use `MODISProducerGranuleID` to parse out the version from a
+MODIS producer granule ID in the form of
+`MOD04_L2.A2016137.2105.061.2017326151115.hdf`
+* `regex`: If `namedRegex` is not used, a regular expression used to extract
+the version
+* `parseVersion`: Use `MODIS` to multiply version numbers below 10 by 10. This
+changes MODIS version numbers from 5, 51, 6, 61 to 50, 51, 60, 61.
+
 ### TimeFilter
 
 Keep granules that meet the following values passed into the `spec`

--- a/web/js/data/handler.js
+++ b/web/js/data/handler.js
@@ -34,7 +34,8 @@ import {
   dataResultsOrbitFilter,
   dataResultsDividePolygon,
   dataResultsOfflineFilter,
-  dataResultsTitleLabel
+  dataResultsTitleLabel,
+  dataResultsTagVersionRegex
 } from './results';
 
 export function dataHandlerGetByName(name) {
@@ -169,6 +170,7 @@ export function dataHandlerModisSwathMultiDay(config, model, spec) {
       dataResultsCollectPreferred(model.prefer),
       dataResultsPreferredFilter(model.prefer),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
       dataResultsGeometryFromCMR(),
@@ -242,6 +244,7 @@ export function dataHandlerCollectionList(config, model, spec) {
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagURS(productConfig.urs),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
       dataResultsProductLabel(config.products[model.selectedProduct].name)
@@ -350,6 +353,7 @@ export function dataHandlerList(config, model, spec) {
       dataResultsCollectPreferred(model.prefer),
       dataResultsPreferredFilter(model.prefer),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
       dataResultsDateTimeLabel(model.time)
@@ -405,6 +409,7 @@ export function dataHandlerDailyAMSRE(config, model, spec) {
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagURS(productConfig.urs),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsVersionFilterExact(productConfig.version),
       dataResultsDateTimeLabel(model.time)
     ];
@@ -459,6 +464,7 @@ export function dataHandlerModisGrid(config, model, spec) {
       dataResultsOfflineFilter(),
       dataResultsTagProduct(model.selectedProduct),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsTagURS(productConfig.urs),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
@@ -586,6 +592,7 @@ export function dataHandlerModisSwath(config, model, spec) {
       dataResultsCollectPreferred(model.prefer),
       dataResultsPreferredFilter(model.prefer),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
       dataResultsGeometryFromCMR(),
@@ -637,6 +644,7 @@ export function dataHandlerHalfOrbit(config, model, spec) {
       dataResultsCollectPreferred(model.prefer),
       dataResultsPreferredFilter(model.prefer),
       dataResultsTagVersion(),
+      dataResultsTagVersionRegex(productConfig.tagVersionRegex),
       dataResultsCollectVersions(),
       dataResultsVersionFilter(),
       dataResultsGeometryFromCMR(),

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -714,6 +714,10 @@ var versionRegex = {
 };
 
 var versionParsers = {
+  // MODIS uses version numbers like 4, 5, 6 as major versions but
+  // 41, 51, 61 for minor versions. This function multiplies values
+  // less than 10 for easy comparision (40, 41, 50, 51, 60, 61).
+  // Will there ever be a collection 10?
   'MODIS': (strVersion) => {
     var version = Number.parseFloat(strVersion);
     if (version < 10) {

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -707,6 +707,51 @@ export function dataResultsTagVersion() {
   return self;
 };
 
+const versionParsers = {
+  'ParseMODISVersion': (strVersion) => {
+    let version = Number.parseFloat(strVersion);
+    if (version < 10) {
+      version *= 10;
+    }
+    return version;
+  }
+};
+
+export function dataResultsTagVersionRegex(spec) {
+  var self = {};
+
+  self.name = 'TagVersionRegex';
+
+  self.process = function (meta, granule) {
+    if (!spec) {
+      return granule;
+    }
+    const match = granule[spec.field].match(spec.regex);
+    let version;
+    if (match) {
+      let strVersion = match[1];
+      if (spec.parseVersion) {
+        const parser = versionParsers[spec.parseVersion];
+        if (!parser) {
+          console.warn('no such parser', spec.parseVersion);
+          return granule;
+        }
+        version = parser(strVersion);
+      } else {
+        version = Number.parseFloat(strVersion);
+      }
+      if (Number.isNaN(version)) {
+        console.warn('version is not a number', strVersion, granule);
+      } else {
+        granule.version = version;
+      }
+    }
+    return granule;
+  };
+
+  return self;
+}
+
 export function dataResultsTimeFilter(spec) {
   var westZone = null;
   var eastZone = null;

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -708,6 +708,8 @@ export function dataResultsTagVersion() {
 };
 
 var versionRegex = {
+  // Form of MOD04_L2.A2016137.2105.061.2017326151115.hdf
+  // Using periods as delimiters, version is the 4th field
   'MODISProducerGranuleID': '[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+)\\.'
 };
 

--- a/web/js/data/results.js
+++ b/web/js/data/results.js
@@ -707,13 +707,13 @@ export function dataResultsTagVersion() {
   return self;
 };
 
-const versionRegex = {
+var versionRegex = {
   'MODISProducerGranuleID': '[^\\.]+\\.[^\\.]+\\.[^\\.]+\\.([^\\.]+)\\.'
 };
 
-const versionParsers = {
+var versionParsers = {
   'MODIS': (strVersion) => {
-    let version = Number.parseFloat(strVersion);
+    var version = Number.parseFloat(strVersion);
     if (version < 10) {
       version *= 10;
     }
@@ -731,7 +731,7 @@ export function dataResultsTagVersionRegex(spec) {
     if (!spec) {
       return granule;
     }
-    let regex = versionRegex[spec.namedRegex];
+    var regex = versionRegex[spec.namedRegex];
     if (!regex) {
       regex = spec.regex;
     }
@@ -739,18 +739,18 @@ export function dataResultsTagVersionRegex(spec) {
       console.warn('no regex', granule);
       return granule;
     }
-    const value = granule[spec.field];
+    var value = granule[spec.field];
     if (!value) {
       console.warn(`no value for ${spec.field}`, granule);
       return granule;
     }
-    const match = value.match(regex);
+    var match = value.match(regex);
     if (match) {
-      let version = null;
-      let strVersion = match[1];
+      var version = null;
+      var strVersion = match[1];
       // If a parsing function is not named, just convert from float
       if (spec.parseVersion) {
-        const parser = versionParsers[spec.parseVersion];
+        var parser = versionParsers[spec.parseVersion];
         if (!parser) {
           console.warn('no such parser', spec.parseVersion);
           return granule;


### PR DESCRIPTION
## Description

Fixes #982.

- Add a results processor to tag version numbers by regular expression.
- Add a named regular expression for MODISProducerGranuleID 
- Add a version parsers for MODIS to multiply version numbers below 10 by 10. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [X] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
