### PR TITLE
Add 'showSubdaily' mock URL parameter #866

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -88,3 +88,4 @@ To run tests for both browsers in sequence: `npm run e2e`.
 | markDownloads | boolean | If any value is specified, layers that can be downloaded will be marked in red in the Add Layers tab. |
 | debugPalette | boolean | If any value is specified, a black debugging custom palette will be added to assist in finding invalid lookup table mappings. |
 | showError | boolean | If any value is specified, an error dialog will be shown on startup. |
+| showSubdaily | boolean | If any value is specified, the hour input, minute input and "minutes" timeline zoom option will be shown. |

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -37,11 +37,16 @@ export function timelineConfig(models, config, ui) {
     // Needs reworked. Repeated from layers/active/toggleSubdaily
     var activeLayers = models.layers.active;
     var subdailyFound = false;
-    for (var i = 0; i < activeLayers.length; i++) {
-      switch (activeLayers[i].period) {
-        case 'subdaily':
-          subdailyFound = true;
-          break;
+    var showSubdaily = config.parameters.showSubdaily;
+    if (showSubdaily === 'true') {
+      subdailyFound = true;
+    } else {
+      for (var i = 0; i < activeLayers.length; i++) {
+        switch (activeLayers[i].period) {
+          case 'subdaily':
+            subdailyFound = true;
+            break;
+        }
       }
     }
 

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -37,8 +37,7 @@ export function timelineConfig(models, config, ui) {
     // Needs reworked. Repeated from layers/active/toggleSubdaily
     var activeLayers = models.layers.active;
     var subdailyFound = false;
-    var showSubdaily = config.parameters.showSubdaily;
-    if (showSubdaily === 'true') {
+    if (config.parameters.showSubdaily) {
       subdailyFound = true;
     } else {
       for (var i = 0; i < activeLayers.length; i++) {

--- a/web/js/debug.js
+++ b/web/js/debug.js
@@ -21,6 +21,7 @@ export var debug = (function () {
         return;
       }
     }
+
     if (parameters.showError) {
       $(function () {
         util.error();

--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -372,12 +372,18 @@ export function layersActive(models, ui, config) {
   var subdailyCheck = function () {
     var activeLayers = models.layers.active;
     var currentProjection = models.proj.selected.id;
+    var showSubdaily = config.parameters.showSubdaily;
     var check;
-    lodashEach(activeLayers, function(activeLayer) {
-      if (Object.keys(activeLayer.projections).some(function(k) { return ~k.indexOf(currentProjection); })) {
-        if (activeLayer.period === 'subdaily' && activeLayer.projections[currentProjection]) check = true;
-      }
-    });
+
+    if (showSubdaily === 'true') {
+      check = true;
+    } else {
+      lodashEach(activeLayers, function(activeLayer) {
+        if (Object.keys(activeLayer.projections).some(function(k) { return ~k.indexOf(currentProjection); })) {
+          if (activeLayer.period === 'subdaily' && activeLayer.projections[currentProjection]) check = true;
+        }
+      });
+    }
     return check;
   };
 

--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -372,10 +372,9 @@ export function layersActive(models, ui, config) {
   var subdailyCheck = function () {
     var activeLayers = models.layers.active;
     var currentProjection = models.proj.selected.id;
-    var showSubdaily = config.parameters.showSubdaily;
     var check;
 
-    if (showSubdaily === 'true') {
+    if (config.parameters.showSubdaily) {
       check = true;
     } else {
       lodashEach(activeLayers, function(activeLayer) {


### PR DESCRIPTION
## Description

Fixes #866

Adds the ability to add `showSubdaily=true` to the URL to show minute & hour inputs + the 10-minute zoom level. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
