### PR TITLE
Fix date time for animation dragger, GIF dialog text, and updated url

### DIFF
--- a/web/js/animation/ui.js
+++ b/web/js/animation/ui.js
@@ -107,7 +107,7 @@ export function animationUi(models, ui) {
    */
   self.getStartDate = function () {
     // get index+1 of date zoom 'yearly', 'monthly', 'daily', '10-Minute'
-    let dateSelectedZoom = models.date.selectedZoom || 0;
+    let dateSelectedZoom = models.date.selectedZoom || 1;
     var state;
     var endDate;
     var startDate;

--- a/web/js/animation/ui.js
+++ b/web/js/animation/ui.js
@@ -106,6 +106,8 @@ export function animationUi(models, ui) {
    *
    */
   self.getStartDate = function () {
+    // get index+1 of date zoom 'yearly', 'monthly', 'daily', '10-Minute'
+    let dateSelectedZoom = models.date.selectedZoom || 0;
     var state;
     var endDate;
     var startDate;
@@ -113,6 +115,13 @@ export function animationUi(models, ui) {
     state = animModel.rangeState;
     endDate = util.parseDateUTC(state.endDate);
     startDate = util.parseDateUTC(state.startDate);
+    // if not index+1 of 4 ('10-Minute'), zero out start/end times and resave
+    if (dateSelectedZoom < 4) {
+      let zeroDate = dateModel.selected;
+      util.clearTimeUTC(zeroDate);
+      util.clearTimeUTC(startDate);
+      dateModel.selected = zeroDate;
+    }
     currentDate = dateModel.selected;
     if (currentDate > startDate && self.nextDate(currentDate) < endDate) {
       return util.toISOStringSeconds(self.nextDate(currentDate));

--- a/web/js/animation/widget.js
+++ b/web/js/animation/widget.js
@@ -273,6 +273,11 @@ export function animationWidget (models, config, ui) {
    *
    */
   self.onPressPlay = function () {
+    let zoomLevel = ui.anim.ui.getInterval();
+    if (zoomLevel !== 'minute') {
+      // zero out start/end date times
+      self.setZeroDateTimes();
+    }
     model.rangeState.playing = true;
     model.events.trigger('play');
   };
@@ -373,7 +378,40 @@ export function animationWidget (models, config, ui) {
    *
    */
   self.onPressGIF = function () {
+    let zoomLevel = ui.anim.ui.getInterval();
+    if (zoomLevel !== 'minute') {
+      // zero out start/end date times
+      self.setZeroDateTimes();
+    }
     model.events.trigger('gif-click');
+  };
+
+  /*
+   * Zero out hours/min/sec for start/end dates
+   * will snap draggers into place on timeline
+   * and zero out GIF Animation preview modal and url time data
+   *
+   * used with onPressPlay and onPressGIF
+   *
+   * @method setZeroDateTimes
+   *
+   * @static
+   *
+   * @returns {void}
+   *
+   */
+  self.setZeroDateTimes = function () {
+    let state = model.rangeState;
+    let startDate = util.parseDateUTC(state.startDate);
+    let endDate = util.parseDateUTC(state.endDate);
+
+    util.clearTimeUTC(startDate);
+    util.clearTimeUTC(endDate);
+
+    // save changes to model
+    model.rangeState.startDate = util.toISOStringSeconds(startDate);
+    model.rangeState.endDate = util.toISOStringSeconds(endDate);
+    model.events.trigger('change');
   };
 
   self.init();


### PR DESCRIPTION
## Description

Fixes #1023  .

Using the GIF animation draggers, the GIF dialog time values should stay at 00:00 if in "DAYS"/"MONTHS"/"YEARS" zoom mode. 

This fix zeroes/snaps draggers into place on clicking 'PLAY' or 'CREATE ANIMATED GIF' for "DAYS"/"MONTHS"/"YEARS". Zeroed out time data is shown in the GIF dialogs and url. This PR also fixes the issue of cut off animations. For example, if your animation start date has a time of 23:00 and the end date only has coverage up to 05:00, it will cut off the end date and cause intermittent jumpy animation behavior.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
