### PR TITLE
Fix layer reordering bug that results in losing layers when toggling projections

### DIFF
--- a/web/js/compare/util.js
+++ b/web/js/compare/util.js
@@ -4,11 +4,17 @@ export function getCompareObjects(models) {
   var obj = {};
   obj.a = {
     dateString: util.toISOStringDate(models.date.selected),
-    layers: models.layers.get({ group: 'all' }, models.layers['active'])
+    layers: models.layers.get(
+      { group: 'all', proj: 'all' },
+      models.layers['active']
+    )
   };
   obj.b = {
     dateString: util.toISOStringDate(models.date.selectedB),
-    layers: models.layers.get({ group: 'all' }, models.layers['activeB'])
+    layers: models.layers.get(
+      { group: 'all', proj: 'all' },
+      models.layers['activeB']
+    )
   };
   return obj;
 }

--- a/web/js/components/sidebar/products/layer-list.js
+++ b/web/js/components/sidebar/products/layer-list.js
@@ -91,44 +91,48 @@ class LayerList extends React.Component {
                       className="category"
                       ref={provided.innerRef}
                     >
-                      {layers.map((object, i) => (
-                        <Layer
-                          layer={object}
-                          groupId={groupId}
-                          layerGroupName={layerGroupName}
-                          getLegend={context.getLegend}
-                          key={i}
-                          index={i}
-                          layerClasses="item productsitem"
-                          zot={
-                            context.zotsObject[object.id]
-                              ? context.zotsObject[object.id].value
-                              : null
-                          }
-                          isMobile={context.isMobile}
-                          names={context.getNames(object.id)}
-                          checkerBoardPattern={context.checkerBoardPattern}
-                          palette={this.getPalette(
-                            object,
-                            context.palettePromise
-                          )}
-                          isDisabled={
-                            !context.getAvailability(
-                              object.id,
-                              undefined,
-                              layerGroupName
-                            )
-                          }
-                          isVisible={object.visible}
-                          updateLayer={context.updateLayer}
-                          runningObject={
-                            context.runningLayers &&
-                            context.runningLayers[object.id]
-                              ? context.runningLayers[object.id]
-                              : null
-                          }
-                        />
-                      ))}
+                      {layers.map((object, i) => {
+                        return object.projections[context.projection] ? (
+                          <Layer
+                            layer={object}
+                            groupId={groupId}
+                            layerGroupName={layerGroupName}
+                            getLegend={context.getLegend}
+                            key={i}
+                            index={i}
+                            layerClasses="item productsitem"
+                            zot={
+                              context.zotsObject[object.id]
+                                ? context.zotsObject[object.id].value
+                                : null
+                            }
+                            isMobile={context.isMobile}
+                            names={context.getNames(object.id)}
+                            checkerBoardPattern={context.checkerBoardPattern}
+                            palette={this.getPalette(
+                              object,
+                              context.palettePromise
+                            )}
+                            isDisabled={
+                              !context.getAvailability(
+                                object.id,
+                                undefined,
+                                layerGroupName
+                              )
+                            }
+                            isVisible={object.visible}
+                            updateLayer={context.updateLayer}
+                            runningObject={
+                              context.runningLayers &&
+                              context.runningLayers[object.id]
+                                ? context.runningLayers[object.id]
+                                : null
+                            }
+                          />
+                        ) : (
+                          ''
+                        );
+                      })}
                       {provided.placeholder}
                     </ul>
                   );

--- a/web/js/components/sidebar/provider.js
+++ b/web/js/components/sidebar/provider.js
@@ -16,7 +16,8 @@ export class SidebarProvider extends React.Component {
       getLegend: props.getLegend,
       zotsObject: props.zotsObject,
       replaceSubGroup: props.replaceSubGroup,
-      isMobile: props.isMobile
+      isMobile: props.isMobile,
+      projection: props.projection
     };
   }
   componentWillReceiveProps(props) {
@@ -31,6 +32,9 @@ export class SidebarProvider extends React.Component {
     }
     if (this.state.isMobile !== props.isMobile) {
       this.setState({ isMobile: props.isMobile });
+    }
+    if (this.state.projection !== props.projection) {
+      this.setState({ projection: props.projection });
     }
   }
   render() {
@@ -52,5 +56,6 @@ SidebarProvider.propTypes = {
   palettePromise: PropTypes.func,
   runningLayers: PropTypes.object,
   getLegend: PropTypes.func,
-  zotsObject: PropTypes.object
+  zotsObject: PropTypes.object,
+  projection: PropTypes.string
 };

--- a/web/js/components/sidebar/sidebar.js
+++ b/web/js/components/sidebar/sidebar.js
@@ -39,7 +39,8 @@ class Sidebar extends React.Component {
       getDataSelectionCounts: props.getDataSelectionCounts,
       dataDownloadObject: {},
       selectedDataProduct: props.selectedDataProduct,
-      showDataUnavailableReason: props.showDataUnavailableReason
+      showDataUnavailableReason: props.showDataUnavailableReason,
+      projection: props.projection
     };
   }
   componentDidMount() {
@@ -155,7 +156,8 @@ class Sidebar extends React.Component {
       comparisonType,
       onGetData,
       windowHeight,
-      filterEventList
+      filterEventList,
+      projection
     } = this.state;
     const {
       onTabClick,
@@ -187,6 +189,7 @@ class Sidebar extends React.Component {
         replaceSubGroup={replaceSubGroup}
         isMobile={isMobile}
         checkerBoardPattern={checkerBoardPattern}
+        projection={projection}
       >
         <a
           href="/"

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -509,7 +509,7 @@ export function layersModel(models, config) {
     });
     lodashEach(defs, function(def) {
       // Skip if this layer isn't available for the selected projection
-      if (!def.projections[projId]) {
+      if (!def.projections[projId] && projId !== 'all') {
         return;
       }
       if (

--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -100,7 +100,11 @@ export function sidebarUi(models, config, ui) {
         });
     }
     models.date.events.on('select', updateLayers);
-    if (models.proj) models.proj.events.on('select', updateLayers);
+    if (models.proj) {
+      models.proj.events.on('select', updateLayers).on('select', () => {
+        self.reactComponent.setState({ projection: models.proj.selected.id });
+      });
+    }
     models.map.events.on('data-running', runningLayers => {
       self.reactComponent.setState({ runningLayers: runningLayers });
     });
@@ -164,6 +168,10 @@ export function sidebarUi(models, config, ui) {
       filterEventList: null,
       selectEvent: null,
       deselectEvent: null,
+      projection:
+        models.proj && models.proj.selected.id
+          ? models.proj.selected.id
+          : 'geographic',
       selectedEvent:
         models.naturalEvents && models.naturalEvents.selected
           ? models.naturalEvents.selected
@@ -277,7 +285,7 @@ export function sidebarUi(models, config, ui) {
       case 'layers':
         return self.reactComponent.setState({
           layers: models.layers.get(
-            { group: 'all' },
+            { group: 'all', proj: 'all' },
             models.layers[models.layers.activeLayers]
           )
         });


### PR DESCRIPTION
## Description
Fix layer reordering bug that results in losing layers when toggling projections

Fixes #1252 .


* Updated `models.layers.get()` function to accept the option `proj: 'all'`,  retrieving
layers of all projections
* Filter layers by projection in layer-list component as opposed to passing them into the sidebar React component pre-filtering layers for the correct projection

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
