### PR TITLE
Make category background images work in Edge

### DIFF
--- a/web/js/components/layer/category.js
+++ b/web/js/components/layer/category.js
@@ -15,9 +15,12 @@ class Category extends React.Component {
       hasMeasurementSource,
       categoryType
     } = this.props;
-    const categoryBgImage = category.image
+    const bgImage = category.image
+      ? 'images/wv.layers/categories/' + category.image
+      : '';
+    const categoryBgImage = bgImage
       ? {
-        backgroundImage: 'url("images/wv.layers/categories/' + category.image
+        backgroundImage: `url(${bgImage})`
       }
       : {};
 


### PR DESCRIPTION
## Description

Fixes #1456  .
Make category background images work in Edge

- [x] Use es6 str template to include background images #1456


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
