### PR TITLE
Updates to MODIS L3 metadata files and IMERG added back in

### DIFF
--- a/config/default/common/config/metadata/layers/modis/Albedo.md
+++ b/config/default/common/config/metadata/layers/modis/Albedo.md
@@ -1,0 +1,2 @@
+### MODIS (Terra and Aqua) Albedo (Level 3, Daily)
+Temporal coverage: 18 May 2000 - present

--- a/config/default/common/config/metadata/layers/modis/FPAR.md
+++ b/config/default/common/config/metadata/layers/modis/FPAR.md
@@ -1,0 +1,8 @@
+### MODIS (Terra and Aqua) Fraction of Photosynthetically Active Radiation (Level 3, 4-Day)
+Temporal coverage: 4 July 2002 - present
+
+### MODIS (Terra and Aqua) Fraction of Photosynthetically Active Radiation (Level 3, 8-Day)
+Temporal coverage: 4 July 2002 - present
+
+### MODIS (Aqua/Terra) Fraction of Photosynthetically Active Radiation (Level 3, 8-Day)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/GrossPrimaryProduction.md
+++ b/config/default/common/config/metadata/layers/modis/GrossPrimaryProduction.md
@@ -1,0 +1,2 @@
+### MODIS (Aqua/Terra) Gross Primary Production (Level 3, 8-Day)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/IceSurfaceTemperature.md
+++ b/config/default/common/config/metadata/layers/modis/IceSurfaceTemperature.md
@@ -6,3 +6,7 @@ The MODIS Sea Ice Surface Temperature layer shows the surface temperature of Arc
 The MODIS Ice Surface Temperature product is available from both the Terra (MOD29) and Aqua (MYD29) satellites. The sensor and imagery resolution is 1km, and the temporal resolution is daily.
 
 References: [NSIDC – MOD29](http://nsidc.org/data/MOD29); [NSIDC – MYD29](http://nsidc.org/data/MYD29)
+
+
+### MODIS (Terra/Aqua) Ice Surface Temperature (Level 3, Daily, Day | Night)
+Temporal Coverage: 24 February 2000 - present (Terra); 3 July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/LandCover.md
+++ b/config/default/common/config/metadata/layers/modis/LandCover.md
@@ -1,0 +1,2 @@
+### MODIS (Terra and Aqua) Land Cover Type (Level 3, IGBP, Yearly)
+Temporal coverage: 2000 - 2017

--- a/config/default/common/config/metadata/layers/modis/LandSurfaceReflectance.md
+++ b/config/default/common/config/metadata/layers/modis/LandSurfaceReflectance.md
@@ -38,3 +38,15 @@ The MODIS Land Surface Reflectance product is available from both the Terra (MOD
 The MODIS Corrected Reflectance algorithm utilizes MODIS Level 1B data (the calibrated, geolocated radiances). It is not a standard, science quality product. The purpose of this algorithm is to provide natural-looking images by removing gross atmospheric effects, such as Rayleigh scattering, from MODIS visible bands 1-7. The algorithm was developed by the original MODIS Rapid Response team to address the needs of the fire monitoring community who want to see smoke. Corrected Reflectance shows smoke more clearly than the standard Surface Reflectance product. In contrast, the MODIS Land Surface Reflectance product (MOD09) is a more complete atmospheric correction algorithm that includes aerosol correction, and is designed to derive land surface properties. In clear atmospheric conditions the Corrected Reflectance product is very similar to the MOD09 product, but they depart from each other in presence of aerosols. If you wish to perform a complete atmospheric correction, please do not use the Corrected Reflectance algorithm. An additional difference is that the Land Surface Reflectance product is only tuned for calculating the reflectance over land surfaces.
 
 References: [MODAPS - MOD09](https://modaps.modaps.eosdis.nasa.gov/services/about/products/c6-nrt/MOD09.html);[MODAPS - MYD09](https://modaps.modaps.eosdis.nasa.gov/services/about/products/c6-nrt/MYD09.html); [NASA Earthdata - Creating Reprojected True Color MODIS Images: A Tutorial](https://earthdata.nasa.gov/files/MODIS_True_Color.pdf)
+
+### MODIS (Aqua/Terra) Land Surface Reflectance (Level 3, Daily, True Color)
+Temporal coverage: 24 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Land Surface Reflectance (Level 3, 8-Day, True Color)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Land Surface Reflectance (Level 3, 8-Day, Bands 7-2-1)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Land Surface Reflectance (Level 3, 8-Day, Bands 1-2-1)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/LandSurfaceTemperature.md
+++ b/config/default/common/config/metadata/layers/modis/LandSurfaceTemperature.md
@@ -6,3 +6,12 @@ The MODIS Land Surface Temperature layer shows the temperature of the land surfa
 The MODIS Land Surface Temperature product is available from both Terra (MOD11) and Aqua (MYD11) satellites. The sensor and imagery resolution is 1 km, and the temporal resolution is daily.
 
 References: [NASA Earth Observations - Land Surface Temperature](http://neo.sci.gsfc.nasa.gov/view.php?datasetId=MOD11C1_M_LSTDA); [ICESS - MODIS Land Surface Temperature Group](http://www.icess.ucsb.edu/modis/modis-lst.html); [MODIS - ATBD MOD11](http://modis.gsfc.nasa.gov/data/atbd/atbd_mod11.pdf); [LP DAAC - MYD11_L2](https://doi.org/10.5067/MODIS/MYD11_L2.006); [LP DAAC - MOD11_L2](https://doi.org/10.5067/MODIS/MOD11_L2.006).
+
+### MODIS (Aqua/Terra) Land Surface Temperature (Level 3, Daily, Day | Night)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Land Surface Temperature (Level 3, 8-Day, Day | Night)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Land Surface Temperature (Level 3, Monthly, Day | Night)
+Temporal coverage: January 2003 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/LandWaterMask.md
+++ b/config/default/common/config/metadata/layers/modis/LandWaterMask.md
@@ -1,0 +1,2 @@
+### MODIS (Terra) Land/Water Mask (Level 3, Annual)
+Temporal coverage: 2000 - 2015

--- a/config/default/common/config/metadata/layers/modis/LeafAreaIndex.md
+++ b/config/default/common/config/metadata/layers/modis/LeafAreaIndex.md
@@ -1,0 +1,8 @@
+### MODIS (Terra and Aqua) Leaf Area Index (Level 3, 4-Day)
+Temporal coverage: 4 July 2002 - present
+
+### MODIS (Terra and Aqua) Leaf Area Index (Level 3, 8-Day)
+Temporal coverage: 4 July 2002 - present
+
+### MODIS (Aqua/Terra) Leaf Area Index (Level 3, 8-Day)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/NetPhotosynthesis.md
+++ b/config/default/common/config/metadata/layers/modis/NetPhotosynthesis.md
@@ -1,0 +1,2 @@
+### MODIS (Aqua/Terra) Net Photosynthesis (Level 3, 8-Day)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/Reflectance.md
+++ b/config/default/common/config/metadata/layers/modis/Reflectance.md
@@ -1,0 +1,2 @@
+### MODIS (Terra and Aqua) Reflectance (Level 3, BRDF-Adjusted, Daily)
+Temporal coverage: 18 May 2000 - present

--- a/config/default/common/config/metadata/layers/modis/SeaIce.md
+++ b/config/default/common/config/metadata/layers/modis/SeaIce.md
@@ -6,3 +6,6 @@ The MODIS Sea Ice extent layer shows the presence of sea ice. Ice forms in the s
 The MODIS Sea Ice product is available from both the Terra (MOD29) and Aqua (MYD29) satellites. The sensor and imagery resolution is 1 km, and the temporal resolution is daily.
 
 References: [NSIDC - MOD29](http://nsidc.org/data/mod29); [NSIDC - MYD29](http://nsidc.org/data/myd29); [NASA Earth Observations - Sea Ice and Snow Extent](http://neo.sci.gsfc.nasa.gov/view.php?datasetId=SCSIE_W)
+
+### MODIS (Aqua/Terra) Sea Ice Extent (Level 3, Daily)
+Temporal Coverage: 24 February 2000 - present (Terra); 4 July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/SnowCover.md
+++ b/config/default/common/config/metadata/layers/modis/SnowCover.md
@@ -6,3 +6,9 @@ The MODIS Normalized Difference Snow Index (NDSI) snow cover layer shows the pre
 The MODIS Snow Cover (Normalized Difference Snow Index) layer is available from both the Terra (MOD10) and Aqua (MYD10) satellites. The sensor and imagery resolution is 500 m and the temporal resolution is daily.
 
 References: [NSIDC - MYD10_L2](http://nsidc.org/data/myd10_l2); [NSIDC - MOD10_L2](http://nsidc.org/data/mod10_l2); [NASA Earth Observations - Snow Cover](http://neo.sci.gsfc.nasa.gov/view.php?datasetId=MOD10C1_M_SNOW)
+
+### MODIS (Aqua/Terra) Snow Cover (Normalized Difference Snow Index, Level 3, Daily)
+Temporal coverage: 24 February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Aqua/Terra) Days with Snow Cover (Level 3, Monthly, Average Percent)
+Temporal coverage: March 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/SnowExtent.md
+++ b/config/default/common/config/metadata/layers/modis/SnowExtent.md
@@ -1,0 +1,2 @@
+### MODIS (Aqua/Terra) Snow Extent (Level 3, 8-Day)
+Temporal coverage: 26 February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/metadata/layers/modis/VegetationIndices.md
+++ b/config/default/common/config/metadata/layers/modis/VegetationIndices.md
@@ -15,3 +15,15 @@ The MODIS rolling 8-day EVI layer is available as a near real-time, rolling 8-da
 
 References:
 [NASA Earth Observatory - Measuring Vegetation](http://earthobservatory.nasa.gov/Features/MeasuringVegetation/measuring_vegetation_4.php); [NASA Earthdata - New Vegetation Indices and Surface Reflectance Products Available from LANCE](https://earthdata.nasa.gov/earth-observation-data/near-real-time/new-vegetation-indices-and-surface-reflectance-products-available-from-lance); [NASA NEO - Vegetation Index](https://neo.sci.gsfc.nasa.gov/view.php?datasetId=MOD_NDVI_M)
+
+### MODIS (Terra/Aqua) Vegetation Index (Level 3, 16-Day)
+Temporal coverage: 4 March 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Terra/Aqua) Vegetation Index (Level 3, Monthly)
+Temporal coverage: February 2000 - present (Terra); July 2002 - present (Aqua)
+
+### MODIS (Terra/Aqua) Enhanced Vegetation Index (Level 3, 16-Day)
+Temporal coverage: 4 March 2000 - present (Terra); 3 July 2002 - present (Aqua)
+
+### MODIS (Terra/Aqua) Enhanced Vegetation Index (Level 3, Monthly)
+Temporal coverage: February 2000 - present (Terra); July 2002 - present (Aqua)

--- a/config/default/common/config/wv.json/categories/scientific/Land Surface.json
+++ b/config/default/common/config/wv.json/categories/scientific/Land Surface.json
@@ -22,6 +22,7 @@
                     "Land Surface Reflectance",
                     "Land Surface Temperature",
                     "Radiance",
+                    "Reflectance",
                     "Solar Induced Chlorophyll Fluorescence",
                     "Soil Moisture",
                     "Soil Temperature",

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Water_Mask.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Water_Mask.json
@@ -11,6 +11,7 @@
               "modis_terra"
             ],
             "product":  "MOD44W",
+            "inactive": true,
             "wrapadjacentdays": true
         }
     }

--- a/config/default/common/config/wv.json/measurements/Ice Surface Temperature.json
+++ b/config/default/common/config/wv.json/measurements/Ice Surface Temperature.json
@@ -13,8 +13,8 @@
                         "settings": [
                             "MODIS_Aqua_Ice_Surface_Temp_Day",
                             "MODIS_Aqua_Ice_Surface_Temp_Night",
-                            "MODIS_Terra_L3_Ice_Surface_Temp_Daily_Day",
-                            "MODIS_Terra_L3_Ice_Surface_Temp_Daily_Night",
+                            "MODIS_Aqua_L3_Ice_Surface_Temp_Daily_Day",
+                            "MODIS_Aqua_L3_Ice_Surface_Temp_Daily_Night",
                             "OrbitTracks_Aqua_Descending",
                             "OrbitTracks_Aqua_Ascending"
                         ]

--- a/config/default/common/config/wv.json/measurements/Reference Map.json
+++ b/config/default/common/config/wv.json/measurements/Reference Map.json
@@ -3,7 +3,7 @@
         "Reference Map": {
             "id": "reference-map",
             "title":    "Reference Map",
-            "subtitle": "OpenStreetMap.org",
+            "subtitle": "OpenStreetMap.org, Terra/MODIS",
             "multichoice": true,
             "sources": {
                 "OpenStreetMap.org": {
@@ -17,6 +17,15 @@
                         "Coastlines",
                         "Land_Mask",
                         "Land_Water_Map"
+                    ]
+                },
+                "Terra/MODIS": {
+                    "id": "terra-modis",
+                    "title": "Terra/MODIS",
+                    "description": "modis/LandWaterMask",
+                    "image": "",
+                    "settings": [
+                      "MODIS_Terra_L3_Land_Water_Mask"
                     ]
                 }
             }

--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -142,10 +142,8 @@
                 ["VIIRS_SNPP_CorrectedReflectance_TrueColor", true],
                 ["MODIS_Aqua_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", false],
-                ["GMI_Rain_Rate_Dsc", false],
-                ["GMI_Rain_Rate_Asc", false],
-                ["AMSR2_Surface_Rain_Rate_Night", false],
-                ["AMSR2_Surface_Rain_Rate_Day", false]
+                ["IMERG_Rain_Rate", true],
+                ["IMERG_Snow_Rate", false]
             ],
             "Snow": [
                 ["Reference_Features", true],
@@ -156,13 +154,15 @@
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", false],
                 ["MODIS_Terra_CorrectedReflectance_Bands367", false],
                 ["MODIS_Aqua_NDSI_Snow_Cover", false],
-                ["MODIS_Terra_NDSI_Snow_Cover", false]
+                ["MODIS_Terra_NDSI_Snow_Cover", false],
+                ["IMERG_Snow_Rate", false]
             ],
             "Floods": [
                 ["Reference_Features", true],
                 ["Reference_Labels", true],
-                ["MODIS_Aqua_SurfaceReflectance_Bands121", false],
-                ["MODIS_Terra_SurfaceReflectance_Bands121", true]
+                ["MODIS_Aqua_CorrectedReflectance_Bands721", false],
+                ["MODIS_Terra_CorrectedReflectance_Bands721", false],
+                ["VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1", true]
             ],
             "Volcanoes": [
                 ["MODIS_Terra_CorrectedReflectance_TrueColor", true],


### PR DESCRIPTION
## Description

- Fixes #1804  - IMERG Rain and Snow rates are back up and running, added them back in as defaults for Severe Storm Events. 
- Added missing metadata files for MODIS Level 3 measurements

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
