### PR TITLE
Check for start page before checking local storage

### DIFF
--- a/web/js/tour/ui.js
+++ b/web/js/tour/ui.js
@@ -74,14 +74,13 @@ export function tourUi(models, ui, config) {
   };
 
   self.checkBuildTimestamp = function() {
-    // If there is no localStorage, always show the tour start modal
-    if (!util.browser.localStorage) return true;
-    var hideTour = localStorage.getItem('hideTour');
-
     // Don't start tour if coming in via a permalink
     if (window.location.search && !config.parameters.tour) {
       return false;
     }
+    // If there is no localStorage, always show the tour start modal
+    if (!util.browser.localStorage) return true;
+    let hideTour = localStorage.getItem('hideTour');
 
     if (hideTour && config.buildDate) {
       let buildDate = new Date(config.buildDate);


### PR DESCRIPTION
## Description

Fixes issue where tour will show on permalink pages when there is no localStorage

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
