### PR TITLE
Fix palette export class name

### DIFF
--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -5,7 +5,7 @@ import { drawPaletteOnCanvas } from '../../../palettes/util';
 import util from '../../../util/util';
 import Scrollbar from '../../util/scrollbar';
 
-class OpacitySelect extends React.Component {
+class PaletteSelect extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -188,7 +188,7 @@ class OpacitySelect extends React.Component {
     );
   }
 }
-OpacitySelect.propTypes = {
+PaletteSelect.propTypes = {
   index: PropTypes.number,
   layer: PropTypes.object,
   clearCustom: PropTypes.func,
@@ -202,4 +202,4 @@ OpacitySelect.propTypes = {
   activePalette: PropTypes.string
 };
 
-export default OpacitySelect;
+export default PaletteSelect;


### PR DESCRIPTION
## Description

palette.js was using a class named `OpacitySelect`, this changes the class name to `PaletteSelect`

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
