### PR TITLE
Support selecting layers with future dates

### DIFF
--- a/tasks/processTemporalLayer.py
+++ b/tasks/processTemporalLayer.py
@@ -60,7 +60,8 @@ def process_temporal(wv_layer, value):
                     date_range_end.append(endTimeParse.strftime("%Y-%m-%d") + "T" + endTimeParse.strftime("%H:%M:%S") + "Z")
                 range_interval.append(re.search(r'\d+', times[2]).group())
             wv_layer["startDate"] = start_date.strftime("%Y-%m-%d") + "T" + start_date.strftime("%H:%M:%S") + "Z"
-            wv_layer["endDate"] = start_date.strftime("%Y-%m-%d") + "T" + start_date.strftime("%H:%M:%S") + "Z"
+            if end_date != datetime.min:
+                wv_layer["endDate"] = end_date.strftime("%Y-%m-%d") + "T" + end_date.strftime("%H:%M:%S") + "Z"
             if date_range_start and date_range_end:
                 wv_layer["dateRanges"] = [{"startDate": s, "endDate": e, "dateInterval": i} for s, e, i in zip(date_range_start, date_range_end, range_interval)]
     except ValueError:

--- a/tasks/processTemporalLayer.py
+++ b/tasks/processTemporalLayer.py
@@ -60,8 +60,7 @@ def process_temporal(wv_layer, value):
                     date_range_end.append(endTimeParse.strftime("%Y-%m-%d") + "T" + endTimeParse.strftime("%H:%M:%S") + "Z")
                 range_interval.append(re.search(r'\d+', times[2]).group())
             wv_layer["startDate"] = start_date.strftime("%Y-%m-%d") + "T" + start_date.strftime("%H:%M:%S") + "Z"
-            if end_date != datetime.min:
-                wv_layer["endDate"] = end_date.strftime("%Y-%m-%d") + "T" + end_date.strftime("%H:%M:%S") + "Z"
+            wv_layer["endDate"] = start_date.strftime("%Y-%m-%d") + "T" + start_date.strftime("%H:%M:%S") + "Z"
             if date_range_start and date_range_end:
                 wv_layer["dateRanges"] = [{"startDate": s, "endDate": e, "dateInterval": i} for s, e, i in zip(date_range_start, date_range_end, range_interval)]
     except ValueError:

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -67,6 +67,7 @@ if tolerant:
     warn("Validation enforcement disabled")
 
 start_date = datetime.max
+end_date = datetime.min
 
 for layer_id in wv["layers"].keys():
     layer = wv["layers"][layer_id]

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -67,7 +67,6 @@ if tolerant:
     warn("Validation enforcement disabled")
 
 start_date = datetime.max
-end_date = datetime.min
 
 for layer_id in wv["layers"].keys():
     layer = wv["layers"][layer_id]

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -129,9 +129,6 @@ for layer_id in wv["layers"].keys():
         layer = process_temporal(layer, layer["temporal"])
     if layer.get("inactive", False):
         pass
-    else:
-        if "endDate" in layer:
-            del layer["endDate"]
 
     if "startDate" in layer:
         startTime = layer["startDate"].replace('T', ' ').replace('Z', '')

--- a/test/data/model-spec.js
+++ b/test/data/model-spec.js
@@ -26,9 +26,9 @@ buster.testCase('wv.data.model', {
     this.models.proj.selected = {
       id: 'geographic'
     };
-    this.models.date = wv.date.model(this.config);
     this.models.layers = wv.layers.model(this.models, this.config);
     this.models.layers.add('layer1');
+    this.models.date = wv.date.model(this.models, this.config);
     this.model = wv.data.model(this.models, this.config);
     this.errors = [];
   },

--- a/test/date/model-spec.js
+++ b/test/date/model-spec.js
@@ -21,7 +21,7 @@ buster.testCase('wv.date.model', (function () {
 
   self['Initializes with a specified date'] = function () {
     var initial = new Date(Date.UTC(2013, 0, 5));
-    var date = wv.date.model(config, {
+    var date = wv.date.model(models, config, {
       initial: initial
     });
     buster.assert.equals(date.selected, initial);

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -150,11 +150,11 @@ fixtures.config = function () {
 fixtures.models = function (config) {
   var models = {};
 
-  models.date = dateModel(config);
   models.proj = projectionModel(config);
   models.layers = layersModel(models, config);
   models.palettes = palettesModel(models, config);
   models.map = mapModel(models, config);
+  models.date = dateModel(models, config);
 
   return models;
 };

--- a/test/main.js
+++ b/test/main.js
@@ -30,10 +30,6 @@ ui.mouse = uiMouse;
 
 window.wv = {
   brand: brand,
-  date: {
-    parse: dateParser,
-    model: dateModel
-  },
   data: {
     parse: dataParser,
     model: dataModel
@@ -41,6 +37,10 @@ window.wv = {
   layers: {
     parse: layerParser,
     model: layersModel
+  },
+  date: {
+    parse: dateParser,
+    model: dateModel
   },
   link: {
     model: linkModel

--- a/web/js/date/model.js
+++ b/web/js/date/model.js
@@ -1,5 +1,3 @@
-import lodashEach from 'lodash/each';
-import lodashFind from 'lodash/find';
 import util from '../util/util';
 
 export function dateModel(models, config, spec) {
@@ -37,7 +35,7 @@ export function dateModel(models, config, spec) {
   };
 
   self.clamp = function (date) {
-    var endDate = self.lastDate(spec);
+    var endDate = models.layers.lastDate(spec);
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         date = util.now();
@@ -56,84 +54,8 @@ export function dateModel(models, config, spec) {
     return date;
   };
 
-  self.dateRange = function (spec) {
-    spec = spec || {};
-    var layers = (spec.layer) ? [lodashFind(models.layers.active, {
-      id: spec.layer
-    })]
-      : models.layers.active;
-    var ignoreRange =
-      config.parameters &&
-      (config.parameters.debugGIBS || config.parameters.ignoreDateRange);
-    if (ignoreRange) {
-      return {
-        start: new Date(Date.UTC(1970, 0, 1)),
-        end: util.now()
-      };
-    }
-    var min = Number.MAX_VALUE;
-    var max = 0;
-    var range = false;
-    lodashEach(layers, function (def) {
-      if (def.startDate) {
-        range = true;
-        var start = util.parseDateUTC(def.startDate)
-          .getTime();
-        min = Math.min(min, start);
-      }
-      // For now, we assume that any layer with an end date is
-      // an ongoing product unless it is marked as inactive.
-      if (def.inactive && def.endDate) {
-        range = true;
-        let end = util.parseDateUTC(def.endDate)
-          .getTime();
-        max = Math.max(max, end);
-      } else if (def.endDate) {
-        range = true;
-        let end = util.parseDateUTC(def.endDate)
-          .getTime();
-        let today = util.today()
-          .getTime();
-        if (end > today) {
-          max = Math.max(max, end);
-        } else {
-          max = Math.max(max, today);
-        }
-      }
-      // If there is a start date but no end date, this is a
-      // product that is currently being created each day, set
-      // the max day to today.
-      if (def.startDate && !def.endDate) {
-        max = util.now()
-          .getTime();
-      }
-    });
-    if (range) {
-      if (max === 0) {
-        max = util.now()
-          .getTime();
-      }
-      return {
-        start: new Date(min),
-        end: new Date(max)
-      };
-    }
-  };
-
-  self.lastDate = function (spec) {
-    var endDate;
-    var layersDateRange = self.dateRange(spec);
-    var now = util.today();
-    if (layersDateRange && layersDateRange.end > now) {
-      endDate = layersDateRange.end;
-    } else {
-      endDate = util.today();
-    }
-    return endDate;
-  };
-
   self.isValid = function (date) {
-    var endDate = self.lastDate(spec);
+    var endDate = models.layers.lastDate(spec);
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         return false;
@@ -160,7 +82,7 @@ export function dateModel(models, config, spec) {
   };
 
   self.maxDate = function () {
-    var endDate = self.lastDate(spec);
+    var endDate = models.layers.lastDate(spec);
     return endDate;
   };
 

--- a/web/js/date/model.js
+++ b/web/js/date/model.js
@@ -1,6 +1,8 @@
+import lodashEach from 'lodash/each';
+import lodashFind from 'lodash/find';
 import util from '../util/util';
 
-export function dateModel(config, spec, models) {
+export function dateModel(models, config, spec) {
   spec = spec || {};
 
   var self = {};
@@ -35,7 +37,7 @@ export function dateModel(config, spec, models) {
   };
 
   self.clamp = function (date) {
-    var endDate = models.layers.lastDate();
+    var endDate = self.lastDate(spec);
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         date = util.now();
@@ -54,8 +56,84 @@ export function dateModel(config, spec, models) {
     return date;
   };
 
+  self.dateRange = function (spec) {
+    spec = spec || {};
+    var layers = (spec.layer) ? [lodashFind(models.layers.active, {
+      id: spec.layer
+    })]
+      : models.layers.active;
+    var ignoreRange =
+      config.parameters &&
+      (config.parameters.debugGIBS || config.parameters.ignoreDateRange);
+    if (ignoreRange) {
+      return {
+        start: new Date(Date.UTC(1970, 0, 1)),
+        end: util.now()
+      };
+    }
+    var min = Number.MAX_VALUE;
+    var max = 0;
+    var range = false;
+    lodashEach(layers, function (def) {
+      if (def.startDate) {
+        range = true;
+        var start = util.parseDateUTC(def.startDate)
+          .getTime();
+        min = Math.min(min, start);
+      }
+      // For now, we assume that any layer with an end date is
+      // an ongoing product unless it is marked as inactive.
+      if (def.inactive && def.endDate) {
+        range = true;
+        let end = util.parseDateUTC(def.endDate)
+          .getTime();
+        max = Math.max(max, end);
+      } else if (def.endDate) {
+        range = true;
+        let end = util.parseDateUTC(def.endDate)
+          .getTime();
+        let today = util.today()
+          .getTime();
+        if (end > today) {
+          max = Math.max(max, end);
+        } else {
+          max = Math.max(max, today);
+        }
+      }
+      // If there is a start date but no end date, this is a
+      // product that is currently being created each day, set
+      // the max day to today.
+      if (def.startDate && !def.endDate) {
+        max = util.now()
+          .getTime();
+      }
+    });
+    if (range) {
+      if (max === 0) {
+        max = util.now()
+          .getTime();
+      }
+      return {
+        start: new Date(min),
+        end: new Date(max)
+      };
+    }
+  };
+
+  self.lastDate = function (spec) {
+    var endDate;
+    var layersDateRange = self.dateRange(spec);
+    var now = util.today();
+    if (layersDateRange && layersDateRange.end > now) {
+      endDate = layersDateRange.end;
+    } else {
+      endDate = util.today();
+    }
+    return endDate;
+  };
+
   self.isValid = function (date) {
-    var endDate = models.layers.lastDate();
+    var endDate = self.lastDate(spec);
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         return false;
@@ -82,7 +160,7 @@ export function dateModel(config, spec, models) {
   };
 
   self.maxDate = function () {
-    var endDate = models.layers.lastDate();
+    var endDate = self.lastDate(spec);
     return endDate;
   };
 

--- a/web/js/date/model.js
+++ b/web/js/date/model.js
@@ -1,6 +1,6 @@
 import util from '../util/util';
 
-export function dateModel(config, spec) {
+export function dateModel(config, spec, models) {
   spec = spec || {};
 
   var self = {};
@@ -35,13 +35,14 @@ export function dateModel(config, spec) {
   };
 
   self.clamp = function (date) {
+    var endDate = models.layers.lastDate();
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         date = util.now();
       }
     } else {
-      if (date > util.today()) {
-        date = util.today();
+      if (date > endDate) {
+        date = endDate;
       }
     }
     if (config.startDate) {
@@ -54,12 +55,13 @@ export function dateModel(config, spec) {
   };
 
   self.isValid = function (date) {
+    var endDate = models.layers.lastDate();
     if (self.maxZoom > 3) {
       if (date > util.now()) {
         return false;
       }
     } else {
-      if (date > util.today()) {
+      if (date > endDate) {
         return false;
       }
     }
@@ -80,7 +82,8 @@ export function dateModel(config, spec) {
   };
 
   self.maxDate = function () {
-    return util.now();
+    var endDate = models.layers.lastDate();
+    return endDate;
   };
 
   self.maxZoom = null;

--- a/web/js/date/timeline-data.js
+++ b/web/js/date/timeline-data.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import util from '../util/util';
 import d3 from 'd3';
 
 export function timelineData(models, config, ui) {
@@ -12,9 +11,10 @@ export function timelineData(models, config, ui) {
   };
 
   self.end = function () {
+    var endDate = models.layers.lastDate();
     return new Date(
-      new Date(util.now())
-        .setUTCDate(util.now()
+      new Date(endDate)
+        .setUTCDate(endDate
           .getUTCDate()));
   };
 

--- a/web/js/date/timeline-input.js
+++ b/web/js/date/timeline-input.js
@@ -68,7 +68,6 @@ export function timelineInput(models, config, ui) {
         }
       })
       .mouseup(stopper);
-
     $(document)
       .mouseout(stopper)
       .keydown(function (event) {
@@ -127,7 +126,6 @@ export function timelineInput(models, config, ui) {
     $buttons.unbind();
     $oneIntervalButtons.unbind();
     $tenIntervalButtons.unbind();
-
     // FIXME: Quick fix for fixing the propagation
     // of events with arrow keys and input field
     $oneIntervalButtons.keydown(function (event) {
@@ -272,10 +270,11 @@ export function timelineInput(models, config, ui) {
    * @return {void}
    */
   var animateByIncrement = function(delta, increment) {
+    var endDate = models.layers.lastDate();
     self.delta = Math.abs(delta);
     function animate() {
       var nextTime = getNextTimeSelection(delta, increment);
-      if (tl.data.start() <= nextTime <= util.now()) {
+      if (tl.data.start() <= nextTime <= endDate) {
         models.date.add(increment, delta);
       };
       animator = setTimeout(animate, self.delay);
@@ -352,6 +351,7 @@ export function timelineInput(models, config, ui) {
 
   // TODO: Replace with WVC
   var validateInput = function (event) {
+    var endDate = models.layers.lastDate();
     var kc = event.keyCode || event.which;
     var entered = (kc === 13) || (kc === 9); // carriage return or horizontal tab
     if (event.type === 'focusout' || entered) {
@@ -422,7 +422,7 @@ export function timelineInput(models, config, ui) {
           break;
       }
       if ((selectedDateObj > tl.data.start()) &&
-        (selectedDateObj <= util.now())) {
+        (selectedDateObj <= endDate)) {
         var parent = selected.parent();
         var sib = parent.next('div.input-wrapper.selectable')
           .find('input.button-input-group');
@@ -496,6 +496,7 @@ export function timelineInput(models, config, ui) {
     var ms = date || new Date(model.selected);
     var nd = new Date(ms.setUTCDate(ms.getUTCDate() + 1));
     var pd = new Date(ms.setUTCDate(ms.getUTCDate() - 1));
+    var endDate = models.layers.lastDate();
 
     // Update fields
     $('#year-input-group')
@@ -525,9 +526,9 @@ export function timelineInput(models, config, ui) {
     }
 
     // Disable arrows if nothing before/after selection
-    if ((model.selectedZoom === 4) && ms >= util.now()) {
+    if ((model.selectedZoom === 4) && ms >= endDate) {
       $incrementBtn.addClass('button-disabled');
-    } else if ((model.selectedZoom !== 4) && nd > util.now()) {
+    } else if ((model.selectedZoom !== 4) && nd > endDate) {
       $incrementBtn.addClass('button-disabled');
     } else {
       $incrementBtn.removeClass('button-disabled');

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -242,6 +242,16 @@ export function timeline(models, config, ui) {
       self.setClip();
     });
 
+    // Determine maximum end date and move tl pick there if selected date is
+    // greater than the max end date
+    models.layers.events.on('remove', function () {
+      var endDate = models.date.maxDate();
+      var selectedDate = models.date.selected;
+      if (selectedDate > endDate) {
+        models.date.select(endDate);
+      }
+    });
+
     models.proj.events.on('select', function () {
       self.resize();
       self.setClip();

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -238,6 +238,7 @@ export function timeline(models, config, ui) {
     models.layers.events.on('change', function () {
       self.data.set();
       self.resize();
+      self.zoom.refresh();
       self.setClip();
     });
 

--- a/web/js/date/wheels.js
+++ b/web/js/date/wheels.js
@@ -116,7 +116,7 @@ var dateWheels = function(models, config) {
 
   var updateRange = function () {
     var startDate = util.parseDateUTC(config.startDate);
-    var endDate = util.now();
+    var endDate = models.layers.lastDate();
     $('#linkmode')
       .mobiscroll('option', 'disabled', false);
     $('#linkmode')

--- a/web/js/layers/info.js
+++ b/web/js/layers/info.js
@@ -22,7 +22,6 @@ export function layersInfo(config, models, layer) {
       .attr('id', 'wv-layers-info-dialog')
       .attr('data-layer', layer.id);
     renderDescription($dialog);
-
     names = models.layers.getTitles(layer.id);
     $dialog.dialog({
       dialogClass: 'wv-panel',
@@ -192,22 +191,26 @@ export function layersInfo(config, models, layer) {
 
       if (layer.endDate) {
         endDate = util.parseDate(layer.endDate);
-        if (layer.period === 'subdaily') {
-          endDate = endDate.getDate() + ' ' + util.giveMonth(endDate) + ' ' +
-          endDate.getFullYear() + ' ' + util.pad(endDate.getHours(), 2, '0') + ':' +
-          util.pad(endDate.getMinutes(), 2, '0');
-        } else if (layer.period === 'yearly') {
-          endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
-          endDate = endDate.getFullYear();
-        } else if (layer.period === 'monthly') {
-          endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
-          endDate = util.giveMonth(endDate) + ' ' + endDate.getFullYear();
+        if (endDate <= util.today() && !layer.inactive) {
+          endDate = 'Present';
         } else {
-          if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
-            endDate = new Date(endDate.setTime(endDate.getTime() - 86400000));
+          if (layer.period === 'subdaily') {
+            endDate = endDate.getDate() + ' ' + util.giveMonth(endDate) + ' ' +
+            endDate.getFullYear() + ' ' + util.pad(endDate.getHours(), 2, '0') + ':' +
+            util.pad(endDate.getMinutes(), 2, '0');
+          } else if (layer.period === 'yearly') {
+            endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
+            endDate = endDate.getFullYear();
+          } else if (layer.period === 'monthly') {
+            endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
+            endDate = util.giveMonth(endDate) + ' ' + endDate.getFullYear();
+          } else {
+            if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
+              endDate = new Date(endDate.setTime(endDate.getTime() - 86400000));
+            }
+            endDate = endDate.getDate() + ' ' + util.giveMonth(endDate) + ' ' +
+            endDate.getFullYear();
           }
-          endDate = endDate.getDate() + ' ' + util.giveMonth(endDate) + ' ' +
-          endDate.getFullYear();
         }
         $layerDateEnd.html(endDate);
       } else {
@@ -249,6 +252,8 @@ export function layersInfo(config, models, layer) {
               if (firstDateRange) {
                 if (layer.endDate === undefined) {
                   rangeEndDate = 'Present';
+                } else if (util.parseDate(layer.endDate) <= util.today() && !layer.inactive) {
+                  rangeEndDate = 'Present';
                 }
                 firstDateRange = false;
               }
@@ -267,6 +272,8 @@ export function layersInfo(config, models, layer) {
               rangeEndDate = util.giveMonth(rangeEndDate) + ' ' + rangeEndDate.getFullYear();
               if (firstDateRange) {
                 if (layer.endDate === undefined) {
+                  rangeEndDate = 'Present';
+                } else if (util.parseDate(layer.endDate) <= util.today() && !layer.inactive) {
                   rangeEndDate = 'Present';
                 }
                 firstDateRange = false;
@@ -288,6 +295,8 @@ export function layersInfo(config, models, layer) {
               if (firstDateRange) {
                 if (layer.endDate === undefined) {
                   rangeEndDate = 'Present';
+                } else if (util.parseDate(layer.endDate) <= util.today() && !layer.inactive) {
+                  rangeEndDate = 'Present';
                 }
                 firstDateRange = false;
               }
@@ -303,6 +312,8 @@ export function layersInfo(config, models, layer) {
             util.pad(rangeEndDate.getMinutes(), 2, '0');
             if (firstDateRange) {
               if (layer.endDate === undefined) {
+                rangeEndDate = 'Present';
+              } else if (util.parseDate(layer.endDate) <= util.today() && !layer.inactive) {
                 rangeEndDate = 'Present';
               }
               firstDateRange = false;

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -137,9 +137,9 @@ export function layersModel(models, config) {
         let today = util.today()
           .getTime();
         if (end > today) {
-          max = end;
+          max = Math.max(max, end);
         } else {
-          max = today;
+          max = Math.max(max, today);
         }
       }
       // If there is a start date but no end date, this is a

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -127,13 +127,20 @@ export function layersModel(models, config) {
       // an ongoing product unless it is marked as inactive.
       if (def.inactive && def.endDate) {
         range = true;
-        var end = util.parseDateUTC(def.endDate)
+        let end = util.parseDateUTC(def.endDate)
           .getTime();
         max = Math.max(max, end);
       } else if (def.endDate) {
         range = true;
-        max = util.now()
+        let end = util.parseDateUTC(def.endDate)
           .getTime();
+        let today = util.today()
+          .getTime();
+        if (end > today) {
+          max = end;
+        } else {
+          max = today;
+        }
       }
       // If there is a start date but no end date, this is a
       // product that is currently being created each day, set
@@ -153,6 +160,18 @@ export function layersModel(models, config) {
         end: new Date(max)
       };
     }
+  };
+
+  self.lastDate = function () {
+    var endDate;
+    var layersDateRange = self.dateRange();
+    var now = util.today();
+    if (layersDateRange && layersDateRange.end > now) {
+      endDate = layersDateRange.end;
+    } else {
+      endDate = util.today();
+    }
+    return endDate;
   };
 
   self.add = function (id, spec) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -196,7 +196,7 @@ window.onload = () => {
     models.layers = layersModel(models, config);
     models.date = dateModel(config, {
       initial: initialDate
-    });
+    }, models);
     models.map = mapModel(models, config);
     models.link = linkModel(config);
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -194,9 +194,9 @@ window.onload = () => {
     models.proj = projectionModel(config);
     models.palettes = palettesModel(models, config);
     models.layers = layersModel(models, config);
-    models.date = dateModel(config, {
+    models.date = dateModel(models, config, {
       initial: initialDate
-    }, models);
+    });
     models.map = mapModel(models, config);
     models.link = linkModel(config);
 

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -150,6 +150,7 @@ export default (function (self) {
   self.parseTimestampUTC = function (str) {
     return self.parseDateUTC(str);
   };
+
   /**
    * Gets a pixel RGBA value from Canvas
    *
@@ -656,9 +657,13 @@ export default (function (self) {
    * @return {Date} The current time or an overriden value.
    */
   var now = function () {
-    return new Date();
+    var now = new Date();
+    var nowOffset = new Date(now.getTime() - (now.getTimezoneOffset() * 60000));
+    return nowOffset;
   };
+
   self.now = now;
+
   self.resetNow = function () {
     self.now = now;
   };
@@ -951,8 +956,10 @@ export default (function (self) {
         coord[0].toFixed(4) + '&deg;';
     }
   };
-  // allows simple printf functionality with strings
-  // arguments array contains all args passed. String must be formatted so that first replacement starts with "{1}"
+
+  // Allows simple printf functionality with strings
+  // arguments array contains all args passed. String must be formatted
+  // so that first replacement starts with "{1}"
   // usage example: wv.util.format("{1}{2}",'World','view')
   self.format = function () {
     var formatted = arguments[0];


### PR DESCRIPTION
## Description

Fixes #826
Connects to nasa-gibs/worldview-components#59

Determines the last endDate in the active layer list and sets the max bounds throughout the app to this endDate instead of today's date.

- [x] Add layers lastDate method to determine the last date from the currently active layers and returns this date if it is after today's date
- [x] Update date model, timeline-data, timeline-input, and time wheels to use layers lastDate method
- [x] Handle automatic start/end date outputs
- [x] Fix bug with time wheel not setting the date
- [x] Move timeline pick when it is passed an endDate of a layer that is removed

Bugs found during review:
- [ ] Create method to add set amount of time to current date (i.e. handle active layers and add additional time on top of it)
- [ ] Animation end date does not update when future layers are removed
- [x] Ensure endDate of future date layers adds the dateInterval to the endDate defined in the GC

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
