### PR TITLE
Switch sourceMetaData state key to use source description in place of id

### DIFF
--- a/web/js/components/layer/product-picker/list.js
+++ b/web/js/components/layer/product-picker/list.js
@@ -71,7 +71,7 @@ class LayerList extends React.Component {
     util.get('config/metadata/' + source.description + '.html').then(data => {
       if (data) {
         let sourceMetadata = this.state.sourceMetadata;
-        sourceMetadata[source.id] = { data: data };
+        sourceMetadata[source.description] = { data: data };
         this.setState({ sourceMetaData: sourceMetadata });
       }
     });

--- a/web/js/components/layer/product-picker/measurement-row.js
+++ b/web/js/components/layer/product-picker/measurement-row.js
@@ -177,8 +177,8 @@ class LayerRow extends React.Component {
     const { isMetadataExpanded } = this.state;
     // Simple test to see if theres a link to some metadata
     if (source.description) {
-      if (sourceMetadata[source.id]) {
-        let data = sourceMetadata[source.id].data;
+      if (sourceMetadata[source.description]) {
+        let data = sourceMetadata[source.description].data;
         let doesMetaDataNeedExpander = data.length >= 1000;
         let isMetaVisible = isMetadataExpanded || !doesMetaDataNeedExpander;
         return (


### PR DESCRIPTION
## Description

Fixes #1606  .

In some cases, source ids used as keys in a state object were the same as other layers causing descriptions to be reused. This fix uses source descriptions as unique state object keys.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
