### PR TITLE
Remove warnings when GIBS layers are not used

### DIFF
--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -78,12 +78,7 @@ for layer_id in wv["layers"].keys():
             continue
         elif tolerant or opt.get("ignoreLayerOrder", False):
             wv["layerOrder"] += [layer_id]
-        elif opt.get("warnOnUnexpectedLayer"):
-            warn("[%s] Unexpected layer, not in layer order" % layer_id)
-            remove_layer(wv, layer_id)
-            continue
         else:
-            error("[%s] Unexpected layer, not in layer order" % layer_id)
             remove_layer(wv, layer_id)
             continue
     if "projections" not in layer or len(layer["projections"]) == 0:


### PR DESCRIPTION
## Description

Fixes #1038.

For historical reasons, the build would report an error if a layer was found in the GIBS GetCapabilities document but was not used in Worldview. This was eventually changed to a warning and "exceptions" to this list could be declared to remove the warning. 

Having this tight coupling between GIBS and Worldview is no longer necessary and having the build always report 50 or so warnings is noisy. In the future, it would be better if the GetCapabilities documents supplement the Worldview configuration instead of driving it. 

Changes: 

- Remove warnings when GIBS layers are not used

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
