### PR TITLE
Prevent track and point removal beyond min/max zoom with mousewheel

### DIFF
--- a/web/js/natural-events/track.js
+++ b/web/js/natural-events/track.js
@@ -53,8 +53,9 @@ export default function naturalEventsTrack (models, ui, config) {
           // restricts track/cluster points from disappearing on min/max zoom
           let isNewTarget = true;
           if (e.target) {
-            let oldValues = e.oldValue.map(val => typeof val === 'number' ? val.toFixed(6) : 0);
-            let targetValues = e.target.values_.center.map(val => typeof val === 'number' ? val.toFixed(6) : 0);
+            const valueCheck = (val) => typeof val === 'number' ? val.toFixed(6) : 0;
+            let oldValues = e.oldValue.map(val => valueCheck(val));
+            let targetValues = e.target.values_.center.map(val => valueCheck(val));
 
             let oldLon = oldValues[0];
             let oldLat = oldValues[1];


### PR DESCRIPTION
## Description

Fixes #1045  .

In natural events with a multiple data point iceberg event that has a track cluster points, the track and cluster points disappear if you zoom out to the max zoom level and then zoom out once more(using the mouse wheel). This same disappear action happens when zooming in to the 0 zoom level.

- Add conditions based on current projection and zoom levels to prevent removal of track and cluster points

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
