### PR TITLE
Fix external links in layer descriptions/stories not opening in new tabs

### DIFF
--- a/tasks/config.js
+++ b/tasks/config.js
@@ -6,7 +6,7 @@ const showdown = require('showdown');
 const shell = require('shelljs');
 
 console.log('Converting markdown to html');
-let converter = new showdown.Converter();
+let converter = new showdown.Converter({ openLinksInNewWindow: true });
 
 let configFiles = glob.sync('build/options/config/metadata/**/*.md');
 for (let configFile of configFiles) {

--- a/web/js/components/util/list.js
+++ b/web/js/components/util/list.js
@@ -28,7 +28,8 @@ export default class List extends React.Component {
               active={isActive}
               id={item.id || ''}
               className={className + ' ' + size + '-item'}
-              href={item.href ? item.href : 'false'}
+              href={item.href ? item.href : undefined}
+              target={item.href ? '_blank' : undefined}
               onClick={
                 item.onClick
                   ? item.onClick


### PR DESCRIPTION


## Description
Configure showdown with openLinksInNewWindow option so that target='_… blank' is added to all links in layer metadata/stories when md files are converted to html

Fixes #1718  

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
