### PR TITLE
Add notificationURL testing parameter and documentation

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -63,3 +63,4 @@ To run tests for both browsers in sequence: `npm run e2e`.
 | `now` | date | *`YYYY-MM-DDThh:mm:ssZ`* | Overrides the current date and time. This only works when using the `now()` function from `js/util/util.js`. |
 | `showError` | boolean | *`true` or `false`* | If any value is specified, an error dialog will be shown on startup. |
 | `showSubdaily` | boolean | *`true` or `false`* | If any value is specified, the hour input, minute input and "minutes" timeline zoom option will be shown. |
+| `notificationURL` | string | `https://testing.url.com` | Overrides the notification URL found in the features.json configuration file. |

--- a/web/js/notifications/ui.js
+++ b/web/js/notifications/ui.js
@@ -48,6 +48,9 @@ export function notificationsUi(models, config) {
     if (config.parameters.mockAlerts) {
       url = 'mock/notify_' + config.parameters.mockAlerts + '.json';
     }
+    if (config.parameters.notificationURL) {
+      url = 'https://status.earthdata.nasa.gov/api/v1/notifications?domain=' + config.parameters.notificationURL;
+    }
 
     mainIcon = $('#wv-info-button')[0];
     mainIconLabel = $('#wv-info-button label')[0];


### PR DESCRIPTION
## Description

Fixes #1352 

Adds a `notificationURL` URL parameter for changing the notification URL set in the features.json configuration file.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
