### PR TITLE
Style fixes for tour step and custom interval selector, fix timeline hide conditional

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -412,7 +412,6 @@ button:focus {
 
 .custom-interval-timescale-select-form-container {
   width: 100px;
-  height: 40px;
   color: #7890cd;
   opacity: 1;
   font-size: 16px;

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -218,11 +218,11 @@
 
 /* .tour-in-progress */
 .tour-in-progress .modal {
-  left: unset;
+  left: auto;
   right: 10px;
-  top: unset;
+  top: auto;
   width: 248px;
-  bottom: 180px;
+  bottom: 275px;
   height: 200px;
   overflow: visible;
 }
@@ -781,7 +781,7 @@
 
 @media (max-height: 712px) {
   .tour-in-progress .modal-content {
-    height: 250px;
+    height: 275px;
   }
 }
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -829,6 +829,7 @@ class Timeline extends React.Component {
       hasMoved
     } = this.state;
     let selectedDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
+    let isTimelineHidden = timelineHidden || hideTimeline;
     return (
       <div className="timeline-container">
         {initialLoadComplete
@@ -883,7 +884,7 @@ class Timeline extends React.Component {
                 <div id="timeline-footer"
                   style={{
                     display:
-                      timelineHidden || hideTimeline ? 'none' : 'block'
+                      isTimelineHidden ? 'none' : 'block'
                   }}
                 >
                   {/* Axis */}
@@ -1032,14 +1033,14 @@ class Timeline extends React.Component {
                   changeTimeScale={this.changeTimeScale}
                   isDraggerDragging={isDraggerDragging}
                   hasSubdailyLayers={hasSubdailyLayers}
-                  timelineHidden={timelineHidden}
+                  timelineHidden={isTimelineHidden}
                 />
 
                 {/* Open/Close Chevron */}
                 <div id="timeline-hide" onClick={this.toggleHideTimeline}>
                   <div
                     className={`wv-timeline-hide wv-timeline-hide-double-chevron-${
-                      timelineHidden ? 'left' : 'right'
+                      isTimelineHidden ? 'left' : 'right'
                     }`}
                   />
                 </div>


### PR DESCRIPTION
## Description

- Fixes #1824 
- Fixes #1833 
- Fixes auto/manual timeline hiding consistency (clicking to hide timeline and automatic hiding of timeline from image/gif creation was slightly different in what got hidden)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

The tour step (related to #1824) may need further style tweaking for browser consistency.

@nasa-gibs/worldview
