### PR TITLE
Ignore stylelinting web folders other than /css

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,9 +6,6 @@ etc/*
 lib/*
 options/*
 reports/*
-web/ext/*
-web/dist/*
-web/build/*
 test/*
-web/js/edsc/*
-
+web/*
+!web/css

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,4 +1,7 @@
 {
+  "ignoreFiles": [
+    "**/*.js"
+  ],
   "rules": {
     "color-no-invalid-hex": true,
     "font-family-no-duplicate-names": true,


### PR DESCRIPTION
## Description

Fixes #1381

Adds the following to `.stylelintignore` to prevent false-positives from appearing in non-css files
```
web/*
!web/css
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

@nasa-gibs/worldview
