### PR TITLE
Fix yearly layer not showing proper range

### DIFF
--- a/tasks/processTemporalLayer.py
+++ b/tasks/processTemporalLayer.py
@@ -42,7 +42,7 @@ def process_temporal(wv_layer, value):
                 if end_date:
                     endDateParse = datetime.strptime(times[1], "%Y-%m-%d")
                     date_range_end.append(endDateParse.strftime("%Y-%m-%d") + "T" + endDateParse.strftime("%H:%M:%S") + "Z")
-                if times[2] not in ["P1D", "P1M", "P1Y"]:
+                if times[2] != "P1D":
                     end_date = determine_end_date(times[2], end_date)
                 range_interval.append(re.search(r'\d+', times[2]).group())
             else:

--- a/web/js/layers/info.js
+++ b/web/js/layers/info.js
@@ -196,14 +196,10 @@ export function layersInfo(config, models, layer) {
           endDate.getFullYear() + ' ' + util.pad(endDate.getHours(), 2, '0') + ':' +
           util.pad(endDate.getMinutes(), 2, '0');
         } else if (layer.period === 'yearly') {
-          if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
-            endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
-          }
+          endDate = new Date(endDate.setFullYear(endDate.getFullYear() - 1));
           endDate = endDate.getFullYear();
         } else if (layer.period === 'monthly') {
-          if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {
-            endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
-          }
+          endDate = new Date(endDate.setMonth(endDate.getMonth() - 1));
           endDate = util.giveMonth(endDate) + ' ' + endDate.getFullYear();
         } else {
           if (layer.dateRanges && layer.dateRanges.slice(-1)[0].dateInterval !== '1') {


### PR DESCRIPTION
## Description

Fixes #1166

Black Marble 2016 is only showing on January 1 2016 and not the entire year range. This PR fixes that issue and changes the info box description to output the correct date range. 

There is a pull request in worldview-components (nasa-gibs/worldview-components#66) which adjusts the year range description in the search results.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
