### PR TITLE
Add reverse tab (shift tab) functionality to date selector input

### DIFF
--- a/web/js/components/date-selector/date-selector.js
+++ b/web/js/components/date-selector/date-selector.js
@@ -35,18 +35,27 @@ class DateSelector extends React.Component {
   blur() {
     this.setState({ tab: null });
   }
-  nextTab(index) {
-    var nextTab;
+  setFocusedTab(tab) {
+    this.setState({ tab: tab });
+  }
+  changeTab(index) {
+    var nextTab = index;
     var maxTab;
     if (this.state.maxZoom >= 4) {
       maxTab = 5;
     } else {
       maxTab = 3;
     }
-    if (index < maxTab) {
-      nextTab = index + 1;
+    if (index > this.state.tab) {
+      // past max tab
+      if (index > maxTab) {
+        nextTab = 1;
+      }
     } else {
-      nextTab = 1;
+      // below min tab
+      if (index < 1) {
+        nextTab = maxTab;
+      }
     }
     this.setState({
       tab: nextTab
@@ -75,7 +84,8 @@ class DateSelector extends React.Component {
             value={util.pad(this.state.date.getUTCHours(), 2, '0')}
             tabIndex={4}
             focused={this.state.tab === 4}
-            nextTab={this.nextTab.bind(this)}
+            setFocusedTab={this.setFocusedTab.bind(this)}
+            changeTab={this.changeTab.bind(this)}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
             blur={this.blur.bind(this)}
@@ -95,7 +105,8 @@ class DateSelector extends React.Component {
             inputId={this.props.idSuffix ? 'minute-' + this.props.idSuffix : ''}
             tabIndex={5}
             focused={this.state.tab === 5}
-            nextTab={this.nextTab.bind(this)}
+            setFocusedTab={this.setFocusedTab.bind(this)}
+            changeTab={this.changeTab.bind(this)}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
             blur={this.blur.bind(this)}
@@ -122,7 +133,8 @@ class DateSelector extends React.Component {
           inputId={this.props.idSuffix ? 'year-' + this.props.idSuffix : ''}
           tabIndex={1}
           focused={this.state.tab === 1}
-          nextTab={this.nextTab.bind(this)}
+          setFocusedTab={this.setFocusedTab.bind(this)}
+          changeTab={this.changeTab.bind(this)}
           maxDate={this.props.maxDate}
           minDate={this.props.minDate}
           blur={this.blur.bind(this)}
@@ -141,7 +153,8 @@ class DateSelector extends React.Component {
           updateDate={this.updateDate.bind(this)}
           tabIndex={2}
           focused={this.state.tab === 2}
-          nextTab={this.nextTab.bind(this)}
+          setFocusedTab={this.setFocusedTab.bind(this)}
+          changeTab={this.changeTab.bind(this)}
           maxDate={this.props.maxDate}
           minDate={this.props.minDate}
           blur={this.blur.bind(this)}
@@ -160,7 +173,8 @@ class DateSelector extends React.Component {
           tabIndex={3}
           inputId={this.props.idSuffix ? 'day-' + this.props.idSuffix : ''}
           focused={this.state.tab === 3}
-          nextTab={this.nextTab.bind(this)}
+          setFocusedTab={this.setFocusedTab.bind(this)}
+          changeTab={this.changeTab.bind(this)}
           maxDate={this.props.maxDate}
           minDate={this.props.minDate}
           blur={this.blur.bind(this)}

--- a/web/js/components/date-selector/input.js
+++ b/web/js/components/date-selector/input.js
@@ -58,7 +58,13 @@ class DateInputColumn extends React.Component {
     var keyCode = e.keyCode;
     var value = e.target.value;
     var newDate;
+    var shiftTab;
     var entered = keyCode === 13 || keyCode === 9;
+
+    // shift down when tab pressed
+    if (e.shiftKey && keyCode === 9) {
+      shiftTab = true;
+    }
     if (keyCode === 38) {
       // up
       e.preventDefault();
@@ -97,8 +103,13 @@ class DateInputColumn extends React.Component {
       if (newDate) {
         this.props.updateDate(newDate);
         if (entered) {
-          // if enetered or tabbed
-          this.nextTab();
+          if (shiftTab) {
+            // shift-tabbed - move backward
+            this.previousTab();
+          } else {
+            // entered or tabbed - move forward
+            this.nextTab();
+          }
         }
       } else if (entered) {
         this.setState({
@@ -212,6 +223,7 @@ class DateInputColumn extends React.Component {
   handleFocus(e) {
     e.target.select();
     this.setState({ selected: true });
+    this.props.setFocusedTab(this.props.tabIndex);
   }
   blur() {
     this.setState({
@@ -228,7 +240,10 @@ class DateInputColumn extends React.Component {
     });
   }
   nextTab() {
-    this.props.nextTab(this.props.tabIndex);
+    this.props.changeTab(this.props.tabIndex + 1);
+  }
+  previousTab() {
+    this.props.changeTab(this.props.tabIndex - 1);
   }
   validateDate(date) {
     if (date > this.props.minDate && date <= this.props.maxDate) {
@@ -305,7 +320,8 @@ DateInputColumn.propTypes = {
   maxDate: PropTypes.object,
   maxZoom: PropTypes.number,
   blur: PropTypes.func,
-  nextTab: PropTypes.func,
+  setFocusedTab: PropTypes.func,
+  changeTab: PropTypes.func,
   height: PropTypes.string,
   inputId: PropTypes.string,
   fontSize: PropTypes.number


### PR DESCRIPTION
## Description

Fixes #1293  .

- Add functionality for users to now use shift-tab along with tab to navigate forward and backwards, respectively, in the date selector inputs.
- Minor refactor of existing tab select function and addition of tab state set function

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
