### PR TITLE
Remove 'Explore Worldview' link when in mobile

### DIFF
--- a/web/js/ui/info.js
+++ b/web/js/ui/info.js
@@ -54,7 +54,7 @@ export function uiInfo (ui, config) {
     if (config.features.feedback) {
       $menuItems.append($feedback);
     }
-    if (config.features.tour && config.stories && config.storyOrder) {
+    if (config.features.tour && config.stories && config.storyOrder && window.innerWidth >= 740 && window.innerHeight >= 615) {
       $menuItems.append($tour);
     }
     $menuItems.append($source);


### PR DESCRIPTION
## Description

Fixes #1635

Removes the ability to initiate the tour when the browser is condensed to mobile size.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
