### PR TITLE
Immutable palette now also applies to continuous values

### DIFF
--- a/web/js/palettes/model.js
+++ b/web/js/palettes/model.js
@@ -51,7 +51,11 @@ export function palettesModel(models, config) {
     if (!palettes.supported) {
       return false;
     }
-    return config.layers[layerId].palette;
+    let palette = config.layers[layerId].palette;
+    if (palette.immutable) {
+      return false;
+    }
+    return palette;
   };
 
   self.setCustom = function (layerId, paletteId, index) {


### PR DESCRIPTION
## Description

Fixes #1109.

The configuration already had a flag for an "immutable" palette, but this only applied to classified palettes. Updated to apply to continuous palettes too. Use:

```json
"palette": {
    "immutable": true
}
```

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
