### PR TITLE
Check for dialog to be initialized prior to closing

### DIFF
--- a/web/js/layers/info.js
+++ b/web/js/layers/info.js
@@ -476,7 +476,7 @@ export function layersInfo(config, models, layer) {
   };
 
   var onLayerRemoved = function(removedLayer) {
-    if (layer.id === removedLayer.id && $dialog) {
+    if (layer.id === removedLayer.id && $dialog && $dialog.hasClass('ui-dialog-content')) {
       $dialog.dialog('close');
     }
   };

--- a/web/js/layers/options.js
+++ b/web/js/layers/options.js
@@ -434,7 +434,7 @@ export function layersOptions(config, models, layer, layerGroupStr) {
   };
 
   var onLayerRemoved = function(removedLayer) {
-    if (layer.id === removedLayer.id && $dialog) {
+    if (layer.id === removedLayer.id && $dialog && $dialog.hasClass('ui-dialog-content')) {
       $dialog.dialog('close');
     }
   };


### PR DESCRIPTION
## Description

Fixes #1515 .

- Add condition that checks for dialog to be initialized prior to closing to fix issue of closing before the dialog fully initialized

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
