### PR TITLE
Set html for sidebar event titles

### DIFF
--- a/web/js/components/sidebar/events/event.js
+++ b/web/js/components/sidebar/events/event.js
@@ -115,11 +115,9 @@ class Event extends React.Component {
           className={'event-icon event-icon-' + event.categories[0].slug}
           title={event.categories[0].title}
         />
-        <h4 className="title">
-          {event.title}
-          <br />
-          {dateString}
-        </h4>
+        <h4 className="title" dangerouslySetInnerHTML={{
+          __html: event.title + '<br />' + dateString
+        }}/>
         <p className="subtitle">{this.getReferenceList()}</p>
 
         {this.getDateLists()}


### PR DESCRIPTION
## Description

Fixes #1399

Changes the event sidebar list titles to output text as HTML

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
