### PR TITLE
Fix A|B draggers touch-event bug

### DIFF
--- a/web/js/components/range-selection/dragger.js
+++ b/web/js/components/range-selection/dragger.js
@@ -154,7 +154,8 @@ class TimelineDragger extends React.Component {
   handleDrag(e, d) {
     e.stopPropagation();
     e.preventDefault();
-    var position = this.state.position + e.movementX;
+    var deltaX = e.movementX || d.deltaX;
+    var position = this.state.position + deltaX;
     this.props.onDrag(d.deltaX, this.props.id, d.x);
     this.setState({ position: position });
   }

--- a/web/js/date/compare-picks.js
+++ b/web/js/date/compare-picks.js
@@ -143,15 +143,18 @@ export function timelineCompare(models, config, ui) {
     return timeline.x(util.roundTimeTenMinute(date));
   };
   var dateSelect = function(e, id, offsetX) {
+    const padding = 10;
     var position = offsetX;
-    if (position > max - 5) {
-      position = max - 5;
-    } else if (position <= 5) {
-      position = 5;
+    if (position > max - padding) {
+      position = max - padding;
+    } else if (position <= padding) {
+      position = padding;
     }
     var date = timeline.x.invert(position);
-    if (models.date[id] !== date) {
+    if (models.date[id] !== date && util.isValidDate(date)) {
       models.date.select(date, id);
+    } else {
+      models.date.select(models.date[id], id);
     }
   };
   var debounceDateSelect = lodashDebounce(dateSelect, DEBOUNCE_TIME);

--- a/web/js/date/compare-picks.js
+++ b/web/js/date/compare-picks.js
@@ -25,10 +25,11 @@ export function timelineCompare(models, config, ui) {
     $timeline.addClass('ab-active');
   }
   var init = function() {
+    const START_EVENT = util.browser.touchDevice ? 'touchstart' : 'mousedown';
     mountObjectA = document.createElementNS(xmlns, 'g');
     mountObjectB = document.createElementNS(xmlns, 'g');
-    mountObjectA.addEventListener('mousedown', toggleCheck);
-    mountObjectB.addEventListener('mousedown', toggleCheck);
+    mountObjectA.addEventListener(START_EVENT, toggleCheck);
+    mountObjectB.addEventListener(START_EVENT, toggleCheck);
     parentSvg = document.getElementById('timeline-footer-svg');
     parentSvg.appendChild(mountObjectA);
     parentSvg.appendChild(mountObjectB);

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -222,7 +222,13 @@ export default (function (self) {
     }
     return date;
   };
-
+  /**
+   * Test if is valid Date
+   * @param {Object} d | Date object
+   */
+  self.isValidDate = function(d) {
+    return d instanceof Date && !isNaN(d);
+  };
   /**
    * Parses a UTC ISO 8601 date to a non UTC date
    *


### PR DESCRIPTION
## Description

Fixes #1286

- [x] Add touch-start event listener to A|B draggers 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
I couldn't test this but I think it might fix the problem. Ipads with local testing are not working on browserstack.

@nasa-gibs/worldview
