### PR TITLE
Show/select first valid available layer measurement in product picker

### DIFF
--- a/web/js/components/layer/measurement-row.js
+++ b/web/js/components/layer/measurement-row.js
@@ -266,9 +266,9 @@ class LayerRow extends React.Component {
     const { activeSourceIndex } = this.state;
     const sources = lodashValues(measurement.sources);
 
-    // handle activeSourceIndex values not valid after projection change
-    let validIndexSelected = false;
+    // set first valid index to handle invalid activeSourceIndex indexes after projection change
     let minValidIndex = -1;
+    let validActiveIndex = activeSourceIndex;
 
     const Tabs = (
       <Nav vertical className="source-tabs col-md-3 col-sm-12">
@@ -276,31 +276,13 @@ class LayerRow extends React.Component {
           .sort((a, b) => a.title.localeCompare(b.title))
           .map(
             (source, index) => {
-              let hasSetting = hasMeasurementSetting(measurement, source);
-
-              if (hasSetting) {
-                // check if activeSourceIndex is satisfied to set flag
-                if (activeSourceIndex === index) {
-                  validIndexSelected = true;
-                }
-                // only set minValidIndex once
+              if (hasMeasurementSetting(measurement, source)) {
+                // only set minValidIndex once to find init active tab/content
                 if (minValidIndex < 0) {
                   minValidIndex = index;
                 }
-              }
-              return [source, hasSetting];
-            }
-          )
-          .map(
-            (sourceCheckResults, index) => {
-              const [source, hasSetting] = sourceCheckResults;
-
-              if (hasSetting) {
-                // if activeSourceIndex does not match any valid indexes, make minValidIndex active tab
-                let validActiveIndex = activeSourceIndex;
-                if (!validIndexSelected && minValidIndex === index) {
-                  validActiveIndex = minValidIndex;
-                }
+                // if activeSourceIndex is less than first valid index, make minValidIndex active tab
+                validActiveIndex = minValidIndex > activeSourceIndex ? minValidIndex : activeSourceIndex;
                 return this.renderSourceTabs(
                   measurement,
                   source,
@@ -316,15 +298,10 @@ class LayerRow extends React.Component {
       </Nav>
     );
 
-    // if no match of valid indexes, make minValidIndex active content
-    let validActiveSourceIndex = activeSourceIndex;
-    if (!validIndexSelected) {
-      validActiveSourceIndex = minValidIndex;
-    }
-
+    // content set as minValidIndex if activeSourceIndex is not valid
     const Content = this.renderSourceContent(
       measurement,
-      sources[validActiveSourceIndex]
+      sources[validActiveIndex]
     );
     return (
       <div className="container">

--- a/web/js/components/layer/measurement-row.js
+++ b/web/js/components/layer/measurement-row.js
@@ -266,7 +266,7 @@ class LayerRow extends React.Component {
     const { activeSourceIndex } = this.state;
     const sources = lodashValues(measurement.sources);
 
-    // handle low empty activeSourceIndex values on projection change
+    // handle activeSourceIndex values not valid after projection change
     let validIndexSelected = false;
     let minValidIndex = -1;
 
@@ -279,13 +279,13 @@ class LayerRow extends React.Component {
               let hasSetting = hasMeasurementSetting(measurement, source);
 
               if (hasSetting) {
+                // check if activeSourceIndex is satisfied to set flag
+                if (activeSourceIndex === index) {
+                  validIndexSelected = true;
+                }
                 // only set minValidIndex once
                 if (minValidIndex < 0) {
                   minValidIndex = index;
-                }
-                // check if activeSourceIndex is satisfied
-                if (activeSourceIndex === index) {
-                  validIndexSelected = true;
                 }
               }
               return [source, hasSetting];
@@ -293,7 +293,7 @@ class LayerRow extends React.Component {
           )
           .map(
             (sourceCheckResults, index) => {
-              let [source, hasSetting] = sourceCheckResults;
+              const [source, hasSetting] = sourceCheckResults;
 
               if (hasSetting) {
                 // if activeSourceIndex does not match any valid indexes, make minValidIndex active tab


### PR DESCRIPTION
## Description

Fixes issue that happened when a layer measurement subgroup item was available in the Geographic projection but not available in the Arctic projection. This issue caused the unavailable Geographic measurement description to be displayed in Arctic and the correct Nav items to not be highlighted.

Fixes #1511  .

This fix first checks for and then uses a valid matching index of the measurement subgroup items while rendering the source data.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

The subtitles for the measurements in the product picker are hardcoded in the `wv.json` and do not differ from projection to projection. We may want to consider changing/updating this in the future.

@nasa-gibs/worldview
