### PR TITLE
Add vendor prefix IE11/Edge scrollbar fix for cut off layer list text

### DIFF
--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -447,6 +447,7 @@
   float: left;
   clear: both;
   overflow: auto;
+  -ms-overflow-style: scrollbar;
   padding: 0;
 }
 


### PR DESCRIPTION
## Description

Fixes #1316 .

Missing scrollbar-x for overflow in IE11/Edge for satellite text in layer list. Any text cut off can't be seen.

- Add vendor prefix ```-ms-overflow-style: scrollbar;``` to allow scrollbar for overflow

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
