### PR TITLE
Retain search terms when modal closes then opens

### DIFF
--- a/web/js/components/layer/header.js
+++ b/web/js/components/layer/header.js
@@ -18,7 +18,7 @@ class ProductPickerHeader extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      inputValue: ''
+      inputValue: props.inputValue
     };
   }
   /**
@@ -90,6 +90,7 @@ class ProductPickerHeader extends React.Component {
 }
 
 ProductPickerHeader.propTypes = {
+  inputValue: PropTypes.string,
   modalView: PropTypes.string,
   runSearch: PropTypes.func,
   selectedProjection: PropTypes.string,

--- a/web/js/components/layer/product-picker.js
+++ b/web/js/components/layer/product-picker.js
@@ -34,7 +34,8 @@ class ProductPicker extends React.Component {
       allLayers: props.allLayers,
       selectedMeasurement: null,
       filteredRows: props.filteredRows,
-      selectedProjection: props.selectedProjection
+      selectedProjection: props.selectedProjection,
+      inputValue: ''
     };
   }
   /**
@@ -62,7 +63,8 @@ class ProductPicker extends React.Component {
     if (val.length === 0) {
       this.setState({
         filteredRows: [],
-        listType: 'category'
+        listType: 'category',
+        inputValue: ''
       });
     } else {
       let terms = val.split(/ +/);
@@ -71,7 +73,8 @@ class ProductPicker extends React.Component {
       });
       this.setState({
         filteredRows: filteredRows,
-        listType: 'search'
+        listType: 'search',
+        inputValue: e.target.value
       });
     }
   }
@@ -133,6 +136,7 @@ class ProductPicker extends React.Component {
       categoryType,
       height,
       category,
+      inputValue,
       width,
       selectedMeasurement
     } = this.state;
@@ -159,11 +163,12 @@ class ProductPicker extends React.Component {
           <ProductPickerHeader
             selectedProjection={selectedProjection}
             listType={listType}
+            inputValue={inputValue}
             category={category}
             modalView={modalView}
             runSearch={this.runSearch.bind(this)}
             updateListState={str => {
-              this.setState({ listType: str });
+              this.setState({ listType: str, inputValue: '' });
             }}
           />
         </ModalHeader>

--- a/web/js/layers/modal.js
+++ b/web/js/layers/modal.js
@@ -27,7 +27,8 @@ export function layersModal(models, ui, config) {
       models.compare.events.on('change', () => {
         self.reactList.setState({
           activeLayers: model[model.activeLayers],
-          listType: 'category'
+          listType: 'category',
+          inputValue: ''
         });
       });
     }
@@ -37,7 +38,8 @@ export function layersModal(models, ui, config) {
         selectedProjection: models.proj.selected.id,
         allLayers: allLayers,
         filteredRows: allLayers,
-        listType: 'category'
+        listType: 'category',
+        inputValue: ''
       });
     });
 


### PR DESCRIPTION
## Description

Fixes #1440 .

Retain search terms when modal closes then opens

- [x] Retain an `inputValue` state in Parent component to pass to header when modal component remounts
- [x] Update input value when projection changes or comparison mode changes

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
