### PR TITLE
Prevent Data Download and Comparison modes from being loaded in mobile

### DIFF
--- a/web/js/compare/model.js
+++ b/web/js/compare/model.js
@@ -55,16 +55,18 @@ export function compareModel(models, config) {
     }
   };
   self.load = function(state) {
-    if (state.ca) {
-      self.active = true;
-      self.isCompareA = state.ca === 'true';
-    }
-    if (state.cm) {
-      self.active = true;
-      self.mode = state.cm;
-    }
-    if (state.cv) {
-      self.value = Number(state.cv);
+    if (!util.browser.small && !util.browser.mobileDevice) {
+      if (state.ca) {
+        self.active = true;
+        self.isCompareA = state.ca === 'true';
+      }
+      if (state.cm) {
+        self.active = true;
+        self.mode = state.cm;
+      }
+      if (state.cv) {
+        self.value = Number(state.cv);
+      }
     }
   };
   return self;

--- a/web/js/data/model.js
+++ b/web/js/data/model.js
@@ -288,7 +288,7 @@ export function dataModel(models, config) {
 
   self.load = function(state, errors) {
     var productId = state.download;
-    if (productId) {
+    if (productId && !util.browser.small && !util.browser.mobileDevice) {
       var found = lodashFind(models.layers[models.layers.activeLayers], {
         product: productId
       });


### PR DESCRIPTION
## Description

Fixes #1484  .

Prevent `Data Download` and `Comparison` modes from being loaded in mobile

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
