### PR TITLE
Fix spacing between dual palette selection legend and image

### DIFF
--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -559,7 +559,7 @@
   margin-bottom: 0.5em;
 }
 .tab-content .wv-palette-selector-row label {
-  margin-left: 8px;
+  margin-left: 3px;
 }
 .wv-layers-options-dialog .wv-label {
   color: #fff;


### PR DESCRIPTION
## Description

Fixes #1582 .

Fix margin between palette selection label and image

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
