### PR TITLE
Override JQuery UI style for map buttons

### DIFF
--- a/web/css/jquery-ui-override.css
+++ b/web/css/jquery-ui-override.css
@@ -20,6 +20,10 @@ a.ui-button.ui-state-default.ui-state-hover {
   color: #404040;
 }
 
+.ui-button.ui-state-disabled {
+  pointer-events: auto;
+}
+
 .ui-button {
   padding: 0;
   color: #eee;
@@ -276,8 +280,10 @@ or dateline overlays to be selectable. */
   user-select: none !important;
 }
 
-.wv-map-zoom:focus {
+.wv-map-zoom:focus,
+.wv-map-zoom.ui-button.ui-state-disabled:hover {
   border: 1px solid #333;
-  color: #eee;
+  color: #eeee;
   background-color: rgba(40, 40, 40, 0.85);
 }
+

--- a/web/css/jquery-ui-override.css
+++ b/web/css/jquery-ui-override.css
@@ -275,3 +275,9 @@ or dateline overlays to be selectable. */
   -ms-user-select: none !important;
   user-select: none !important;
 }
+
+.wv-map-zoom:focus {
+  border: 1px solid #333;
+  color: #eee;
+  background-color: rgba(40, 40, 40, 0.85);
+}


### PR DESCRIPTION
## Description

Fixes #1199.
Fixes #1201.

- override JQuery UI style for map buttons
- set pointer-events to auto when button is disabled
- override style when hovering over disabled button

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
