### PR TITLE
v2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21087,7 +21087,7 @@
       }
     },
     "worldview-options-eosdis": {
-      "version": "github:nasa-gibs/worldview-options-eosdis#32302f7b6f4f212145142ad7e3ce42a615f83c46"
+      "version": "github:nasa-gibs/worldview-options-eosdis#71f509610d766c7a810ad7727987fc0f0b262f4f"
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",
@@ -171,7 +171,7 @@
     "simplebar": "^3.0.0-beta.1",
     "supercluster": "3.0.2",
     "web-streams-polyfill": "^1.3.2",
-    "worldview-options-eosdis": "github:nasa-gibs/worldview-options-eosdis#v2.14.1-rc.3"
+    "worldview-options-eosdis": "github:nasa-gibs/worldview-options-eosdis#v2.15.0"
   },
   "browser": {
     "d3": "./web/ext/d3/d3.js",


### PR DESCRIPTION
## New Feature
- A|B Comparison #1084 

## Technical Updates
- Update developing docs #1240 

## Bug Fixes
- Fix tour break when used with A|B #1248
- Fix collapse spacing #1249 
- Fix tour break when not in geographic projection #1253 
- Fix layer reordering bug that results in losing layers when toggling projections #1255 
- Remove granule download item from dialog #1260
- Close layer settings on tab change #1273 
- Remove extra palette spacing #1272 
- Small Style fixes #1274
- Date selector Adjustments #1271 
- Button styling #1287 
- Fix map shift when clicking on image download #1291
- Constrain drag-drop to within parent layer-group #1285
- Remove dateline dates when in AB #1288 
- Fix compare styling #1295 
- Fix discrete palettes with multiple rows #1297 
- Make Tab hover border not overlap blue area #1301 
- Fix fuzzy logo #1300 
- Checkbox label position fix #1233 
- Update tour image #1299 
- Fix A|B draggers touch-event bug #1298 
- Remove guitar pick when in A|B #1313 
- Only trigger hasData event if events is active #1315
- Fix Image download coordinate offset #1322
- Remove dangling apache config link #1325
- Allow event tab to be clicked even when EONET isn't responding #1339
- Mobile expand fix #1338
- Make A|B draggers work the same as guitar pick #1331
- Fix polar drag and dropping #1337
- Sidebar Styling bug fixes #1340
- Update compare E2E tests to work with UAT/SIT bug fixes #1341
- Keep layer add button red #1349
- Add space between Base and Layers #1350