### PR TITLE
Fix custom palettes in compare mode

### DIFF
--- a/web/js/palettes/model.js
+++ b/web/js/palettes/model.js
@@ -252,8 +252,7 @@ export function palettesModel(models, config) {
   self.saveSingle = function(state, layerId, groupStr) {
     groupStr = groupStr || models.layers.activeLayers;
     var stateStr = 'l';
-    if (groupStr === 'activeB') stateStr = 'l1';
-
+    if (groupStr === 'activeB' && models.compare && models.compare.active) stateStr = 'l1';
     var attr = lodashFind(state[stateStr], {
       id: layerId
     }).attributes;
@@ -296,7 +295,7 @@ export function palettesModel(models, config) {
     var hasMax = false;
     var squash = [];
     var hasSquash = false;
-    if (groupStr === 'activeB') stateStr = 'l1';
+    if (groupStr === 'activeB' && models.compare && models.compare.active) stateStr = 'l1';
 
     for (var i = 0; i < self.getCount(layerId); i++) {
       var def = self.get(layerId, i, groupStr);


### PR DESCRIPTION
## Description
Custom Palettes pretty much completely broken in B layer group

Fixes #1411 .

- [x] Save palette to correct url_parameter

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

The break happened when trying to append custom palette info to a url parameter that did not exist when not in Compare mode

@nasa-gibs/worldview
