### PR TITLE
Fix image download size adjuster

### DIFF
--- a/web/css/image.css
+++ b/web/css/image.css
@@ -67,13 +67,13 @@
   white-space: pre;
   color: #fff;
   text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
-  padding: 5px;
+  padding: 0 5px;
 }
 
-#wv-image-bottom {
+.wv-image-bottom {
   text-align: left;
 }
 
-#wv-image-top {
+.wv-image-top {
   text-align: right;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -49,10 +49,10 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (http://opensource.gs
   <div data-role="page" id="app">
   </div>
   <div id="wv-tour-content" class="tour-content"></div>
-  <div id="wv-image-top" class="wv-image-coords"></div>
-  <div id="wv-image-right" class="wv-image-coords"></div>
-  <div id="wv-image-bottom" class="wv-image-coords"></div>
-  <div id="wv-image-left" class="wv-image-coords"></div>
+  <div id="wv-image-top" class="wv-image-coords wv-image-top"></div>
+  <div id="wv-image-right" class="wv-image-coords wv-image-right"></div>
+  <div id="wv-image-bottom" class="wv-image-coords wv-image-bottom"></div>
+  <div id="wv-image-left" class="wv-image-coords wv-image-left"></div>
   <div class="backdrop"></div>
 </body>
 

--- a/web/js/image/panel.js
+++ b/web/js/image/panel.js
@@ -286,8 +286,8 @@ export function imagePanel(models, ui, config, dialogConfig) {
     }
     $('#wv-image-top')
       .css({
-        left: x1 - 10,
-        top: y1 - 20,
+        left: x1,
+        top: y1 - 15,
         width: x2 - x1
       })
       .html(topRightCoordinates);
@@ -295,7 +295,7 @@ export function imagePanel(models, ui, config, dialogConfig) {
     $('#wv-image-bottom')
       .css({
         left: x1,
-        top: y2,
+        top: y2 + 5,
         width: x2 - x1
       })
       .html(bottomLeftCoordinates);
@@ -379,14 +379,14 @@ export function imagePanel(models, ui, config, dialogConfig) {
       url
     );
     googleTagManager.pushEvent({
-      'event': 'image_download',
-      'layers': {
-        'activeCount': models.layers.active.length
+      event: 'image_download',
+      layers: {
+        activeCount: models.layers.active.length
       },
-      'image': {
-        'resolution': imgRes,
-        'format': imgFormat,
-        'worldfile': imgWorldfile
+      image: {
+        resolution: imgRes,
+        format: imgFormat,
+        worldfile: imgWorldfile
       }
     });
 


### PR DESCRIPTION
## Description

Fixes #1528 
Can't use upper left corner adjuster of image download, lat-long label element is in the way

- [x] replace some css ids with classes
- [x] make it so label does not overlap size adjuster
- [x] Make bottom and top labels have same x-padding 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
