### PR TITLE
Make settings unmount before reloading new settings modal

### DIFF
--- a/e2e/features/layers/layers-test.js
+++ b/e2e/features/layers/layers-test.js
@@ -1,75 +1,123 @@
-const reuseables = require('../../reuseables/skip-tour.js');
+const skipTour = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 const TIME_LIMIT = 10000;
 
 module.exports = {
-  before: function (client) {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  before: function(client) {
+    skipTour.loadAndSkipTour(client, TIME_LIMIT);
   },
   'Toggle layer Info': function(client) {
     client.click(localSelectors.infoButton);
     client.waitForElementVisible(localSelectors.infoDialog, 1000, function(e) {
-      client.click(localSelectors.infoButton)
-        .pause(100);
+      client.click(localSelectors.infoButton).pause(100);
       client.expect.element(localSelectors.infoDialog).to.not.be.present;
-      client.click(localSelectors.infoButton)
-        .pause(1000);
+      client.click(localSelectors.infoButton).pause(1000);
       client.expect.element(localSelectors.infoDialog).to.be.present;
     });
   },
   'Toggle Layer Options': function(client) {
     client.click(localSelectors.optionsButton);
-    client.waitForElementVisible(localSelectors.optionsDialog, 1000, function(e) {
-      client.click(localSelectors.optionsButton)
-        .pause(100);
+    client.waitForElementVisible(localSelectors.optionsDialog, 1000, function(
+      e
+    ) {
+      client.click(localSelectors.optionsButton).pause(100);
       client.expect.element(localSelectors.optionsDialog).to.not.be.present;
-      client.click(localSelectors.optionsButton)
-        .pause(1000);
+      client.click(localSelectors.optionsButton).pause(1000);
       client.expect.element(localSelectors.optionsDialog).to.be.present;
     });
   },
   'Finding VIIRs Corrected Reflectance layer with search': function(client) {
-    client
-      .click(localSelectors.addLayers);
-    client.waitForElementVisible(localSelectors.layersSearchField, TIME_LIMIT, function(e) {
-      client.setValue(localSelectors.layersSearchField, 'VIIRS_SNPP_Corrected');
-      client.waitForElementVisible(localSelectors.sourceInfoIcon, TIME_LIMIT, function(e) {
-        client.useCss().assert.containsText(localSelectors.layersAll, 'Corrected Reflectance (True Color)');
-        client.useCss().assert.containsText(localSelectors.layersAll, 'Suomi NPP / VIIRS');
-      });
-    });
+    client.click(localSelectors.addLayers);
+    client.waitForElementVisible(
+      localSelectors.layersSearchField,
+      TIME_LIMIT,
+      function(e) {
+        client.setValue(
+          localSelectors.layersSearchField,
+          'VIIRS_SNPP_Corrected'
+        );
+        client.waitForElementVisible(
+          localSelectors.sourceInfoIcon,
+          TIME_LIMIT,
+          function(e) {
+            client
+              .useCss()
+              .assert.containsText(
+                localSelectors.layersAll,
+                'Corrected Reflectance (True Color)'
+              );
+            client
+              .useCss()
+              .assert.containsText(
+                localSelectors.layersAll,
+                'Suomi NPP / VIIRS'
+              );
+          }
+        );
+      }
+    );
   },
   'Verify Corrected Reflectance Layer is selected': function(client) {
     client.assert.cssClassPresent(localSelectors.layerHeader, 'checked');
   },
   'Open And Close info about Layer found in search': function(client) {
-    client.useCss().expect.element(localSelectors.layersAll).text.not.contains('(VIIRS) Corrected Reflectance');
     client
-      .click(localSelectors.sourceInfoIcon)
-      .pause(2000);
-    client.useCss().assert.containsText(localSelectors.layersAll, '(VIIRS) Corrected Reflectance');
-    client.useCss().moveToElement(localSelectors.sourceMetadataCloseButton, 10, 10);
+      .useCss()
+      .expect.element(localSelectors.layersAll)
+      .text.not.contains('(VIIRS) Corrected Reflectance');
+    client.click(localSelectors.sourceInfoIcon).pause(2000);
+    client
+      .useCss()
+      .assert.containsText(
+        localSelectors.layersAll,
+        '(VIIRS) Corrected Reflectance'
+      );
+    client
+      .useCss()
+      .moveToElement(localSelectors.sourceMetadataCloseButton, 10, 10);
     client.click(localSelectors.sourceMetadataCloseButton);
-    client.useCss().expect.element(localSelectors.layersAll).text.not.contains('(VIIRS) Corrected Reflectance');
+    client
+      .useCss()
+      .expect.element(localSelectors.layersAll)
+      .text.not.contains('(VIIRS) Corrected Reflectance');
   },
   'Close Layer modal': function(client) {
-    client.click(localSelectors.layersModalCloseButton)
-      .pause(2000);
+    client.click(localSelectors.layersModalCloseButton).pause(2000);
     client.useCss().expect.element(localSelectors.layersAll).to.not.be.visible;
   },
-  'Open Layer modal and click breadcrumb to return to main selection': function(client) {
+  'Open Layer modal and click breadcrumb to return to main selection': function(
+    client
+  ) {
     client.click(localSelectors.addLayers);
-    client.waitForElementVisible(localSelectors.backToCategories, TIME_LIMIT, function(e) {
-      client.click(localSelectors.backToCategories);
-      client.waitForElementVisible(localSelectors.aerosolOpticalDepth, TIME_LIMIT);
-    });
+    client.waitForElementVisible(
+      localSelectors.backToCategories,
+      TIME_LIMIT,
+      function(e) {
+        client.click(localSelectors.backToCategories);
+        client.waitForElementVisible(
+          localSelectors.aerosolOpticalDepth,
+          TIME_LIMIT
+        );
+      }
+    );
   },
   'Browsing Layers by Category: Aerosol Optical Depth': function(client) {
     client.click(localSelectors.aerosolOpticalDepth);
-    client.waitForElementVisible(localSelectors.headerForAOD, 20000, function(e) { // This is a very slow process
-      client.click('[aria-labelledby="accordion-legacy-all-aerosol-optical-depth"] > ul > li:nth-child(3) > a')
+    client.waitForElementVisible(localSelectors.headerForAOD, 20000, function(
+      e
+    ) {
+      // This is a very slow process
+      client
+        .click(
+          '[aria-labelledby="accordion-legacy-all-aerosol-optical-depth"] > ul > li:nth-child(3) > a'
+        )
         .pause(1000);
-      client.useCss().assert.containsText('#modisterraandaquacombinedvalueaddedaerosolopticaldepth', 'MODIS (Terra and Aqua) Combined Value-Added Aerosol Optical Depth');
+      client
+        .useCss()
+        .assert.containsText(
+          '#modisterraandaquacombinedvalueaddedaerosolopticaldepth',
+          'MODIS (Terra and Aqua) Combined Value-Added Aerosol Optical Depth'
+        );
     });
   },
   after: function(client) {

--- a/e2e/features/layers/options-test.js
+++ b/e2e/features/layers/options-test.js
@@ -1,0 +1,62 @@
+const customsSquashedQuerystring =
+  '?p=geographic&l=VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor,MODIS_Combined_Value_Added_AOD(opacity=0.7,palette=blue_2,min=0.1,0.105,max=0.56,0.565),MODIS_Terra_Aerosol,Reference_Labels(opacity=0.94),Reference_Features(hidden),Coastlines&t=2019-01-15-T00%3A00%3A00Z&z=3&v=-271.7031658620978,-216.84375,370.1093341379022,36.84375';
+const TIME_LIMIT = 10000;
+const skipTour = require('../../reuseables/skip-tour.js');
+const combinedAodSettingsButton =
+  '#active-MODIS_Combined_Value_Added_AOD .wv-layers-options';
+const terraAodSettingsButton = '#active-MODIS_Terra_Aerosol .wv-layers-options';
+const terraAodSettingsDialog = '#wv-options-body-MODIS_Terra_Aerosol';
+const thresholdMinLabel = '#wv-layer-options-threshold0 .wv-label-range-min';
+const activeBluePaletteCheckbox =
+  '.wv-palette-selector-row.checked #wv-palette-radio-blue_2';
+const activeDefaultPaletteCheckbox =
+  '.wv-palette-selector-row.checked #wv-palette-radio-__default';
+const opacityLabel = '.layer-opacity-select .wv-label';
+module.exports = {
+  before: function(client) {
+    skipTour.loadAndSkipTour(client, TIME_LIMIT);
+  },
+  'Verify that settings button opens settings modal': function(client) {
+    client.url(client.globals.url + customsSquashedQuerystring);
+    client.waitForElementVisible(
+      combinedAodSettingsButton,
+      TIME_LIMIT,
+      function(e) {
+        if (client.options.desiredCapabilities.browser !== 'ie') {
+          client.expect.element(thresholdMinLabel).to.not.be.present;
+          client.click(combinedAodSettingsButton).pause(1000);
+          client.waitForElementPresent(thresholdMinLabel, TIME_LIMIT);
+        }
+      }
+    );
+  },
+  'Verify that custom blue custom palette is checked': function(client) {
+    if (client.options.desiredCapabilities.browser !== 'ie') {
+      client.expect.element(activeDefaultPaletteCheckbox).to.not.be.present;
+      client.expect.element(activeBluePaletteCheckbox).to.be.present;
+    }
+  },
+  'Verify that threshold and opacity components update when different layer setting button clicked': function(
+    client
+  ) {
+    if (client.options.desiredCapabilities.browser !== 'ie') {
+      client.useCss().assert.containsText(thresholdMinLabel, '0.1 – 0.105');
+      client.useCss().assert.containsText(opacityLabel, '70%');
+      client.click(terraAodSettingsButton).pause(1000);
+      client.waitForElementPresent(
+        terraAodSettingsDialog,
+        TIME_LIMIT,
+        function() {
+          client.useCss().assert.containsText(thresholdMinLabel, '< 0.000');
+          client.useCss().assert.containsText(opacityLabel, '100%');
+        }
+      );
+    }
+  },
+  'Verify that default palette is now checked': function(client) {
+    if (client.options.desiredCapabilities.browser !== 'ie') {
+      client.expect.element(activeBluePaletteCheckbox).to.not.be.present;
+      client.expect.element(activeDefaultPaletteCheckbox).to.be.present;
+    }
+  }
+};

--- a/web/js/components/layer/settings/opacity.js
+++ b/web/js/components/layer/settings/opacity.js
@@ -10,12 +10,12 @@ class OpacitySelect extends React.Component {
     };
   }
   render() {
-    const { layer, setOpacity } = this.props;
+    const { layer, setOpacity, start } = this.props;
     return (
       <div className="layer-opacity-select settings-component">
         <h2 className="wv-header">Opacity</h2>
         <Slider
-          defaultValue={this.props.start}
+          defaultValue={start}
           onChange={val => {
             setOpacity(layer.id, (val / 100).toFixed(2));
             this.setState({ value: val });

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -200,6 +200,7 @@ class LayerSettings extends React.Component {
         isOpen={isOpen}
         toggle={close}
         backdrop={false}
+        modalTransition={{ timeout: 150 }}
       >
         {layer.id ? (
           <React.Fragment>

--- a/web/js/layers/options.js
+++ b/web/js/layers/options.js
@@ -21,9 +21,15 @@ export function layersOptions(models, ui, config) {
       loaded();
     }
   };
-  self.close = function() {
+  self.close = function(timeout) {
+    timeout = timeout || 0;
     self.reactComponent.setState({ isOpen: false });
     self.layerId = null;
+    return new Promise(resolve => {
+      setTimeout(() => {
+        resolve();
+      }, timeout);
+    });
   };
   /**
    * Open react component with new layer info
@@ -31,15 +37,19 @@ export function layersOptions(models, ui, config) {
    */
   self.createNewLayer = function(layer) {
     if (layer.id === self.layerId) {
-      return self.close();
+      self.close();
+      return;
     }
-    var names = models.layers.getTitles(layer.id);
-    self.layerId = layer.id;
-    self.reactComponent.setState({
-      layer: layer,
-      title: names.title,
-      palettedAllowed: models.palettes.allowed(layer.id),
-      isOpen: true
+    const timeout = layer.id ? 300 : 0;
+    self.close(timeout).then(() => {
+      const names = models.layers.getTitles(layer.id);
+      self.layerId = layer.id;
+      self.reactComponent.setState({
+        layer: layer,
+        title: names.title,
+        palettedAllowed: models.palettes.allowed(layer.id),
+        isOpen: true
+      });
     });
   };
   /**

--- a/web/js/layers/options.js
+++ b/web/js/layers/options.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import palettes from '../palettes/palettes';
 import { palettesTranslate, getCheckerboard } from '../palettes/util';
 import LayerSettings from '../components/layer/settings/settings';
+import Promise from 'bluebird';
 
 export function layersOptions(models, ui, config) {
   var self = {};


### PR DESCRIPTION
## Description

Fixes #1577 

"While the layer settings dialog is open in the sidebar, clicking the layer settings for another layer causes state carrying over/crashing. There seems to be some state persisting between layer settings that allows the Opacity value to carry over until closing/reopening the layer settings. If the layer settings has palettes, this causes a crash." -Ed

- [x] Added `Promise` that waits for dialog to close before reopening and rendering new layer settings. The dismounting prevents the old state from being used .
- [x] add e2e verification

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

This might not be the best solution but I am in the process of implementing a reusable reduxed modal component across the a that will replace a lot of this code.

@nasa-gibs/worldview
