### PR TITLE
Change in-progress modal max-height to height for IE

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -774,19 +774,19 @@
 
 @media (max-height: 776px) {
   .tour-in-progress .modal-content {
-    max-height: 300px;
+    height: 300px;
   }
 }
 
 @media (max-height: 712px) {
   .tour-in-progress .modal-content {
-    max-height: 250px;
+    height: 250px;
   }
 }
 
 @media (max-height: 665px) {
   .tour-in-progress .modal-content {
-    max-height: 200px;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #1636

Changes `max-height` to `height` for IE11

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
