### PR TITLE
Animation start/end date updates

### DIFF
--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -3,6 +3,7 @@ import { register } from 'ol/proj/proj4';
 import { initialState as initialLayerState } from './modules/layers/reducers';
 import { initialCompareState } from './modules/compare/reducers';
 import { getInitialState as getInitialDateState } from './modules/date/reducers';
+import { defaultState as initialAnimationState } from './modules/animation/reducers';
 var fixtures = {
   red: 'ff0000ff',
   light_red: 'fff0f0ff',
@@ -19,6 +20,7 @@ fixtures.getState = function() {
     config: fixtures.config(),
     layers: initialLayerState,
     date: getInitialDateState(fixtures.config()),
+    animation: initialAnimationState,
     palettes: {
       active: {},
       activeB: {},

--- a/web/js/modules/animation/actions.js
+++ b/web/js/modules/animation/actions.js
@@ -19,17 +19,17 @@ export function onActivate() {
     const activeDate = date[dateStr];
     if (!animation.startDate || !animation.endDate) {
       const sevenDaysBefore = util.dateAdd(activeDate, 'day', -7);
-      const severDaysAfter = util.dateAdd(activeDate, 'day', 7);
+      const sevenDaysAfter = util.dateAdd(activeDate, 'day', 7);
       const startDate = animation.startDate
         ? animation.startDate
-        : date.appNow < severDaysAfter
+        : date.appNow < sevenDaysAfter
           ? sevenDaysBefore
           : activeDate;
       const endDate = animation.endDate
         ? animation.endDate
-        : date.appNow < severDaysAfter
+        : date.appNow < sevenDaysAfter
           ? activeDate
-          : severDaysAfter;
+          : sevenDaysAfter;
       dispatch({ type: UPDATE_START_AND_END_DATE, startDate, endDate });
     }
     dispatch({ type: OPEN_ANIMATION });

--- a/web/js/modules/animation/actions.js
+++ b/web/js/modules/animation/actions.js
@@ -10,12 +10,29 @@ import {
   UPDATE_END_DATE,
   TOGGLE_GIF
 } from './constants';
+import util from '../../util/util';
 
 export function onActivate() {
   return (dispatch, getState) => {
-    const { compare, date } = getState();
+    const { compare, date, animation } = getState();
     const dateStr = compare.isCompareA ? 'selected' : 'selectedB';
-    dispatch({ type: OPEN_ANIMATION, date: date[dateStr] });
+    const activeDate = date[dateStr];
+    if (!animation.startDate || !animation.endDate) {
+      const sevenDaysBefore = util.dateAdd(activeDate, 'day', -7);
+      const severDaysAfter = util.dateAdd(activeDate, 'day', 7);
+      const startDate = animation.startDate
+        ? animation.startDate
+        : date.appNow < severDaysAfter
+          ? sevenDaysBefore
+          : activeDate;
+      const endDate = animation.endDate
+        ? animation.endDate
+        : date.appNow < severDaysAfter
+          ? activeDate
+          : severDaysAfter;
+      dispatch({ type: UPDATE_START_AND_END_DATE, startDate, endDate });
+    }
+    dispatch({ type: OPEN_ANIMATION });
   };
 }
 export function onClose() {

--- a/web/js/modules/animation/actions.test.js
+++ b/web/js/modules/animation/actions.test.js
@@ -125,8 +125,13 @@ test(
     const mockStore = configureMockStore(middlewares);
     const store = mockStore(state);
     store.dispatch(onActivate());
-    const response = store.getActions()[0];
-    expect(response.type).toEqual(constants.OPEN_ANIMATION);
-    expect(response.date).toEqual(state.date.selected);
+    const response1 = store.getActions()[0];
+    const response2 = store.getActions()[1];
+    expect(response1.type).toEqual(constants.UPDATE_START_AND_END_DATE);
+    expect(response1.endDate).toEqual(state.date.selected);
+    expect(response1.startDate).toEqual(
+      util.dateAdd(state.date.selected, 'day', -7)
+    );
+    expect(response2.type).toEqual(constants.OPEN_ANIMATION);
   }
 );

--- a/web/js/modules/animation/reducer.test.js
+++ b/web/js/modules/animation/reducer.test.js
@@ -5,13 +5,11 @@ import update from 'immutability-helper';
 const now = new Date();
 const then = util.dateAdd(now, 'day', -7);
 
-test('OPEN_ANIMATION action updates start and end dates', () => {
+test('OPEN_ANIMATION action updates active state', () => {
   const response = animationReducer(defaultState, {
-    type: CONSTANTS.OPEN_ANIMATION,
-    date: now
+    type: CONSTANTS.OPEN_ANIMATION
   });
-  expect(response.startDate).toEqual(then);
-  expect(response.endDate).toEqual(now);
+
   expect(response.isActive).toEqual(true);
 });
 

--- a/web/js/modules/animation/reducers.js
+++ b/web/js/modules/animation/reducers.js
@@ -35,11 +35,7 @@ export function animationReducer(state = defaultState, action) {
     case OPEN_ANIMATION:
       return lodashAssign({}, state, {
         isActive: true,
-        gifActive: false,
-        startDate: state.startDate
-          ? state.startDate
-          : util.dateAdd(action.date, 'day', -7),
-        endDate: state.endDate ? state.endDate : action.date
+        gifActive: false
       });
     case EXIT_ANIMATION:
       return lodashAssign({}, state, {

--- a/web/js/modules/animation/util.js
+++ b/web/js/modules/animation/util.js
@@ -1,4 +1,4 @@
-import { round as lodashRound } from 'lodash';
+import { round as lodashRound, get as lodashGet } from 'lodash';
 import canvg from 'canvg-browser';
 import util from '../../util/util';
 import update from 'immutability-helper';
@@ -117,9 +117,21 @@ export function mapLocationToAnimationState(
   state,
   config
 ) {
+  const startDate = lodashGet(stateFromLocation, 'animation.startDate');
+  const endDate = lodashGet(stateFromLocation, 'animation.endDate');
   if (parameters.playanim && parameters.ab) {
     stateFromLocation = update(stateFromLocation, {
       animation: { isPlaying: { $set: true } }
+    });
+  } else if (!parameters.ae || (!parameters.as && (!!endDate || !!startDate))) {
+    // wipe anim start & end dates on tour change
+
+    stateFromLocation = update(stateFromLocation, {
+      animation: { endDate: { $set: undefined } }
+    });
+
+    stateFromLocation = update(stateFromLocation, {
+      animation: { startDate: { $set: undefined } }
     });
   }
   return stateFromLocation;


### PR DESCRIPTION
## Description

Fixes #1869

- [x] start and end dates are refreshed when tour date changes
- [x] startdate should be active date and end date should be 7 days later unless 7 days later is past today's date

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
