### PR TITLE
Constrain drag-drop to within parent layer-group #1256

### DIFF
--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -187,7 +187,8 @@ li.item ul.palette li {
 }
 
 .sidebar-panel ul.category {
-  overflow: auto;
+  position: relative;
+  overflow: hidden;
 }
 
 .sidebar-panel ul.category li h3,

--- a/web/js/components/sidebar/products/layer.js
+++ b/web/js/components/sidebar/products/layer.js
@@ -5,7 +5,13 @@ import { Draggable } from 'react-beautiful-dnd';
 import util from '../../../util/util';
 
 const visibilityButtonClasses = 'hdanchor hide hideReg bank-item-img';
-
+const getItemStyle = (isDragging, draggableStyle) => ({
+  // some basic styles to make the items look a bit nicer
+  ...draggableStyle,
+  position: isDragging ? 'absolute' : 'relative',
+  top: null,
+  left: null
+});
 class Layer extends React.Component {
   constructor(props) {
     super(props);
@@ -91,6 +97,10 @@ class Layer extends React.Component {
               {...provided.draggableProps}
               {...provided.dragHandleProps}
               id={layerGroupName + '-' + util.encodeId(layer.id)}
+              style={getItemStyle(
+                snapshot.isDragging,
+                provided.draggableProps.style
+              )}
               className={
                 isDisabled
                   ? layerClasses + ' disabled layer-hidden'


### PR DESCRIPTION
## Description

Fixes #1256 .

[Description of the bug or feature]

- [x] Override some `react-beautiful-dnd` styles to constrain layer to correct layer-group
- [x] Add yellow background when dragging

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If we decide that we want to lock the axis later, the forked code to do so is here: https://github.com/Benjaki2/react-beautiful-dnd/commit/db69256abc597770157853d93bcd671a6b85c4c7

@nasa-gibs/worldview
