### PR TITLE
Add full core-js es5,es6,es7 support for polyfills used in IE11

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -7,6 +7,8 @@ import 'core-js/fn/object/keys';
 import 'core-js/fn/object/entries';
 import 'core-js/fn/string/includes';
 import 'core-js/fn/array/includes';
+import 'core-js/fn/number/is-nan';
+import 'core-js/fn/number/parse-float';
 import 'core-js/es6/symbol';
 import 'core-js/es6/promise';
 import 'regenerator-runtime/runtime';

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,16 +1,8 @@
 /* global DEBUG */
 // IE11 corejs polyfills container
-import 'core-js/fn/array/find';
-import 'core-js/fn/object/assign';
-import 'core-js/fn/object/values';
-import 'core-js/fn/object/keys';
-import 'core-js/fn/object/entries';
-import 'core-js/fn/string/includes';
-import 'core-js/fn/array/includes';
-import 'core-js/fn/number/is-nan';
-import 'core-js/fn/number/parse-float';
-import 'core-js/es6/symbol';
-import 'core-js/es6/promise';
+import 'core-js/es5';
+import 'core-js/es6';
+import 'core-js/es7';
 import 'regenerator-runtime/runtime';
 // IE11 corejs polyfills container
 import 'whatwg-fetch';


### PR DESCRIPTION
## Description

Fixes #1825  .

Add full core-js es5, es6, and es7 support for polyfills used in IE11. This fix will address current polfyill needs and should handle any future packages/necessary polyfills for IE11.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
