### PR TITLE
Allow event tracks to go over date line

### DIFF
--- a/web/js/natural-events/cluster.js
+++ b/web/js/natural-events/cluster.js
@@ -32,8 +32,14 @@ export function naturalEventsClusterCreateObject() {
         accumulated.startDate = newDate;
         accumulated.endDate = newDate;
       } else {
-        accumulated.startDate = Date.parse(new Date(pastStartDate)) > Date.parse(new Date(newDate)) ? newDate : pastStartDate;
-        accumulated.endDate = Date.parse(new Date(pastEndDate)) < Date.parse(new Date(newDate)) ? newDate : pastEndDate;
+        accumulated.startDate =
+          Date.parse(new Date(pastStartDate)) > Date.parse(new Date(newDate))
+            ? newDate
+            : pastStartDate;
+        accumulated.endDate =
+          Date.parse(new Date(pastEndDate)) < Date.parse(new Date(newDate))
+            ? newDate
+            : pastEndDate;
       }
     },
     setPolar: function() {
@@ -45,7 +51,7 @@ export function naturalEventsClusterCreateObject() {
       this.maxZoom = 12;
     }
   });
-};
+}
 /**
  * Create a geoJSON point out of a point
  *
@@ -67,7 +73,7 @@ export function naturalEventsClusterPointToGeoJSON(id, coordinates, date) {
       coordinates: coordinates
     }
   };
-};
+}
 /**
  * @param  {Array}
  * @return {void}
@@ -80,7 +86,7 @@ export function naturalEventsClusterSort(clusterArray) {
     return new Date(secondDate) - new Date(firstDate);
   });
   return newArray;
-};
+}
 /**
  * Load points given superCluster Object
  *
@@ -89,7 +95,12 @@ export function naturalEventsClusterSort(clusterArray) {
  * @param  {number} zoomLevel
  * @return {Object}
  */
-export function naturalEventsClusterGetPoints(superClusterObj, pointArray, zoomLevel) {
+export function naturalEventsClusterGetPoints(
+  superClusterObj,
+  pointArray,
+  zoomLevel,
+  extent
+) {
   superClusterObj.load(pointArray);
-  return superClusterObj.getClusters([-180, -90, 180, 90], lodashRound(zoomLevel));
-};
+  return superClusterObj.getClusters(extent, lodashRound(zoomLevel));
+}

--- a/web/js/natural-events/track.js
+++ b/web/js/natural-events/track.js
@@ -350,7 +350,7 @@ var createTrack = function(models, eventObj, map, selectedDate, callback) {
   const extent =
     models.proj.selected.id === 'geographic'
       ? [-250, -90, 250, 90]
-      : models.proj.selected.maxExtent;
+      : [-180, -90, 180, 90];
   const selectedCoords = lodashFind(eventObj.geometries, function(geometry) {
     return geometry.date.split('T')[0] === selectedDate;
   }).coordinates;

--- a/web/js/natural-events/track.js
+++ b/web/js/natural-events/track.js
@@ -215,10 +215,7 @@ export default function naturalEventsTrack(models, ui, config) {
  * @return {Boolean}
  */
 const crossesDateLine = function(activeCoord, nextCoord) {
-  return (
-    Math.abs(Math.abs(activeCoord[0]) - Math.abs(nextCoord[0])) <
-    Math.abs(activeCoord[0] - nextCoord[0])
-  );
+  return Math.abs(activeCoord[0] - nextCoord[0]) > 180;
 };
 /**
  * Convert coordinates to be over date line

--- a/web/mock/events_data.json-20170530
+++ b/web/mock/events_data.json-20170530
@@ -132,6 +132,43 @@
 			]
 		},
 		{
+			"id": "EONET_2777",
+			"title": "Tropical Worldview Storm",
+            "description": "",
+			"link": "http://eonet.sci.gsfc.nasa.gov/api/v2/events/EONET_2804",
+			"categories": [
+				{
+					"id": 10,
+					"title": "Severe Storms"
+				}
+			],
+			"sources": [
+				{
+					"id": "UNISYS",
+					"url": "http://weather.unisys.com/hurricane/n_indian/2017/MORA/track.dat"
+				}
+
+			],
+			"geometries": [
+				{
+					"date": "2017-05-27T18:00:00Z",
+					"type": "Point", "coordinates": [178.50, 14.00 ]
+				},
+				{
+					"date": "2017-05-28T00:00:00Z",
+					"type": "Point", "coordinates": [ 179.50, 14.20 ]
+				},
+				{
+					"date": "2017-05-29T06:00:00Z",
+					"type": "Point", "coordinates": [ -179.50, 14.80 ]
+				},
+				{
+					"date": "2017-05-31T12:00:00Z",
+					"type": "Point", "coordinates": [ 179.50, 18.80 ]
+				}
+			]
+		},
+		{
       "id": "EONET_3931",
       "title": "Rattlesnake Fire",
       "description": "",
@@ -217,7 +254,7 @@
 			]
 		},
 		{
-			"id": "EONET_2733",
+			"id": "EONET_2703",
 			"title": "Iceberg B30",
             "description": "",
 			"link": "http://eonet.sci.gsfc.nasa.gov/api/v2/events/EONET_2733",


### PR DESCRIPTION

## Description

Fixes #1568.

Events that cross the dateline cross the entire map, from east to west

- [x] Make event track go over date line
- [x] Add new testable event over date line to `mock/events_data.json-20170530`

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
