### PR TITLE
Geostationary wrap

### DIFF
--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared_v0_NRT.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared_v0_NRT.json
@@ -11,7 +11,8 @@
               "GOES"
             ],
             "inactive": true,
-            "period": "subdaily"
+            "period": "subdaily",
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared_v0_NRT.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared_v0_NRT.json
@@ -11,7 +11,8 @@
             "Himawari"
           ],
           "inactive": true,
-          "period": "subdaily"
+          "period": "subdaily",
+          "wrapX": true
       }
   }
 }

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -271,7 +271,7 @@ export function mapLayerBuilder(models, config, cache, mapUi, store) {
       // date = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
       date = new Date(date.getTime());
     }
-    if (day) {
+    if (day && (def.period !== 'subdaily')) {
       date = util.dateAdd(date, 'day', day);
     }
 


### PR DESCRIPTION
## Description

Fixes #1690.

Adds a check to handle wrapping of sub-daily / geostationary imagery around the anti-meridian.  Also added the `wrapX` flag to GOES West and Himawari-8 layers to use this functionality.
