### PR TITLE
Fix guitar pick and selection draggers from getting cutoff on edges of timeline

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -386,11 +386,11 @@ g.plot rect.data-bar-invisible {
 }
 
 #timeline-footer svg {
+  overflow: visible;
   margin-top: -16px;
 }
 
 #timeline-footer > svg {
-  overflow-y: hidden;
   margin-top: -23px;
 }
 

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -155,7 +155,7 @@ export function timeline(models, config, ui) {
 
     self.boundary = self.svg
       .append('svg:g')
-      .attr('clip-path', '#timeline-boundary')
+      .attr('clip-path', 'url(#timeline-boundary)')
       .attr('style', 'clip-path:url(#timeline-boundary)')
       .attr('transform', 'translate(0,16)');
 


### PR DESCRIPTION
## Description

Fixes #905  .

Fix guitar pick and selection draggers from getting cutoff on edges of timeline

- Overflow set to 'hidden' was necessary to prevent data bars from overflowing on window resize. A change in the clip-path syntax made the clip-path work on the data bars svg group. This allowed overflow to be changed to 'visible' for the other elements svg elements in the timeline-footer (guitar pick and selection draggers).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
