### PR TITLE
Image download and GIF bug fixes

### DIFF
--- a/web/js/animation/gif-stream.js
+++ b/web/js/animation/gif-stream.js
@@ -172,7 +172,7 @@ export default class GifStream {
         delay = (processedImages === totalImages && options.extraLastFrameDelay) ? delay + (options.extraLastFrameDelay / 10) : delay;// Add an extra
         ctx = self.addFrameDetails(ctx, frame);
         imgData = ctx.getImageData(0, 0, width, height);
-        rgbComponents = dataToRGB(imgData.data, imgData.height, imgData.height);
+        rgbComponents = dataToRGB(imgData.data, imgData.width, imgData.height);
         nq = new NeuQuant(rgbComponents, rgbComponents.length, 15);
         paletteRGB = nq.process();
         paletteArray = new Uint32Array(componentizedPaletteToArray(paletteRGB));

--- a/web/js/animation/gif-stream.js
+++ b/web/js/animation/gif-stream.js
@@ -135,6 +135,7 @@ export default class GifStream {
       img.delay = frame.delay;
       img.crossOrigin = 'Anonymous';
       img.onload = () => {
+        URL.revokeObjectURL(img.src); // Free up some memory
         resolve(img);
         delete img.onload;
         delete img.onerror;

--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -371,7 +371,7 @@ export function animationGif(models, config, ui) {
         onOk: function() {
           resetRotation();
           // Let rotation finish before reselecting can occur
-          setImageCoords();
+          setTimeout(setImageCoords, 500);
         }
       });
       return;

--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -112,7 +112,11 @@ export function imagePanel (models, ui, config, dialogConfig) {
     models.proj.events.on('select', setProjectionGlobals);
   };
   var setProjectionGlobals = function() {
-    if (models.proj.selected.id === 'geographic') {
+    var isGeoProjection = (models.proj.selected.id === 'geographic');
+    var curZoom = Math.round(ui.map.selected.getView()
+      .getZoom());
+    imgRes = imageUtilCalculateResolution(curZoom, isGeoProjection, models.proj.selected.resolutions);
+    if (isGeoProjection) {
       resolutions = resolutionsGeo;
       fileTypes = fileTypesGeo;
     } else {
@@ -213,6 +217,7 @@ export function imagePanel (models, ui, config, dialogConfig) {
     $('.wv-image-coords')
       .show();
   };
+
   self.update = function(c) {
     try {
       let pixels, map, px, x1, y1, x2, y2, crs;


### PR DESCRIPTION
## Description

Fixes #1011, fixes #1013 .
- [x] The GIF-stream class now uses the actual dimensions of the imagery provided instead overwriting that with parameter dimensions.
- [x] Bug with Image download when app is loaded pre-rotated
- [x] White bar at bottom of high res GIF
- [x] Bug with GIF creation when app is loaded pre-rotated

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview