### PR TITLE
Make Tab hover border not overlap blue area 

### DIFF
--- a/web/css/sidebar.css
+++ b/web/css/sidebar.css
@@ -50,6 +50,9 @@
 .nav-tabs .nav-link {
   padding: 4px 8px;
 }
+.main-nav .nav-link {
+  margin: 1px 0;
+}
 #productsHolder .nav-tabs .disabled {
   color: #fff;
   opacity: 0.5;


### PR DESCRIPTION
## Description

Fixes #1278 .
- [x] Make it so white tab border does not cover blue bottom-border on hover

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
