### PR TITLE
add to conditonal for mouseOut to prevent undefined

### DIFF
--- a/web/js/components/map/ol-coordinates.js
+++ b/web/js/components/map/ol-coordinates.js
@@ -50,7 +50,7 @@ class OlCoordinates extends React.Component {
   }
 
   mouseOut(event) {
-    if (event.relatedTarget) {
+    if (event.relatedTarget && event.relatedTarget.classList) {
       let cl = event.relatedTarget.classList;
       // Ignore when the mouse goes over the coordinate display. Clearing
       // the coordinates in this situation causes a flicker.


### PR DESCRIPTION
## Description

Fixes #1471 

Seen in IE11, in ```ol-coordinates.js```, certain mouseOut events have a relatedTarget but do not contain a classList property and allow null/undefined references through conditional. This fix adds a check to see if classList property is available before further assigning it and using the ```contains``` method on it.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
