### PR TITLE
Make IE11 minimum site requirement

### DIFF
--- a/web/css/date.css
+++ b/web/css/date.css
@@ -31,33 +31,6 @@ menu {
   -webkit-padding-start: 0;
 }
 
-.spanContainerLabel {
-  width: 25%;
-  float: left;
-  text-shadow: none;
-  display: block;
-  margin-top: 20px;
-  text-align: center;
-  font-size: 0.1em;
-  color: #fff;
-}
-
-.spanContainerLabelDate,
-.spanContainerLabelDay {
-  display: block;
-  font-size: 0.25em;
-}
-
-.spanContainerLabelDay {
-  font-size: 0.16em;
-}
-
-.spanContainer {
-  float: left;
-  min-height: 100%;
-  width: 100%;
-}
-
 div.datespan {
   width: auto;
   overflow: hidden;
@@ -76,26 +49,6 @@ div.datespan {
   display: block;
 }
 
-a.ecbutton {
-  display: block;
-  width: 24px;
-  height: 24px;
-  float: left;
-  position: relative;
-  background: transparent;
-  left: -28px;
-  top: 3px;
-}
-
-.dateSpanSlider {
-  display: none !important;
-}
-
-input.ui-slider-input {
-  width: 0;
-  margin: 0;
-}
-
 .slider {
   margin-bottom: 0;
   background: --webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.6)), color-stop(50%, rgba(0, 0, 0, 0.7)), to(rgba(0, 0, 0, 0.8)));
@@ -103,46 +56,6 @@ input.ui-slider-input {
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.7) 50%, rgba(0, 0, 0, 0.8) 100%);
   height: 23px;
   cursor: pointer;
-}
-
-:root ul.sliderLabel {
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr= '#90000', endColorstr='#c0000', GradientType=0) \0/IE9;
-}
-
-/* IE9 */
-ul.sliderLabel {
-  text-shadow: none;
-  color: #fff;
-  margin: -20px 0 0;
-  background: none;
-  overflow: hidden;
-}
-
-ul.sliderLabel li {
-  float: left;
-  background: none;
-  margin: 0;
-  text-align: center;
-  overflow: hidden;
-  font-weight: 700;
-  font-size: 0.9em;
-  padding: 0.1em 0;
-}
-
-div.sliderDivYear {
-  clear: both;
-}
-
-div.sliderDivMonth {
-  background: rgba(25, 30, 35, 0.5);
-}
-
-#timesliderLabelDay {
-  margin: -24px 0 0;
-}
-
-.disabledItem {
-  color: rgba(125, 125, 125, 0.9) !important;
 }
 
 a.ui-slider-handle {
@@ -182,20 +95,4 @@ div.ui-slider {
 
 a.ui-btn {
   margin: 0;
-}
-
-a.ui-shadow {
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-
-a.ui-btn-up-c {
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-
-#mapdiv {
-  margin: 0;
-  padding: 0;
-  left: 0;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (http://opensource.gs
   <script type="text/javascript">
     if (/MSIE (\d+\.\d+);/.test(navigator.userAgent) && ! /unsupported/.test(location.search)) {
       var version = parseFloat(navigator.appVersion.split("MSIE")[1]);
-      if (version < 9) {
+      if (version < 11) {
         document.location.replace("pages/unsupported_browser.html" + location.search);
       }
     }

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -15,7 +15,6 @@ export default class SimpleBar extends React.Component {
   }
   componentDidUpdate() {
     this.updateBoolean();
-    this.scrollBar.recalculate(); // Necessary for IE10 and below
   }
   /**
    * Use offsetHeight to determine if scrollbar should be visible

--- a/web/js/polyfill.js
+++ b/web/js/polyfill.js
@@ -7,8 +7,6 @@
 
 /* eslint-disable no-extend-native */
 
-import util from './util/util';
-
 export function polyfill () {
   /*
    * Date.toISOString
@@ -78,35 +76,6 @@ export function polyfill () {
   (function () {
     window.scrollTo(0, 0);
   })();
-
-  /*
-   * setTimeout that properly sets this and allows arguments. The only case where
-   * this is helpful at the moment is IE9 -- only attempt to do this in that case
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/Window.setTimeout
-   */
-  if (util.browser.ie && util.browser.version <= 9) {
-    (function () {
-      var __nativeST__ = window.setTimeout;
-      var __nativeSI__ = window.setInterval;
-
-      window.setTimeout = function (vCallback, nDelay /*, argumentToPass1, argumentToPass2, etc. */) {
-        var oThis = this;
-        var aArgs = Array.prototype.slice.call(arguments, 2);
-        return __nativeST__(vCallback instanceof Function ? function () {
-          vCallback.apply(oThis, aArgs);
-        } : vCallback, nDelay);
-      };
-
-      window.setInterval = function (vCallback, nDelay /*, argumentToPass1, argumentToPass2, etc. */) {
-        var oThis = this;
-        var aArgs = Array.prototype.slice.call(arguments, 2);
-        return __nativeSI__(vCallback instanceof Function ? function () {
-          vCallback.apply(oThis, aArgs);
-        } : vCallback, nDelay);
-      };
-    })();
-  }
 
   /*
    * String.contains

--- a/web/js/util/browser.test.js
+++ b/web/js/util/browser.test.js
@@ -39,20 +39,10 @@ describe('browser', () => {
     answer: true,
     userAgent: 'Mozilla/5.0 (MSIE 9.0; Windows NT 6.1; Trident/5.0)'
   }, {
-    name: 'internet explorer 10',
-    fn: 'ie',
-    answer: true,
-    userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C)'
-  }, {
     name: 'not internet explorer',
     fn: 'ie',
     answer: false,
     userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:26.0) Gecko/20100101 Firefox/26.0'
-  }, {
-    name: 'internet explorer version',
-    fn: 'ieVersion',
-    answer: 9,
-    userAgent: 'Mozilla/5.0 (MSIE 9.0; Windows NT 6.1; Trident/5.0)'
   }];
 
   tests.forEach((t) => {

--- a/web/pages/unsupported_browser.html
+++ b/web/pages/unsupported_browser.html
@@ -1,65 +1,62 @@
 <!doctype html>
 <html>
 <head>
-    <title>@OFFICIAL_NAME@</title>
-    <style>
-        body {
-            background-color: black;
-        }
+  <title>@OFFICIAL_NAME@</title>
+  <style>
+    body {
+      background-color: #000;
+      font-family: sans-serif;
+    }
 
-        #unsupported {
-            position: fixed;
-            width: 500px;
-            height: 300px;
-            left: 50%;
-            top: 50%;
-            margin-left: -250px;
-            margin-top: -150px;
-            padding: 20px;
-            background-color: #ffffee;
-            border: 1px solid: #ffffff;
-        }
+    #unsupported {
+      position: fixed;
+      width: 500px;
+      height: 300px;
+      left: 50%;
+      top: 50%;
+      margin-left: -250px;
+      margin-top: -150px;
+      padding: 20px;
+      background-color: #f3f3f3;
+    }
 
-        h4 {
-            text-align: center;
-        }
+    h4 {
+      text-align: center;
+    }
 
-        #continue {
-            font-size: 14pt;
-            text-align: center;
-        }
+    #continue {
+      text-align: center;
+    }
 
-    </style>
+  </style>
 
-    <script>
-        window.onload = function() {
-            var link = document.getElementById("continue");
-            if ( location.search.length == 0 ) {
-                link.href = "../index.html?unsupported"
-            } else {
-                link.href = "../index.html" + location.search + "&unsupported";
-            }
-        };
-    </script>
+  <script>
+    window.onload = function() {
+      var link = document.getElementById("continue");
+      if ( location.search.length == 0 ) {
+        link.href = "../index.html?unsupported"
+      } else {
+        link.href = "../index.html" + location.search + "&unsupported";
+      }
+    };
+  </script>
 </head>
 <body>
-    <img src="../brand/images/wv-logo.png">
-    <div id="unsupported">
-        <h4>This version of Internet Explorer is currently not supported</h4>
-        <p>
-        Worldview uses a set of browser technologies that requires at least
-        Internet Explorer 9. Please try
-        loading this page in Mozilla Firefox, Google Chrome, Apple Safari, or
-        a mobile device.
-        </p>
-        <p>
-        Thanks for your patience.
-        </p>
-        <p>
-        -The Worldview development team
-        </p>
-        <h4>
-            <a id="continue">Continue anyway</a>
-        </h4>
-    </div>
+  <img src="../brand/images/wv-logo.png">
+  <div id="unsupported">
+    <h4>Your browser is not supported.</h4>
+    <p>
+    Worldview uses a set of browser technologies that requires at least
+    Internet Explorer 11. For the best experience, please try using the latest 
+    version of Google Chrome, Mozilla Firefox, Apple Safari, or a mobile device.
+    Thanks for your patience.
+    </p>
+    <p>
+    -The Worldview development team
+    </p>
+    <br/>
+    <h4>
+      <a id="continue">Continue anyway</a>
+    </h4>
+  </div>
 </body>


### PR DESCRIPTION
## Description

Fixes #1335  .

- Revise logic and unsupported browser page to reflect Internet Explorer 11 as the minimum required browser.
- Remove:
  - IE9 specific polyfill and marked CSS styling (note: further unmarked CSS may remain)
  - IE10 & IE9 from browser test
  - <=IE10 needed scrollbar function call
  - additional unused CSS from date.css

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
