### PR TITLE
change nightwatch process module path from bin to module

### DIFF
--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -18,7 +18,7 @@ var environment_names = environments.map(
 );
 
 try {
-  process.mainModule.filename = './node_modules/.bin/nightwatch';
+  process.mainModule.filename = './node_modules/nightwatch/bin/nightwatch';
 
   // Code to start browserstack local before start of test
   console.log('Connecting localhost to Browserstack...');


### PR DESCRIPTION
## Description

Fixes issue with Nightwatch and Browserstack running on Windows due to npm .bin packaging.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
