### PR TITLE
Override body position to static

### DIFF
--- a/web/css/jquery-ui-override.css
+++ b/web/css/jquery-ui-override.css
@@ -289,3 +289,8 @@ or dateline overlays to be selectable. */
 #wv-toolbar .ui-button.ui-state-disabled:hover {
   color: #eeee;
 }
+
+/* Overide jQuery joyride */
+body {
+  position: static !important;
+}

--- a/web/css/jquery-ui-override.css
+++ b/web/css/jquery-ui-override.css
@@ -292,5 +292,5 @@ or dateline overlays to be selectable. */
 
 /* Overide jQuery joyride */
 body {
-  position: static !important;
+  position: static;
 }


### PR DESCRIPTION
## Description

Fixes #1463 .

Override ```body``` from ```relative``` to ```static``` to prevent dragging the map off the page.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
