### PR TITLE
v2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## Layer Updates
- Added OMI UV Aerosol Index layer #1424
- Added CYGNSS Wind Speed layer #1425
- Added AMSRU2 Snow Water Equivalent Daily, 5 Day and Monthly layers #1423 
- Added GCOM-C orbit tracks #1435
- Changed DMSP-F8 to DMSP-F08 #1377
- Added PO.DAAC tag to PO.DAAC layers #1378
- Updated layer numbers #1414
- Changed start date for OSCAR layers #1430
- Added ISS LIS Layers #1452
- Removed new AMSRU2 SWE layers #1470

## Technical Updates
- Deprecated worldview-options-eosdis
- Brought main configuration into worldview repository #1367
- Updated messages notifications #1373
- Webpack build enhancements #1275
- Added new A|B url parameters to Docs #1397
- Added layer parameters to utilize future layer timeline support #1391
- Added drag feature for timeline GIF animation dragger range #1254
- Made IE11 minimum site requirement #1408
- Improved site metrics #1376
- Optimized rendering of event tracks #1398
- Added unit tests in another timezone #1406
- Improved product picker #1436
- Added natural event E2E tests #1236
- Updated developing docs #1240
- Added Degrees Decimal Minutes format #1357 
- Upgraded OpenLayers to v5.2.0 #1262 
- Added new README image #1360
- Added .stylelintignore #1343
- Added english lang support to HTML document #1230
- Changed getCapabilities script to use urllib3 #1302
- Added notificationURL testing parameter and documentation #1353
- Added Selenium testing in docker container #1296
- Converted unit tests to use Jest #1241
- Added "wrapX" configuration parameter #1303 
- Sorted satellite/sensor list in categories view #1309

## Bug Fixes
- Changed nightwatch process module path from bin to module #1356
- Added libcario to docker build #1365
- Updated dependencies #1368
- Added event marker hover IE11 CustomEvent fix #1289
- Fixed toolbar spacing #1379
- Checked for button on mouseout, removed throttle #1383 
- Removed additional timezone offset compensation for year zoom timeline #1294
- Updates to text and added night layers to storm and fire categories #1392
- Set html for sidebar event titles #1400
- Only update checkbox if custom palette is in effect #1393
- Fixed day of year label in timeline #1402
- Ignore stylelinting web folders other than /css #1382
- Highlight full width of long names in product picker #1409
- Removed README caret #1413
- Fixed sub-daily permalink flag #1344
- Fixed palettes while keeping event track performance #1418
- Fixed when newly added base layers can appear at bottom of stack #1417
- Fixed custom palettes in compare mode #1422
- Replaced touch device checks #1419
- Removed dates from console when animation is playing #1433
- Don't show coords until mouse is detected #1426
- Fixed infinite loop issue on certain devices #1429
- Fixed guitar pick offset in alternate timezones #1437
- Checkbox label position fixed #1233
- Fixed mobile expand #1338
- Keep layer add button red #1349
- Removed dangling apache config link #1325
- Update compare E2E tests to work with UAT/SIT bug fixes  #1341
- Added vendor prefix IE11/Edge scrollbar fix for cut off layer list text #1318
- Added reverse tab (shift tab) functionality to date selector input #1308 
- Fixed links in about section open in a new tab/window #1306 
- Only hoist links when more than one granule is present #1317
- Renamed id to ident #1310
- Removed 'Events may not be visible at all times' notice when not in events mode #1319
- Checked that granule to remove has been selected #1321
- Fixed date input not respecting max date #1447 
- Product Picker Font Fixes #1445 
- Search back button in polar views #1473 
- Retained search terms when modal closes then opens #1446
- Added autoFocus when not using a touch device #1474 
- Added to conditonal for mouseOut to prevent undefined #1472 
- Made category background images work in Edge #1475 
- Added stylelint to tests and fix css lint errors #1448
- Fixed additional stylelint errors #1476
- Redid sort measurement source order #1477 
- Removed layer-list resizing when add layer modal is open #1461 
- Renamed exceedLength to overflow #1479 
- Overrode body position to static #1485 
- Fixed sub-daily check #1478 
- Removed inactive tag and updated end date #1487 
- Made layer add/remove faster #1483 
- Used ol drag listener to update spy #1482 
- Removed breadcrumb in smaller windows #1481 
- Fixed IE11 scrollbars #1489 
- Applied preventDefault #1490 
- Added animation margin and fix spy bug #1491
- Fixed layer count in sidebar #1492
- Removed GA code from GTM upgrade #1500
- Fixed timeline forward arrow missing #1501
- Fixed timeline data bar colors not updating #1502
- Removed date key for static layers #1504