### PR TITLE
Add checks for localStorage & remove hideTour checkbox if no localStorage

### DIFF
--- a/web/js/alert/ui.js
+++ b/web/js/alert/ui.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TourAlert from '../components/alert/alert-tour';
+import util from '../util/util';
 
 export function alertUi(ui) {
   var self = {};
@@ -21,6 +22,7 @@ export function alertUi(ui) {
   };
 
   self.showTourAlert = function(e) {
+    if (!util.browser.localStorage) return;
     var hideTour = localStorage.getItem('hideTour');
     if (!hideTour) return;
 

--- a/web/js/components/tour/modal-tour-start.js
+++ b/web/js/components/tour/modal-tour-start.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { Modal, ModalHeader, ModalBody, ModalFooter, InputGroup, InputGroupText, Input } from 'reactstrap';
 import TourIntro from './content-intro';
 import TourBoxes from './tour-boxes';
+import util from '../../util/util';
 
 class ModalStart extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      checked: localStorage.hideTour
+      checked: this.props.storageCheck
     };
 
     this.setWrapperRef = this.setWrapperRef.bind(this);
@@ -68,6 +69,7 @@ class ModalStart extends React.Component {
           <TourIntro toggleModalStart={this.props.toggleModalStart}></TourIntro>
           <TourBoxes stories={this.props.stories} storyOrder={this.props.storyOrder} selectTour={this.props.selectTour}></TourBoxes>
         </ModalBody>
+        {util.browser.localStorage &&
         <ModalFooter>
           <InputGroup>
             <InputGroupText className="w-100">
@@ -76,6 +78,7 @@ class ModalStart extends React.Component {
             </InputGroupText>
           </InputGroup>
         </ModalFooter>
+        }
       </Modal>
     );
   }
@@ -90,6 +93,7 @@ ModalStart.propTypes = {
   showTourAlert: PropTypes.func.isRequired,
   hideTour: PropTypes.func.isRequired,
   showTour: PropTypes.func.isRequired,
+  storageCheck: PropTypes.bool.isRequired,
   className: PropTypes.string
 };
 

--- a/web/js/components/tour/tour.js
+++ b/web/js/components/tour/tour.js
@@ -132,6 +132,7 @@ class Tour extends React.Component {
             showTourAlert={this.props.showTourAlert}
             hideTour={this.props.hideTour}
             showTour={this.props.showTour}
+            storageCheck={this.props.storageCheck}
           ></TourStart>
 
           <TourInProgress
@@ -197,7 +198,8 @@ Tour.propTypes = {
   hideTour: PropTypes.func.isRequired,
   showTour: PropTypes.func.isRequired,
   restartTour: PropTypes.bool.isRequired,
-  metaLoaded: PropTypes.bool.isRequired
+  metaLoaded: PropTypes.bool.isRequired,
+  storageCheck: PropTypes.bool.isRequired
 };
 
 export default Tour;

--- a/web/js/notifications/ui.js
+++ b/web/js/notifications/ui.js
@@ -31,9 +31,7 @@ export function notificationsUi(models, config) {
    */
   var init = function () {
     var p;
-    if (!util.browser.localStorage) {
-      return;
-    }
+    if (!util.browser.localStorage) return;
     if (config.parameters.mockAlerts) {
       url = 'mock/notify_' + config.parameters.mockAlerts + '.json';
     }

--- a/web/js/tour/ui.js
+++ b/web/js/tour/ui.js
@@ -54,14 +54,29 @@ export function tourUi(models, ui, config) {
       selectTour: self.selectTour,
       showTourAlert: ui.alert.showTourAlert,
       hideTour: self.hideTour,
-      showTour: self.showTour
+      showTour: self.showTour,
+      storageCheck: self.storageChecked()
     };
   };
 
-  self.checkBuildTimestamp = function() {
-    var hideTour = localStorage.getItem('hideTour');
+  self.storageChecked = function() {
+    if (!util.browser.localStorage) {
+      return false;
+    } else {
+      // Do the opposite of the results of checking the build timestamp / setting modalStart
+      // i.e. Checking hide means (true) not showing the start modal
+      if (self.checkBuildTimestamp() === true) {
+        return false;
+      } else {
+        return true;
+      }
+    }
+  };
 
-    if (!util.browser.localStorage) return;
+  self.checkBuildTimestamp = function() {
+    // If there is no localStorage, always show the tour start modal
+    if (!util.browser.localStorage) return true;
+    var hideTour = localStorage.getItem('hideTour');
 
     // Don't start tour if coming in via a permalink
     if (window.location.search && !config.parameters.tour) {
@@ -137,6 +152,7 @@ export function tourUi(models, ui, config) {
   };
 
   self.hideTour = function(e) {
+    if (!util.browser.localStorage) return;
     var hideTour = localStorage.getItem('hideTour');
 
     // Checkbox to "hide tour modal until a new story has been added" has been checked
@@ -144,13 +160,13 @@ export function tourUi(models, ui, config) {
       'event': 'tour_hide_checked'
     });
 
-    if (!util.browser.localStorage) return;
     if (hideTour) return;
 
     localStorage.setItem('hideTour', new Date());
   };
 
   self.showTour = function(e) {
+    if (!util.browser.localStorage) return;
     var hideTour = localStorage.getItem('hideTour');
 
     // Checkbox to "hide tour modal until a new story has been added" has been checked
@@ -158,7 +174,6 @@ export function tourUi(models, ui, config) {
       'event': 'tour_hide_unchecked'
     });
 
-    if (!util.browser.localStorage) return;
     if (!hideTour) return;
 
     localStorage.removeItem('hideTour');


### PR DESCRIPTION
## Description

Fixes #1704 

- Adds checks for local storage throughout app
- Create function to handle checkbox / modalStart when localStorage is not available
- Don't output tour start modal footer (with localStorage "Hide Tour" checkbox) if no localStorage available

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

To test this PR,
1. Build this branch locally
2. open localhost:3000 in chrome
3. Go to `chrome://settings/content/cookies`
4. Add `localhost:3000` to the "Block" section
5. localStorage should be blocked on localhost:3000
6. Ensure no browser errors
7. Ensure that the footer with Hide Tour checkbox no longer displays on Tour start modal
8. Remove `localhost:3000` from the "Block" section
9. Refresh localhost:3000
10. Test check Hide Tour checkbox and re-enabling tour to ensure no errors.

@nasa-gibs/worldview
