### PR TITLE
Fix layer count in sidebar

### DIFF
--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -221,7 +221,7 @@ export function sidebarUi(models, config, ui) {
       } else {
         self.reactComponent.setState({
           layers: models.layers.get(
-            { group: 'all', proj: 'all' },
+            { group: 'all', proj: models.proj.selected.id },
             models.layers[models.layers.activeLayers]
           ),
           zotsObject: getZotsForActiveLayers(config, models, ui)


### PR DESCRIPTION
## Description

Fixes #1488  .

Update with projection to get current total of layers displayed in sidebar (when in mobile or sidebar isn't expanded on desktop).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
