### PR TITLE
Remove additional timezone offset compensation for year zoom timeline

### DIFF
--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -173,9 +173,6 @@ export function timelineConfig(models, config, ui) {
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
-          prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
           return new Date(
             d.getUTCFullYear(),
             prevDate.getUTCMonth(),
@@ -227,9 +224,6 @@ export function timelineConfig(models, config, ui) {
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
-          prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
           return new Date(
             d.getUTCFullYear(),
             prevDate.getUTCMonth(),


### PR DESCRIPTION
## Description

Fixes #1258  . 

- Removes extra subtraction of timezone offset from ```previous date``` used in calculating new date when clicking ticks and boundaries on the timeline in the year zoom level. The timezone offset is already calculated in the original ```previous date``` and subtracting it twice causes unintended date selection.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
