### PR TITLE
Fix tour breaking when using manipulating comparison mode b-state

### DIFF
--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -241,7 +241,8 @@ class ModalInProgress extends React.Component {
           selectedB = new Date(selectedB);
           models.date.selectedB = selectedB;
         }
-      }).then(util.wrap(() => this.loadLink(currentState, stepTransition, prevState, currentStepIndex)));
+      })
+      .then(util.wrap(() => this.loadLink(currentState, stepTransition, prevState, currentStepIndex)));
   }
 
   loadLink(currentState, stepTransition, prevState, currentStepIndex) {
@@ -251,15 +252,8 @@ class ModalInProgress extends React.Component {
     var ui = this.props.ui;
     var rotation = 0;
 
-    // Set rotation value if it exists
-    if (currentState.p === 'arctic' || currentState.p === 'antarctic') {
-      if (!isNaN(currentState.r)) {
-        rotation = currentState.r * (Math.PI / 180.0);
-      }
-    }
-
     // Close the comparison mode if there is no comparison mode in the step link
-    if ((!currentState.ca || !currentState.cm) && models.compare.active === true) {
+    if (((!currentState.ca || !currentState.cm) && models.compare.active === true) || (prevState.ca || prevState.cm)) {
       models.compare.toggle();
       models.compare.load({});
       ui.sidebar.reactComponent.setState({
@@ -275,6 +269,13 @@ class ModalInProgress extends React.Component {
           isCompareA: true
         });
         models.compare.isCompareA = true;
+      }
+    }
+
+    // Set rotation value if it exists
+    if (currentState.p === 'arctic' || currentState.p === 'antarctic') {
+      if (!isNaN(currentState.r)) {
+        rotation = currentState.r * (Math.PI / 180.0);
       }
     }
 

--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -114,7 +114,6 @@ class ModalInProgress extends React.Component {
     var errors = [];
     var config = this.props.config;
     var models = this.props.models;
-    var ui = this.props.ui;
 
     // When the link is loaded, save the tour to URL
     models.tour.active = true;
@@ -242,25 +241,6 @@ class ModalInProgress extends React.Component {
           selectedB = new Date(selectedB);
           models.date.selectedB = selectedB;
         }
-      }).then(() => {
-        // Close the comparison mode if there is no comparison mode in the step link
-        if ((!currentState.ca || !currentState.cm) && models.compare.active === true) {
-          models.compare.toggle();
-          models.compare.load({});
-          ui.sidebar.reactComponent.setState({
-            isCompareMode: false
-          });
-          models.compare.active = false;
-        } else {
-          if (!models.compare.isCompareA) {
-            models.compare.load({});
-            models.compare.toggleState();
-            ui.sidebar.reactComponent.setState({
-              isCompareA: true
-            });
-            models.compare.isCompareA = true;
-          }
-        }
       }).then(util.wrap(() => this.loadLink(currentState, stepTransition, prevState, currentStepIndex)));
   }
 
@@ -275,6 +255,26 @@ class ModalInProgress extends React.Component {
     if (currentState.p === 'arctic' || currentState.p === 'antarctic') {
       if (!isNaN(currentState.r)) {
         rotation = currentState.r * (Math.PI / 180.0);
+      }
+    }
+
+    // Close the comparison mode if there is no comparison mode in the step link
+    if ((!currentState.ca || !currentState.cm) && models.compare.active === true) {
+      models.compare.toggle();
+      models.compare.load({});
+      ui.sidebar.reactComponent.setState({
+        isCompareMode: false
+      });
+      models.compare.active = false;
+    } else {
+      if (!models.compare.isCompareA) {
+        models.layers.activeLayers = 'active';
+        models.compare.load({});
+        models.compare.toggleState();
+        ui.sidebar.reactComponent.setState({
+          isCompareA: true
+        });
+        models.compare.isCompareA = true;
       }
     }
 

--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -114,6 +114,7 @@ class ModalInProgress extends React.Component {
     var errors = [];
     var config = this.props.config;
     var models = this.props.models;
+    var ui = this.props.ui;
 
     // When the link is loaded, save the tour to URL
     models.tour.active = true;
@@ -241,8 +242,26 @@ class ModalInProgress extends React.Component {
           selectedB = new Date(selectedB);
           models.date.selectedB = selectedB;
         }
-      })
-      .then(util.wrap(() => this.loadLink(currentState, stepTransition, prevState, currentStepIndex)));
+      }).then(() => {
+        // Close the comparison mode if there is no comparison mode in the step link
+        if ((!currentState.ca || !currentState.cm) && models.compare.active === true) {
+          models.compare.toggle();
+          models.compare.load({});
+          ui.sidebar.reactComponent.setState({
+            isCompareMode: false
+          });
+          models.compare.active = false;
+        } else {
+          if (!models.compare.isCompareA) {
+            models.compare.load({});
+            models.compare.toggleState();
+            ui.sidebar.reactComponent.setState({
+              isCompareA: true
+            });
+            models.compare.isCompareA = true;
+          }
+        }
+      }).then(util.wrap(() => this.loadLink(currentState, stepTransition, prevState, currentStepIndex)));
   }
 
   loadLink(currentState, stepTransition, prevState, currentStepIndex) {
@@ -251,16 +270,6 @@ class ModalInProgress extends React.Component {
     var models = this.props.models;
     var ui = this.props.ui;
     var rotation = 0;
-
-    // Close the comparison mode if there is no comparison mode in the step link
-    if (((!currentState.ca || !currentState.cm) && models.compare.active === true) || (prevState.ca || prevState.cm)) {
-      models.compare.toggle();
-      models.compare.load({});
-      ui.sidebar.reactComponent.setState({
-        isCompareMode: false
-      });
-      models.compare.active = false;
-    }
 
     // Set rotation value if it exists
     if (currentState.p === 'arctic' || currentState.p === 'antarctic') {

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -565,7 +565,8 @@ export function mapui(models, config) {
         id: def.id
       }
     });
-    if (!layer && layers[0].get('group')) {
+
+    if (!layer && layers.length && layers[0].get('group')) {
       let subGroup, olGroupLayer;
       lodashEach(layers, layerGroup => {
         if (layerGroup.get('group') === layerGroupStr) {


### PR DESCRIPTION
## Description

Fixes #1685

- If mode has switched to B state by the user, switch back to a state before parsing the tour step.
- Add some validation if there are no layers in the layer list (additional bug breaking in current production)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
