### PR TITLE
Fix event track points not setting date correctly after clicking a supercluster (or switching sidebar tabs)

### DIFF
--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -50,11 +50,13 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
               ui.naturalEvents.eventsData,
               selectedEvent.id
             );
-            debounceTrackUpdate(event, selectedEvent.date, map, () =>
+            debounceTrackUpdate(event, selectedEvent.date, map, (id, date) => {
+              id = id || selectedEvent.id;
+              date = date || selectedEvent.date;
               store.dispatch(
-                selectEventAction(selectedEvent.id, selectedEvent.date)
-              )
-            );
+                selectEventAction(id, date)
+              );
+            });
           }
         }
       }
@@ -291,6 +293,7 @@ var naturalEventsTrackPoint = function(
   overlayEl.dataset.id = eventID;
   overlayEl.id = 'track-marker-case-' + date;
   overlayEl.onclick = function() {
+    console.log('SELECTED DATE:', date);
     callback(eventID, date);
   };
   textEl.appendChild(content);


### PR DESCRIPTION
## Description

Fixes #1871
After debounceTrackUpdate was called (due to clicking a supercluster, for example), the selected event date being passed to the callback for update track fn was always the previously selected event date, since the callback was ignoring the id/date params that were being passed in from the onClick handler for the track point. The callback function was modified to accept id/date params so that the action being dispatched properly uses the id/date of the event track point that was just clicked.

This issue also occurred whenever the user switched away from the "Events" tab and back again.  Therefore, in order to test all of the changes in this PR reviewers should also test the following scenario (in addition to the one mentioned in the original ticket):

1. Go to: `?v=-151.0240425531915,-78.8268085106383,-124.02404255319149,-51.03957446808511&t=2019-06-14-T00%3A00%3A00Z&e=EONET_2733&l=MODIS_Terra_Sea_Ice(hidden),MODIS_Aqua_Sea_Ice(hidden),MODIS_Aqua_Brightness_Temp_Band31_Night(hidden),MODIS_Aqua_Brightness_Temp_Band31_Day(hidden),MODIS_Terra_Brightness_Temp_Band31_Night(hidden),MODIS_Terra_Brightness_Temp_Band31_Day(hidden),VIIRS_SNPP_DayNightBand_ENCC(hidden),Reference_Labels,Reference_Features,Coastlines(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor`
2. Switch away from the "Events" tab by clicking on the "Layers" tab
3. Confirm all event tracks/points are removed
4. Click on the "Events" tab again
5. Confirm event tracks/points show again
6. Start clicking visible points on the track
7. Confirm that the current date is updated as you click through track points

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
