### PR TITLE
Check data state at time of granule swath removal for currently selected granules

### DIFF
--- a/web/js/map/data/ui.js
+++ b/web/js/map/data/ui.js
@@ -765,6 +765,8 @@ var dataUiDownloadListPanel = function(config, store) {
 
   var removeGranule = function() {
     var id = $(this).attr('data-granule');
+    let state = store.getState();
+    let dataStore = state.data;
     store.dispatch(toggleGranule(dataStore.selectedGranules[id]));
     onHoverOut.apply(this);
   };

--- a/web/js/map/data/ui.js
+++ b/web/js/map/data/ui.js
@@ -416,8 +416,6 @@ var dataUiBulkDownloadPage = (function() {
 })();
 
 var dataUiDownloadListPanel = function(config, store) {
-  const state = store.getState();
-  const dataStore = state.data;
   var NOTICE =
     "<div id='wv-data-selection-notice'>" +
     "<i class='icon fa fa-info-circle fa-3x'></i>" +
@@ -765,9 +763,8 @@ var dataUiDownloadListPanel = function(config, store) {
 
   var removeGranule = function() {
     var id = $(this).attr('data-granule');
-    let state = store.getState();
-    let dataStore = state.data;
-    store.dispatch(toggleGranule(dataStore.selectedGranules[id]));
+    const dataState = store.getState().data;
+    store.dispatch(toggleGranule(dataState.selectedGranules[id]));
     onHoverOut.apply(this);
   };
 


### PR DESCRIPTION
## Description

Fixes #1845 

- Granule swath removal wasn't using updated store - check data state at time of granule removal for currently selected granules

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
