### PR TITLE
Fix cut off animation-dragger svg stroke

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -390,6 +390,7 @@ g.plot rect.data-bar-invisible {
 
 #timeline-footer > svg {
   overflow-y: hidden;
+  margin-top: -23px;
 }
 
 #wv-rangeselector-case > .wv-timeline-range-selector {

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -99,7 +99,8 @@ export function timeline(models, config, ui) {
     if (self.enabled) {
       self.getWidth();
 
-      self.svg.attr('width', self.width);
+      self.svg.attr('width', self.width)
+        .attr('viewBox', '0 -7 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
 
       d3.select('#timeline-boundary rect')
         .attr('width', self.width);
@@ -133,7 +134,8 @@ export function timeline(models, config, ui) {
     self.svg = d3.select('#timeline-footer')
       .append('svg:svg')
       .attr('width', self.width) // + margin.left + margin.right)
-      .attr('height', self.height + self.margin.top + self.margin.bottom + 32);
+      .attr('height', self.height + self.margin.top + self.margin.bottom + 26)
+      .attr('viewBox', '0 -7 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
 
     self.svg
       .append('svg:defs')


### PR DESCRIPTION
## Description

Top of animation-draggers were cut off. Added viewbox to svg. Tested in Chrome/Edge/IE11/Firefox.

Fixes #1024  .


- Top of animation draggers now visible

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
