### PR TITLE
Fix animation window contents float dropping

### DIFF
--- a/web/css/anim.widget.css
+++ b/web/css/anim.widget.css
@@ -216,7 +216,8 @@
 }
 .gif-results-dialog-case .gif-results-dialog,
 .gif-results-dialog-case img {
-  display: inline-block;
+  display: block;
+  float: left;
 }
 
 .gif-results-dialog-case .gif-results-dialog {
@@ -224,10 +225,10 @@
   text-align: center;
   color: #444;
   vertical-align: top;
-  margin-left: 10px;
   border-radius: 6px;
   font-size: 12px;
   width: 162px;
+  margin-left: 10px;
 }
 
 .gif-results-dialog-case .gif-results-dialog b {

--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -564,10 +564,8 @@ export function animationGif(models, config, ui) {
       var downloadSize = lodashRound((blob.size / 1024 * 0.001), 2);
 
       // Create download link and apply button CSS
-      var $download = $('<a><span class=ui-button-text>Download</span></a>')
-        .attr('type', 'button')
-        .attr('role', 'button')
-        .attr('class', 'ui-button ui-widget ui-state-default ui-button-text-only')
+      var $download = $('<button><span class=ui-button-text>Download</span></button>')
+        .attr('class', 'wv-button')
         .hover(function() {
           $(this)
             .addClass('ui-state-hover');

--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -625,7 +625,7 @@ export function animationGif(models, config, ui) {
         '</div>' +
         '</div>';
       var $dialogBodyCase = $('<div></div>');
-      $dialogBodyCase.addClass('gif-results-dialog-case');
+      $dialogBodyCase.addClass('gif-results-dialog-case clearfix');
       $dialogBodyCase.css('padding', '10px 0');
       $dialogBodyCase.append(animatedImage);
       $dialogBodyCase.append($catalog);
@@ -642,7 +642,7 @@ export function animationGif(models, config, ui) {
       $imgDialog.dialog({
         dialogClass: 'wv-panel wv-gif-results',
         title: 'Your GIF',
-        width: animatedImage.width + 198,
+        width: animatedImage.width + 204,
         resizable: false,
         maxWidth: window.innerWidth,
         maxHeight: window.innerHeight,


### PR DESCRIPTION
## Description

Fixes #1068

- Adjusted dialog width to account for border-box
- Changed inner image and inner content div to display block / float left
- Change "Download" from an anchor element to button element and add `wv-button` class (fixes white button on Safari)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
