### PR TITLE
Add status flag to prevent multiple GIFs from being creating while one is in progress

### DIFF
--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -60,6 +60,7 @@ const resolutionsPolar = {
 
 export function animationGif(models, config, ui) {
   var self = {};
+  var creatingGIF = false;
   var jcropAPI = null;
   var animationCoordinates = null;
   var previousCoords = null;
@@ -229,6 +230,8 @@ export function animationGif(models, config, ui) {
    *
    */
   self.createGIF = function() {
+    // set creating GIF status flag
+    creatingGIF = true;
     var imageArra;
     var stampWidth;
     var build;
@@ -383,6 +386,10 @@ export function animationGif(models, config, ui) {
    *
    */
   var getGif = function() {
+    // prevent if status flag shows already creating a GIF
+    if (creatingGIF) {
+      return;
+    }
     var layers;
     // check for rotation, changed palettes, and graticule layers and ask for reset if so
 
@@ -639,6 +646,8 @@ export function animationGif(models, config, ui) {
    *
    */
   var onGifComplete = function(obj) {
+    // reset GIF creating status flag
+    creatingGIF = false;
     // callback function for when image is finished
     $('#timeline-footer').removeClass('wv-anim-active');
     models.anim.rangeState.state = 'off';

--- a/web/js/animation/gif.js
+++ b/web/js/animation/gif.js
@@ -646,7 +646,7 @@ export function animationGif(models, config, ui) {
    *
    */
   var onGifComplete = function(obj) {
-    // reset GIF creating status flag
+    // reset creating GIF status flag
     creatingGIF = false;
     // callback function for when image is finished
     $('#timeline-footer').removeClass('wv-anim-active');


### PR DESCRIPTION
## Description

Fixes #1505  .

- Add boolean status flag in GIF creation to prevent multiple GIFs from being created while one is in process. This fixes unnecessary calls and prevents the second Loading indicator.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
