### PR TITLE
Fix when newly added base layers can appear at bottom of stack #1412

### DIFF
--- a/web/js/layers/model.js
+++ b/web/js/layers/model.js
@@ -287,7 +287,7 @@ export function layersModel(models, config) {
     var baseLayers =
       subGroup === 'baselayers' ? newSubGroup : layers.baselayers;
     var overlays = subGroup === 'overlays' ? newSubGroup : layers.overlays;
-    self[activeLayerString] = baseLayers.concat(overlays);
+    self[activeLayerString] = overlays.concat(baseLayers);
     self.events.trigger('update');
     self.events.trigger('change');
   };


### PR DESCRIPTION
## Description
Newly added base layers can appear at bottom of stack when layers have been dragged and dropped to update the order.
Fixes #1412 .

[Description of the bug or feature]

- [x] Fix when newly added base layers can appear at bottom of stack

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
