### PR TITLE
Fix custom interval widget getting behind sidebar

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -350,13 +350,13 @@ button:focus {
 
 /* Interval selector */
 .custom-interval-widget {
-  height: 57px;
+  height: 54px;
   width: 225px;
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
   background: rgba(40, 40, 40, 0.85);
   position: absolute;
-  top: -58px;
+  top: -54px;
   left: 0;
   display: none;
   color: #fff;

--- a/web/js/containers/sidebar/compare.js
+++ b/web/js/containers/sidebar/compare.js
@@ -51,7 +51,6 @@ class CompareCase extends React.Component {
         ) : (
           ''
         )}
-        }
         <div className={outerClass}>
           <div className="ab-tabs-case">
             <Nav tabs>


### PR DESCRIPTION
## Description

Fixes #1788  .

Top of custom interval selector widget was able to render behind the sidebar in compare mode and certain browser zoom resolutions. This fix reduces height from the custom interval widget and removes a spacing character within the sidebar compare mode.

Old version:
![image](https://user-images.githubusercontent.com/24417194/60614970-0b351d00-9d9c-11e9-9f62-e16a98382847.png)


New version:
![image](https://user-images.githubusercontent.com/24417194/60614948-fe182e00-9d9b-11e9-905b-f9a81405b71c.png)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
