### PR TITLE
Fix missing bulk download section of data download window

### DIFF
--- a/web/js/data/ui.js
+++ b/web/js/data/ui.js
@@ -555,7 +555,7 @@ var dataUiDownloadListPanel = function (config, model) {
     $('a.curl')
       .click(showCurlPage);
 
-    $dialog.find('.collapse')
+    $dialog.find('.dd-collapse')
       .accordion({
         collapsible: true,
         active: false,
@@ -813,7 +813,7 @@ var dataUiDownloadListPanel = function (config, model) {
 
   var bulkDownloadText = function () {
     var bulk =
-      '<div class=\'bulk collapse\'>' +
+      '<div class=\'bulk dd-collapse\'>' +
       '<h5>Bulk Download</h5>' +
       '<ul class=\'BulkDownload\'>' +
       '<li><a class=\'wget\' href=\'#\'>List of Links</a>: ' +


### PR DESCRIPTION
## Description

Fixes #1073

- Changed class name from `collapse` to `dd-collapse`, since `.collapse` is a bootstrap class that hides the element.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
