### PR TITLE
Add condition to check for swipe-line node before performing window resize functions

### DIFF
--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -26,8 +26,10 @@ export class Swipe {
     events = compareEvents;
     this.create();
     $(window).resize(() => {
-      this.destroy();
-      this.create();
+      if (document.querySelector('.ab-swipe-line')) {
+        this.destroy();
+        this.create();
+      }
     });
   }
   create() {


### PR DESCRIPTION
## Description

Fixes #1516  .

- Adds condition in swipe to check for `.ab-swipe-line` node prior to window resize functions, which includes destroying that node. This condition prevents the window resize functions from happening when compare mode is inactive.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
