### PR TITLE
Add layer parameters to utilize future layer timeline support

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -73,8 +73,8 @@ The following properties are required if this information is not available via t
 - **startDate**: The first day that data is available, represented in YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ format.
 - **endDate**: The last day that data is available, represented in YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ format.
 - **inactive**: Use *true* if the layer is no longer being produced.
-- **futurelayer**: Use *true* if the layer has an end date after the current date.
-- **addedTime**: Use `[number][type="D,M,Y"]` (i.e. "3D")  with the `futurelayer` parameter to denote a layer that has a dynamic, future end date. The `[number]` parameter represents the dateInterval, `[type]` can be equal to `"D"`, `"M"`, or `"Y"` to represent day, month or year interval.
+- **futureLayer**: Use *true* if the layer has an end date after the current date.
+- **futureTime**: Use `[number][type="D,M,Y"]` (i.e. "3D")  with the `futurelayer` parameter to denote a layer that has a dynamic, future end date. The `[number]` parameter represents the dateInterval, `[type]` can be equal to `"D"`, `"M"`, or `"Y"` to represent day, month or year interval.
 
 A *projections* object must exist which contains an object for each projection supported by this layer. Projection information is keyed by the projection identifier (found in `config/wv.json/projections`). Example:
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -73,6 +73,8 @@ The following properties are required if this information is not available via t
 - **startDate**: The first day that data is available, represented in YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ format.
 - **endDate**: The last day that data is available, represented in YYYY-MM-DD or YYYY-MM-DDThh:mm:ssZ format.
 - **inactive**: Use *true* if the layer is no longer being produced.
+- **futurelayer**: Use *true* if the layer has an end date after the current date.
+- **addedTime**: Use `[number][type="D,M,Y"]` (i.e. "3D")  with the `futurelayer` parameter to denote a layer that has a dynamic, future end date. The `[number]` parameter represents the dateInterval, `[type]` can be equal to `"D"`, `"M"`, or `"Y"` to represent day, month or year interval.
 
 A *projections* object must exist which contains an object for each projection supported by this layer. Projection information is keyed by the projection identifier (found in `config/wv.json/projections`). Example:
 

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -126,10 +126,10 @@ for layer_id in wv["layers"].keys():
     if "temporal" in layer:
         warn("[%s] GC Layer temporal values overwritten by Options" % layer_id)
         layer = process_temporal(layer, layer["temporal"])
-    if layer.get("addedTime"):
+    if layer.get("futureTime"):
         if "endDate" in layer:
            del layer["endDate"]
-    if layer.get("inactive", False) or layer.get("futurelayer", False):
+    if layer.get("inactive", False) or layer.get("futureLayer", False):
         pass
     else:
         if "endDate" in layer:

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -126,7 +126,10 @@ for layer_id in wv["layers"].keys():
     if "temporal" in layer:
         warn("[%s] GC Layer temporal values overwritten by Options" % layer_id)
         layer = process_temporal(layer, layer["temporal"])
-    if layer.get("inactive", False):
+    if layer.get("addedTime", True):
+        if "endDate" in layer:
+           del layer["endDate"]
+    if layer.get("inactive", False) or layer.get("futurelayer", False):
         pass
     else:
         if "endDate" in layer:

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -126,7 +126,7 @@ for layer_id in wv["layers"].keys():
     if "temporal" in layer:
         warn("[%s] GC Layer temporal values overwritten by Options" % layer_id)
         layer = process_temporal(layer, layer["temporal"])
-    if layer.get("addedTime", True):
+    if layer.get("addedTime"):
         if "endDate" in layer:
            del layer["endDate"]
     if layer.get("inactive", False) or layer.get("futurelayer", False):

--- a/web/js/date/timeline-data.js
+++ b/web/js/date/timeline-data.js
@@ -60,6 +60,19 @@ export function timelineData(models, config, ui) {
 
       if (this.inactive === true || this.futureLayer === true) {
         layerEnd = new Date(this.endDate);
+        if (this.futureTime) {
+          layerEnd = util.now();
+          var futureTime = this.futureTime;
+          var dateType = futureTime.slice(-1);
+          var dateInterval = futureTime.slice(0, -1);
+          if (dateType === 'D') {
+            layerEnd.setDate(layerEnd.getDate() + parseInt(dateInterval));
+          } else if (dateType === 'M') {
+            layerEnd.setMonth(layerEnd.getMonth() + parseInt(dateInterval));
+          } else if (dateType === 'Y') {
+            layerEnd.setYear(layerEnd.getYear() + parseInt(dateInterval));
+          }
+        }
       } else if (Array.isArray(futureLayers) && futureLayers.length) {
         layerEnd = util.now();
       } else {

--- a/web/js/date/timeline-data.js
+++ b/web/js/date/timeline-data.js
@@ -1,4 +1,5 @@
 import d3 from 'd3';
+import util from '../util/util';
 
 export function timelineData(models, config, ui) {
   var tl = ui.timeline;
@@ -14,6 +15,7 @@ export function timelineData(models, config, ui) {
   };
 
   self.set = function() {
+    var futureLayers = [];
     var activeLayers = models.layers.get({});
     var activeLayersDynamic = activeLayers.filter(function(al) {
       return al.startDate;
@@ -28,6 +30,9 @@ export function timelineData(models, config, ui) {
 
     $(activeLayersDynamic).each(function(i) {
       activeLayersTitles[i] = this.id;
+      if (this.futureLayer === true) {
+        futureLayers.push(this.id);
+      }
     });
 
     tl.y = d3.scale
@@ -52,8 +57,11 @@ export function timelineData(models, config, ui) {
       } else {
         layerStart = self.start();
       }
-      if (this.inactive === true) {
+
+      if (this.inactive === true || this.futureLayer === true) {
         layerEnd = new Date(this.endDate);
+      } else if (Array.isArray(futureLayers) && futureLayers.length) {
+        layerEnd = util.now();
       } else {
         layerEnd = new Date(self.end().setUTCDate(self.end().getUTCDate() + 1));
       }

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -202,6 +202,7 @@ export function timeline(models, config, ui) {
   var onLayerUpdate = function() {
     self.data.set();
     self.resize();
+    self.zoom.refresh();
     self.setClip();
   };
   var init = function() {

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -204,6 +204,7 @@ export function timeline(models, config, ui) {
     self.resize();
     self.zoom.refresh();
     self.setClip();
+    self.input.update();
   };
   var init = function() {
     var $timelineFooter = $('#timeline-footer');

--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -145,7 +145,7 @@ export function layersModel(models, config) {
       }
       // For now, we assume that any layer with an end date is
       // an ongoing product unless it is marked as inactive.
-      if (def.futurelayer & def.endDate) {
+      if (def.futureLayer && def.endDate) {
         range = true;
         max = util.parseDateUTC(def.endDate).getTime();
         maxDates.push(new Date(max));
@@ -162,30 +162,33 @@ export function layersModel(models, config) {
       // If there is a start date but no end date, this is a
       // product that is currently being created each day, set
       // the max day to today.
-      if (def.futurelayer && def.addedTime && !def.endDate) {
-        // Calculate endDate + parsed addedTime from layer JSON
-        max = util.now().getTime();
-        max = new Date(max);
-        var addedTime = def.addedTime;
-        var dateType = addedTime.slice(-1);
-        var dateInterval = addedTime.slice(0, -1);
+      if (def.futureLayer && def.futureTime && !def.endDate) {
+        // Calculate endDate + parsed futureTime from layer JSON
+        max = new Date();
+        var futureTime = def.futureTime;
+        var dateType = futureTime.slice(-1);
+        var dateInterval = futureTime.slice(0, -1);
         if (dateType === 'D') {
-          max.setDate(max.getDate() + dateInterval);
+          max.setDate(max.getDate() + parseInt(dateInterval));
+          maxDates.push(new Date(max));
         } else if (dateType === 'M') {
-          max.setMonth(max.getMonth() + dateInterval);
+          max.setMonth(max.getMonth() + parseInt(dateInterval));
+          maxDates.push(new Date(max));
         } else if (dateType === 'Y') {
-          max.setYear(max.getYear() + dateInterval);
+          max.setYear(max.getYear() + parseInt(dateInterval));
+          maxDates.push(new Date(max));
         }
       } else if (def.startDate && !def.endDate) {
         max = util.now().getTime();
+        maxDates.push(new Date(max));
       }
     });
     if (range) {
       if (max === 0) {
         max = util.now().getTime();
-        maxDates.push(new Date(max));
+        maxDates.push(max);
       }
-      var maxDate = new Date(Math.max.apply(null, maxDates));
+      var maxDate = Math.max.apply(max, maxDates);
       return {
         start: new Date(min),
         end: new Date(maxDate)


### PR DESCRIPTION
## Description

Fixes #1387

There is currently support for for the timeline to support future layers but no parameters established to utilize the feature. This fix adds `futureLayer` and `futureTime` parameters to support layers with static and dynamic future dates.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Testing

Testing future static dates:
- Pull latest getcapabilities doc via `npm run getcapabilities`
- Change the date of a layer in the GetCapabilities file to a future date
(example: worldview/config/defauly/release/gc/gibs-geographic.xml: layer -> AMSR2_Snow_Water_Equivalent)
- Add `"futureLayer": true` to this layer's json file 
(example: worldview/config/default/common/config/wv.json/layers/amsr2/AMSR2_Snow_Water_Equivalent.json)
- Build worldview with `npm run build:config` then, `npm run build:dev`
- Load worldview at http://localhost:3000
- Click 'Add Layers' -> Search for: "AMSR2_Snow_Water_Equivalent"
- Add this layer.

Expected result:
- Timeline should expand to future date defined in GC when added to active layer list
- Timeline should should retract when a future date layer is remove from active layer list 

----

Testing future dynamic dates:
- Pull latest getcapabilities doc via `npm run getcapabilities`
- Add `"futureLayer": true` and `"futureTime: 3D"*` to this layer's json file 
(example: worldview/config/default/common/config/wv.json/layers/amsr2/AMSR2_Snow_Water_Equivalent.json)
*Note: "3D" is [dateInterval][dateType], so "3D" = +3 days from current time. You can also use `M` and `Y` to repesent +X Months or +X Years
- Build worldview with `npm run build:config` then, `npm run build:dev`
- Load worldview at http://localhost:3000
- Click 'Add Layers' -> Search for: "AMSR2_Snow_Water_Equivalent"
- Add this layer.

Expected result:
- Timeline should expand by the future interval defined in the layer JSON file when added to active layer list
- Timeline should should retract when the future date layer is remove from active layer list

@nasa-gibs/worldview
