### PR TITLE
Fix palettes while keeping event track performance #1346 [!mportant]

### DIFF
--- a/web/js/components/sidebar/products/layer-list.js
+++ b/web/js/components/sidebar/products/layer-list.js
@@ -18,7 +18,7 @@ class LayerList extends React.Component {
       palettes: {},
       layers: props.layers
     };
-    this._promises = [];
+    this.promises = {};
   }
 
   componentWillReceiveProps(props) {
@@ -34,17 +34,19 @@ class LayerList extends React.Component {
   getPalette(layer, palettePromise) {
     if (this.state.palettes[layer.id]) {
       return this.state.palettes[layer.id];
+    } else if (this.promises[layer.id]) {
+      return null;
     } else if (layer.palette) {
-      let promise = palettePromise(layer.id).then(palette => {
-        if (this._mounted) {
-          var palettes = this.state.palettes;
-          palettes[layer.id] = palette;
-          this.setState({
-            palettes: palettes
-          });
-        }
+      this.promises[layer.id] = true;
+      let promise = palettePromise(layer.id);
+      promise.then(palette => {
+        var palettes = this.state.palettes;
+        delete this.promises[layer.id];
+        palettes[layer.id] = palette;
+        this.setState({
+          palettes: palettes
+        });
       });
-      this._promises.push(promise);
     }
     return null;
   }

--- a/web/js/palettes/model.js
+++ b/web/js/palettes/model.js
@@ -6,6 +6,7 @@ import lodashIsUndefined from 'lodash/isUndefined';
 import lodashParseInt from 'lodash/parseInt';
 import util from '../util/util';
 import palettes from './palettes';
+import Promise from 'bluebird';
 
 export function palettesModel(models, config) {
   config.palettes = config.palettes || {


### PR DESCRIPTION
## Description
Palettes not working 😨 
(Removed palettes by accident when fixing event track performance)

Fixes #1346 .



- [x] Only request palette once

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
@edplato not as fast as before because there were no palettes being requested. But still much faster...
