### PR TITLE
Fix tour break when not in geographic projection

### DIFF
--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -60,9 +60,9 @@ export function sidebarUi(models, config, ui) {
       .on('update', updateLayers);
 
     ui.tour.events.on('reset', () => {
-      updateState('isCompareMode');
-      updateData();
       updateLayers();
+      updateData();
+      updateState('isCompareMode');
     });
     models.palettes.events
       .on('set-custom', updateLayers)

--- a/web/js/tour.js
+++ b/web/js/tour.js
@@ -218,16 +218,16 @@ export default function(models, ui, config) {
 
     leading = models.map.getLeadingExtent();
     map.getView().fit(leading, map.getSize());
-    setTourState();
     self.resetting = false;
     self.events.trigger('reset');
+    setTourState();
   };
 
   var setTourState = function() {
+    models.proj.selectDefault();
     ui.sidebar.expandNow();
     ui.sidebar.selectTab('layers');
     ui.timeline.expandNow();
-    models.proj.selectDefault();
   };
 
   var validScreenSize = function() {


### PR DESCRIPTION
## Description
Fix: Layer-sidebar disappears when you click `Start Tour` from a `non-geographic` projection
Fixes #1251.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
