### PR TITLE
Fix Time ows:Identifier on build and no metadata error

### DIFF
--- a/tasks/extractConfigFromWMTS.py
+++ b/tasks/extractConfigFromWMTS.py
@@ -73,7 +73,7 @@ def process_layer(gc_layer, wv_layers, colormaps):
     # Extract start and end dates
     if "Dimension" in gc_layer:
         dimension = gc_layer["Dimension"]
-        if dimension["ows:Identifier"] == "time":
+        if dimension["ows:Identifier"] == "Time":
             wv_layer = process_temporal(wv_layer, dimension["Value"])
     # Extract matrix set
     matrixSet = gc_layer["TileMatrixSetLink"]["TileMatrixSet"]

--- a/web/js/components/layer/product-picker/list.js
+++ b/web/js/components/layer/product-picker/list.js
@@ -68,13 +68,15 @@ class LayerList extends React.Component {
     }
   }
   getSourceMetadata(source) {
-    util.get('config/metadata/layers/' + source.description + '.html').then(data => {
-      if (data) {
-        let sourceMetadata = this.state.sourceMetadata;
-        sourceMetadata[source.description] = { data: data };
-        this.setState({ sourceMetaData: sourceMetadata });
-      }
-    });
+    if (source.description) {
+      util.get('config/metadata/layers/' + source.description + '.html').then(data => {
+        if (data) {
+          let sourceMetadata = this.state.sourceMetadata;
+          sourceMetadata[source.description] = { data: data };
+          this.setState({ sourceMetaData: sourceMetadata });
+        }
+      });
+    }
   }
   /*
    * Toggles expansion of date ranges for a layer given that layer's ID


### PR DESCRIPTION
## Description

- Fixes build issue where ows:identifier 'time' changed to 'Time' causing date selector to no longer work.
- Added check for metadata file. Layers without metadata files would cause the app to crash.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
