### PR TITLE
Empty ows:Metadata

### DIFF
--- a/tasks/extractConfigFromWMTS.py
+++ b/tasks/extractConfigFromWMTS.py
@@ -85,7 +85,7 @@ def process_layer(gc_layer, wv_layers, colormaps):
     }
 
     # Colormap links
-    if "ows:Metadata" in gc_layer:
+    if "ows:Metadata" in gc_layer and gc_layer["ows:Metadata"] is not None:
         if "skipPalettes" in config and ident in config["skipPalettes"]:
             sys.stderr.write("%s: WARNING: Skipping palette for %s\n" % (
                 prog, ident))

--- a/tasks/getCapabilities.py
+++ b/tasks/getCapabilities.py
@@ -55,7 +55,7 @@ def process_layer(layer):
                              prog, ident)
             global warning_count
             warning_count += 1
-        else:
+        elif layer["ows:Metadata"] is not None:
             for item in layer["ows:Metadata"]:
                 schema_version = item["@xlink:role"]
                 if schema_version == "http://earthdata.nasa.gov/gibs/metadata-type/colormap/1.3":


### PR DESCRIPTION
## Description

Fixes a bug where the config generator crashes if a GC document contains an empty ows:Metadata element.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
