### PR TITLE
Add feedback email location when in mobile mode

### DIFF
--- a/web/js/feedback.js
+++ b/web/js/feedback.js
@@ -19,6 +19,8 @@ export function feedbackUi() {
       }
       feedback.showForm();
       feedbackInit = true;
+    } else {
+      location.href = 'mailto:@MAIL@?subject=Feedback for @LONG_NAME@ tool';
     }
   };
   return self;


### PR DESCRIPTION
## Description

Fixes #1673

Adds an email link on mobile when clicking on feedback as it did in before v2.13.0.
 
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
