### PR TITLE
Use today for end date in active layers

### DIFF
--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -132,15 +132,8 @@ export function layersModel(models, config) {
         max = Math.max(max, end);
       } else if (def.endDate) {
         range = true;
-        let end = util.parseDateUTC(def.endDate)
+        max = util.now()
           .getTime();
-        let today = util.today()
-          .getTime();
-        if (end > today) {
-          max = Math.max(max, end);
-        } else {
-          max = Math.max(max, today);
-        }
       }
       // If there is a start date but no end date, this is a
       // product that is currently being created each day, set


### PR DESCRIPTION
## Description

Fixes #1188.

- change active layers to use today as the end date instead of the value provided by the GetCapabilities document

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
