### PR TITLE
Fixes unset left property of timeline being called 'auto' in some browsers

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -3,6 +3,10 @@ button:focus {
   outline: 0;
 }
 
+#timeline {
+  left: 0;
+}
+
 .timeline-inner {
   position: absolute;
   border: 1px solid #333;


### PR DESCRIPTION
## Description

Fixes #1082  .

- Add '0' to a 'left' property that was being interpreted as 'auto' in some browsers causing a related calculation function to break timeline.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
