### PR TITLE
Fix date rendering between A & B states

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -308,7 +308,7 @@ export function mapui(models, config) {
           });
         }),
       group: arr[0],
-      date: models.date[arr[1]]
+      date: arr[1]
     });
   };
   /*
@@ -357,7 +357,7 @@ export function mapui(models, config) {
             renderable = layersModel.isRenderable(
               subLayer.wv.id,
               layersModel[group],
-              layer.get('date')
+              models.date[layer.get('date')]
             );
             subLayer.setVisible(renderable);
           }

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -307,7 +307,8 @@ export function mapui(models, config) {
             group: arr[0]
           });
         }),
-      group: arr[0]
+      group: arr[0],
+      date: models.date[arr[1]]
     });
   };
   /*


### PR DESCRIPTION
## Description

Fixes #1363 

- [x] Add correct date to layer group object


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

This problem was not noticeable unless we compared layers with different availability ranges. The `isRenderable` method was always using the `active` date to determine if a layer should be rendered

@nasa-gibs/worldview
