### PR TITLE
Reapply event-related layers on second selection

### DIFF
--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -10,10 +10,10 @@
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
                 ["VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1", false],
                 ["VIIRS_SNPP_DayNightBand_ENCC", false],
-                ["MODIS_Fires_Terra", true],
-                ["MODIS_Fires_Aqua", false],
-                ["VIIRS_SNPP_Fires_375m_Day", false],
-                ["VIIRS_SNPP_Fires_375m_Night", false],
+                ["MODIS_Terra_Thermal_Anomalies_All", true],
+                ["MODIS_Aqua_Thermal_Anomalies_All", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Day", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Night", false],
                 ["Reference_Features", true],
                 ["Reference_Labels", true]
             ],
@@ -72,12 +72,12 @@
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
-                ["MODIS_Fires_Terra", true],
-                ["MODIS_Fires_Aqua", false],
+                ["MODIS_Terra_Thermal_Anomalies_All", true],
+                ["MODIS_Aqua_Thermal_Anomalies_All", false],
                 ["Reference_Features", true],
                 ["Reference_Labels", true],
-                ["VIIRS_SNPP_Fires_375m_Day", false],
-                ["VIIRS_SNPP_Fires_375m_Night", false]
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Day", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Night", false]
             ],
             "Default": [
                 ["Reference_Features", true],
@@ -96,10 +96,10 @@
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
                 ["VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1", false],
                 ["VIIRS_SNPP_DayNightBand_ENCC", false],
-                ["MODIS_Fires_Terra", true],
-                ["MODIS_Fires_Aqua", false],
-                ["VIIRS_SNPP_Fires_375m_Day", false],
-                ["VIIRS_SNPP_Fires_375m_Night", false],
+                ["MODIS_Terra_Thermal_Anomalies_All", true],
+                ["MODIS_Aqua_Thermal_Anomalies_All", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Day", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Night", false],
                 ["Reference_Features", true],
                 ["Reference_Labels", true]
             ],
@@ -167,12 +167,12 @@
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", false],
                 ["AIRS_Prata_SO2_Index_Day", true],
                 ["AIRS_Prata_SO2_Index_Night", false],
-                ["MODIS_Fires_Terra", true],
-                ["MODIS_Fires_Aqua", false],
+                ["MODIS_Terra_Thermal_Anomalies_All", true],
+                ["MODIS_Aqua_Thermal_Anomalies_All", false],
                 ["Reference_Features", true],
                 ["Reference_Labels", true],
-                ["VIIRS_SNPP_Fires_375m_Day", false],
-                ["VIIRS_SNPP_Fires_375m_Night", false]
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Day", false],
+                ["VIIRS_SNPP_Thermal_Anomalies_375m_Night", false]
             ],
             "Default": [
                 ["Reference_Features", true],

--- a/tasks/validateOptions.py
+++ b/tasks/validateOptions.py
@@ -158,6 +158,13 @@ for startingLayer in wv["defaults"]["startingLayers"]:
 wv["defaults"]["startingLayers"] = startingLayers
 wv["buildDate"] = datetime.now().isoformat(" ")
 
+for projection, projectionValue in wv["naturalEvents"]["layers"].iteritems():
+    for eventType, eventTypeLayerList in projectionValue.iteritems():
+        for layerObject in eventTypeLayerList:
+            if layerObject[0] not in wv["layers"]:
+                error("The %s layer in the Natural events %s %s config does not have a matching ID in the layer config" %
+                (layerObject[0], projection, eventType))
+
 for measurement in wv["measurements"].values():
     if "sources" not in measurement:
         continue

--- a/web/js/map/animate.js
+++ b/web/js/map/animate.js
@@ -1,6 +1,6 @@
 import * as olExtent from 'ol/extent';
 import OlGeomLineString from 'ol/geom/LineString';
-
+import Promise from 'bluebird';
 export function mapAnimate(models, config, ui) {
   var self = {};
 
@@ -11,7 +11,7 @@ export function mapAnimate(models, config, ui) {
    * @param  {integer} endZoom Ending Zoom Level
    * @return {Promise}         Promise that is fulfilled when animation completes
    */
-  self.fly = function (endPoint, endZoom) {
+  self.fly = function(endPoint, endZoom) {
     var view = ui.map.selected.getView();
     var polarProjectionCheck = models.proj.selected.id !== 'geographic'; // boolean if current projection is polar
     view.cancelAnimations();
@@ -24,16 +24,16 @@ export function mapAnimate(models, config, ui) {
     var line = new OlGeomLineString([startPoint, endPoint]);
     var distance = line.getLength(); // In map units, which is usually degrees
     var distanceDuration = polarProjectionCheck ? distance / 50000 : distance; // limit large polar projection distances from coordinate transforms
-    var duration = Math.floor((distanceDuration * 20) + 1000); // approx 6 seconds to go 360 degrees
-    var animationPromise = function () {
+    var duration = Math.floor(distanceDuration * 20 + 1000); // approx 6 seconds to go 360 degrees
+    var animationPromise = function() {
       var args = Array.prototype.slice.call(arguments);
-      return new Promise(function (resolve, reject) {
-        args.push(function (complete) {
+      return new Promise(function(resolve, reject) {
+        args.push(function(complete) {
           if (complete) resolve();
           if (!complete) reject(new Error('Animation interrupted!'));
         });
         view.animate.apply(view, args);
-      }).catch(function () {});
+      }).catch(function() {});
     };
     if (hasEndInView) {
       // allow faster fly with nearby events
@@ -48,7 +48,10 @@ export function mapAnimate(models, config, ui) {
     return Promise.all([
       animationPromise({ center: endPoint, duration: duration }),
       animationPromise(
-        { zoom: getBestZoom(distance, startZoom, endZoom, view), duration: duration / 2 },
+        {
+          zoom: getBestZoom(distance, startZoom, endZoom, view),
+          duration: duration / 2
+        },
         { zoom: endZoom, duration: duration / 2 }
       )
     ]);
@@ -63,18 +66,20 @@ export function mapAnimate(models, config, ui) {
    * @param  {object} view     map view
    * @return {integer}          best zoom level for flight animation
    */
-  var getBestZoom = function (distance, start, end, view) {
+  var getBestZoom = function(distance, start, end, view) {
     var idealLength = 1500;
-    var lines = [2, 3, 4, 5, 6, 7, 8].map(function (zoom) {
+    var lines = [2, 3, 4, 5, 6, 7, 8].map(function(zoom) {
       return {
         zoom: zoom,
         pixels: distance / view.getResolutionForZoom(zoom)
       };
     });
-    var bestFit = lines.sort(function (a, b) {
-      return Math.abs(idealLength - a.pixels) - Math.abs(idealLength - b.pixels);
+    var bestFit = lines.sort(function(a, b) {
+      return (
+        Math.abs(idealLength - a.pixels) - Math.abs(idealLength - b.pixels)
+      );
     })[0];
     return Math.max(2, Math.min(bestFit.zoom, start - 1, end - 1));
   };
   return self;
-};
+}

--- a/web/js/natural-events/ui.js
+++ b/web/js/natural-events/ui.js
@@ -184,6 +184,11 @@ export default function naturalEventsUI(models, ui, config, request) {
   };
   self.selectEvent = function(id, date, isInitialLoad) {
     var isIdChange = !self.selected || self.selected.id !== id;
+    var prevId = self.selected.id ? self.selected.id : false;
+    var prevEvent = prevId
+      ? naturalEventsUtilGetEventById(model.data.events, prevId)
+      : false;
+    var prevCategory = prevEvent ? prevEvent.categories[0].title : false;
 
     // Store selected id and date in model
     self.selected = { id: id };
@@ -193,6 +198,9 @@ export default function naturalEventsUI(models, ui, config, request) {
       wvui.notify('The event with an id of ' + id + ' is no longer active.');
       return;
     }
+
+    var category = event.categories[0].title;
+    var isSameCategory = category === prevCategory;
 
     date = date || self.getDefaultEventDate(event);
     const zoomPromise = getZoomPromise(event, date, !isIdChange, isInitialLoad);
@@ -205,7 +213,7 @@ export default function naturalEventsUI(models, ui, config, request) {
     self.markers = naturalEventMarkers.draw();
     zoomPromise.then(function() {
       self.selecting = true;
-      if (!isInitialLoad && isIdChange) {
+      if (isIdChange && !isSameCategory && !isInitialLoad) {
         activateLayersForCategory(event.categories[0].title);
       }
       if (!isInitialLoad) models.date.select(util.parseDateUTC(date));
@@ -249,6 +257,7 @@ export default function naturalEventsUI(models, ui, config, request) {
       }
       naturalEventsTrack.update(event, ui.map.selected, date, self.selectEvent);
       self.selecting = false;
+      model.events.trigger('selection-done', self.selected);
     });
 
     model.events.trigger('selected-event', self.selected);

--- a/web/js/natural-events/ui.js
+++ b/web/js/natural-events/ui.js
@@ -184,11 +184,6 @@ export default function naturalEventsUI(models, ui, config, request) {
   };
   self.selectEvent = function(id, date, isInitialLoad) {
     var isIdChange = !self.selected || self.selected.id !== id;
-    var prevId = self.selected.id ? self.selected.id : false;
-    var prevEvent = prevId
-      ? naturalEventsUtilGetEventById(model.data.events, prevId)
-      : false;
-    var prevCategory = prevEvent ? prevEvent.categories[0].title : false;
 
     // Store selected id and date in model
     self.selected = { id: id };
@@ -198,9 +193,6 @@ export default function naturalEventsUI(models, ui, config, request) {
       wvui.notify('The event with an id of ' + id + ' is no longer active.');
       return;
     }
-
-    var category = event.categories[0].title;
-    var isSameCategory = category === prevCategory;
 
     date = date || self.getDefaultEventDate(event);
     const zoomPromise = getZoomPromise(event, date, !isIdChange, isInitialLoad);
@@ -213,7 +205,7 @@ export default function naturalEventsUI(models, ui, config, request) {
     self.markers = naturalEventMarkers.draw();
     zoomPromise.then(function() {
       self.selecting = true;
-      if (isIdChange && !isSameCategory && !isInitialLoad) {
+      if (!isInitialLoad && isIdChange) {
         activateLayersForCategory(event.categories[0].title);
       }
       if (!isInitialLoad) models.date.select(util.parseDateUTC(date));

--- a/web/js/sidebar/ui.js
+++ b/web/js/sidebar/ui.js
@@ -77,9 +77,9 @@ export function sidebarUi(models, config, ui) {
       models.naturalEvents.events
         .on('activate', () => self.selectTab('events'))
         .on('list-change', debounceUpdateEventsList)
+        .on('selection-done', updateLayers)
         .on('selected-event', selected => {
           self.reactComponent.setState({ selectedEvent: selected });
-          updateLayers();
         });
     }
     if (models.compare) {


### PR DESCRIPTION
## Description

Fixes #1565 
fixes #1570 

- [x] When you remove layers that have been added by an event, and load event again, the layers do not load in the layer list
- [x] Add validation to build that layers in natural events config are in layer config
- [x] Update Fire IDs in `naturalEvents.json`

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
