### PR TITLE
Remove 'Events may not be visible at all times' notice when not in events mode

### DIFF
--- a/web/js/natural-events/ui.js
+++ b/web/js/natural-events/ui.js
@@ -107,6 +107,10 @@ export default function naturalEventsUI(models, ui, config, request) {
       } else {
         model.active = false;
         naturalEventMarkers.remove(self.markers);
+        if (eventVisibilityAlert) {
+          eventVisibilityAlert.dialog('close');
+          eventVisibilityAlert = null;
+        }
       }
       model.events.trigger('change');
     });


### PR DESCRIPTION
## Description

Fixes #1224.

- remove 'Events may not be visible at all times' notice when not in events mode

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
