### PR TITLE
Added backticks to overcome italics issue

### DIFF
--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89H_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89H_Day.md
@@ -4,4 +4,4 @@ On board NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocea
 
 References: [AMSR-E/Aqua L2A Global Swath Spatially-Resampled Brightness Temperatures](http://nsidc.org/data/ae_l2a)
 
-Data fields: 89.0H_Res.5B_TB_(not-resampled)
+Data fields: `89.0H_Res.5B_TB_(not-resampled)`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89H_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89H_Night.md
@@ -4,4 +4,4 @@ On board NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocea
 
 References: [AMSR-E/Aqua L2A Global Swath Spatially-Resampled Brightness Temperatures](http://nsidc.org/data/ae_l2a)
 
-Data fields: 89.0H_Res.5B_TB_(not-resampled)
+Data fields: `89.0H_Res.5B_TB_(not-resampled)`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89V_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89V_Day.md
@@ -4,4 +4,4 @@ On board NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocea
 
 References: [AMSR-E/Aqua L2A Global Swath Spatially-Resampled Brightness Temperatures](http://nsidc.org/data/ae_l2a)
 
-Data fields: 89.0V_Res.5B_TB_(not-resampled)
+Data fields: `89.0V_Res.5B_TB_(not-resampled)`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89V_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Brightness_Temp_89V_Night.md
@@ -4,4 +4,4 @@ On board NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocea
 
 References: [AMSR-E/Aqua L2A Global Swath Spatially-Resampled Brightness Temperatures](http://nsidc.org/data/ae_l2a)
 
-Data fields: 89.0V_Res.5B_TB_(not-resampled)
+Data fields: `89.0V_Res.5B_TB_(not-resampled)`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89H.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89H.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 6.25 km 89 GHz Brightness Temperature Polar Grids](http://nsidc.org/data/ae_si6)
 
-Data fields: SI_06km_NH_89H_DAY; SI_06km_SH_89H_DAY
+Data fields: `SI_06km_NH_89H_DAY`; `SI_06km_SH_89H_DAY`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89V.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89V.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 6.25 km 89 GHz Brightness Temperature Polar Grids](http://nsidc.org/data/ae_si6)
 
-Data fields: SI_06km_NH_89V_DAY; SI_06km_SH_89V_DAY
+Data fields: `SI_06km_NH_89V_DAY`; `SI_06km_SH_89V_DAY`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_12km.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_12km.md
@@ -6,4 +6,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 12.5 km Brightness Temperature, Sea Ice Concentration, & Snow Depth Polar Grids](https://nsidc.org/data/ae_si12)
 
-Data fields: SI_12km_NH_ICECON_DAY; SI_12km_SH_ICECON_DAY
+Data fields: `SI_12km_NH_ICECON_DAY`; `SI_12km_SH_ICECON_DAY`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_25km.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_25km.md
@@ -6,4 +6,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 25 km Brightness Temperature & Sea Ice Concentration Polar Grids](http://nsidc.org/data/ae_si25)
 
-Data fields: SI_25km_NH_ICECON_DAY; SI_25km_SH_ICECON_DAY
+Data fields: `SI_25km_NH_ICECON_DAY`; `SI_25km_SH_ICECON_DAY`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Snow_Depth_Over_Ice.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Snow_Depth_Over_Ice.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Reference: [AMSR-E/Aqua Daily L3 12.5 km Brightness Temperature, Sea Ice Concentration, & Snow Depth Polar Grids](http://nsidc.org/data/ae_si12)
 
-Data fields: SI_12km_NH_SNOWDEPTH_5DAY; SI_12km_SH_SNOWDEPTH_5DAY
+Data fields: `SI_12km_NH_SNOWDEPTH_5DAY`; `SI_12km_SH_SNOWDEPTH_5DAY`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Day.md
@@ -6,4 +6,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfacePrecipitation
+Data field: `surfacePrecipitation`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Night.md
@@ -6,4 +6,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfacePrecipitation
+Data field: `surfacePrecipitation`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Rain_Rate_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Rain_Rate_Day.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfaceRain
+Data field: `surfaceRain`

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Rain_Rate_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Rain_Rate_Night.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfaceRain
+Data field: `surfaceRain`

--- a/config/default/common/config/metadata/layers/amsre/BrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/amsre/BrightnessTemperature.md
@@ -7,4 +7,4 @@ On board NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocea
 
 References: [AMSR-E/Aqua L2A Global Swath Spatially-Resampled Brightness Temperatures](http://nsidc.org/data/ae_l2a)
 
-Data fields: 89.0H_Res.5B_TB_(not-resampled), 89.0V_Res.5B_TB_(not-resampled)
+Data fields: `89.0H_Res.5B_TB_(not-resampled)`, `89.0V_Res.5B_TB_(not-resampled)`

--- a/config/default/common/config/metadata/layers/amsre/SeaIceBrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/amsre/SeaIceBrightnessTemperature.md
@@ -7,4 +7,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 6.25 km 89 GHz Brightness Temperature Polar Grids](http://nsidc.org/data/ae_si6)
 
-Data fields: SI_06km_NH_89H_DAY; SI_06km_SH_89H_DAY, SI_06km_NH_89V_DAY; SI_06km_SH_89V_DAY
+Data fields: `SI_06km_NH_89H_DAY`; `SI_06km_SH_89H_DAY`, `SI_06km_NH_89V_DAY`; `SI_06km_SH_89V_DAY`

--- a/config/default/common/config/metadata/layers/amsre/SeaIceConcentration.md
+++ b/config/default/common/config/metadata/layers/amsre/SeaIceConcentration.md
@@ -9,7 +9,7 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 12.5 km Brightness Temperature, Sea Ice Concentration, & Snow Depth Polar Grids](https://nsidc.org/data/ae_si12)
 
-Data fields: SI_12km_NH_ICECON_DAY; SI_12km_SH_ICECON_DAY
+Data fields: `SI_12km_NH_ICECON_DAY`; `SI_12km_SH_ICECON_DAY`
 
 ### AMSR-E Sea Ice Concentration, 25 km
 Temporal coverage: 18 June 2002 - 4 October 2011
@@ -22,4 +22,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 25 km Brightness Temperature & Sea Ice Concentration Polar Grids](http://nsidc.org/data/ae_si25)
 
-Data fields: SI_25km_NH_ICECON_DAY; SI_25km_SH_ICECON_DAY
+Data fields: `SI_25km_NH_ICECON_DAY`; `SI_25km_SH_ICECON_DAY`

--- a/config/default/common/config/metadata/layers/amsre/SnowDepthOverIce.md
+++ b/config/default/common/config/metadata/layers/amsre/SnowDepthOverIce.md
@@ -7,4 +7,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua Daily L3 12.5 km Brightness Temperature, Sea Ice Concentration, & Snow Depth Polar Grids](http://nsidc.org/data/ae_si12)
 
-Data fields: SI_12km_NH_SNOWDEPTH_5DAY; SI_12km_SH_SNOWDEPTH_5DAY
+Data fields: `SI_12km_NH_SNOWDEPTH_5DAY`; `SI_12km_SH_SNOWDEPTH_5DAY`

--- a/config/default/common/config/metadata/layers/amsre/SurfacePrecipitationRate.md
+++ b/config/default/common/config/metadata/layers/amsre/SurfacePrecipitationRate.md
@@ -9,7 +9,7 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfacePrecipitation
+Data field: `surfacePrecipitation`
 
 ### AMSR-E Surface Rain Rate (Day | Night)
 Temporal coverage: 1 June 2002 - 4 October 2011
@@ -22,4 +22,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfaceRain
+Data field: `surfaceRain`

--- a/config/default/common/config/metadata/layers/amsre/SurfaceRainRate.md
+++ b/config/default/common/config/metadata/layers/amsre/SurfaceRainRate.md
@@ -7,4 +7,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 References: [AMSR-E/Aqua L2B Global Swath Surface Precipitation GSFC Profiling Algorithm](http://nsidc.org/data/ae_rain)
 
-Data field: surfaceRain
+Data field: `surfaceRain`

--- a/config/default/common/config/metadata/layers/aquarius/Aquarius_Soil_Moisture_Daily.md
+++ b/config/default/common/config/metadata/layers/aquarius/Aquarius_Soil_Moisture_Daily.md
@@ -4,4 +4,4 @@ The Aquarius instrument includes three radiometers and one scatterometer. The so
 
 References: [Aquarius L3 Gridded 1-Degree Daily Soil Moisture](http://nsidc.org/data/AQ3_DYSM/versions/4); [Aquarius Soil Moisture ATBD Users Guide](http://nsidc.org/data/docs/daac/aquarius/pdfs/Aquarius_VSM_ATBD_UsersGuide.pdf)
 
-Data Field: l3m_data
+Data Field: `l3m_data`

--- a/config/default/common/config/metadata/layers/aquarius/Aquarius_Soil_Moisture_Weekly.md
+++ b/config/default/common/config/metadata/layers/aquarius/Aquarius_Soil_Moisture_Weekly.md
@@ -4,4 +4,4 @@ The Aquarius instrument includes three radiometers and one scatterometer. The so
 
 References: [Aquarius L3 Gridded 1-Degree Weekly Soil Moisture](http://nsidc.org/data/AQ3_WKSM/versions/4); [Aquarius Soil Moisture ATBD Users Guide](http://nsidc.org/data/docs/daac/aquarius/pdfs/Aquarius_VSM_ATBD_UsersGuide.pdf)
 
-Data Field: l3m_data
+Data Field: `l3m_data`

--- a/config/default/common/config/metadata/layers/aquarius/SoilMoisture.md
+++ b/config/default/common/config/metadata/layers/aquarius/SoilMoisture.md
@@ -7,4 +7,4 @@ The Aquarius instrument includes three radiometers and one scatterometer. The so
 
 References: [Aquarius L3 Gridded 1-Degree Daily Soil Moisture](http://nsidc.org/data/AQ3_DYSM/versions/4); [Aquarius L3 Gridded 1-Degree Weekly Soil Moisture](http://nsidc.org/data/AQ3_WKSM/versions/4); [Aquarius Soil Moisture ATBD Users Guide](http://nsidc.org/data/docs/daac/aquarius/pdfs/Aquarius_VSM_ATBD_UsersGuide.pdf)
 
-Data Field: l3m_data
+Data Field: `l3m_data`

--- a/config/default/common/config/metadata/layers/smap/BrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/smap/BrightnessTemperature.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_h_fore, cell_tb_h_aft, cell_tb_v_fore, cell_tb_v_aft
+Data fields: `cell_tb_h_fore`, `cell_tb_h_aft`, `cell_tb_v_fore`, `cell_tb_v_aft`
 
 ### Uncorrected Brightness Temperature 36 km QA and RFI Flags
 Temporal coverage: 31 March 2015 - present
@@ -25,7 +25,7 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](http://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_fore, cell_tb_qual_flag_h_aft, cell_tb_qual_flag_v_fore, cell_tb_qual_flag_v_aft
+Data fields: `cell_tb_qual_flag_h_fore`, `cell_tb_qual_flag_h_aft`, `cell_tb_qual_flag_v_fore`, `cell_tb_qual_flag_v_aft`
 
 ### Uncorrected Brightness Temperature 9 km (L1, Passive, Fore | Aft, H Polarization | V Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -36,7 +36,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_h_fore, cell_tb_h_aft, cell_tb_v_fore, cell_tb_v_aft
+Data fields: `cell_tb_h_fore`, `cell_tb_h_aft`, `cell_tb_v_fore`, `cell_tb_v_aft`
 
 ### Uncorrected Brightness Temperature 9 km QA and RFI Flags
 Temporal coverage: 31 March 2015 - present
@@ -53,7 +53,7 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_fore, cell_tb_qual_flag_h_aft, cell_tb_qual_flag_v_fore, cell_tb_qual_flag_v_aft
+Data fields: `cell_tb_qual_flag_h_fore`, `cell_tb_qual_flag_h_aft`, `cell_tb_qual_flag_v_fore`, `cell_tb_qual_flag_v_aft`
 
 ### Corrected Brightness Temperature (L3, Passive, H Polarization | V Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -64,4 +64,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data fields: tb_h_corrected, tb_v_corrected
+Data fields: `tb_h_corrected`, `tb_v_corrected`

--- a/config/default/common/config/metadata/layers/smap/CorrectedBrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/smap/CorrectedBrightnessTemperature.md
@@ -9,4 +9,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data fields: tb_h_corrected, tb_v_corrected
+Data fields: `tb_h_corrected`, `tb_v_corrected`

--- a/config/default/common/config/metadata/layers/smap/DisaggregatedBrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/smap/DisaggregatedBrightnessTemperature.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar/Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3smap/)
 
-Data fields: tb_h_disaggregated, tb_v_disaggregated
+Data fields: `tb_h_disaggregated`, `tb_v_disaggregated`

--- a/config/default/common/config/metadata/layers/smap/FaradayRotationAngle.md
+++ b/config/default/common/config/metadata/layers/smap/FaradayRotationAngle.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1B Radiometer Half-Orbit Time-Ordered Brightness Temperatures](https://nsidc.org/data/spl1btb/)
 
-Data field: faraday_rotation_angle
+Data field: `faraday_rotation_angle`

--- a/config/default/common/config/metadata/layers/smap/FreezeThaw.md
+++ b/config/default/common/config/metadata/layers/smap/FreezeThaw.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global and Northern Hemisphere Daily 36 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`
 
 ### Freeze/Thaw 9 km (L3, Passive)
 Temporal coverage: 31 March 2015 - present
@@ -18,7 +18,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global and Northern Hemisphere Daily 9 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp_e)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`
 
 ### Freeze/Thaw 3 km (L3, Active)
 Temporal coverage: 13 April 2015 - 7 July 2015
@@ -29,4 +29,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Northern Hemisphere Daily 3 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3fta/)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/GrossPrimaryProduction.md
+++ b/config/default/common/config/metadata/layers/smap/GrossPrimaryProduction.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: gpp_mean
+Data field: `gpp_mean`

--- a/config/default/common/config/metadata/layers/smap/HeterotrophicResipration.md
+++ b/config/default/common/config/metadata/layers/smap/HeterotrophicResipration.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: rh_mean
+Data field: `rh_mean`

--- a/config/default/common/config/metadata/layers/smap/NetEcosystemCO2Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/NetEcosystemCO2Exchange.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: nee_mean
+Data field: `nee_mean`
 
 ### Net Ecosystem CO2 Exchange Uncertainty (L4, 9 km Grid Cell Mean, Model Value-Added)
 Temporal coverage: 13 April 2015 - present
@@ -18,4 +18,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: nee_mean
+Data field: `nee_mean`

--- a/config/default/common/config/metadata/layers/smap/PercentFrozenArea.md
+++ b/config/default/common/config/metadata/layers/smap/PercentFrozenArea.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: frozen_area
+Data field: `frozen_area`

--- a/config/default/common/config/metadata/layers/smap/PercentPotentialVegetationLightUseEfficiency.md
+++ b/config/default/common/config/metadata/layers/smap/PercentPotentialVegetationLightUseEfficiency.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: emult_mean
+Data field: `emult_mean`

--- a/config/default/common/config/metadata/layers/smap/RootZoneSoilMoisture.md
+++ b/config/default/common/config/metadata/layers/smap/RootZoneSoilMoisture.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis
+Data field: `sm_rootzone_analysis`
 
 ### Root Zone Soil Moisture 9 km Uncertainty (L4, 12z Instantaneous, Model Value-Added)
 Temporal coverage: 31 March 2015 - present
@@ -18,4 +18,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis_ensstd
+Data field: `sm_rootzone_analysis_ensstd`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_h_aft
+Data field: `cell_tb_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_aft
+Data field: `cell_tb_qual_flag_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_H_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_aft
+Data field: `cell_tb_qual_flag_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_v_aft
+Data field: `cell_tb_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_v_aft
+Data field: `cell_tb_qual_flag_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Aft_V_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 eferences: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_v_aft
+Data field: `cell_tb_qual_flag_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_h_fore
+Data field: `cell_tb_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_fore
+Data field: `cell_tb_qual_flag_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_H_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_fore
+Data field: `cell_tb_qual_flag_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_v_fore
+Data field: `cell_tb_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_v_fore
+Data field: `cell_tb_qual_flag_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Brightness_Temp_Fore_V_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_v_fore
+Data field: `cell_tb_qual_flag_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_h_aft
+Data field: `cell_tb_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_aft
+Data field: `cell_tb_qual_flag_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_H_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_aft
+Data field: `cell_tb_qual_flag_h_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_v_aft
+Data field: `cell_tb_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_v_aft
+Data field: `cell_tb_qual_flag_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Aft_V_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_v_aft
+Data field: `cell_tb_qual_flag_v_aft`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_h_fore
+Data field: `cell_tb_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_fore
+Data field: `cell_tb_qual_flag_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_H_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_fore
+Data field: `cell_tb_qual_flag_h_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_v_fore
+Data field: `cell_tb_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations have acceptable quality f
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_v_fore
+Data field: `cell_tb_qual_flag_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Enhanced_Brightness_Temp_Fore_V_RFI.md
@@ -4,4 +4,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_v_fore
+Data field: `cell_tb_qual_flag_v_fore`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Aft.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Aft.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1B Radiometer Half-Orbit Time-Ordered Brightness Temperatures](https://nsidc.org/data/spl1btb/)
 
-Data field: faraday_rotation_angle
+Data field: `faraday_rotation_angle`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Fore.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L1_Passive_Faraday_Rotation_Fore.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1B Radiometer Half-Orbit Time-Ordered Brightness Temperatures](https://nsidc.org/data/spl1btb/)
 
-Data field: faraday_rotation_angle
+Data field: `faraday_rotation_angle`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option1.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option2.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option2.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option3.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Day_Soil_Moisture_Option3.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option1.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option2.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option2.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option3.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Day_Soil_Moisture_Option3.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option1.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option2.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option2.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option3.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Enhanced_Night_Soil_Moisture_Option3.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option1.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option2.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option2.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option3.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L2_Passive_Night_Soil_Moisture_Option3.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Day_Freeze_Thaw.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Day_Freeze_Thaw.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Northern Hemisphere Daily 3 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3fta/)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_H.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar/Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3smap/)
 
-Data fields: tb_h_disaggregated
+Data field: `tb_h_disaggregated`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Brightness_Temp_V.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar/Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3smap/)
 
-Data fields: tb_v_disaggregated
+Data field: `tb_v_disaggregated`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Passive_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar/Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3smap/)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_hh_mean
+Data field: `sigma0_hh_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that Sigma0 observations have acceptable quali
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_hh=
+Data field: `sigma0_qual_flag_hh`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_HH_RFI.md
@@ -6,4 +6,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_hh
+Data field: `sigma0_qual_flag_hh`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_vv_mean
+Data field: `sigma0_vv_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV_QA.md
@@ -3,5 +3,5 @@ The Soil Moisture Active Passive (SMAP) "Sigma0 3 km QA (L3, Active, VV Polariza
 Within the image, green indicates that Sigma0 observations have acceptable quality for science use, yellow indicates that caution should be used with the Sigma0 observations as one or more quality-impacting conditions have been identified, and red indicates that Sigma0 observations are flagged as bad due to unacceptable quality.
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
-
-Data fields: sigma0_qual_flag_vv
+`
+Data field: `sigma0_qual_flag_vv`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_VV_RFI.md
@@ -6,4 +6,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_vv
+Data field: `sigma0_qual_flag_vv`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_xpol_mean
+Data field: `sigma0_xpol_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL_QA.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL_QA.md
@@ -4,4 +4,4 @@ Within the image, green indicates that Sigma0 observations have acceptable quali
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_xpol
+Data field: `sigma0_qual_flag_xpol`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL_RFI.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Sigma0_XPOL_RFI.md
@@ -6,4 +6,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_xpol
+Data field: `sigma0_qual_flag_xpol`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Active_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Brightness_Temp_H.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Brightness_Temp_H.md
@@ -6,4 +6,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data fields: tb_h_corrected
+Data field: `tb_h_corrected`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Brightness_Temp_V.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Brightness_Temp_V.md
@@ -6,4 +6,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data fields: tb_v_corrected
+Data field: `tb_v_corrected`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Day_Freeze_Thaw.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Day_Freeze_Thaw.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global and Northern Hemisphere Daily 36 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Day_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Day_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Day_Freeze_Thaw.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Day_Freeze_Thaw.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global and Northern Hemisphere Daily 9 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp_e)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Day_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Day_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP_E)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Night_Freeze_Thaw.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Night_Freeze_Thaw.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global and Northern Hemisphere Daily 9 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp_e)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Night_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Enhanced_Night_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP_E)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Night_Freeze_Thaw.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Night_Freeze_Thaw.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global and Northern Hemisphere Daily 36 km EASE-Grid Freeze/Thaw State](https://nsidc.org/data/spl3ftp)
 
-Data field : freeze_thaw
+Data field: `freeze_thaw`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Night_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L3_Passive_Night_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis
+Data field: `sm_rootzone_analysis`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis
+Data field: `sm_surface_analysis`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Emult_Average.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Emult_Average.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: emult_mean
+Data field: `emult_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Frozen_Area.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Frozen_Area.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: frozen_area
+Data field: `frozen_area`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: gpp_mean
+Data field: `gpp_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: rh_mean
+Data field: `rh_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: nee_mean
+Data field: `nee_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Snow_Mass.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Snow_Mass.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Geophysical Data](https://nsidc.org/data/spl4smgp/)
 
-Data field: snow_mass
+Data field: `snow_mass`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: soil_temp_layer1_analysis
+Data field: `soil_temp_layer1_analysis`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis_ensstd
+Data field: `sm_rootzone_analysis_ensstd`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis_ensstd
+Data field: `sm_surface_analysis_ensstd`

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 Global Daily 9 km Carbon Net Ecosystem Exchange](https://nsidc.org/data/spl4cmdl/)
 
-Data field: nee_mean
+Data field: `nee_mean`

--- a/config/default/common/config/metadata/layers/smap/SMAP_Sentinel-1_L2_Active_Passive_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_Sentinel-1_L2_Active_Passive_Soil_Moisture.md
@@ -6,4 +6,4 @@ References: [SMAP/Sentinel-1 L2 Radiometer/Radar 30-Second Scene 3 km EASE-Grid 
 
 This data set contains modified Copernicus Sentinel-1 data (2015-present), acquired by the European Space Agency (ESA), distributed through the Alaska Satellite Facility (ASF), and processed by the SMAP Science Data System.
 
-Data field: soil_moisture_3km
+Data field: `soil_moisture_3km`

--- a/config/default/common/config/metadata/layers/smap/Sigma0.md
+++ b/config/default/common/config/metadata/layers/smap/Sigma0.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_hh_mean, sigma0_vv_mean, sigma0_xpol_mean
+Data fields: `sigma0_hh_mean`, `sigma0_vv_mean`, `sigma0_xpol_mean`
 
 ### Sigma0 3 km QA and RFI Flags
 Temporal coverage: 13 April 2015 - 7 July 2015
@@ -26,4 +26,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data fields: sigma0_qual_flag_hh, sigma0_qual_flag_vv, sigma0_qual_flag_xpol
+Data fields: `sigma0_qual_flag_hh`, `sigma0_qual_flag_vv`, `sigma0_qual_flag_xpol`

--- a/config/default/common/config/metadata/layers/smap/SnowMass.md
+++ b/config/default/common/config/metadata/layers/smap/SnowMass.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Geophysical Data](https://nsidc.org/data/spl4smgp/)
 
-Data field: snow_mass
+Data field: `snow_mass`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_L2_L3_Passive.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_L2_L3_Passive.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`
 
 ### Soil Moisture 36 km (L2, Passive, Day | Night, Single Channel Algorithm, V Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -18,7 +18,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`
 
 ### Soil Moisture 36 km (L2, Passive, Day | Night, Dual Channel Algorithm)
 Temporal coverage: 31 March 2015 - present
@@ -29,7 +29,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L2 Radiometer Half-Orbit 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`
 
 ### Soil Moisture 9 km (L2, Passive, Day | Night, Single Channel Algorithm, H Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -40,7 +40,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option1
+Data field: `soil_moisture_option1`
 
 ### Soil Moisture 9 km (L2, Passive, Day | Night, Single Channel Algorithm, V Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -51,7 +51,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option2
+Data field: `soil_moisture_option2`
 
 ### Soil Moisture 9 km (L2, Passive, Day | Night, Dual Channel Algorithm)
 Temporal coverage: 31 March 2015 - present
@@ -62,7 +62,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L2 Radiometer Half-Orbit 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL2SMP_E)
 
-Data field: soil_moisture_option3
+Data field: `soil_moisture_option3`
 
 ### Soil Moisture 36 km (L3, Passive, Day | Night)
 Temporal coverage: 31 March 2015 - present
@@ -73,7 +73,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data field: soil_moisture
+Data field: `soil_moisture`
 
 ### Soil Moisture 9 km (L3, Passive, Day | Night)
 Temporal coverage: 31 March 2015 - present
@@ -84,4 +84,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L3 Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP_E)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_L2_SMAPandSentinel-1.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_L2_SMAPandSentinel-1.md
@@ -9,4 +9,4 @@ References: [SMAP/Sentinel-1 L2 Radiometer/Radar 30-Second Scene 3 km EASE-Grid 
 
 This data set contains modified Copernicus Sentinel-1 data (2015-present), acquired by the European Space Agency (ESA), distributed through the Alaska Satellite Facility (ASF), and processed by the SMAP Science Data System.
 
-Data field: soil_moisture_3km
+Data field: `soil_moisture_3km`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_Active.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_Active.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar Global Daily 3 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3sma/)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_ActivePassive.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_ActivePassive.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radar/Radiometer Global Daily 9 km EASE-Grid Soil Moisture](https://nsidc.org/data/spl3smap/)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_Passive.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_L3_Passive.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture](https://nsidc.org/data/SPL3SMP)
 
-Data field: soil_moisture
+Data field: `soil_moisture`

--- a/config/default/common/config/metadata/layers/smap/SoilMoisture_Value-Added.md
+++ b/config/default/common/config/metadata/layers/smap/SoilMoisture_Value-Added.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis
+Data field: `sm_rootzone_analysis`
 
 ### Root Zone Soil Moisture 9 km Uncertainty (L4, 12z Instantaneous, Model Value-Added)
 Temporal coverage: 31 March 2015 - present
@@ -18,7 +18,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_rootzone_analysis_ensstd
+Data field: `sm_rootzone_analysis_ensstd`
 
 ### Surface Soil Moisture 9 km (L4, 12z Instantaneous, Model Value-Added)
 Temporal coverage: 31 March 2015 - present
@@ -29,7 +29,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis
+Data field: `sm_surface_analysis`
 
 ### Surface Soil Moisture 9 km Uncertainty (L4, 12z Instantaneous, Model Value-Added)
 Temporal coverage: 31 March 2015 - present
@@ -40,4 +40,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis_ensstd
+Data field: `sm_surface_analysis_ensstd`

--- a/config/default/common/config/metadata/layers/smap/SurfaceSoilMoisture.md
+++ b/config/default/common/config/metadata/layers/smap/SurfaceSoilMoisture.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis
+Data field: `sm_surface_analysis`
 
 ### Surface Soil Moisture 9 km Uncertainty (L4, 12z Instantaneous, Model Value-Added)
 Temporal coverage: 31 March 2015 - present
@@ -18,4 +18,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: sm_surface_analysis_ensstd
+Data field: `sm_surface_analysis_ensstd`

--- a/config/default/common/config/metadata/layers/smap/SurfaceSoilTemperature.md
+++ b/config/default/common/config/metadata/layers/smap/SurfaceSoilTemperature.md
@@ -7,4 +7,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L4 9 km EASE-Grid Surface and Root Zone Soil Moisture Analysis Update](https://nsidc.org/data/spl4smau/)
 
-Data field: soil_temp_layer1_analysis
+Data field: `soil_temp_layer1_analysis`

--- a/config/default/common/config/metadata/layers/smap/UncorrectedBrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/smap/UncorrectedBrightnessTemperature.md
@@ -7,7 +7,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_h_fore, cell_tb_h_aft, cell_tb_v_fore, cell_tb_v_aft
+  Data fields: cell_tb_h_fore, cell_tb_h_aft, cell_tb_v_fore, cell_tb_v_aft
 
 ### Uncorrected Brightness Temperature 36 km QA and RFI Flags
 Temporal coverage: 31 March 2015 - present
@@ -17,7 +17,6 @@ The Soil Moisture Active Passive (SMAP) "Uncorrected Brightness Temperature 36 k
 
 Within the image, green indicates that TB observations have acceptable quality for science use, yellow indicates that caution should be used with the TB observations as one or more quality-impacting conditions have been identified, and red indicates that TB observations are flagged as bad due to unacceptable quality.
 
-
 ### Uncorrected Brightness Temperature 36 km RFI (L1, Passive, Fore | Aft, H Polarization | V Polarization)
 The Soil Moisture Active Passive (SMAP) "Uncorrected Brightness Temperature 36 km RFI” layers displays Radio Frequency Interference (RFI) quality flags of uncorrected brightness temperatures (TBs) on a 36 km EASE-Grid 2.0 for the horizontal (H) and vertical (V) polarizations of the fore and aft scans from the SMAP radiometer. RFI refers to the interference in measurements from other transmitters operating at frequencies adjacent to the SMAP L-band frequency.
 
@@ -25,7 +24,7 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP L1C Radiometer Half-Orbit 36 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB)
 
-Data fields: cell_tb_qual_flag_h_fore, cell_tb_qual_flag_h_aft, cell_tb_qual_flag_v_fore, cell_tb_qual_flag_v_aft
+  Data fields: `cell_tb_qual_flag_h_fore`, `cell_tb_qual_flag_h_aft`, `cell_tb_qual_flag_v_fore`, `cell_tb_qual_flag_v_aft`
 
 ### Uncorrected Brightness Temperature 9 km (L1, Passive, Fore | Aft, H Polarization | V Polarization)
 Temporal coverage: 31 March 2015 - present
@@ -36,7 +35,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_h_fore, cell_tb_h_aft, cell_tb_v_fore, cell_tb_v_aft
+  Data fields: `cell_tb_h_fore`, `cell_tb_h_aft`, `cell_tb_v_fore`, `cell_tb_v_aft`
 
 ### Uncorrected Brightness Temperature 9 km QA and RFI Flags
 Temporal coverage: 31 March 2015 - present
@@ -53,4 +52,4 @@ Within the image, green indicates that TB observations are free of RFI and appro
 
 References: [SMAP Enhanced L1C Radiometer Half-Orbit 9 km EASE-Grid Brightness Temperatures](https://nsidc.org/data/SPL1CTB_E)
 
-Data fields: cell_tb_qual_flag_h_fore, cell_tb_qual_flag_h_aft, cell_tb_qual_flag_v_fore, cell_tb_qual_flag_v_aft
+  Data fields: `cell_tb_qual_flag_h_fore`, `cell_tb_qual_flag_h_aft`, `cell_tb_qual_flag_v_fore`, `cell_tb_qual_flag_v_aft`


### PR DESCRIPTION
## Description
Markdown uses underscores to denote text that should be in italics. Data Fields information in the layer descriptions had underscores in them making them confusing to read. Added backticks around these data fields to prevent the markdown from changing the text into italics.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
