### PR TITLE
Close layer settings on tab change

### DIFF
--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -329,6 +329,7 @@ export function sidebarUi(models, config, ui) {
   self.selectTab = function(tab) {
     if (activeTab === tab) return;
     activeTab = tab;
+    wvui.close();
     self.events.trigger('selectTab', tab);
     updateState('activeTab');
   };


### PR DESCRIPTION
## Description
Close Info/settings dialogs when changing TAB (between layers and events/Data-download)
Fixes #1267 .

- [x] Close layer settings on tab change

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
