### PR TITLE
Fix panels moving when opened

### DIFF
--- a/web/css/reset.css
+++ b/web/css/reset.css
@@ -539,6 +539,7 @@ label {
 
 .wv-panel {
   border: 1px solid #333;
+  box-sizing: content-box;
 }
 
 .wv-panel .ui-dialog-titlebar {


### PR DESCRIPTION
## Description

Fixes #1089

Bootstrap 4's reset file targets all elements and sets `box-sizing: border-box`; jQuery dialog animation does not account for borders (when border-box is applied) during animation and only expands once the animation is complete. This PR set's the dialog back to `box-sizing: content-box`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
