### PR TITLE
Only update checkbox if custom palette is in effect

### DIFF
--- a/web/js/layers/options.js
+++ b/web/js/layers/options.js
@@ -99,7 +99,6 @@ export function layersOptions(config, models, layer, layerGroupStr) {
 
     $('#wv-squash-button-check').on('ifChanged', function() {
       var squash = $('#wv-squash-button-check').prop('checked');
-      // var $slider = $("#wv-range-slider");
       var $slider = $range;
       models.palettes.setRange(
         layer.id,
@@ -248,10 +247,13 @@ export function layersOptions(config, models, layer, layerGroupStr) {
       $range.val([imin, imax]);
     }
 
-    if (palette.squash) {
-      $('#wv-squash-button-check').iCheck('check');
-    } else {
-      $('#wv-squash-button-check').iCheck('uncheck');
+    // If the squash value is undefined, no custom pallete is in effect.
+    if (palette.squash !== undefined) {
+      if (palette.squash) {
+        $('#wv-squash-button-check').iCheck('check');
+      } else {
+        $('#wv-squash-button-check').iCheck('uncheck');
+      }
     }
   };
 


### PR DESCRIPTION
## Description

Fixes #1390.

- Only update checkbox if custom palette is in effect
- Remove comment

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
