### PR TITLE
Highlight full width of long names in product picker

### DIFF
--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -448,10 +448,10 @@
   clear: both;
   overflow: auto;
   padding: 0;
+  width: 160px;
 }
 
 .layer-modal-content .selected-category .ui-tabs .ui-tabs-nav li {
-  max-width: 200px;
   border: transparent;
   background: none;
   margin: 0 0 0 10px;
@@ -471,7 +471,7 @@
   -webkit-box-sizing: border-box;
   -o-box-sizing: border-box;
   padding: 0.5em;
-  width: 150px;
+  min-width: 150px;
   font-family: 'Open Sans', sans-serif;
   font-size: 13px;
   text-align: left;


### PR DESCRIPTION
## Description

Fixes #1312 .

- Fix styling to allow highlighting of long names in product picker

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
