### PR TITLE
v2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12167,6 +12167,11 @@
         "prop-types": "15.6.2"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-popper": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.8.3.tgz",
@@ -12177,13 +12182,14 @@
       }
     },
     "react-transition-group": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
-      "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
+      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
       "requires": {
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.2"
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4"
       }
     },
     "reactstrap": {
@@ -12197,7 +12203,7 @@
         "lodash.tonumber": "4.0.3",
         "prop-types": "15.6.2",
         "react-popper": "0.8.3",
-        "react-transition-group": "2.3.1"
+        "react-transition-group": "2.4.0"
       }
     },
     "read-all-stream": {
@@ -16091,9 +16097,9 @@
       "dev": true
     },
     "worldview-components": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/worldview-components/-/worldview-components-1.8.1.tgz",
-      "integrity": "sha512-xEBbk+cBB7mwuWmCVNUgWHiTuGuHnMEgkIakVw/6ihZA/63i+nkqOKuKLk2oa4nD3pp2ZGOrJmwLyy+Ed00l7Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/worldview-components/-/worldview-components-1.9.0.tgz",
+      "integrity": "sha512-1dzKGwTFdFB5/0tuJAaQdfd0HqWWmpIP+UNIhyRUvYuGstVWkZQcEs5bdbP8IgU8/qDE0zFu1ZciALrtL95FkQ==",
       "requires": {
         "babel-preset-env": "1.7.0",
         "babel-preset-react": "6.24.1",
@@ -16107,7 +16113,7 @@
       }
     },
     "worldview-options-eosdis": {
-      "version": "github:nasa-gibs/worldview-options-eosdis#2f9c7f1d65f061afc2e014a91b6783cfe2b83eeb"
+      "version": "github:nasa-gibs/worldview-options-eosdis#c39e2adda8680a00a2666be50d525e670b455558"
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",
@@ -149,9 +149,9 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "supercluster": "3.0.2",
-    "worldview-components": "1.8.1",
-    "worldview-options-eosdis": "github:nasa-gibs/worldview-options-eosdis#v2.12.0",
-    "web-streams-polyfill": "^1.3.2"
+    "web-streams-polyfill": "^1.3.2",
+    "worldview-components": "1.9.0",
+    "worldview-options-eosdis": "github:nasa-gibs/worldview-options-eosdis#v2.13.0"
   },
   "browser": {
     "d3": "./web/ext/d3/d3.js",


### PR DESCRIPTION
## Technical Updates
- Fix date time for animation dragger, GIF dialog text, and updated url #1152
- Update URL parameter documentation #1150
- Close layer setting dialogs when showing Add Layers modal #1148
- Fix guitar pick and selection draggers from getting cutoff on edges of timeline #1147
- Add 'showSubdaily' mock URL parameter #1146
- Add vscode directory and settings #1142
- Build fixes for GIBS #1140
- Break up build bundle transforms to run conditionally depending on dev or production #1138
- Fixes unset left property of timeline being called 'auto' in some browsers #1136
- Immutable palette now also applies to continuous values #1135
- Check for transparent colormap before legend #1134
- Data download scrollbar overflow #1131
- Remove warnings when GIBS layers are not used #1130
- Add a Worldview client identifier in CMR requests #1129
- Prevent track and point removal beyond min/max zoom with mousewheel #1153
- Multiple products per layer #1151 
- Fix yearly layer not showing proper range #1165