### PR TITLE
Fix broken E2E tests

### DIFF
--- a/e2e/features/compare/layer-dialog-test.js
+++ b/e2e/features/compare/layer-dialog-test.js
@@ -3,12 +3,15 @@ const localSelectors = require('../../reuseables/selectors.js');
 const localQuerystrings = require('../../reuseables/querystrings.js');
 const TIME_LIMIT = 20000;
 const aerosolLayer = '#active-MODIS_Terra_Aerosol';
-const AodOptionsPanel = '.wv-options-panel-MODIS_Terra_Aerosol';
+const AodOptionsPanelBody = '#wv-options-body-MODIS_Terra_Aerosol';
+const AodOptionsPanelHeader = '#wv-options-header-MODIS_Terra_Aerosol';
 const AodInfoPanel = '.wv-info-panel-MODIS_Terra_Aerosol';
 const correctedReflectanceBLayer =
   '#activeB-MODIS_Terra_CorrectedReflectance_TrueColor';
-const correctedReflectanceOptionsPanel =
-  '.wv-options-panel-MODIS_Terra_CorrectedReflectance_TrueColor';
+const correctedReflectanceOptionsPanelHeader =
+  '#wv-options-header-MODIS_Terra_CorrectedReflectance_TrueColor';
+const correctedReflectanceOptionsPanelBody =
+  '#wv-options-body-MODIS_Terra_CorrectedReflectance_TrueColor';
 const correctedReflectanceInfoPanel =
   '.wv-info-panel-MODIS_Terra_CorrectedReflectance_TrueColor';
 
@@ -20,7 +23,7 @@ module.exports = {
     client.url(client.globals.url + localQuerystrings.swipeAOD);
 
     client.waitForElementVisible(aerosolLayer, TIME_LIMIT, function() {
-      client.expect.element(AodOptionsPanel).to.not.be.present;
+      client.expect.element(AodOptionsPanelBody).to.not.be.present;
       client.click(aerosolLayer + ' .wv-layers-options');
       client.waitForElementVisible(
         '#wv-layers-options-dialog',
@@ -29,12 +32,12 @@ module.exports = {
           client
             .useCss()
             .assert.containsText(
-              AodOptionsPanel + ' .ui-dialog-title',
+              AodOptionsPanelHeader + ' .modal-title',
               'Aerosol Optical Depth'
             );
           if (client.options.desiredCapabilities.browser !== 'ie') {
-            client.expect.element(AodOptionsPanel + ' #wv-palette-selector').to
-              .be.visible;
+            client.expect.element(AodOptionsPanelBody + ' .wv-palette-selector')
+              .to.be.visible;
           }
         }
       );
@@ -58,21 +61,21 @@ module.exports = {
   'expect clicking A|B button to close options dialog': function(client) {
     client.click(localSelectors.compareButton);
     client.waitForElementVisible(aerosolLayer, TIME_LIMIT, function() {
-      client.expect.element(AodOptionsPanel).to.not.be.present;
+      client.expect.element(AodOptionsPanelBody).to.not.be.present;
     });
   },
   'Layer option features after exiting A|B mode': function(client) {
     client.click(aerosolLayer + ' .wv-layers-options');
-    client.waitForElementVisible(AodOptionsPanel, TIME_LIMIT, function() {
+    client.waitForElementVisible(AodOptionsPanelBody, TIME_LIMIT, function() {
       client
         .useCss()
         .assert.containsText(
-          AodOptionsPanel + ' .ui-dialog-title',
+          AodOptionsPanelHeader + ' .modal-title',
           'Aerosol Optical Depth'
         );
       if (client.options.desiredCapabilities.browser !== 'ie') {
-        client.expect.element(AodOptionsPanel + ' #wv-palette-selector').to.be
-          .visible;
+        client.expect.element(AodOptionsPanelBody + ' .wv-palette-selector').to
+          .be.visible;
       }
     });
   },
@@ -96,7 +99,7 @@ module.exports = {
   ) {
     client.click(localSelectors.compareButton);
     client.waitForElementVisible(aerosolLayer, TIME_LIMIT, function() {
-      client.expect.element(AodOptionsPanel).to.not.be.present;
+      client.expect.element(AodOptionsPanelBody).to.not.be.present;
       client.click(localSelectors.bTab);
     });
   },
@@ -105,7 +108,7 @@ module.exports = {
       correctedReflectanceBLayer,
       TIME_LIMIT,
       function() {
-        client.expect.element(AodOptionsPanel).to.not.be.present;
+        client.expect.element(AodOptionsPanelBody).to.not.be.present;
         client.click(correctedReflectanceBLayer + ' .wv-layers-options');
         client.waitForElementVisible(
           '#wv-layers-options-dialog',
@@ -114,12 +117,12 @@ module.exports = {
             client
               .useCss()
               .assert.containsText(
-                correctedReflectanceOptionsPanel + ' .ui-dialog-title',
+                correctedReflectanceOptionsPanelHeader + ' .modal-title',
                 'Corrected Reflectance (True Color)'
               );
             if (client.options.desiredCapabilities.browser !== 'ie') {
               client.expect.element(
-                correctedReflectanceOptionsPanel + ' #wv-palette-selector'
+                correctedReflectanceOptionsPanelBody + ' .wv-palette-selector'
               ).to.not.be.present;
             }
           }

--- a/e2e/features/compare/layer-picker-test.js
+++ b/e2e/features/compare/layer-picker-test.js
@@ -1,8 +1,9 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const selectors = require('../../reuseables/selectors.js');
 const localQuerystrings = require('../../reuseables/querystrings.js');
+const aodCombinedValueId = 'MODIS_Combined_Value_Added_AOD';
 const aodCheckBox =
-  '#checkbox-case-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly .wv-checkbox';
+  '#checkbox-case-MODIS_Combined_Value_Added_AOD .wv-checkbox';
 const aodIndexCheckbox = '#checkbox-case-OMI_Aerosol_Index .wv-checkbox';
 const TIME_LIMIT = 20000;
 module.exports = {
@@ -24,7 +25,7 @@ module.exports = {
             client.waitForElementVisible(aodCheckBox, 20000, function() {
               client.click(aodCheckBox);
               client.waitForElementVisible(
-                '#active-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly',
+                '#active-' + aodCombinedValueId,
                 TIME_LIMIT
               );
               client.click(selectors.layersModalCloseButton);
@@ -35,13 +36,11 @@ module.exports = {
     );
   },
   'Toggle compare mode to Active state B': function(client) {
-    client.click(selectors.bTab);
+    client.click(selectors.bTab + ' .productsIcon');
     client.waitForElementVisible('#activeB-Coastlines', TIME_LIMIT);
   },
   'Verify that AOD layer is not visible': function(client) {
-    client.expect.element(
-      '#active-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly'
-    ).to.not.be.visible;
+    client.expect.element('#active-' + aodCombinedValueId).to.not.be.visible;
   },
   'Add AOD index layer to Active state B and verify it has been added': function(
     client
@@ -61,10 +60,10 @@ module.exports = {
             TIME_LIMIT
           );
           client.expect.element(
-            '#activeB-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly'
+            '#activeB-' + aodCombinedValueId
           ).to.not.be.present;
           client.expect.element(
-            '#active-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly'
+            '#active-' + aodCombinedValueId
           ).to.not.be.visible;
         });
       }
@@ -77,7 +76,7 @@ module.exports = {
     client.pause(100);
     client.click(selectors.aTab);
     client.waitForElementVisible(
-      '#active-MISR_Aerosol_Optical_Depth_Avg_Green_Monthly',
+      '#active-' + aodCombinedValueId,
       TIME_LIMIT,
       function() {
         client.expect.element('#activeB-OMI_Aerosol_Index').to.not.be.visible;

--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -78,20 +78,13 @@ module.exports = {
     });
   },
   'Click Events tab and select an Event from the List': function(client) {
-    const globalSelectors = client.globals.selectors;
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
-    client.waitForElementVisible(
-      globalSelectors.eventsTab,
-      TIME_LIMIT,
-      function() {
-        client.click(globalSelectors.eventsTab);
-        client.waitForElementVisible(listOfEvents, TIME_LIMIT, function() {
-          client.click(firstEvent).pause(3000);
-          client.expect.element(selectedMarker).to.be.visible;
-          client.expect.element(selectedFirstEvent).to.be.visible;
-        });
-      }
-    );
+    client.url(client.globals.url + localQuerystrings.mockEvents);
+    client.waitForElementVisible(listOfEvents, TIME_LIMIT, function() {
+      client.click(firstEvent);
+      client.waitForElementVisible(selectedMarker, TIME_LIMIT, function() {
+        client.expect.element(selectedFirstEvent).to.be.visible;
+      });
+    });
   },
   'Verify that Url is updated': function(client) {
     client.assert

--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -9,20 +9,28 @@ const boltListItem = '#wv-info-menu li.bolt';
 const exclamationListItem = '#wv-info-menu li.exclamation-circle';
 const alertContentHightlighted = '.wv-notify-modal .alert';
 const outageContentHightlighted = '.wv-notify-modal .outage';
+const messageContentHightlighted = '.wv-notify-modal .message';
 const notifyModal = '.wv-notify-modal';
 
 module.exports = {
-  'No visible notifications with mockAlert parameter set to no_types': function(client) {
+  'No visible notifications with mockAlert parameter set to no_types': function(
+    client
+  ) {
     client.url(client.globals.url + mockParam + 'no_types');
     client.waitForElementVisible(infoButtonLabel, TIME_LIMIT, () => {
       client.useCss().click(infoButtonLabel);
       client.pause(2000);
-      client.useCss().expect.element(infoMenu).text.not.contains('Notifications');
+      client
+        .useCss()
+        .expect.element(infoMenu)
+        .text.not.contains('Notifications');
       client.expect.element(giftListItem).to.not.be.present;
       client.expect.element(boltListItem).to.not.be.present;
     });
   },
-  'Outage takes precedence when both alerts and outages are present': function(client) {
+  'Outage takes precedence when all three notifications are present': function(
+    client
+  ) {
     client.url(client.globals.url + mockParam + 'all_types');
     client.waitForElementVisible(infoButtonLabel, TIME_LIMIT, () => {
       client.expect.element(infoButton + '.wv-status-outage').to.be.present;
@@ -32,31 +40,34 @@ module.exports = {
       client.expect.element(exclamationListItem).to.be.present;
     });
   },
-  'Both alert and outage content is highlighted and found in modal': function(client) {
+  'Both alert, outage, and message content is highlighted and found in modal': function(
+    client
+  ) {
     client.useCss().click(exclamationListItem + ' a');
     client.waitForElementVisible(outageContentHightlighted, TIME_LIMIT, () => {
-      client.useCss().assert.containsText(outageContentHightlighted + ' span', 'Posted 20 May 2018');
-      client.useCss().assert.containsText(alertContentHightlighted, 'Posted 20 February 2018');
+      client
+        .useCss()
+        .assert.containsText(
+          outageContentHightlighted + ' span',
+          'Posted 20 May 2018'
+        );
+      client
+        .useCss()
+        .assert.containsText(
+          alertContentHightlighted + ' p',
+          'learn how to visualize global satellite imagery'
+        );
+      client
+        .useCss()
+        .assert.containsText(
+          messageContentHightlighted + ' p',
+          'This is a message test'
+        );
     });
   },
-  'Message is in info menu with mockAlert parameter set to message': function(client) {
-    client.url(client.globals.url + mockParam + 'message');
-    client.waitForElementVisible(infoButtonLabel, TIME_LIMIT, () => {
-      client.useCss().click(infoButtonLabel);
-      client.pause(2000);
-      client.useCss().expect.element(infoMenu).text.not.contains('Notifications');
-      client.expect.element(giftListItem).to.be.present;
-    });
-  },
-  'Message modal contains message content': function(client) {
-    client.useCss().click(giftListItem + ' a');
-    client.waitForElementVisible(notifyModal, TIME_LIMIT, () => {
-      client.expect.element(alertContentHightlighted).to.not.be.present;
-      client.useCss().assert.containsText(notifyModal + ' span', 'Posted 20 March 2018');
-      client.useCss().assert.containsText(notifyModal + ' p', 'This is a message test');
-    });
-  },
-  'Verify that the user is only alerted if he has not already stored all items in localStorage': function(client) {
+  'Verify that the user is only alerted if he has not already stored all items in localStorage': function(
+    client
+  ) {
     client.url(client.globals.url + mockParam + 'all_types');
     client.waitForElementVisible(infoButtonLabel, TIME_LIMIT, () => {
       client.expect.element(infoButton + '.wv-status-hide').to.be.present;

--- a/e2e/reuseables/selectors.js
+++ b/e2e/reuseables/selectors.js
@@ -1,6 +1,6 @@
 module.exports = {
   // animations
-  createGifIcon: '.fa-file-video-o.wv-animation-widget-icon',
+  createGifIcon: '#wv-animation-widget-file-video-icon',
   createGifButton: '.gif-dialog .button-text',
   gifPreviewStartDate: '.gif-download-grid .grid-child:nth-child(2) span',
   gifPreviewEndDate: '.gif-download-grid .grid-child:nth-child(4) span',

--- a/web/js/components/animation-widget/animation-widget.js
+++ b/web/js/components/animation-widget/animation-widget.js
@@ -147,7 +147,10 @@ class AnimationWidget extends React.Component {
           className="wv-icon-case"
           onClick={this.props.onPushGIF}
         >
-          <i className="fas fa-file-video wv-animation-widget-icon" />
+          <i
+            id="wv-animation-widget-file-video-icon"
+            className="fas fa-file-video wv-animation-widget-icon"
+          />
         </a>
         <div className="wv-anim-dates-case">
           <TimeSelector

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -203,8 +203,10 @@ class LayerSettings extends React.Component {
       >
         {layer.id ? (
           <React.Fragment>
-            <ModalHeader toggle={close}>{layer.title}</ModalHeader>
-            <ModalBody>
+            <ModalHeader id={'wv-options-header-' + layer.id} toggle={close}>
+              {layer.title}
+            </ModalHeader>
+            <ModalBody id={'wv-options-body-' + layer.id}>
               <Opacity
                 start={Math.ceil(layer.opacity * 100)}
                 setOpacity={setOpacity}


### PR DESCRIPTION
## Description

Fixes #1564

Fix broken `E2E` tests caused by recent updates

- [x] `e2e` tests test for separate `notification` and `message` buttons wen they are now the same #904
- [x] GIF selections broken by font awesome migration #1375 
- [x] Use mock with event test that tests if link opens new tab so that it doesn't sometimes download data instead of opening in a new tab
- [x] Options panel selectors have changed #375 
- [x] Layer picker source order changed expected layers present in product picker  #85

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
