### PR TITLE
Fix yOffset issue for timeline tick hover

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -396,11 +396,6 @@ g.plot rect.data-bar-invisible {
 
 #timeline-footer svg {
   overflow: visible;
-  margin-top: -16px;
-}
-
-#timeline-footer > svg {
-  margin-top: -23px;
 }
 
 #wv-rangeselector-case > .wv-timeline-range-selector {
@@ -548,7 +543,8 @@ g.plot rect.data-bar-invisible {
 }
 
 #guitarpick.pick-clicked rect,
-#guitarpick:hover rect {
+#guitarpick:hover rect,
+#guitarpick:hover {
   fill: #999;
 }
 

--- a/web/js/components/range-selection/dragger-range.js
+++ b/web/js/components/range-selection/dragger-range.js
@@ -215,7 +215,7 @@ class TimelineDraggerRange extends React.Component {
         handle=".dragger-range"
         axis="x"
         position={null}
-        defaultPosition={{ x: 0, y: 0 }}
+        defaultPosition={{ x: 0, y: -16 }}
         onStop={this.props.onStop}
         onDrag={this.handleDrag.bind(this)}
       >

--- a/web/js/components/range-selection/dragger.js
+++ b/web/js/components/range-selection/dragger.js
@@ -190,7 +190,7 @@ TimelineDragger.defaultProps = {
   color: '#fff',
   position: 0,
   visibility: 'visible',
-  yOffset: 0,
+  yOffset: -16,
   path: null,
   textColor: '#000'
 };

--- a/web/js/date/compare-picks.js
+++ b/web/js/date/compare-picks.js
@@ -86,7 +86,7 @@ export function timelineCompare(models, config, ui) {
   var getInitialProps = function(compareLetter, label) {
     max = getMaxTimelineWidth(ui);
     return {
-      yOffset: 15,
+      yOffset: 0,
       path: PICK_PATH,
       height: 59.51,
       width: 58.42,

--- a/web/js/date/timeline-pick.js
+++ b/web/js/date/timeline-pick.js
@@ -99,13 +99,13 @@ export function timelinePick(models, config, ui) {
   var change = function() {
     var newDate = tipDate;
 
-    tl.guitarPick.attr('transform', 'translate(' + self.offset + ',' + 0 + ')');
+    tl.guitarPick.attr('transform', 'translate(' + self.offset + ',' + -16 + ')');
 
     tl.guitarPick
       .data([
         {
           x: self.offset,
-          y: 0
+          y: -16
         }
       ])
       .call(drag);
@@ -180,10 +180,10 @@ export function timelinePick(models, config, ui) {
       .data([
         {
           x: self.offset,
-          y: 0
+          y: -16
         }
       ])
-      .attr('transform', 'translate(' + self.offset + ',0)')
+      .attr('transform', 'translate(' + self.offset + ', -16)')
       .call(drag);
 
     prevChange = undefined;

--- a/web/js/date/timeline.js
+++ b/web/js/date/timeline.js
@@ -99,7 +99,7 @@ export function timeline(models, config, ui) {
         .attr('width', self.width)
         .attr(
           'viewBox',
-          '0 1 ' +
+          '0 9 ' +
             self.width +
             ' ' +
             (self.height + self.margin.top + self.margin.bottom + 26)
@@ -143,7 +143,7 @@ export function timeline(models, config, ui) {
       .attr('id', 'timeline-footer-svg')
       .attr(
         'viewBox',
-        '0 1 ' +
+        '0 9 ' +
           self.width +
           ' ' +
           (self.height + self.margin.top + self.margin.bottom + 26)
@@ -169,7 +169,7 @@ export function timeline(models, config, ui) {
       .append('svg:g')
       .attr('clip-path', 'url(#timeline-boundary)')
       .attr('style', 'clip-path:url(#timeline-boundary)')
-      .attr('transform', 'translate(0,16)');
+      .attr('transform', 'translate(0,1)');
 
     self.axis = self.boundary
       .append('svg:g')


### PR DESCRIPTION
## Description

Fixes #1575  .

Addresses Firefox 64+ issue where timeline tick backgrounds were not fully vertically hovered causing some wonky behavior. Fixed by adjusting transforms, viewbox, minor CSS, and yOffsets for elements.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
