### PR TITLE
Don't show coords until mouse is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
       "node_modules/(?!(ol)/)"
     ],
     "modulePathIgnorePatterns": [
-      "build/"
+      "<rootDir>/build/"
     ]
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -202,6 +202,9 @@
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(ol)/)"
+    ],
+    "modulePathIgnorePatterns": [
+      "build/"
     ]
   },
   "prettier": {

--- a/web/js/components/map/__snapshots__/ol-coordinates.test.js.snap
+++ b/web/js/components/map/__snapshots__/ol-coordinates.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`clears coordinates when mouse moves off the map 1`] = `<div />`;
 
-exports[`does not display on small devices 1`] = `null`;
-
 exports[`reprojects (0,0) to (-45, 90) for EPSG:3413 1`] = `
 <div>
   <div

--- a/web/js/components/map/ol-coordinates.js
+++ b/web/js/components/map/ol-coordinates.js
@@ -54,7 +54,7 @@ class OlCoordinates extends React.Component {
       let cl = event.relatedTarget.classList;
       // Ignore when the mouse goes over the coordinate display. Clearing
       // the coordinates in this situation causes a flicker.
-      if (cl.contains('map-coord') || cl.contains('coord-btn')) {
+      if (cl.contains('map-coord')) {
         return;
       }
     }

--- a/web/js/components/map/ol-coordinates.js
+++ b/web/js/components/map/ol-coordinates.js
@@ -8,6 +8,7 @@ class OlCoordinates extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      hasMouse: false,
       latitude: null,
       longitude: null,
       crs: null,
@@ -40,6 +41,7 @@ class OlCoordinates extends React.Component {
     }
 
     this.setState({
+      hasMouse: true,
       format: util.getCoordinateFormat(),
       latitude: pcoord[1],
       longitude: pcoord[0],
@@ -69,8 +71,8 @@ class OlCoordinates extends React.Component {
   }
 
   render() {
-    // if mobile return
-    if (util.browser.small) {
+    // Don't render until a mouse is being used
+    if (!this.state.hasMouse) {
       return null;
     }
 

--- a/web/js/components/map/ol-coordinates.test.js
+++ b/web/js/components/map/ol-coordinates.test.js
@@ -20,7 +20,6 @@ beforeEach(() => {
 
 afterEach(() => {
   util.setCoordinateFormat('latlon-dd');
-  util.browser.small = false;
 });
 
 test('shows coordinates of (10, 20) when moving the mouse', () => {
@@ -45,12 +44,6 @@ test('clears coordinates when mouse moves off the map', () => {
 
 test('reprojects (0,0) to (-45, 90) for EPSG:3413', () => {
   map.getCoordinateFromPixel = () => [0, 0];
-  events.trigger('mousemove', {}, map, 'EPSG:3413');
-  expect(component.toJSON()).toMatchSnapshot();
-});
-
-test('does not display on small devices', () => {
-  util.browser.small = true;
   events.trigger('mousemove', {}, map, 'EPSG:3413');
   expect(component.toJSON()).toMatchSnapshot();
 });

--- a/web/js/map/rotation.js
+++ b/web/js/map/rotation.js
@@ -90,7 +90,11 @@ export function MapRotate(ui, models, map) {
       })
       .mouseout(function() {
         clearInterval(self.intervalId);
-      });
+      })
+      // This component is inside the map viewport container. Allowing
+      // mouse move events to bubble up displays map coordinates--let those
+      // be blank when over a component.
+      .mousemove((e) => e.stopPropagation());
 
     $rightButton.button({
       text: false
@@ -106,7 +110,9 @@ export function MapRotate(ui, models, map) {
       })
       .mouseout(function() {
         clearInterval(self.intervalId);
-      });
+      })
+      // See note above
+      .mousemove((e) => e.stopPropagation());
 
     $resetButton.button({
       label: Number(models.map.rotation * (180 / Math.PI))
@@ -121,7 +127,9 @@ export function MapRotate(ui, models, map) {
           });
 
         $resetButton.button('option', 'label', '0');
-      });
+      })
+      // See note above
+      .mousemove((e) => e.stopPropagation());
   };
 
   /**

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -857,7 +857,7 @@ export function mapui(models, config) {
   var createZoomButtons = function(map, proj) {
     var $map = $('#' + map.getTarget());
 
-    var $zoomOut = $('<button></button>')
+    var $zoomOut = $('<div></div>')
       .addClass('wv-map-zoom-out')
       .addClass('wv-map-zoom');
     var $outIcon = $('<i></i>')
@@ -874,7 +874,7 @@ export function mapui(models, config) {
     });
     $zoomOut.mousemove((e) => e.stopPropagation());
 
-    var $zoomIn = $('<button></button>')
+    var $zoomIn = $('<div></div>')
       .addClass('wv-map-zoom-in')
       .addClass('wv-map-zoom');
     var $inIcon = $('<i></i>')

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -793,6 +793,12 @@ export function mapui(models, config) {
     createZoomButtons(map, proj);
     createMousePosSel(map, proj);
 
+    // This component is inside the map viewport container. Allowing
+    // mouse move events to bubble up displays map coordinates--let those
+    // be blank when over a component.
+    $('.wv-map-scale-metric').mousemove((e) => e.stopPropagation());
+    $('.wv-map-scale-imperial').mousemove((e) => e.stopPropagation());
+
     // allow rotation by dragging for polar projections
     if (proj.id !== 'geographic' && proj.id !== 'webmerc') {
       rotation.init(map, proj.id);
@@ -866,6 +872,7 @@ export function mapui(models, config) {
     $zoomOut.click(() => {
       mapUtilZoomAction(map, -1);
     });
+    $zoomOut.mousemove((e) => e.stopPropagation());
 
     var $zoomIn = $('<button></button>')
       .addClass('wv-map-zoom-in')
@@ -882,6 +889,7 @@ export function mapui(models, config) {
     $zoomIn.click(() => {
       mapUtilZoomAction(map, 1);
     });
+    $zoomIn.mousemove((e) => e.stopPropagation());
 
     /*
      * Sets zoom buttons as active or inactive based


### PR DESCRIPTION
## Description

Fixes #708.
Fixes #1235.

- Don't show coords until mouse is detected
- Ignore files in build when running tests
- Prevent mouse move events from propagating up to the map view port on zoom/rotate buttons and map scale. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview