### PR TITLE
Close layer setting dialogs when showing Add Layers modal

### DIFF
--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -74,6 +74,7 @@ export function layersActive(models, ui, config) {
     var $addBtn = $('#layers-add');
     $addBtn.button();
     $addBtn.click(function (e) {
+      wvui.closeDialog();
       $('#layer-modal').dialog('open');
     });
 


### PR DESCRIPTION
## Description

Fixes #849

Close all layer setting dialogs (info & options) when showing the Add Layers modal.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
