### PR TITLE
Prevent highlighting of custom palettes 

### DIFF
--- a/web/css/util.css
+++ b/web/css/util.css
@@ -192,15 +192,16 @@ button[data-tooltip] {
 [data-tooltip-length="fit"]::after {
   width: 100%;
 }
+
 /* https://stackoverflow.com/a/4407335 */
 .noselect {
   -webkit-touch-callout: none; /* iOS Safari */
-    -webkit-user-select: none; /* Safari */
-       -moz-user-select: none; /* Firefox */
-        -ms-user-select: none; /* Internet Explorer/Edge */
-            user-select: none; /* Non-prefixed version, currently
-                                  supported by Chrome and Opera */
+  -webkit-user-select: none; /* Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
 }
+
 /* Clearfix classes */
 .clearfix::after {
   content: "";

--- a/web/css/util.css
+++ b/web/css/util.css
@@ -192,7 +192,15 @@ button[data-tooltip] {
 [data-tooltip-length="fit"]::after {
   width: 100%;
 }
-
+/* https://stackoverflow.com/a/4407335 */
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+       -moz-user-select: none; /* Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome and Opera */
+}
 /* Clearfix classes */
 .clearfix::after {
   content: "";

--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -169,7 +169,7 @@ class OpacitySelect extends React.Component {
 
     return (
       <div
-        className="wv-palette-selector settings-component"
+        className="wv-palette-selector settings-component noselect"
         id={'wv-palette-selector' + index}
       >
         <h2 className="wv-header">Color Palette</h2>


### PR DESCRIPTION
## Description

Fixes #1573 .

[Description of the bug or feature]

- [x] Make a `.noselect` utility class
- [x] Prevent custom palettes from being highlighted

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
