### PR TITLE
Add flexbox to fix timeline wrapping bug

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -9,10 +9,11 @@ button:focus {
   background: rgb(40, 40, 40);
   background: rgba(40, 40, 40, 0.9);
   border-radius: 5px;
-  display: inline-block;
+  display: flex;
+  flex-flow: row nowrap;
   margin-left: 10px;
   margin-right: 10px;
-  min-height: 65px;
+  height: 65px;
   bottom: 10px;
 }
 
@@ -133,7 +134,8 @@ g.plot rect.data-bar-invisible {
 
 #timeline-header {
   margin-top: 2px;
-  width: 310px;
+  min-width: 310px;
+  display: inline-block;
 }
 
 #timeline-header.subdaily {
@@ -354,11 +356,6 @@ g.plot rect.data-bar-invisible {
   fill: #333;
 }
 
-#timeline-footer,
-#timeline-header {
-  float: left;
-}
-
 #timeline-header .animate-button .wv-animate {
   color: #fff;
   font-size: 2.5em;
@@ -379,7 +376,6 @@ g.plot rect.data-bar-invisible {
 }
 
 #timeline-footer {
-  height: 65px;
   border-left: 1px solid #666;
   border-right: 1px solid #666;
 }
@@ -500,7 +496,7 @@ g.plot rect.data-bar-invisible {
   position: absolute;
   top: 0;
   right: 0;
-  height: 65px;
+  height: 64px;
   width: 20px;
   cursor: pointer;
   border-left: 1px solid #1a1a1a;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -201,6 +201,7 @@ g.plot rect.data-bar-invisible {
   background: transparent;
   border: 0;
   font-family: 'Roboto Mono', monospace;
+  line-height: 1.2em;
   vertical-align: middle;
   box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -375,6 +375,10 @@ g.plot rect.data-bar-invisible {
   color: #ccc;
 }
 
+#timeline-header, #timeline-footer {
+  float: left;
+}
+
 #timeline-footer {
   border-left: 1px solid #666;
   border-right: 1px solid #666;

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -100,7 +100,7 @@ export function timeline(models, config, ui) {
       self.getWidth();
 
       self.svg.attr('width', self.width)
-        .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 24));
+        .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
 
       d3.select('#timeline-boundary rect')
         .attr('width', self.width);
@@ -134,8 +134,8 @@ export function timeline(models, config, ui) {
     self.svg = d3.select('#timeline-footer')
       .append('svg:svg')
       .attr('width', self.width) // + margin.left + margin.right)
-      .attr('height', self.height + self.margin.top + self.margin.bottom + 24)
-      .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 24));
+      .attr('height', self.height + self.margin.top + self.margin.bottom + 26)
+      .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
 
     self.svg
       .append('svg:defs')

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -100,7 +100,7 @@ export function timeline(models, config, ui) {
       self.getWidth();
 
       self.svg.attr('width', self.width)
-        .attr('viewBox', '0 -7 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
+        .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 24));
 
       d3.select('#timeline-boundary rect')
         .attr('width', self.width);
@@ -134,8 +134,8 @@ export function timeline(models, config, ui) {
     self.svg = d3.select('#timeline-footer')
       .append('svg:svg')
       .attr('width', self.width) // + margin.left + margin.right)
-      .attr('height', self.height + self.margin.top + self.margin.bottom + 26)
-      .attr('viewBox', '0 -7 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 26));
+      .attr('height', self.height + self.margin.top + self.margin.bottom + 24)
+      .attr('viewBox', '0 -6 ' + self.width + ' ' + (self.height + self.margin.top + self.margin.bottom + 24));
 
     self.svg
       .append('svg:defs')


### PR DESCRIPTION
## Description

Fixes #1061 .

- add flexbox to timeline and remove floats to fix wrapping to next line bug
- minor width/height edits for browser specific nuances
- fixes ongoing firefox window resize issue with timeline wrapping

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
