### PR TITLE
Add escape key commands and click outside of modal to close

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -741,10 +741,6 @@
   .tour {
     display: block;
   }
-}
-
-/* Breakpoint: Medium (768px to 991px) */
-@media (min-width: 768px) {
 
   /* .tour-start */
   .tour-start .modal {

--- a/web/js/components/tour/modal-tour-complete.js
+++ b/web/js/components/tour/modal-tour-complete.js
@@ -20,7 +20,7 @@ class ModalComplete extends React.Component {
     }
     return (
       <div>
-        <Modal isOpen={this.props.modalComplete} toggle={this.props.toggleModalComplete} wrapClassName='tour tour-complete' className={this.props.className} backdrop={true}>
+        <Modal isOpen={this.props.modalComplete} toggle={this.props.toggleModalComplete} wrapClassName='tour tour-complete' className={this.props.className} backdrop={'static'} fade={false} keyboard={true}>
           <ModalHeader toggle={this.props.toggleModalComplete} charCode="">Story Complete</ModalHeader>
           <ModalBody>
             <p>You have now completed a story in Worldview. To view more stories, click the "More Stories" button below to explore more events within the app. Click the "Exit Tutorial" button or close this window to start using Worldview on your own.</p>

--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -30,6 +30,15 @@ class ModalInProgress extends React.Component {
     this.loadLink = this.loadLink.bind(this);
     this.setUI = this.setUI.bind(this);
     this.processActions = this.processActions.bind(this);
+    this.escFunction = this.escFunction.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.escFunction, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.escFunction, false);
   }
 
   componentDidUpdate(prevProps) {
@@ -70,6 +79,13 @@ class ModalInProgress extends React.Component {
         this.fetchMetadata(currentStory, currentStepIndex);
         this.processLink(currentStory, currentStepIndex, prevStepIndex);
       }
+    }
+  }
+
+  // Use custom escFunction since tabIndex prevents escape key use on loading WV
+  escFunction(e) {
+    if (e.keyCode === 27 && this.props.modalInProgress) {
+      this.props.toggleModalInProgress(e);
     }
   }
 
@@ -403,7 +419,7 @@ class ModalInProgress extends React.Component {
 
     return (
       <div>
-        <Modal isOpen={this.props.modalInProgress} toggle={this.props.toggleModalInProgress} onClosed={this.props.showTourAlert} wrapClassName='tour tour-in-progress' className={this.props.className + ' ' + this.props.currentStory['type']} backdrop={false}>
+        <Modal isOpen={this.props.modalInProgress} toggle={this.props.toggleModalInProgress} onClosed={this.props.showTourAlert} wrapClassName='tour tour-in-progress' className={this.props.className + ' ' + this.props.currentStory['type']} backdrop={false} keyboard={false}>
           <ModalHeader toggle={this.props.toggleModalInProgress} charCode="">{this.props.currentStory['title']}<i className="modal-icon" aria-hidden="true"></i></ModalHeader>
           <ModalBody>
             {/* eslint-disable */}

--- a/web/js/components/tour/modal-tour-start.js
+++ b/web/js/components/tour/modal-tour-start.js
@@ -11,9 +11,43 @@ class ModalStart extends React.Component {
       checked: localStorage.hideTour
     };
 
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
     this.handleCheck = this.handleCheck.bind(this);
+    this.escFunction = this.escFunction.bind(this);
   }
 
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+    document.addEventListener('keydown', this.escFunction, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
+    document.removeEventListener('keydown', this.escFunction, false);
+  }
+
+  // Set a reference to the inner div for checking clicks outside of the scrollbar
+  setWrapperRef(node) {
+    this.wrapperRef = node;
+  }
+
+  // Use custom escFunction since tabIndex prevents escape key use on loading WV
+  escFunction(e) {
+    if (e.keyCode === 27 && this.props.modalStart) {
+      this.props.toggleModalStart(e);
+    }
+  }
+
+  // Use custom clickOutside function since we contained the clickable area with
+  // CSS to have a cleaner looking scrollbar
+  handleClickOutside(e) {
+    if (this.wrapperRef && !this.wrapperRef.contains(e.target)) {
+      this.props.toggleModalStart(e);
+    }
+  }
+
+  // Handle the show/hide checkbox state
   handleCheck() {
     this.setState({
       checked: !this.state.checked,
@@ -28,7 +62,7 @@ class ModalStart extends React.Component {
 
   render() {
     return (
-      <Modal isOpen={this.props.modalStart} toggle={this.props.toggleModalStart} onClosed={this.props.showTourAlert} wrapClassName='tour tour-start' className={this.props.className} backdrop={true}>
+      <Modal isOpen={this.props.modalStart} toggle={this.props.toggleModalStart} onClosed={this.props.showTourAlert} wrapClassName='tour tour-start' className={this.props.className} backdrop={true} fade={false} keyboard={false} innerRef={this.setWrapperRef}>
         <ModalHeader toggle={this.props.toggleModalStart} charCode="">Welcome to Worldview!</ModalHeader>
         <ModalBody>
           <TourIntro toggleModalStart={this.props.toggleModalStart}></TourIntro>


### PR DESCRIPTION
## Description

Fixes #1642

Change escape key & click outside modal behavior:
- Escape key should be used to close the startup, in-progress and completion modals.
- Clicking outside of the startup modal should close the modal so users can bypass the startup quickly if desired.
- Clicking outside of the completion modal should **not** close the modal.

Other changes:
- Tweak min-width CSS sizes 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
