### PR TITLE
Keep layer add button red

### DIFF
--- a/web/js/components/sidebar/footer-content.js
+++ b/web/js/components/sidebar/footer-content.js
@@ -33,16 +33,12 @@ class FooterContent extends React.Component {
             <Button
               text="+ Add Layers"
               id="layers-add"
-              className={isCompareMode ? 'layers-add ' : 'layers-add red'}
+              className="layers-add red"
               onClick={addLayers}
             />
             <Button
               onClick={toggleMode}
-              className={
-                isCompareMode
-                  ? 'compare-toggle-button red'
-                  : 'compare-toggle-button'
-              }
+              className="compare-toggle-button"
               id="compare-toggle-button"
               style={isMobile || !compareFeature ? { display: 'none' } : null}
               text={!isCompareMode ? 'Start Comparison' : 'Exit Comparison'}
@@ -117,6 +113,7 @@ FooterContent.propTypes = {
   addLayers: PropTypes.func,
   toggleMode: PropTypes.func,
   getDataSelectionCounts: PropTypes.func,
-  getDataSelectionSize: PropTypes.func
+  getDataSelectionSize: PropTypes.func,
+  compareFeature: PropTypes.bool
 };
 export default FooterContent;


### PR DESCRIPTION
## Description

Fixes #1345  .

Keep `add layers` button red instead of toggling the color when `A|B` is active

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
