### PR TITLE
Improve cache policy for fonts and images

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -5,6 +5,10 @@ ExpiresActive On
    Header set Pragma "no-cache"
 </FilesMatch>
 
+<FilesMatch "\.(eot|ttf|woff|woff2|svg|jpg|png|gif)">
+   ExpiresDefault "modification plus 1 year"
+</FilesMatch>
+
 AddOutputFilterByType DEFLATE text/html
 AddOutputFilterByType DEFLATE text/css
 AddOutputFilterByType DEFLATE text/javascript


### PR DESCRIPTION
## Description
**Part of Google Chrome Audit Recommendation.** #1126 

Fixes #1127 . Google Audit recommends improved static asset caching. This fix adds ```cache-control``` and ```expires``` headers to fonts and images.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
