### PR TITLE
Fix no 'List All' button in events tab on zoomed in page load

### DIFF
--- a/web/js/natural-events/ui.js
+++ b/web/js/natural-events/ui.js
@@ -76,10 +76,18 @@ export default function naturalEventsUI (models, ui, config, request) {
       if (tab === 'events') {
         model.active = true;
 
+        if (self.markers.length === 0) {
+          createEventList();
+        }
         // Remove previously stored markers
         naturalEventMarkers.remove(self.markers);
         // Store markers so the can be referenced later
         self.markers = naturalEventMarkers.draw();
+
+        var isZoomed = Math.floor(view.getZoom()) >= 3;
+        if (isZoomed || models.proj.selected.id !== 'geographic') {
+          self.filterEventList();
+        }
         ui.sidebar.sizeEventsTab();
 
         // check if selected event is in changed projection


### PR DESCRIPTION
## Description

Fixes #1078 .

Fixes issue of permalink page load to a zoomed in area (with layers tab already selected) where no events are within current view which resulted in no 'List All' button when the events tab was selected.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
