### PR TITLE
Update v3.0 tour modal styles to match v2.17

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -785,7 +785,7 @@
 
 @media (max-height: 712px) {
   .tour-in-progress .modal {
-    bottom: 278px;
+    bottom: 232px;
   }
   .tour-in-progress .modal-content {
     height: 250px;
@@ -794,7 +794,7 @@
 
 @media (max-height: 665px) {
   .tour-in-progress .modal {
-    bottom: 228px;
+    bottom: 178px;
   }
 
   .tour-in-progress .modal-content {
@@ -803,10 +803,6 @@
 }
 
 @media (min-height: 450px) {
-  .tour-in-progress .modal {
-    bottom: 78px;
-  }
-
   .tour {
     display: block;
   }

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -775,24 +775,38 @@
 }
 
 @media (max-height: 776px) {
+  .tour-in-progress .modal {
+    bottom: 278px;
+  }
   .tour-in-progress .modal-content {
     height: 300px;
   }
 }
 
 @media (max-height: 712px) {
+  .tour-in-progress .modal {
+    bottom: 278px;
+  }
   .tour-in-progress .modal-content {
-    height: 275px;
+    height: 250px;
   }
 }
 
 @media (max-height: 665px) {
+  .tour-in-progress .modal {
+    bottom: 228px;
+  }
+
   .tour-in-progress .modal-content {
     height: 200px;
   }
 }
 
 @media (min-height: 450px) {
+  .tour-in-progress .modal {
+    bottom: `78px;
+  }
+
   .tour {
     display: block;
   }

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -804,7 +804,7 @@
 
 @media (min-height: 450px) {
   .tour-in-progress .modal {
-    bottom: `78px;
+    bottom: 78px;
   }
 
   .tour {

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -65,7 +65,6 @@
   -webkit-transform: translate(0, 0);
 }
 
-.tour-complete .modal-dialog .modal-content,
 .tour-start .modal-dialog .modal-content {
   background-color: #eee;
   border: 0;
@@ -599,7 +598,8 @@
   -webkit-transform: translate(0, 0);
 }
 
-.tour-complete .modal-content {
+.tour-complete .modal-dialog .modal-content {
+  background-color: #fff;
   border: 0;
   border-radius: 0;
 }

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -219,10 +219,10 @@
 /* .tour-in-progress */
 .tour-in-progress .modal {
   left: auto;
-  right: 10px;
+  right: 0;
   top: auto;
   width: 248px;
-  bottom: 275px;
+  bottom: 333px;
   height: 200px;
   overflow: visible;
 }
@@ -247,11 +247,12 @@
   -webkit-transform: translate(0, 0);
 }
 
-.tour-in-progress .modal-content {
+.tour-in-progress .modal-dialog .modal-content {
   min-width: 248px;
   max-height: 357px;
   background-color: rgba(255, 255, 255, 0.85);
   border-radius: 8px 0 0 8px;
+  border: none;
 }
 
 .tour-in-progress .modal-header {


### PR DESCRIPTION
## Description

The background color became slightly darker on the tour in-progress and tour complete modals (likely due to an update to bootstrap/reactstrap adding an extra div). A bordered also got added to the in-progress modal. 

- Revert the styles back to how they appeared before the update.
- Position the in-progress modal to be flush with the edge of the screen. 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

@edplato double-check the styles in IE11

@nasa-gibs/worldview
