### PR TITLE
Truncate selected date to UTC midnight when not subdaily

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -120,6 +120,11 @@ export function mapLayerBuilder(models, config, cache, Parent) {
       date = options.date;
     } else {
       date = models.date.selected;
+      // If this not a subdaily layer, truncate the selected time to
+      // UTC midnight
+      if (def.period !== 'subdaily') {
+        date = util.clearTimeUTC(date);
+      }
     }
     // Perform extensive checks before finding closest date
     if (!options.precache && (animRange && animRange.playing === false) &&
@@ -156,11 +161,6 @@ export function mapLayerBuilder(models, config, cache, Parent) {
     var projId = models.proj.selected.id;
     var palette = '';
 
-    if (options.date) {
-      date = options.date;
-    } else {
-      date = models.date.selected;
-    }
     date = self.closestDate(def, options);
 
     if (models.palettes.isActive(def.id)) {


### PR DESCRIPTION
## Description

Fixes #1216.

Non-subdaily layers were getting added to the layer cache with the selected time. On subsequent lookups, it was searching for layers at UTC midnight but couldn't find any. 

- truncate selected date to UTC midnight when not subdaily
- remove dead code segment

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
