### PR TITLE
v2.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## New Feature
- Enhanced Worldview Tour #1618 

## Layer Updates
- Added hbase gmis layers #1627 
- Added new orbit tracks #1628 
- Edited SEDAC titles #1632

## Technical Updates
- Allow event tracks to go over date line #1620 
- Added more measurements to categories #1626 
- Change in-progress modal max-height to height in IE #1637
- Remove 'Explore Worldview' link when in mobile #1638
- Change order of startup stories #1640
- Add escape key commands and click outside of modal to close #1643
- Change all tour images to 396pxx 396px and optimize #1647