### PR TITLE
Remove dateline dates when in AB 

### DIFF
--- a/web/js/components/dateline/dateline.js
+++ b/web/js/components/dateline/dateline.js
@@ -17,8 +17,7 @@ class Line extends React.Component {
     this.state = {
       hovered: false,
       height: props.height,
-      active: true,
-      isTooltipActive: props.isTooltipActive
+      active: true
     };
   }
 
@@ -53,7 +52,6 @@ class Line extends React.Component {
    * return {Void}
    */
   mouseOverHidden(e) {
-    if (!this.state.isTooltipActive) return;
     this.props.lineOver(
       [e.clientX, e.clientY],
       this.props.overlay,
@@ -70,7 +68,6 @@ class Line extends React.Component {
    * return {Void}
    */
   mouseOutHidden() {
-    if (!this.state.isTooltipActive) return;
     this.props.lineOut(this.props.tooltip);
   }
 
@@ -143,8 +140,7 @@ Line.propTypes = {
   overlay: PropTypes.object,
   style: PropTypes.object,
   id: PropTypes.string,
-  classes: PropTypes.string,
-  isTooltipActive: PropTypes.bool
+  classes: PropTypes.string
 };
 
 export default Line;

--- a/web/js/components/dateline/dateline.js
+++ b/web/js/components/dateline/dateline.js
@@ -17,7 +17,8 @@ class Line extends React.Component {
     this.state = {
       hovered: false,
       height: props.height,
-      active: true
+      active: true,
+      isTooltipActive: props.isTooltipActive
     };
   }
 
@@ -52,6 +53,7 @@ class Line extends React.Component {
    * return {Void}
    */
   mouseOverHidden(e) {
+    if (!this.state.isTooltipActive) return;
     this.props.lineOver(
       [e.clientX, e.clientY],
       this.props.overlay,
@@ -68,6 +70,7 @@ class Line extends React.Component {
    * return {Void}
    */
   mouseOutHidden() {
+    if (!this.state.isTooltipActive) return;
     this.props.lineOut(this.props.tooltip);
   }
 
@@ -140,7 +143,8 @@ Line.propTypes = {
   overlay: PropTypes.object,
   style: PropTypes.object,
   id: PropTypes.string,
-  classes: PropTypes.string
+  classes: PropTypes.string,
+  isTooltipActive: PropTypes.bool
 };
 
 export default Line;

--- a/web/js/components/dateline/text.js
+++ b/web/js/components/dateline/text.js
@@ -37,7 +37,7 @@ class LineText extends React.Component {
       <svg className="dateline-text" style={svgStyle}>
         <rect
           fill={this.props.fill}
-          width={leftTextWidth + 10}
+          width={leftTextWidth + 12}
           height={this.props.textHeight}
           x={0}
           rx={this.props.recRadius}
@@ -62,7 +62,7 @@ class LineText extends React.Component {
         </text>
         <rect
           fill={this.props.fill}
-          width={rightTextWidth + 10}
+          width={rightTextWidth + 12}
           height={this.props.textHeight}
           x={leftTextWidth + 40}
           rx={this.props.recRadius}
@@ -95,14 +95,9 @@ LineText.defaultProps = {
   color: 'white',
   textY: 14,
   fill: 'rgba(40,40,40,0.5)',
-  x2: 155,
-  x1: 45,
   textWidth: 80,
   textHeight: 20,
-  recRadius: 3,
-  svgStyle: {
-    transform: 'translateX(-140px)'
-  }
+  recRadius: 3
 };
 
 LineText.propTypes = {
@@ -114,8 +109,6 @@ LineText.propTypes = {
   fill: PropTypes.string,
   dateLeft: PropTypes.string,
   dateRight: PropTypes.string,
-  x2: PropTypes.number,
-  x1: PropTypes.number,
   textWidth: PropTypes.number,
   textHeight: PropTypes.number,
   recRadius: PropTypes.number,

--- a/web/js/components/dateline/text.js
+++ b/web/js/components/dateline/text.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import util from '../../util/util';
+
 /*
  * Builds an SVG text box
  *
@@ -20,38 +22,65 @@ class LineText extends React.Component {
   }
 
   render() {
+    const leftTextWidth =
+      Math.round(
+        util.getTextWidth(this.state.dateLeft, '13px Open Sans') * 100
+      ) / 100 || this.props.textWidth;
+    const rightTextWidth =
+      Math.round(
+        util.getTextWidth(this.state.dateRight, '13px Open Sans') * 100
+      ) / 100 || this.props.textWidth;
+    const svgStyle = {
+      transform: 'translateX(' + -(leftTextWidth + 20) + 'px)'
+    };
     return (
-      <svg className="dateline-text" style={this.props.svgStyle}>
+      <svg className="dateline-text" style={svgStyle}>
         <rect
           fill={this.props.fill}
-          width={this.props.textWidth}
+          width={leftTextWidth + 10}
           height={this.props.textHeight}
-          x={this.props.x1}
+          x={0}
           rx={this.props.recRadius}
-          opacity={this.state.active ? this.props.rectOpacity : '0'}
+          opacity={
+            this.state.active && this.state.dateLeft
+              ? this.props.rectOpacity
+              : '0'
+          }
         />
         <text
           y={this.props.textY}
-          x={this.props.x1 + 6}
+          x={6}
           fill={this.props.color}
           width={this.props.width}
-          opacity={this.state.active ? this.props.textOpacity : '0'}
+          opacity={
+            this.state.active && this.state.dateLeft
+              ? this.props.textOpacity
+              : '0'
+          }
         >
           {this.state.dateLeft}
         </text>
         <rect
           fill={this.props.fill}
-          width={this.props.textWidth}
+          width={rightTextWidth + 10}
           height={this.props.textHeight}
-          x={this.props.x2}
+          x={leftTextWidth + 40}
           rx={this.props.recRadius}
-          opacity={this.state.active ? this.props.rectOpacity : '0'}
+          opacity={
+            this.state.active && this.state.dateRight
+              ? this.props.rectOpacity
+              : '0'
+          }
         />
         <text
           y={this.props.textY}
-          x={this.props.x2 + 6}
+          x={leftTextWidth + 46}
           fill={this.props.color}
-          opacity={this.state.active ? this.props.textOpacity : '0'}
+          opacity={
+            this.state.active && this.state.dateRight
+              ? this.props.textOpacity
+              : '0'
+          }
         >
           {this.state.dateRight}
         </text>

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -137,18 +137,13 @@ export function mapDateLineBuilder(models, config) {
   };
 
   /*
-   * Add Props to React Compents that creates an
-   *  SVG text component
-   *
    * @method updateTextState
    * @private
    *
-   * @param {object} Factory - React component Factory
-   * @param {object} reactCase - Dom El in which to render component
    * @param {object} date - JS date object
    * @param {boolean} isLeft - is this on left or right side of map
    *
-   * @returns {object} React Component
+   * @returns {object} Object with tooltip state
    */
   var getTextState = function(date, isLeft) {
     const isCompareActive = models.compare && models.compare.active;

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -68,6 +68,7 @@ export function mapDateLineBuilder(models, config) {
         };
         lineRight.setState(state);
         lineLeft.setState(state);
+        updateDate(models.date[models.date.activeDate]);
       });
     }
     models.proj.events.on('select', function() {

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -61,6 +61,15 @@ export function mapDateLineBuilder(models, config) {
     models.date.events.on('select', function() {
       updateDate(models.date[models.date.activeDate]);
     });
+    if (models.compare) {
+      models.compare.events.on('toggle', function() {
+        var state = {
+          isTooltipActive: !(models.compare && models.compare.active)
+        };
+        lineRight.setState(state);
+        lineLeft.setState(state);
+      });
+    }
     models.proj.events.on('select', function() {
       proj = models.proj.selected.id;
     });
@@ -101,7 +110,8 @@ export function mapDateLineBuilder(models, config) {
       lineOut: onMouseOut,
       lineX: lineX,
       overlay: overlay,
-      tooltip: tooltip
+      tooltip: tooltip,
+      isTooltipActive: !(models.compare && models.compare.active)
     };
     var component = ReactDOM.render(
       React.createElement(ReactComponent, props),


### PR DESCRIPTION
## Description

Fixes #1246 .

Eliminate tooltip that shows dateline dates when in A|B mode


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
Having date tooltips at the dateline would be confusing because the user would not know what state (A or B) the dateline's date refers to.

@nasa-gibs/worldview
