### PR TITLE
Format GIF addFrame to upload to Twitter

### DIFF
--- a/web/ext/gifwriter/gifwriter.js
+++ b/web/ext/gifwriter/gifwriter.js
@@ -102,7 +102,7 @@ export default class gifWriter {
 
     return new ReadableStream({
       start: function start(controller) {
-        controller.enqueue(buf);
+        controller.enqueue(new Uint8Array(buf));
       },
       pull: function pull(controller) {
         return reader.read().then(function (_ref2) {
@@ -110,8 +110,7 @@ export default class gifWriter {
               value = _ref2.value;
 
           if (done) {
-            buf[p++] = 0x3b;
-            controller.enqueue(buf);
+            controller.enqueue(new Uint8Array([0x3b]));
             controller.close();
             return;
           }
@@ -220,7 +219,7 @@ export default class gifWriter {
 
     p = GifWriterOutputLZWCodeStream(
       buf, p, min_code_size < 2 ? 2 : min_code_size, indexed_pixels);
-    controller.enqueue(buf);
+    controller.enqueue(new Uint8Array(buf));
   };
 }
 // Main compression routine, palette indexes -> LZW code stream.
@@ -374,4 +373,3 @@ function check_palette_and_num_colors(palette) {
     throw "Invalid code/color length, must be power of 2 and 2 .. 256.";
   return num_colors;
 }
-


### PR DESCRIPTION
## Description

Fixes #1263  .

Fixes an issue that GIFs could not be directly uploaded to Twitter or opened in Photoshop.

- add UintArray to buffer in addFrame

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
