### PR TITLE
Fix guitar pick offset in alternate timezones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,24 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.54",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.54.tgz",
-      "integrity": "sha1-Oeu0JyP+fKSz4bAOln6AE41Hyt8=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.1.2.tgz",
+      "integrity": "sha512-drxaPByExlcRDKW4ZLubUO4ZkI8/8ax9k9wve1aEthdLKFzjB7XRkOQ0xoTIWGxqdDnWDElkjYq77bt7yrcYJQ==",
       "requires": {
         "core-js": "^2.5.7",
         "regenerator-runtime": "^0.12.0"
@@ -509,7 +524,7 @@
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
           "dev": true,
           "optional": true
@@ -792,17 +807,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
-    },
-    "array.prototype.flat": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
-      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.10.0",
-        "function-bind": "^1.1.1"
-      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -2922,7 +2926,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -2993,7 +2997,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -3023,7 +3027,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -3050,7 +3054,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -4285,9 +4289,12 @@
       }
     },
     "css-box-model": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.0.0.tgz",
-      "integrity": "sha512-MGipbCM6/HGmsOwN6Enq1OvNKy8H5Q1XKoyBszxwv2efly7ZVg+HcFILX8O6S0xfj27l1+6P7FyCjcQ90m5HBQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.1.0.tgz",
+      "integrity": "sha512-T+/q/VoHaTZ8ezGJrV9JSpaeTEpchEVg3v3Gq7v4TBuk7J0WGM/v0Q4XQomJMofoxxzqYjB60ffOBaCzKPvsTQ==",
+      "requires": {
+        "tiny-invariant": "^1.0.1"
+      }
     },
     "css-color-list": {
       "version": "0.0.1",
@@ -5128,12 +5135,6 @@
         }
       }
     },
-    "discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
-      "dev": true
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -5618,41 +5619,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
-    },
-    "enzyme": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.6.0.tgz",
-      "integrity": "sha512-onsINzVLGqKIapTVfWkkw6bYvm1o4CyJ9s8POExtQhAkVa4qFDW6DGCQGRy/5bfZYk+gmUbMNyayXiWDzTkHFQ==",
-      "dev": true,
-      "requires": {
-        "array.prototype.flat": "^1.2.1",
-        "cheerio": "^1.0.0-rc.2",
-        "function.prototype.name": "^1.1.0",
-        "has": "^1.0.3",
-        "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.4",
-        "is-number-object": "^1.0.3",
-        "is-string": "^1.0.4",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.6.0",
-        "object-is": "^1.0.1",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4",
-        "object.values": "^1.0.4",
-        "raf": "^3.4.0",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.1.2"
-      },
-      "dependencies": {
-        "is-callable": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-          "dev": true
-        }
-      }
     },
     "errno": {
       "version": "0.1.7",
@@ -6188,7 +6154,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -6710,7 +6676,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -7987,17 +7953,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "function.prototype.name": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "is-callable": "^1.1.3"
-      }
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -8269,7 +8224,7 @@
     },
     "got": {
       "version": "5.6.0",
-      "resolved": "http://registry.npmjs.org/got/-/got-5.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
       "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
       "dev": true,
       "requires": {
@@ -8524,9 +8479,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz",
+      "integrity": "sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==",
+      "requires": {
+        "react-is": "^16.3.2"
+      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -9460,12 +9418,6 @@
         "binary-extensions": "^1.0.0"
       }
     },
-    "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-      "dev": true
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -9644,12 +9596,6 @@
         "kind-of": "^3.0.2"
       }
     },
-    "is-number-object": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-      "dev": true
-    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -9781,18 +9727,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-      "dev": true
-    },
-    "is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-      "dev": true
     },
     "is-supported-regexp-flag": {
       "version": "1.0.1",
@@ -10978,9 +10912,9 @@
       }
     },
     "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "jquery-bridget": {
       "version": "2.0.1",
@@ -11086,7 +11020,7 @@
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
           "dev": true,
           "optional": true
@@ -11517,11 +11451,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
       "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
     },
-    "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
-    },
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
@@ -11674,18 +11603,6 @@
         }
       }
     },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
-      "dev": true
-    },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -11696,12 +11613,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isfunction": {
@@ -12062,9 +11973,9 @@
       }
     },
     "memoize-one": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.0.tgz",
-      "integrity": "sha512-wdpOJ4XBejprGn/xhd1i2XR8Dv1A25FJeIvR7syQhQlz9eXsv+06llcvcmBxlWVGv4C73QBsWA8kxvZozzNwiQ=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.2.tgz",
+      "integrity": "sha512-ucx2DmXTeZTsS4GPPUZCbULAN7kdPT1G+H49Y34JjbQ5ESc6OGhVxKvb1iKhr9v19ZB9OtnHwNnhUnNR/7Wteg=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -12475,18 +12386,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI=",
-      "dev": true
-    },
-    "moo": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
-      "dev": true
-    },
     "mori": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/mori/-/mori-0.3.2.tgz",
@@ -12539,7 +12438,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -12636,19 +12535,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "nearley": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.15.1.tgz",
-      "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
-      "dev": true,
-      "requires": {
-        "moo": "^0.4.3",
-        "nomnom": "~1.6.2",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6",
-        "semver": "^5.4.1"
-      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -13331,30 +13217,6 @@
         }
       }
     },
-    "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-      "dev": true,
-      "requires": {
-        "colors": "0.5.x",
-        "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-          "dev": true
-        }
-      }
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -13656,18 +13518,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
-    },
-    "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -13703,18 +13553,6 @@
           "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "dev": true
         }
-      }
-    },
-    "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -14363,13 +14201,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "express": {
           "version": "3.0.6",
-          "resolved": "http://registry.npmjs.org/express/-/express-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/express/-/express-3.0.6.tgz",
           "integrity": "sha1-0nT8uGi5V4i/SvYhaNddE/132LQ=",
           "dev": true,
           "requires": {
@@ -14394,7 +14232,7 @@
         },
         "mkdirp": {
           "version": "0.3.3",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
           "integrity": "sha1-WV4lHBNww6aLqyE20ONIuBBa3xM=",
           "dev": true
         },
@@ -16559,12 +16397,6 @@
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.0.tgz",
       "integrity": "sha512-m7zq0JkIrECzw9mO5Zcq6jN4KayE34yoIS9hJoiZNXyOAT06PPA8PrR+WtJIeFW09YjUfNkMMN9lrmAt6BURCA=="
     },
-    "railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
-      "dev": true
-    },
     "ramp": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ramp/-/ramp-2.0.2.tgz",
@@ -16660,20 +16492,10 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
-      }
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
       }
     },
     "randomatic": {
@@ -16770,31 +16592,19 @@
       }
     },
     "react-beautiful-dnd": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-8.0.7.tgz",
-      "integrity": "sha512-j2cClhKuACXp/KcG+YXSrVxZ7AQl13dG9X+ojstR6H2G0yoA+1GZn/O147PWVVScmfk/mSt60GNseH7vjae7vQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-9.0.2.tgz",
+      "integrity": "sha512-hZJJeOUnWLecgD52cJ51zsvosRTsSoweOlyYa+RQzvXHejCdzKUecEqSzF0aNaCsuHGx/GCVBHTdUR4be1HbWg==",
       "requires": {
-        "@babel/runtime": "7.0.0-beta.54",
+        "@babel/runtime-corejs2": "^7.0.0",
         "css-box-model": "^1.0.0",
         "memoize-one": "^4.0.0",
-        "prop-types": "15.6.1",
+        "prop-types": "^15.6.1",
         "raf-schd": "^4.0.0",
         "react-motion": "^0.5.2",
         "react-redux": "^5.0.7",
         "redux": "^4.0.0",
-        "tiny-invariant": "^0.0.3"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.6.1",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
-          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
-          "requires": {
-            "fbjs": "^0.8.16",
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "tiny-invariant": "^1.0.0"
       }
     },
     "react-dom": {
@@ -16829,8 +16639,7 @@
     "react-is": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
-      "dev": true
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -16864,22 +16673,23 @@
       }
     },
     "react-redux": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
-      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.0.tgz",
+      "integrity": "sha512-CRMpEx8+ccpoVxQrQDkG1obExNYpj6dZ1Ni7lUNFB9wcxOhy02tIqpFo4IUXc0kYvCGMu6ABj9A4imEX2VGZJQ==",
       "requires": {
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.17.5",
-        "lodash-es": "^4.17.5",
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.0.0",
+        "invariant": "^2.2.4",
         "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        "react-is": {
+          "version": "16.6.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
+          "integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
         }
       }
     },
@@ -17114,12 +16924,22 @@
       }
     },
     "redux": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
-      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
       "requires": {
-        "loose-envify": "^1.1.0",
+        "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        }
       }
     },
     "ref": {
@@ -17157,7 +16977,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -17673,16 +17493,6 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
-      }
-    },
-    "rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
-      "dev": true,
-      "requires": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
       }
     },
     "rsvp": {
@@ -18911,7 +18721,7 @@
       "dependencies": {
         "uglify-js": {
           "version": "1.2.5",
-          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
           "integrity": "sha1-tULCx29477NLIAsgF3Y0Mw/3ArY=",
           "dev": true
         },
@@ -19137,7 +18947,7 @@
     },
     "split": {
       "version": "0.2.10",
-      "resolved": "http://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "dev": true,
       "requires": {
@@ -19458,17 +19268,6 @@
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
         "function-bind": "^1.0.2"
       }
     },
@@ -20992,9 +20791,9 @@
       "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "tiny-invariant": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-0.0.3.tgz",
-      "integrity": "sha512-SA2YwvDrCITM9fTvHTHRpq9W6L2fBsClbqm3maT5PZux4Z73SPPDYwJMtnoWh6WMgmCkJij/LaOlWiqJqFMK8g=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.2.tgz",
+      "integrity": "sha512-J5T/Z/4GhqAipQlAB5NYJSDNMm/68AxRJyDSAGIK3d1o788OPgAB/zKxHG3KSYws8ncxpQ7NuAnsOMQywdaJOQ=="
     },
     "tinycolor": {
       "version": "0.0.1",
@@ -23895,10 +23694,6 @@
         "errno": "~0.1.7"
       }
     },
-    "worldview-options-eosdis": {
-      "version": "github:nasa-gibs/worldview-options-eosdis#71f509610d766c7a810ad7727987fc0f0b262f4f",
-      "from": "github:nasa-gibs/worldview-options-eosdis#v2.15.0"
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -24043,7 +23838,7 @@
       "dependencies": {
         "commander": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "less": "^3.8.0",
     "less-loader": "^4.1.0",
     "mini-css-extract-plugin": "^0.4.1",
-    "moment": "^2.19.3",
     "nightwatch": "^0.9.16",
     "node-fetch": "^2.1.2",
     "node-sass": "^4.9.2",

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -372,37 +372,46 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
           var prevDate = model.selected;
-          d = new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
-          );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
           if (!moment(prevDate).isDST() && moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
-          prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
           return new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate() - 1,
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            d.getFullYear(),
+            d.getMonth(),
+            prevDate.getDate(),
+            prevDate.getHours(),
+            prevDate.getMinutes()
           );
         };
 
         // Value for hovered boundary tick
         tl.zoom.current.ticks.boundary.hover = function(d) {
-          return new Date(
+          var prevDate = model.selected;
+
+          d = new Date(
             d.getUTCFullYear(),
-            model.selected.getUTCMonth(),
-            model.selected.getUTCDate()
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
@@ -419,28 +428,29 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked boundary tick
         tl.zoom.current.ticks.boundary.clickDate = function(d) {
           var prevDate = model.selected;
+
           d = new Date(
             d.getUTCFullYear(),
-            prevDate.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
           );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
+
           prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
-          return new Date(
-            d.getUTCFullYear(),
+            prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
@@ -471,8 +481,8 @@ export function timelineConfig(models, config, ui) {
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
               return (
-                d.getUTCFullYear() === newDate.getUTCFullYear() &&
-                d.getUTCMonth() === newDate.getUTCMonth()
+                d.getFullYear() === newDate.getFullYear() &&
+                d.getMonth() === newDate.getMonth()
               );
             });
         };
@@ -595,7 +605,6 @@ export function timelineConfig(models, config, ui) {
         // Value for hovered boundary tick
         tl.zoom.current.ticks.boundary.hover = function(d) {
           var prevDate = model.selected;
-          console.log('d', d);
           d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -595,17 +595,29 @@ export function timelineConfig(models, config, ui) {
         // Value for hovered boundary tick
         tl.zoom.current.ticks.boundary.hover = function(d) {
           var prevDate = model.selected;
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-          return new Date(
+          console.log('d', d);
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
             prevDate.getDate(),
-            prevDate.getHours(),
-            prevDate.getMinutes()
+            0,
+            0)
           );
         };
 
@@ -622,18 +634,28 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked boundary tick
         tl.zoom.current.ticks.boundary.clickDate = function(d) {
           var prevDate = model.selected;
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-
-          return new Date(
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
             prevDate.getDate(),
-            prevDate.getHours(),
-            prevDate.getMinutes()
+            0,
+            0)
           );
         };
 

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -578,37 +578,34 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
           var prevDate = model.selected;
-          d = new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
-          );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
           if (!moment(prevDate).isDST() && moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
-          prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
           return new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate() - 1,
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            prevDate.getHours(),
+            prevDate.getMinutes()
           );
         };
 
         // Value for hovered boundary tick
         tl.zoom.current.ticks.boundary.hover = function(d) {
+          var prevDate = model.selected;
+          if (!moment(prevDate).isDST() && moment(d).isDST()) {
+            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
+          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
+            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
+          }
           return new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            model.selected.getUTCDate()
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            prevDate.getHours(),
+            prevDate.getMinutes()
           );
         };
 
@@ -625,28 +622,17 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked boundary tick
         tl.zoom.current.ticks.boundary.clickDate = function(d) {
           var prevDate = model.selected;
-          d = new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
-          );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
           if (!moment(prevDate).isDST() && moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
-          prevDate = new Date(
-            prevDate.getTime() - prevDate.getTimezoneOffset() * 60000
-          );
           return new Date(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            prevDate.getHours(),
+            prevDate.getMinutes()
           );
         };
 
@@ -669,9 +655,9 @@ export function timelineConfig(models, config, ui) {
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
               return (
-                d.getUTCFullYear() === newDate.getUTCFullYear() &&
-                (d.getUTCMonth() === newDate.getUTCMonth() &&
-                  d.getUTCDate() === newDate.getUTCDate())
+                d.getFullYear() === newDate.getFullYear() &&
+                (d.getMonth() === newDate.getMonth() &&
+                  d.getDate() === newDate.getDate())
               );
             });
         };

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -148,49 +148,91 @@ export function timelineConfig(models, config, ui) {
 
         // Value for hovered normal label
         tl.zoom.current.ticks.normal.hover = function(d) {
-          // No modifications to date obj at this zoom level
-          return new Date(
+          var prevDate = model.selected;
+
+          d = new Date(
             d.getUTCFullYear(),
-            model.selected.getUTCMonth(),
-            model.selected.getUTCDate()
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
           var prevDate = model.selected;
+
           d = new Date(
             d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            0,
+            0
           );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-          return new Date(
-            d.getUTCFullYear(),
-            prevDate.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
-          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Value for hovered boundary tick
         tl.zoom.current.ticks.boundary.hover = function(d) {
+          var prevDate = model.selected;
           var yearOffset =
-            model.selected.getUTCFullYear() -
-            Math.ceil(new Date(model.selected.getUTCFullYear() / 10) * 10);
+            prevDate.getUTCFullYear() -
+            Math.ceil(new Date(prevDate.getUTCFullYear() / 10) * 10);
 
-          return new Date(
-            d.getUTCFullYear() + yearOffset,
-            model.selected.getUTCMonth(),
-            model.selected.getUTCDate()
+          d = new Date(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear() + yearOffset,
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
@@ -210,25 +252,29 @@ export function timelineConfig(models, config, ui) {
           var yearOffset =
             prevDate.getUTCFullYear() -
             Math.ceil(new Date(prevDate.getUTCFullYear() / 10) * 10);
+
           d = new Date(
-            d.getUTCFullYear() + yearOffset,
-            prevDate.getUTCMonth(),
-            prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
-          );
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-          return new Date(
             d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            prevDate.getUTCHours(),
-            prevDate.getUTCMinutes()
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear() + yearOffset,
+            prevDate.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
@@ -258,7 +304,7 @@ export function timelineConfig(models, config, ui) {
           tl.zoom.current.pick.hoveredTick = d3
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
-              return d.getUTCFullYear() === newDate.getUTCFullYear();
+              return d.getFullYear() === newDate.getFullYear();
             });
         };
 
@@ -361,29 +407,61 @@ export function timelineConfig(models, config, ui) {
 
         // Value for hovered normal label
         tl.zoom.current.ticks.normal.hover = function(d) {
-          // No modifications to date obj at this zoom level
-          return new Date(
+          var prevDate = model.selected;
+
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
-            model.selected.getUTCDate()
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
+            prevDate.getDate(),
+            0,
+            0)
           );
         };
 
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
           var prevDate = model.selected;
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-          return new Date(
+
+          d = new Date(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+
+          return new Date(Date.UTC(
             d.getFullYear(),
             d.getMonth(),
             prevDate.getDate(),
             prevDate.getHours(),
             prevDate.getMinutes()
-          );
+          ));
         };
 
         // Value for hovered boundary tick
@@ -588,18 +666,30 @@ export function timelineConfig(models, config, ui) {
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
           var prevDate = model.selected;
-          if (!moment(prevDate).isDST() && moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() + 1 * 60 * 60 * 1000);
-          } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
-            prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
-          }
-          return new Date(
+
+          d = new Date(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate(),
+            0,
+            0
+          );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            0,
+            0
+          );
+
+          return new Date(Date.UTC(
             d.getFullYear(),
             d.getMonth(),
             d.getDate(),
             prevDate.getHours(),
             prevDate.getMinutes()
-          );
+          ));
         };
 
         // Value for hovered boundary tick

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -56,7 +56,7 @@ export function timelineConfig(models, config, ui) {
       case 1: // Year
         dateStep = 1;
         labelFormat = d3.time.format.utc('%Y');
-        dateInterval = d3.time.year;
+        dateInterval = d3.time.year.utc;
         tickCount =
           tl.data.end().getUTCFullYear() - tl.data.start().getUTCFullYear();
         tickWidth = 15;
@@ -269,7 +269,7 @@ export function timelineConfig(models, config, ui) {
       case 2: // Month
         dateStep = 1;
         labelFormat = d3.time.format.utc('%Y');
-        dateInterval = d3.time.month;
+        dateInterval = d3.time.month.utc;
 
         tickCount =
           (tl.data.end().getUTCFullYear() - tl.data.start().getUTCFullYear()) *
@@ -484,7 +484,7 @@ export function timelineConfig(models, config, ui) {
       case 3: // Day
         dateStep = 1;
         labelFormat = d3.time.format.utc('%b');
-        dateInterval = d3.time.day;
+        dateInterval = d3.time.day.utc;
         tickCount = (tl.data.end() - tl.data.start()) / 1000 / 60 / 60 / 24;
         tickWidth = 11;
         tickCountMax = Math.ceil(tl.width / tickWidth);
@@ -699,7 +699,7 @@ export function timelineConfig(models, config, ui) {
       case 4: // 10-Minute
         dateStep = 10;
         labelFormat = d3.time.format.utc('%H:%M');
-        dateInterval = d3.time.minutes;
+        dateInterval = d3.time.minutes.utc;
         tickCount = (tl.data.end() - tl.data.start()) / 1000 / 60 / 10;
         tickWidth = 1;
         tickCountMax = tl.width;

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -1,6 +1,5 @@
 import d3 from 'd3';
 import util from '../util/util';
-import moment from 'moment';
 
 /**
  * Modify zoom levels here. Maybe this isnt the best way to do this.
@@ -154,25 +153,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             prevDate.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Value for clicked normal tick
@@ -183,16 +182,16 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
@@ -215,25 +214,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear() + yearOffset,
             prevDate.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Displayed default label
@@ -257,25 +256,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear() + yearOffset,
             prevDate.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // When the date updates while dragging the pick forward
@@ -413,25 +412,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             d.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Value for clicked normal tick
@@ -442,18 +441,17 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
-
 
           return new Date(Date.UTC(
             d.getFullYear(),
@@ -472,25 +470,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             prevDate.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Displayed default label
@@ -511,25 +509,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             prevDate.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // When the date updates while dragging the pick forward
@@ -671,16 +669,16 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
@@ -699,25 +697,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             d.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // Displayed default label
@@ -737,25 +735,25 @@ export function timelineConfig(models, config, ui) {
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
-            0,
-            0
+            d.getUTCHours(),
+            d.getUTCMinutes()
           );
 
           prevDate = new Date(
             prevDate.getUTCFullYear(),
             prevDate.getUTCMonth(),
             prevDate.getUTCDate(),
-            0,
-            0
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
           );
 
           return new Date(Date.UTC(
             d.getFullYear(),
             d.getMonth(),
             prevDate.getDate(),
-            0,
-            0)
-          );
+            prevDate.getHours(),
+            prevDate.getMinutes()
+          ));
         };
 
         // When the date updates while dragging the pick forward
@@ -946,7 +944,6 @@ export function timelineConfig(models, config, ui) {
 
         // Value for boundary ribbon hover label
         tl.zoom.current.ticks.boundary.hover = function(d) {
-
           d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
@@ -1004,8 +1001,8 @@ export function timelineConfig(models, config, ui) {
             d.getFullYear(),
             d.getMonth(),
             d.getDate(),
-            d.getUTCHours(),
-            prevDate.getUTCMinutes()
+            d.getHours(),
+            prevDate.getMinutes()
           ));
         };
 

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -304,7 +304,7 @@ export function timelineConfig(models, config, ui) {
           tl.zoom.current.pick.hoveredTick = d3
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
-              return d.getFullYear() === newDate.getFullYear();
+              return d.getUTCFullYear() === newDate.getUTCFullYear();
             });
         };
 
@@ -559,8 +559,8 @@ export function timelineConfig(models, config, ui) {
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
               return (
-                d.getFullYear() === newDate.getFullYear() &&
-                d.getMonth() === newDate.getMonth()
+                d.getUTCFullYear() === newDate.getUTCFullYear() &&
+                d.getUTCMonth() === newDate.getUTCMonth()
               );
             });
         };
@@ -777,9 +777,9 @@ export function timelineConfig(models, config, ui) {
             .selectAll('.x.axis>g.tick')
             .filter(function(d) {
               return (
-                d.getFullYear() === newDate.getFullYear() &&
-                (d.getMonth() === newDate.getMonth() &&
-                  d.getDate() === newDate.getDate())
+                d.getUTCFullYear() === newDate.getUTCFullYear() &&
+                (d.getUTCMonth() === newDate.getUTCMonth() &&
+                  d.getUTCDate() === newDate.getUTCDate())
               );
             });
         };
@@ -927,26 +927,41 @@ export function timelineConfig(models, config, ui) {
 
         // Value for clicked normal tick
         tl.zoom.current.ticks.normal.clickDate = function(d) {
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          return new Date(
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
             d.getUTCHours(),
             d.getUTCMinutes()
           );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            d.getHours(),
+            d.getMinutes()
+          ));
         };
 
         // Value for boundary ribbon hover label
         tl.zoom.current.ticks.boundary.hover = function(d) {
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          return new Date(
+
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
             d.getUTCHours(),
             d.getUTCMinutes()
           );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            d.getHours(),
+            d.getMinutes()
+          ));
         };
 
         // Displayed default label
@@ -968,18 +983,30 @@ export function timelineConfig(models, config, ui) {
         // TODO: Return to 6 hr with 0 minute if pick is within 6 hour range, otherwise
         // maintain the minute interval
         tl.zoom.current.ticks.boundary.clickDate = function(d) {
-          d = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
-          var selected = model.selected;
-          selected = new Date(
-            selected.getTime() - selected.getTimezoneOffset() * 60000
-          );
-          return new Date(
+          var prevDate = model.selected;
+          d = new Date(
             d.getUTCFullYear(),
             d.getUTCMonth(),
             d.getUTCDate(),
             d.getUTCHours(),
-            selected.getUTCMinutes()
+            d.getUTCMinutes()
           );
+
+          prevDate = new Date(
+            prevDate.getUTCFullYear(),
+            prevDate.getUTCMonth(),
+            prevDate.getUTCDate(),
+            prevDate.getUTCHours(),
+            prevDate.getUTCMinutes()
+          );
+
+          return new Date(Date.UTC(
+            d.getFullYear(),
+            d.getMonth(),
+            d.getDate(),
+            d.getUTCHours(),
+            prevDate.getUTCMinutes()
+          ));
         };
 
         // When the date updates while dragging the pick forward

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -1087,6 +1087,7 @@ export function timelineConfig(models, config, ui) {
   var switchZoom = function(zoomLevel) {
     var clone;
     var zoomElement;
+    model.events.trigger('update-timewheel');
     switch (zoomLevel) {
       case 1:
         zoomElement = '#zoom-years';

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -532,23 +532,41 @@ export function timelineConfig(models, config, ui) {
 
         // When the date updates while dragging the pick forward
         tl.zoom.current.pick.nextChange = function(d) {
+          var prevDate = model.selected;
+          var maxDayInMonth = new Date(d.getUTCFullYear(), d.getUTCMonth() + 1, 0).getDate();
+
+          if (prevDate.getUTCDate() > maxDayInMonth) {
+            prevDate = new Date(
+              new Date(prevDate).setUTCDate(
+                maxDayInMonth
+              )
+            );
+          }
+
           return new Date(
-            Date.UTC(
-              d.getUTCFullYear(),
-              d.getUTCMonth() + 1,
-              model.selected.getUTCDate()
-            )
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            prevDate.getUTCDate()
           );
         };
 
         // When the date updates while dragging the pick backward
         tl.zoom.current.pick.prevChange = function(d) {
+          var prevDate = model.selected;
+          var maxDayInMonth = new Date(d.getUTCFullYear(), d.getUTCMonth() + 1, 0).getDate();
+
+          if (prevDate.getUTCDate() > maxDayInMonth) {
+            prevDate = new Date(
+              new Date(prevDate).setUTCDate(
+                maxDayInMonth
+              )
+            );
+          }
+
           return new Date(
-            Date.UTC(
-              d.getUTCFullYear(),
-              d.getUTCMonth(),
-              model.selected.getUTCDate()
-            )
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            prevDate.getUTCDate()
           );
         };
 

--- a/web/js/date/config.js
+++ b/web/js/date/config.js
@@ -601,9 +601,9 @@ export function timelineConfig(models, config, ui) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
           return new Date(
-            d.getFullYear(),
-            d.getMonth(),
-            d.getDate(),
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            prevDate.getDate(),
             prevDate.getHours(),
             prevDate.getMinutes()
           );
@@ -627,10 +627,11 @@ export function timelineConfig(models, config, ui) {
           } else if (moment(prevDate).isDST() && !moment(d).isDST()) {
             prevDate = new Date(prevDate.getTime() - 1 * 60 * 60 * 1000);
           }
+
           return new Date(
-            d.getFullYear(),
-            d.getMonth(),
-            d.getDate(),
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            prevDate.getDate(),
             prevDate.getHours(),
             prevDate.getMinutes()
           );

--- a/web/js/date/timeline-input.js
+++ b/web/js/date/timeline-input.js
@@ -149,7 +149,7 @@ export function timelineInput(models, config, ui) {
     var max = model.maxDate();
     var date = model[model.activeDate];
     var maxZoom = model.maxZoom;
-    if (config.parameters.showSubdaily) {
+    if (model.maxZoom >= 4 || config.parameters.showSubdaily) {
       document.getElementById('timeline-header').classList.add('subdaily');
       maxZoom = 4;
     }
@@ -245,9 +245,9 @@ export function timelineInput(models, config, ui) {
     var endDate = models.layers.lastDate();
 
     // Disable arrows if nothing before/after selection
-    if (model.selectedZoom === 4 && ms >= endDate) {
+    if (model.selectedZoom > 3 && ms >= endDate) {
       $incrementBtn.addClass('button-disabled');
-    } else if (model.selectedZoom !== 4 && nd > endDate) {
+    } else if (model.selectedZoom < 4 && nd > endDate) {
       $incrementBtn.addClass('button-disabled');
     } else {
       $incrementBtn.removeClass('button-disabled');

--- a/web/js/layers/active.js
+++ b/web/js/layers/active.js
@@ -20,7 +20,7 @@ export function layersActive(models, ui, config) {
     var currentProjection = models.proj.selected.id;
     var check;
 
-    if (config.parameters.showSubdaily) {
+    if (model.maxZoom >= 4 || config.parameters.showSubdaily) {
       check = true;
     } else {
       lodashEach(activeLayers, function(activeLayer) {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -127,7 +127,7 @@ export function mapLayerBuilder(models, config, cache, mapUi) {
       date = models.date[models.date.activeDate];
       // If this not a subdaily layer, truncate the selected time to
       // UTC midnight
-      if (def.period !== 'subdaily') {
+      if (models.layers.maxZoom < 4) {
         date = util.clearTimeUTC(date);
       }
     }

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -591,6 +591,7 @@ export default (function (self) {
     var range = self.rollRange(date, interval, minDate, maxDate);
     var min = range.first;
     var max = range.last;
+    var second = date.getUTCSeconds();
     var minute = date.getUTCMinutes();
     var hour = date.getUTCHours();
     var day = date.getUTCDate();
@@ -623,7 +624,7 @@ export default (function (self) {
     if (day > daysInMonth) {
       day = daysInMonth;
     }
-    var newDate = new Date(Date.UTC(year, month, day, hour, minute));
+    var newDate = new Date(Date.UTC(year, month, day, hour, minute, second));
     newDate = new Date(self.clamp(newDate, minDate, maxDate));
     return newDate;
   };


### PR DESCRIPTION
## Description

Fixes #1410, Fixes #1205

Guitar pick will not move around when in other timezones. This PR should also fix weird "jumping" behavior seen in other timezones and likely the behavior outlined in #1205. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

There PR includes bug fixes for enabling the minute zoom level when using the `showSubdaily` param. The subdaily zoom level selector and inputs were not showing when the param was added.

**To Test**
- Test moving the pick, clicking the boundary, etc. in each zoom level. 
- Change the timezone in "Date & Time" settings on your machine and repeat.

There should be no noticable difference when changing the timezone. 
The guitar pick should be at the start of each tick mark.

@nasa-gibs/worldview
