### PR TITLE
Add Snapshots support to GIF

### DIFF
--- a/web/js/components/animation-widget/gif-panel-grid.js
+++ b/web/js/components/animation-widget/gif-panel-grid.js
@@ -14,13 +14,13 @@ export class GifPanelGrid extends React.Component {
       return (
         <div id='gif-size' className='gif-size gif-size-invalid grid-child'>
           <i className='fa fa-times fa-fw' />
-          <span>{'~' + size + ' MB (Before Compression)'}</span>
+          <span>{this.props.maxGifSize + ' MB' + '~' + size + ' MB'}</span>
         </div>
       );
     } else {
       return (
         <div id='gif-size' className='gif-size grid-child'>
-          <span>{'~' + size + ' MB (Before Compression)'} </span>
+          <span>{this.props.maxGifSize + ' MB / ~' + size + ' MB'} </span>
         </div>
       );
     }
@@ -37,15 +37,15 @@ export class GifPanelGrid extends React.Component {
         <div className='grid-child'><span>{this.props.speed + ' Frames Per Second'}</span></div>
         <div className='grid-child label'><span>Increment:</span></div>
         <div className='grid-child'><span>{this.props.increment}</span></div>
-        <div className='grid-child label'><span>Request Size:</span></div>
+        <div className='grid-child label'><span>Max / Raw Size:</span></div>
         {imageSize}
-        <div className='grid-child label'><span>Max Request Size: </span></div>
+        <div className='grid-child label'><span>Max Dimension: </span></div>
         <div className={this.props.valid ? 'grid-child gif-max-size' : 'grid-child gif-max-size gif-size-invalid'}>
-          <span>{this.props.maxGifSize + ' MB (Before Compression)'}</span>
+          <span>{this.props.maxImageDimensionSize + 'px'}</span>
         </div>
         <div className='grid-child label'><span>Image Dimensions:</span></div>
         <div className='grid-child' id='wv-image-width'>
-          <span>{this.props.width + ' x ' + this.props.height + 'px' }</span>
+          <span>{this.props.width + 'px x ' + this.props.height + 'px' }</span>
         </div>
       </div>
     );
@@ -55,6 +55,7 @@ GifPanelGrid.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   maxGifSize: PropTypes.number,
+  maxImageDimensionSize: PropTypes.number,
   startDate: PropTypes.string,
   endDate: PropTypes.string,
   speed: PropTypes.number,

--- a/web/js/components/animation-widget/gif-panel.js
+++ b/web/js/components/animation-widget/gif-panel.js
@@ -51,6 +51,7 @@ export default class GifPanel extends React.Component {
           height={this.state.imgHeight}
           requestSize={this.state.requestSize}
           maxGifSize={this.props.maxGifSize}
+          maxImageDimensionSize={this.props.maxImageDimensionSize}
           valid={this.state.valid}
           onClick={this.props.onDownloadClick}
           startDate={this.state.startDate}
@@ -88,6 +89,7 @@ GifPanel.propTypes = {
   imgWidth: PropTypes.number,
   imgHeight: PropTypes.number,
   maxGifSize: PropTypes.number,
+  maxImageDimensionSize: PropTypes.number,
   showDates: PropTypes.bool,
   onDownloadClick: PropTypes.func,
   onClick: PropTypes.func,


### PR DESCRIPTION
## Description

Fixes #1578  .

- Revise GIF url creation for Worldview Snapshots parameter formatting requirements.
- Add valid check for max image dimension size (8200px at this time) and implement into preventing invalid downloads within the GIF dialog.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
