### PR TITLE
Check for transparent colormap before legend

### DIFF
--- a/tasks/processColormap.py
+++ b/tasks/processColormap.py
@@ -114,6 +114,14 @@ def replace_duplicates(duplicates, tooltip_list, entries):
 
 def process_entries(colormap):
     entries = to_list(colormap["Entries"]["ColorMapEntry"])
+
+    transparent_map = "true"
+    for entry in entries:
+        if entry["@transparent"] == "false":
+            transparent_map = "false"
+    if (transparent_map == "true"):
+        return "transparent"
+
     if "Legend" not in colormap:
         raise KeyError("No Legend")
     else:
@@ -123,13 +131,7 @@ def process_entries(colormap):
     values = []
     tooltips = []
     matches = []
-    transparent_map = "true"
 
-    for entry in entries:
-        if entry["@transparent"] == "false":
-            transparent_map = "false"
-    if (transparent_map == "true"):
-        return "transparent"
     color_format = "{0:02x}{1:02x}{2:02x}{3:02x}"
     for index, entry in enumerate(entries):
         legend = match_legend(entry, legends)


### PR DESCRIPTION
## Description

Fixes #1133.

- check for transparent colormap before legend

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
