### PR TITLE
Redo sort measurement source order

### DIFF
--- a/web/js/components/layer/measurement-row.js
+++ b/web/js/components/layer/measurement-row.js
@@ -284,17 +284,19 @@ class LayerRow extends React.Component {
 
     const Tabs = (
       <Nav vertical className="source-tabs col-md-3 col-sm-12">
-        {sources.map(
-          (source, index) =>
-            hasMeasurementSetting(measurement, source)
-              ? this.renderSourceTabs(
-                measurement,
-                source,
-                index,
-                activeSourceIndex
-              )
-              : ''
-        )}
+        {sources
+          .sort((a, b) => a.title.localeCompare(b.title))
+          .map(
+            (source, index) =>
+              hasMeasurementSetting(measurement, source)
+                ? this.renderSourceTabs(
+                  measurement,
+                  source,
+                  index,
+                  activeSourceIndex
+                )
+                : ''
+          )}
       </Nav>
     );
 


### PR DESCRIPTION
## Description

Fixes #85 .

Prod picker replace left out measurement source order sort
- [x] sort source order

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
