### PR TITLE
Floor animation start and end dates to allow predictable animation/GIF ranges

### DIFF
--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -104,10 +104,16 @@ class AnimationWidget extends React.Component {
   openGif() {
     const {
       toggleGif,
+      onUpdateStartAndEndDate,
       hasCustomPalettes,
       isRotated,
       hasGraticule
     } = this.props;
+    const {
+      startDate,
+      endDate
+    } = this.zeroDates();
+
     this.getPromise(hasCustomPalettes, 'palette', clearCustoms, 'Notice').then(
       () => {
         this.getPromise(
@@ -122,6 +128,8 @@ class AnimationWidget extends React.Component {
             clearGraticule,
             'Remove Graticule?'
           ).then(() => {
+            onUpdateStartAndEndDate(startDate, endDate);
+          }).then(() => {
             toggleGif();
           });
         });

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -181,7 +181,6 @@ class AnimationWidget extends React.Component {
   }
 
   /*
-   * Zeroes start and end animation dates to UTC 00:00:00 for predictable animation range
    * update global store startDate, endDate, and isPlaying
    *
    * @method onPushPlay
@@ -189,12 +188,49 @@ class AnimationWidget extends React.Component {
    * @return {void}
    */
   onPushPlay = () => {
-    const { onUpdateStartAndEndDate, onPushPlay } = this.props;
-    // zero start and end dates to UTC 00:00:00
-    let startDate = util.clearTimeUTC(this.props.startDate);
-    let endDate = util.clearTimeUTC(this.props.endDate);
+    const {
+      onUpdateStartAndEndDate,
+      onPushPlay
+    } = this.props;
+    const {
+      startDate,
+      endDate
+    } = this.zeroDates();
     onUpdateStartAndEndDate(startDate, endDate);
     onPushPlay();
+  }
+
+  /*
+   * Zeroes start and end animation dates to UTC 00:00:00 for predictable animation range
+   * subdaily intervals retain hours and minutes
+   *
+   * @method zeroDates
+   *
+   * @return {Object}
+    * @param {Object} JS Date - startDate
+    * @param {Object} JS Date - endDate
+   */
+  zeroDates = () => {
+    let {
+      interval,
+      startDate,
+      endDate
+    } = this.props;
+    if (interval === 'minute' || interval === 'hour') {
+      // for subdaily, zero start and end dates to UTC XX:YY:00:00
+      startDate.setUTCSeconds(0);
+      startDate.setUTCMilliseconds(0);
+      endDate.setUTCSeconds(0);
+      endDate.setUTCMilliseconds(0);
+    } else {
+      // for nonsubdaily, zero start and end dates to UTC 00:00:00:00
+      startDate = util.clearTimeUTC(startDate);
+      endDate = util.clearTimeUTC(endDate);
+    }
+    return {
+      startDate,
+      endDate
+    };
   }
 
   render() {

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -5,6 +5,7 @@ import {
   find as lodashFind,
   get as lodashGet
 } from 'lodash';
+import util from '../util/util';
 import ErrorBoundary from './error-boundary';
 import PropTypes from 'prop-types';
 import Slider, { Handle } from 'rc-slider';
@@ -35,6 +36,7 @@ import {
   changeFrameRate,
   changeStartDate,
   changeEndDate,
+  changeStartAndEndDate,
   toggleComponentGifActive
 } from '../modules/animation/actions';
 import { notificationWarnings } from '../modules/image-download/constants';
@@ -177,6 +179,24 @@ class AnimationWidget extends React.Component {
       onZoomSelect(customDelta, customInterval, true);
     }
   }
+
+  /*
+   * Zeroes start and end animation dates to UTC 00:00:00 for predictable animation range
+   * update global store startDate, endDate, and isPlaying
+   *
+   * @method onPushPlay
+   *
+   * @return {void}
+   */
+  onPushPlay = () => {
+    const { onUpdateStartAndEndDate, onPushPlay } = this.props;
+    // zero start and end dates to UTC 00:00:00
+    let startDate = util.clearTimeUTC(this.props.startDate);
+    let endDate = util.clearTimeUTC(this.props.endDate);
+    onUpdateStartAndEndDate(startDate, endDate);
+    onPushPlay();
+  }
+
   render() {
     const {
       hasSubdailyLayers,
@@ -189,7 +209,6 @@ class AnimationWidget extends React.Component {
       sliderLabel,
       startDate,
       endDate,
-      onPushPlay,
       onPushPause,
       isActive,
       interval,
@@ -255,7 +274,7 @@ class AnimationWidget extends React.Component {
 
             <PlayButton
               playing={isPlaying}
-              play={onPushPlay}
+              play={this.onPushPlay}
               pause={onPushPause}
             />
             <LoopButton looping={looping} onLoop={this.onLoop} />
@@ -472,6 +491,9 @@ const mapDispatchToProps = dispatch => ({
   },
   onUpdateEndDate(date) {
     dispatch(changeEndDate(date));
+  },
+  onUpdateStartAndEndDate: (startDate, endDate) => {
+    dispatch(changeStartAndEndDate(startDate, endDate));
   }
 });
 
@@ -514,6 +536,7 @@ AnimationWidget.propTypes = {
   onPushPlay: PropTypes.func,
   onSlide: PropTypes.func,
   onUpdateEndDate: PropTypes.func,
+  onUpdateStartAndEndDate: PropTypes.func,
   onUpdateStartDate: PropTypes.func,
   onZoomSelect: PropTypes.func,
   promiseImageryForTime: PropTypes.func,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -511,12 +511,12 @@ class Timeline extends React.Component {
   }
 
   /**
-  * @desc handle animation dragger location update and state update
+  * @desc handle animation dragger location and date state update
   * @param {String} startDate
   * @param {String} endDate
   * @returns {void}
   */
-  animationDraggerDateUpdate = (startDate, endDate) => {
+  animationDraggerDateUpdateLocal = (startDate, endDate) => {
     let { position, transformX } = this.state;
     let { timeScale } = this.props;
 
@@ -533,6 +533,16 @@ class Timeline extends React.Component {
       animationStartLocationDate: startDate,
       animationEndLocationDate: endDate
     });
+  }
+
+  /**
+  * @desc handle animation dragger location and date state update and global date update
+  * @param {String} startDate
+  * @param {String} endDate
+  * @returns {void}
+  */
+  animationDraggerDateUpdate = (startDate, endDate) => {
+    this.animationDraggerDateUpdateLocal(startDate, endDate);
     this.debounceOnUpdateStartAndEndDate(startDate, endDate);
   }
 
@@ -623,6 +633,11 @@ class Timeline extends React.Component {
       customIntervalValue,
       customIntervalZoomLevel
     } = this.props;
+
+    // handle update animation positioning and local state from play button zeroing
+    if (!prevProps.isAnimationPlaying && this.props.isAnimationPlaying) {
+      this.animationDraggerDateUpdateLocal(animStartLocationDate, animEndLocationDate);
+    }
 
     // handle location update triggered from animation start/end date change from animation widget
     if (isAnimationWidgetOpen) {

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -628,14 +628,21 @@ class Timeline extends React.Component {
       animEndLocationDate,
       dateA,
       dateB,
+      isAnimationPlaying,
       isAnimationWidgetOpen,
+      isGifActive,
+      isTourActive,
       customSelected,
       customIntervalValue,
-      customIntervalZoomLevel
+      customIntervalZoomLevel,
+      timeScale,
+      timeScaleChangeUnit,
+      deltaChangeAmt
     } = this.props;
 
-    // handle update animation positioning and local state from play button zeroing
-    if (!prevProps.isAnimationPlaying && this.props.isAnimationPlaying) {
+    // handle update animation positioning and local state from play button/gif creation
+    if ((!prevProps.isAnimationPlaying && isAnimationPlaying) ||
+        (!prevProps.isGifActive && isGifActive)) {
       this.animationDraggerDateUpdateLocal(animStartLocationDate, animEndLocationDate);
     }
 
@@ -644,7 +651,7 @@ class Timeline extends React.Component {
       if (prevStartLocationDate && prevEndLocationDate) {
         if (prevStartLocationDate.getTime() !== animStartLocationDate.getTime() ||
             prevEndLocationDate.getTime() !== animEndLocationDate.getTime() ||
-            (prevState.frontDate !== this.state.frontDate && !this.props.isAnimationPlaying)) {
+            (prevState.frontDate !== this.state.frontDate && !isAnimationPlaying)) {
           this.animationDraggerDateUpdate(animStartLocationDate, animEndLocationDate);
         }
       }
@@ -670,10 +677,10 @@ class Timeline extends React.Component {
     // on tour page change, will update interval to selectedzoom if differs
     // (e.g., 'month' zoom will default to 'month' interval)
     // TODO: investigate how to handle this page update better - this limits functionality when in tour mode
-    if (this.props.isTourActive) {
-      if (this.props.timeScale !== prevProps.timeScale && prevProps.timeScaleChangeUnit !== this.props.timeScale) {
-        if (this.props.timeScale !== this.props.timeScaleChangeUnit && !this.props.customSelected) {
-          this.props.selectInterval(this.props.deltaChangeAmt, timeScaleToNumberKey[this.props.timeScale], false);
+    if (isTourActive) {
+      if (timeScale !== prevProps.timeScale && prevProps.timeScaleChangeUnit !== timeScale) {
+        if (timeScale !== timeScaleChangeUnit && !customSelected) {
+          this.props.selectInterval(deltaChangeAmt, timeScaleToNumberKey[timeScale], false);
         }
       }
     }
@@ -1153,7 +1160,8 @@ function mapStateToProps(state) {
       sidebar.activeTab === 'download' ||
       compare.active,
     isDataDownload: sidebar.activeTab === 'download',
-    isAnimationPlaying: animation.isPlaying
+    isAnimationPlaying: animation.isPlaying,
+    isGifActive: animation.gifActive
   };
 }
 
@@ -1229,6 +1237,7 @@ Timeline.propTypes = {
   isAnimationWidgetOpen: PropTypes.bool,
   isCompareModeActive: PropTypes.bool,
   isDataDownload: PropTypes.bool,
+  isGifActive: PropTypes.bool,
   isSmallScreen: PropTypes.bool,
   isTourActive: PropTypes.bool,
   leftArrowDisabled: PropTypes.bool,


### PR DESCRIPTION
## Description

Fixes #1813  .

- Floor nonsubdaily start/end animation dates to UTC midnight on play animation and creating GIF
- Subdaily intervals will zero out seconds and milliseconds - this may be revisited once subdaily layers make it to production

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
