### PR TITLE
Improve site metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,9 @@
       "node_modules",
       "./web/ext/d3"
     ],
+    "moduleNameMapper": {
+      "^googleTagManager$": "<rootDir>/web/js/components/util/google-tag-manager.js"
+    },
     "transformIgnorePatterns": [
       "node_modules/(?!(ol)/)"
     ]

--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -10,7 +10,7 @@ import lodashThrottle from 'lodash/throttle';
 import lodashCapitalize from 'lodash/capitalize';
 import canvg from 'canvg-browser';
 import FileSaver from 'file-saver';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 import GifResSelection from '../components/animation-widget/gif-panel';
 import {
   imageUtilGetLayerOpacities,
@@ -433,7 +433,15 @@ export function animationGif(models, config, ui) {
       });
       return;
     }
-    googleAnalytics.event('Animation', 'Click', 'Create GIF');
+    googleTagManager.pushEvent({
+      'event': 'GIF_create',
+      'layers': {
+        'activeCount': models.layers.active.length
+      },
+      'GIF': {
+        'resolution': resolution
+      }
+    });
     self.createGIF();
   };
 
@@ -673,7 +681,14 @@ export function animationGif(models, config, ui) {
         .click(function(e) {
           e.preventDefault();
           FileSaver.saveAs(blob, dlURL);
-          googleAnalytics.event('Animation', 'Download', 'GIF', downloadSize);
+          googleTagManager.pushEvent({
+            'event': 'GIF_download',
+            'GIF': {
+              'downloadSize': downloadSize,
+              'increments': ui.anim.widget.getIncrements(),
+              'frameSpeed': animModel.rangeState.speed
+            }
+          });
         });
 
       var $catalog =

--- a/web/js/animation/widget.js
+++ b/web/js/animation/widget.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import AnimationWidget from '../components/animation-widget/animation-widget';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import lodashWithout from 'lodash/without';
@@ -56,7 +56,7 @@ export function animationWidget(models, config, ui) {
     );
     $timelineFooter = $('#timeline-footer');
     $animateButton.on('click', function() {
-      googleAnalytics.event('Animation', 'Click', 'Animation Icon');
+      googleTagManager.pushEvent({ 'event': 'GIF_setup_animation_button' });
       self.toggleAnimationWidget();
     });
     if (model.rangeState.state === 'on') {
@@ -405,10 +405,22 @@ export function animationWidget(models, config, ui) {
    */
   self.onPressGIF = function() {
     let zoomLevel = ui.anim.ui.getInterval();
+    let looping = ui.anim.widget.reactComponent.state.looping;
     if (zoomLevel !== 'minute') {
       // zero out start/end date times
       self.setZeroDateTimes();
     }
+
+    let increment = self.getIncrements();
+    let frameSpeed = model.rangeState.speed;
+    googleTagManager.pushEvent({
+      'event': 'GIF_create_animated_button',
+      'GIF': {
+        'increment': increment,
+        'frameSpeed': frameSpeed,
+        'looping': looping
+      }
+    });
     model.events.trigger('gif-click');
   };
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4,6 +4,7 @@ import 'babel-polyfill'; // Needed for worldview-components in IE and older brow
 import $ from 'jquery';
 import lodashEach from 'lodash/each';
 import googleAnalytics from './components/util/google-analytics';
+import googleTagManager from './components/util/google-tag-manager';
 
 // Utils
 import util from './util/util';
@@ -396,6 +397,9 @@ class App extends React.Component {
       models.link.load(state);
       if (config.features.googleAnalytics) {
         googleAnalytics.init(config.features.googleAnalytics.id); // Insert google tracking
+      }
+      if (config.features.googleTagManager) {
+        googleTagManager.init(config.features.googleTagManager.id); // Insert google tag manager
       }
 
       // HACK: Map needs to be created before the data download model

--- a/web/js/components/animation-widget/animation-widget.js
+++ b/web/js/components/animation-widget/animation-widget.js
@@ -5,6 +5,7 @@ import TimeSelector from '../date-selector/date-selector';
 import LoopButton from './loop-button';
 import PlayButton from './play-button';
 import AnimWidgetHeader from './header';
+import googleTagManager from 'googleTagManager';
 
 /*
  * A react component, Builds a rather specific
@@ -91,6 +92,9 @@ class AnimationWidget extends React.Component {
   }
   onDateChange(date, id) {
     const { endDate, startDate } = this.state;
+    googleTagManager.pushEvent({
+      'event': 'GIF_animation_date_case'
+    });
     if (id === 'start') {
       this.setState({
         startDate: date

--- a/web/js/components/range-selection/range-selection.js
+++ b/web/js/components/range-selection/range-selection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Dragger from './dragger.js';
 import DraggerRange from './dragger-range.js';
+import googleTagManager from 'googleTagManager';
 
 /*
  * A react component, is a draggable svg
@@ -94,6 +95,9 @@ class TimelineRangeSelector extends React.Component {
    */
   onDragStop() {
     this.props.onDrag(this.state.startLocation, this.state.endLocation);
+    googleTagManager.pushEvent({
+      'event': 'GIF_animation_dragger'
+    });
   }
   onRangeClick(d) {
     this.props.onRangeClick(d.nativeEvent);

--- a/web/js/components/sidebar/data/product.js
+++ b/web/js/components/sidebar/data/product.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../../util/util';
+import googleTagManager from 'googleTagManager';
 const listId = 'wv-data';
 
 class Data extends React.Component {
@@ -32,6 +33,9 @@ class Data extends React.Component {
           <span
             onClick={e => {
               showUnavailableReason();
+              googleTagManager.pushEvent({
+                'event': 'data_download_not_available'
+              });
             }}
             className="link"
           >

--- a/web/js/components/sidebar/events/event.js
+++ b/web/js/components/sidebar/events/event.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../../util/util';
 import lodashFind from 'lodash/find';
+import googleTagManager from 'googleTagManager';
 
 class Event extends React.Component {
   /**
@@ -50,6 +51,12 @@ class Event extends React.Component {
       deselectEvent();
     } else {
       selectEvent(event.id, date);
+      googleTagManager.pushEvent({
+        'event': 'natural_event_selected',
+        'natural_events': {
+          'category': event.categories[0].title
+        }
+      });
     }
   }
   /**

--- a/web/js/components/sidebar/footer-content.js
+++ b/web/js/components/sidebar/footer-content.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../util/button';
 import ModeSelection from './mode-selection';
+import googleTagManager from 'googleTagManager';
 
 class FooterContent extends React.Component {
   render() {
@@ -34,10 +35,20 @@ class FooterContent extends React.Component {
               text="+ Add Layers"
               id="layers-add"
               className="layers-add red"
-              onClick={addLayers}
+              onClick={() => {
+                addLayers();
+                googleTagManager.pushEvent({
+                  'event': 'add_layers'
+                });
+              }}
             />
             <Button
-              onClick={toggleMode}
+              onClick={() => {
+                toggleMode();
+                googleTagManager.pushEvent({
+                  'event': 'comparison_mode'
+                });
+              }}
               className="compare-toggle-button"
               id="compare-toggle-button"
               style={isMobile || !compareFeature ? { display: 'none' } : null}
@@ -62,6 +73,9 @@ class FooterContent extends React.Component {
             onClick={() => {
               if (filterEventList) {
                 filterEventList(true);
+                googleTagManager.pushEvent({
+                  'event': 'natural_events_list_all'
+                });
               }
             }}
             text="List All"
@@ -79,7 +93,12 @@ class FooterContent extends React.Component {
       return (
         <div className="data-download-footer-case">
           <Button
-            onClick={onGetData}
+            onClick={() => {
+              onGetData();
+              googleTagManager.pushEvent({
+                'event': 'data_download_button'
+              });
+            }}
             className={
               noDataSelected
                 ? 'wv-data-download-button black no-pointer-events'

--- a/web/js/components/sidebar/sidebar.js
+++ b/web/js/components/sidebar/sidebar.js
@@ -9,6 +9,7 @@ import { TabContent, TabPane } from 'reactstrap';
 import { SidebarProvider as Provider } from './provider';
 import CollapsedButton from './collapsed-button';
 import NavCase from './nav/nav-case';
+import googleTagManager from 'googleTagManager';
 
 class Sidebar extends React.Component {
   constructor(props) {
@@ -89,6 +90,9 @@ class Sidebar extends React.Component {
   }
   toggleSidebar() {
     var isNowCollapsed = !this.state.isCollapsed;
+    googleTagManager.pushEvent({
+      'event': 'sidebar_chevron'
+    });
     if (this.props.localStorage) {
       let storageValue = isNowCollapsed ? 'collapsed' : 'expanded';
       localStorage.setItem('sidebarState', storageValue);
@@ -324,7 +328,8 @@ Sidebar.propTypes = {
   filterEventList: PropTypes.func,
   selectedDataProduct: PropTypes.string,
   showDataUnavailableReason: PropTypes.func,
-  compareFeature: PropTypes.bool
+  compareFeature: PropTypes.bool,
+  projection: PropTypes.string
 };
 
 export default Sidebar;

--- a/web/js/components/util/google-tag-manager.js
+++ b/web/js/components/util/google-tag-manager.js
@@ -1,0 +1,47 @@
+/* eslint-disable */
+
+export default {
+  /*
+  * Initialize GTM tracking if tracking
+  * code is present - will add to head in document
+  * noscript will not be handled
+  *
+  * @func init
+  * @static
+  *
+  * @param Category {id} GTM tracking code
+  *
+  * @return {void}
+  */
+  init(id) {
+    if(id) {
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer',id);
+
+        // create inline SCRIPT tag with dataLayer array and push to HEAD after TITLE tag
+        let dataLayerScript = document.createElement('script');
+        dataLayerScript.type = 'text/javascript';
+        let inlineScript = document.createTextNode('window.dataLayer = window.dataLayer || [];');
+        dataLayerScript.appendChild(inlineScript);
+        document.head.insertBefore(dataLayerScript, document.head.firstElementChild.nextSibling);
+    }
+  },
+
+  /*
+  * @func dataLayerPush object to GoogleTagManager
+  * can add custom javascript object that can be retrieved as custom data layer variables
+  * @static
+  *
+  * @param EventObject {object}
+  *
+  * @return {void}
+  */
+  pushEvent(eventObject) {
+    if (typeof (dataLayer) !== 'undefined') {
+      window.dataLayer.push(eventObject);
+    }
+  }
+};

--- a/web/js/data/ui.js
+++ b/web/js/data/ui.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import lodashSize from 'lodash/size';
 import lodashEach from 'lodash/each';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 import * as olExtent from 'ol/extent';
 
 import { dataMap } from './map';
@@ -43,7 +43,9 @@ export function dataUi(models, ui, config) {
 
     ui.sidebar.events.on('selectTab', function(tab) {
       if (tab === 'download') {
-        googleAnalytics.event('Data Download', 'Click', 'Data Download Tab');
+        googleTagManager.pushEvent({
+          'event': 'data_download_tab'
+        });
         model.activate();
       } else {
         model.deactivate();
@@ -155,7 +157,6 @@ export function dataUi(models, ui, config) {
   };
 
   self.showDownloadList = function() {
-    googleAnalytics.event('Data Download', 'Click', 'Download Button');
     if (selectionListPanel) {
       selectionListPanel.setVisible(false);
     }
@@ -627,10 +628,16 @@ var dataUiDownloadListPanel = function(config, model) {
   };
 
   var showWgetPage = function() {
+    googleTagManager.pushEvent({
+      'event': 'data_download_list_wget'
+    });
     dataUiBulkDownloadPage.show(selection, 'wget');
   };
 
   var showCurlPage = function() {
+    googleTagManager.pushEvent({
+      'event': 'data_download_list_curl'
+    });
     dataUiBulkDownloadPage.show(selection, 'curl');
   };
 

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import util from '../util/util';
 import d3 from 'd3';
+import googleTagManager from 'googleTagManager';
 
 export function timeline(models, config, ui) {
   var self = {};
@@ -245,6 +246,9 @@ export function timeline(models, config, ui) {
     }
 
     $('#timeline-hide').click(function() {
+      googleTagManager.pushEvent({
+        'event': 'timeline_hamburger'
+      });
       self.toggle();
     });
 

--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import 'jquery-ui-bundle/jquery-ui';
 import * as olProj from 'ol/proj';
 import ImageResSelection from '../components/image-panel/select';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 import util from '../util/util';
 import wvui from '../ui/ui';
 import React from 'react';
@@ -379,7 +379,18 @@ export function imagePanel(models, ui, config, dialogConfig) {
       imageUtilGetLayerOpacities(products),
       url
     );
-    googleAnalytics.event('Image Download', 'Click', 'Download');
+    googleTagManager.pushEvent({
+      'event': 'image_download',
+      'layers': {
+        'activeCount': models.layers.active.length
+      },
+      'image': {
+        'resolution': imgRes,
+        'format': imgFormat,
+        'worldfile': imgWorldfile
+      }
+    });
+
     util.metrics(
       'lc=' +
         encodeURIComponent(

--- a/web/js/layers/modal.js
+++ b/web/js/layers/modal.js
@@ -13,6 +13,7 @@ import lodashSortBy from 'lodash/sortBy';
 import lodashStartCase from 'lodash/startCase';
 import lodashValues from 'lodash/values';
 import util from '../util/util';
+import googleTagManager from 'googleTagManager';
 
 export function layersModal(models, ui, config) {
   var crumbText;
@@ -361,6 +362,12 @@ export function layersModal(models, ui, config) {
             alt: category.title
           }).click(function(e) {
             drawMeasurements(category);
+            googleTagManager.pushEvent({
+              'event': 'layers_category',
+              'layers': {
+                'category': category.title
+              }
+            });
           });
 
           $categoryTitle.append($categoryLink);
@@ -434,6 +441,12 @@ export function layersModal(models, ui, config) {
       }).click(function(e) {
         $categories.isotope({
           filter: '.layer-category-' + interestCssName(metaCategoryName)
+        });
+        googleTagManager.pushEvent({
+          'event': 'layers_meta_category',
+          'layers': {
+            'meta_category': metaCategoryName
+          }
         });
         $nav.find('.layer-category-button').removeClass('nav-selected');
         $('label[for=' + $(this).attr('id') + ']').addClass('nav-selected');

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -6,6 +6,7 @@ import lodashFindIndex from 'lodash/findIndex';
 import lodashIsUndefined from 'lodash/isUndefined';
 import lodashCloneDeep from 'lodash/cloneDeep';
 import util from '../util/util';
+import googleTagManager from 'googleTagManager';
 
 export function layersModel(models, config) {
   var self = {};
@@ -27,7 +28,7 @@ export function layersModel(models, config) {
     self.clear();
     if (config.defaults && config.defaults.startingLayers) {
       lodashEach(config.defaults.startingLayers, function(start) {
-        self[layerStr] = self.add(start.id, start, layerStr);
+        self[layerStr] = self.add(start.id, start, layerStr, 'reset');
       });
     }
   };
@@ -182,7 +183,7 @@ export function layersModel(models, config) {
     return endDate;
   };
 
-  self.add = function(id, spec, activeLayerString) {
+  self.add = function(id, spec, activeLayerString, addType) {
     activeLayerString = activeLayerString || self.activeLayers;
     if (
       lodashFind(self[activeLayerString], {
@@ -208,6 +209,15 @@ export function layersModel(models, config) {
       split[activeLayerString] += 1;
     } else {
       self[activeLayerString].splice(split[activeLayerString], 0, def);
+    }
+
+    if (self.loaded && addType !== 'natural-event' && addType !== 'reset') {
+      googleTagManager.pushEvent({
+        'event': 'layer_added',
+        'layers': {
+          'id': id
+        }
+      });
     }
     self.events.trigger('add', def, null, self[activeLayerString]);
     self.events.trigger('change');

--- a/web/js/link/ui.js
+++ b/web/js/link/ui.js
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Clipboard from 'clipboard';
 import Share from '../components/share/share';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 
 import util from '../util/util';
 import wvui from '../ui/ui';
@@ -35,7 +35,9 @@ export function linkUi(models, config) {
       })
       .click(function() {
         var checked = $('#wv-link-button-check').prop('checked');
-        googleAnalytics.event('Link', 'Click', 'Share link Button');
+        googleTagManager.pushEvent({
+          'event': 'social_link_share'
+        });
         if (checked) {
           self.show();
         } else {
@@ -115,6 +117,10 @@ export function linkUi(models, config) {
     var shareMessage = 'Check out what I found in NASA Worldview!';
     var twMessage = 'Check out what I found in #NASAWorldview -';
     var emailBody = shareMessage + ' - ' + url;
+    googleTagManager.pushEvent({
+      'event': 'social_share_platform',
+      'social_type': type
+    });
 
     switch (type) {
       case 'twitter':
@@ -250,7 +256,9 @@ export function linkUi(models, config) {
       var checked = $('#wv-link-shorten-check').prop('checked');
       if (checked) {
         var promise = models.link.shorten();
-        googleAnalytics.event('Link', 'Check', 'Shorten');
+        googleTagManager.pushEvent({
+          'event': 'social_link_shorten'
+        });
         $('#permalink_content').val('Please wait...');
         promise
           .done(function(result) {
@@ -265,7 +273,6 @@ export function linkUi(models, config) {
           });
       } else {
         $('#permalink_content').val(models.link.get());
-        googleAnalytics.event('Link', 'Check', 'Lengthen');
       }
       $('#permalink_content').focus();
       $('#permalink_content').select();

--- a/web/js/natural-events/markers.js
+++ b/web/js/natural-events/markers.js
@@ -9,6 +9,7 @@ import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
 import OlGeomPolygon from 'ol/geom/Polygon';
 import * as olProj from 'ol/proj';
+import googleTagManager from 'googleTagManager';
 
 export default function markers (models, ui) {
   var self = {};
@@ -132,6 +133,12 @@ export default function markers (models, ui) {
         pinEl.addEventListener('click', function (e) {
           if (willSelect && !isSelected) {
             ui.naturalEvents.selectEvent(event.id, date);
+            googleTagManager.pushEvent({
+              'event': 'natural_event_selected',
+              'natural_events': {
+                'category': category.title
+              }
+            });
           } else {
             passEventToTarget(e, olViewport);
           }

--- a/web/js/natural-events/ui.js
+++ b/web/js/natural-events/ui.js
@@ -8,7 +8,7 @@ import track from './track';
 import wvui from '../ui/ui';
 import util from '../util/util';
 import { naturalEventsUtilGetEventById } from './util';
-import googleAnalytics from '../components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 
 const zoomLevelReference = {
   Wildfires: 8,
@@ -65,7 +65,9 @@ export default function naturalEventsUI(models, ui, config, request) {
     ui.sidebar.events.on('selectTab', function(tab) {
       if (tab === 'events') {
         model.active = true;
-        googleAnalytics.event('Natural Events', 'Click', 'Events Tab');
+        googleTagManager.pushEvent({
+          'event': 'natural_events_tab'
+        });
 
         // Remove previously stored markers
         naturalEventMarkers.remove(self.markers);
@@ -359,7 +361,8 @@ export default function naturalEventsUI(models, ui, config, request) {
           {
             visible: visible
           },
-          layerString
+          layerString,
+          'natural-event'
         );
       }
     });

--- a/web/js/projection/ui.js
+++ b/web/js/projection/ui.js
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import 'jquery-ui-bundle/jquery-ui';
 import lodashEach from 'lodash/each';
 import wvui from '../ui/ui';
+import googleTagManager from 'googleTagManager';
 
 export function projectionUi(models, config) {
   var self = {};
@@ -61,6 +62,10 @@ export function projectionUi(models, config) {
         '</i>' + ui.name + '</a></li>');
       $menuItems.append($item);
       $item.click(function () {
+        googleTagManager.pushEvent({
+          'event': 'change_projection',
+          'projection': ui.name
+        });
         models.proj.select(ui.id);
         $('#wv-proj-button-check')
           .prop('checked', false);

--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -13,6 +13,7 @@ import { layersInfo } from '../layers/info';
 import { getZotsForActiveLayers } from '../layers/util';
 import { timelineDataHightlight } from '../date/util';
 import wvui from '../ui/ui';
+import googleTagManager from 'googleTagManager';
 
 export function sidebarUi(models, config, ui) {
   var isCollapsed = false;
@@ -355,6 +356,9 @@ export function sidebarUi(models, config, ui) {
         updateState(getStateType(isCompareMode));
         break;
       case 'info':
+        googleTagManager.pushEvent({
+          'event': 'sidebar_layer_info'
+        });
         let $infoDialog = $('#wv-layers-info-dialog');
         if (
           $infoDialog.attr('data-layer') !== layerId ||
@@ -368,6 +372,9 @@ export function sidebarUi(models, config, ui) {
 
         break;
       case 'options':
+        googleTagManager.pushEvent({
+          'event': 'sidebar_layer_options'
+        });
         let $optionDialog = $('#wv-layers-options-dialog');
         if (
           $optionDialog.attr('data-layer') !== layerId ||

--- a/web/js/tour.js
+++ b/web/js/tour.js
@@ -3,7 +3,7 @@ import 'jquery-ui-bundle/jquery-ui';
 import 'jquery.joyride';
 import util from './util/util';
 import wvui from './ui/ui';
-import googleAnalytics from './components/util/google-analytics';
+import googleTagManager from 'googleTagManager';
 import feedbackModal from './feedback';
 
 export default function(models, ui, config) {
@@ -122,6 +122,9 @@ export default function(models, ui, config) {
         closeText: ''
       });
       feedbackModal.decorate($dialog.find('.feedback'));
+      googleTagManager.pushEvent({
+        'event': 'tour_completed'
+      });
       $('#repeat').click(repeatTour);
       $('#done').click(handleDone);
     };
@@ -164,7 +167,6 @@ export default function(models, ui, config) {
 
     var onStop = function(index, tip, button) {
       setTourState();
-      googleAnalytics.event('Tour', 'Click', 'Post Tour View', index + 1);
       if (index === 5 && button === false) {
         endTour();
       }
@@ -177,7 +179,9 @@ export default function(models, ui, config) {
       e.stopPropagation();
       $('.ui-dialog-content').dialog('close');
       initTourState();
-      googleAnalytics.event('Tour', 'Click', 'Take Tour');
+      googleTagManager.pushEvent({
+        'event': 'tour_start'
+      });
       $('#joyRideTipContent').joyride({
         scroll: false,
         autoStart: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,11 @@ if (process.env.NODE_ENV === 'testing') {
 */
 
 module.exports = {
+  resolve: {
+    alias: {
+      googleTagManager$: path.resolve(__dirname, './web/js/components/util/google-tag-manager.js')
+    }
+  },
   mode: devMode ? 'development' : 'production',
   stats: {
     // reduce output text on build - remove for more verbose


### PR DESCRIPTION
## Description

Fixes #831 .

- Improves event triggered metrics for the site using Google Tag Manager(GTM).
  * Add new event tags, triggers, and access event specific variable data. Was able to directly inject metrics into existing methods without changes in most cases. However, some methods were changed to allow conditional firing of event metrics.
  * Transition from Google Analytics
  * Create webpack alias of GTM for easier imports


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
