### PR TITLE
Allow A|B alert to close

### DIFF
--- a/web/js/compare/ui.js
+++ b/web/js/compare/ui.js
@@ -14,34 +14,39 @@ export function compareUi(models, ui, config) {
   var alertDialog;
 
   var alert = function() {
-    if (!alertDialog) {
-      alertDialog = wvui.alert(
-        compareAlertBody,
-        'You are now in comparison mode',
-        800,
-        'exclamation-triangle',
-        'fas',
-        function() {
-          if (util.browser.localStorage) {
-            localStorage.setItem('dismissedCompareAlert', true);
+    if (!localStorage.getItem('dismissedCompareAlert')) {
+      if (!alertDialog) {
+        alertDialog = wvui.alert(
+          compareAlertBody,
+          'You are now in comparison mode',
+          800,
+          'exclamation-triangle',
+          'fas',
+          function() {
+            if (util.browser.localStorage) {
+              localStorage.setItem('dismissedCompareAlert', true);
+            }
+            alertDialog.dialog('close');
           }
-          alertDialog.dialog('close');
-        }
-      );
-    }
-    if (
-      util.browser.localStorage &&
-      !localStorage.getItem('dismissedCompareAlert')
-    ) {
+        );
+      }
       alertDialog.dialog('open');
     }
   };
   var init = function() {
     var model = models.compare;
-    if (model.active) alert();
-    model.events.on('toggle', function() {
+    if (util.browser.localStorage) {
       if (model.active) alert();
-    });
+
+      model.events.on('toggle', function() {
+        if (model.active) {
+          alert();
+        } else if (alertDialog) {
+          alertDialog.dialog('close');
+          alertDialog = null;
+        }
+      });
+    }
   };
   init();
   return self;

--- a/web/js/compare/ui.js
+++ b/web/js/compare/ui.js
@@ -19,7 +19,8 @@ export function compareUi(models, ui, config) {
         compareAlertBody,
         'You are now in comparison mode',
         800,
-        'warning',
+        'exclamation-triangle',
+        'fas',
         function() {
           if (util.browser.localStorage) {
             localStorage.setItem('dismissedCompareAlert', true);


### PR DESCRIPTION
## Description

Fixes #1562

- [x] Fix `A|B` alert that won't close
- [x] open/close alert when `A|B` activates/deactivates

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
