### PR TITLE
Prevent timeline left/right arrow event listener change when focused on input

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -326,6 +326,10 @@ button:focus {
   margin-bottom: 5px;
 }
 
+#zoom-btn-container-axis:hover {
+  cursor: pointer;
+}
+
 .zoom-level-display-text {
   color: #fff;
   font-family: 'Roboto Mono', monospace;

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -372,12 +372,17 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   handleKeyDown = (e) => {
-    if (e.keyCode === 37) {
-      e.preventDefault();
-      this.throttleDecrementDate();
-    } else if (e.keyCode === 39) {
-      e.preventDefault();
-      this.throttleIncrementDate();
+    // prevent left/right arrows changing date within inputs
+    if (e.target.tagName !== 'INPUT') {
+      // left arrow
+      if (e.keyCode === 37) {
+        e.preventDefault();
+        this.throttleDecrementDate();
+      // right arrow
+      } else if (e.keyCode === 39) {
+        e.preventDefault();
+        this.throttleIncrementDate();
+      }
     }
   };
   /**
@@ -386,9 +391,11 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   handleKeyUp = (e) => {
+    // left arrow
     if (e.keyCode === 37) {
       e.preventDefault();
       this.stopLeftArrow();
+    // right arrow
     } else if (e.keyCode === 39) {
       e.preventDefault();
       this.stopRightArrow();


### PR DESCRIPTION
## Description


- [x] Prevent timeline left/right arrow event listener change when focused on input. Fixes #1866  
- [x] Add hover cursor styling for selected zoom

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
