### PR TITLE
Fix 0px sidebar padding-bottom causing layer button to move on load

### DIFF
--- a/web/css/products.css
+++ b/web/css/products.css
@@ -1,5 +1,5 @@
 #productsHolder .ui-tabs-panel {
-  padding: 0;
+  padding: 0 0 37px;
   position: relative;
 }
 

--- a/web/js/layers/sidebar.js
+++ b/web/js/layers/sidebar.js
@@ -105,7 +105,7 @@ export function layersSidebar(models, config) {
     // Resize after browser repaints
     setTimeout(function () {
       self.sizeEventsTab();
-    }, 400);
+    }, 100);
   };
 
   self.expandNow = function () {


### PR DESCRIPTION
## Description

Fixes #1114

Add padding-bottom to the sidebar so that the Add Layers button doesn't jump down on the initial load. Also adjust the timeout so that the padding-bottom is applied quicker when switching tabs.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
