### PR TITLE
Event marker hover IE11 CustomEvent fix

### DIFF
--- a/web/js/natural-events/markers.js
+++ b/web/js/natural-events/markers.js
@@ -167,7 +167,7 @@ export default function markers (models, ui) {
 
   var passEventToTarget = function (event, target) {
     try {
-      var eventCopy = new event.constructor(event.type, event);
+      var eventCopy = new CustomEvent(event.type, event);
       target.dispatchEvent(eventCopy);
     } catch (err) {
       console.log(err);

--- a/web/js/natural-events/markers.js
+++ b/web/js/natural-events/markers.js
@@ -167,7 +167,14 @@ export default function markers (models, ui) {
 
   var passEventToTarget = function (event, target) {
     try {
-      var eventCopy = new CustomEvent(event.type, event);
+      let eventCopy;
+      // polyfill fix for IE11 CustomEvent from https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+      if (typeof window.CustomEvent !== 'function') {
+        eventCopy = document.createEvent('CustomEvent');
+        eventCopy.initCustomEvent(event, event.bubbles, event.cancelable, event.detail);
+      } else {
+        eventCopy = new event.constructor(event.type, event);
+      }
       target.dispatchEvent(eventCopy);
     } catch (err) {
       console.log(err);

--- a/web/js/polyfill.js
+++ b/web/js/polyfill.js
@@ -164,28 +164,6 @@ export function polyfill () {
   }
 
   /*
-   * CustomEvent()
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
-   */
-  if (typeof window.CustomEvent !== 'function') {
-    (function () {
-      function CustomEvent(event, params) {
-        params = params || {
-          bubbles: false,
-          cancelable: false,
-          detail: undefined
-        };
-        var evt = document.createEvent('CustomEvent');
-        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
-        return evt;
-      }
-      CustomEvent.prototype = window.Event.prototype;
-      window.CustomEvent = CustomEvent;
-    })();
-  }
-
-  /*
    * Mobile device quirks.  This section is mostly overwriting things that jquery.mobile is adding
    */
   (function () {

--- a/web/js/polyfill.js
+++ b/web/js/polyfill.js
@@ -164,6 +164,28 @@ export function polyfill () {
   }
 
   /*
+   * CustomEvent()
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+   */
+  if (typeof window.CustomEvent !== 'function') {
+    (function () {
+      function CustomEvent(event, params) {
+        params = params || {
+          bubbles: false,
+          cancelable: false,
+          detail: undefined
+        };
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+        return evt;
+      }
+      CustomEvent.prototype = window.Event.prototype;
+      window.CustomEvent = CustomEvent;
+    })();
+  }
+
+  /*
    * Mobile device quirks.  This section is mostly overwriting things that jquery.mobile is adding
    */
   (function () {


### PR DESCRIPTION
## Description

Fixes #1155  .

- Add conditional polyfill fix for CustomEvent in IE11 to remove errors on event marker hover
https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
