### PR TITLE
Fix compare/timeline-test errors related to dragger x position

### DIFF
--- a/e2e/features/compare/timeline-test.js
+++ b/e2e/features/compare/timeline-test.js
@@ -26,7 +26,7 @@ module.exports = {
 
     client
       .useCss()
-      .moveToElement(draggerA, 30, 20)
+      .moveToElement(draggerA, -20, 20)
       .mouseButtonDown(0)
       .moveToElement(draggerB, -100, 0)
       .mouseButtonUp(0)
@@ -42,7 +42,7 @@ module.exports = {
     client.assert.cssClassPresent(localSelectors.aTab, 'active');
     client
       .useCss()
-      .moveToElement(draggerB, 30, 20)
+      .moveToElement(draggerB, -20, 20)
       .mouseButtonDown(0)
       .mouseButtonUp(0);
     // Reference labels were not active in A but are in B
@@ -58,7 +58,7 @@ module.exports = {
     client.useCss().assert.containsText(localSelectors.bTab, '2018-08-16');
     client
       .useCss()
-      .moveToElement(draggerB, 30, 20)
+      .moveToElement(draggerB, -20, 20)
       .mouseButtonDown(0)
       .moveToElement(draggerA, -100, 0)
       .mouseButtonUp(0)


### PR DESCRIPTION
## Description

Fixes errors seen in `compare/timeline-test` where dragger wasn't being moved.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
