### PR TITLE
Fix IE11 selecting other DOM elements while dragging swiper in compare mode and cursor

### DIFF
--- a/web/css/compare.css
+++ b/web/css/compare.css
@@ -5,6 +5,11 @@
   top: 0;
   width: 1px;
   background: #fff;
+  cursor: move;
+  cursor: grab;
+  user-select: none;
+}
+.ab-swipe-line:active {
   cursor: grabbing;
 }
 .ab-swipe-dragger {


### PR DESCRIPTION
## Description

- [x] Prevent IE11 user select while dragging compare swipe (would highlight swipe, +/- buttons, and distance scale). Fixes #1888 
- [x] `grab` and `grabbing` cursors are not supported in IE11, so use backup `move` cursor.
- [x] The above fix prompted a quick css styling that moves `grabbing` to the `active` selector and `grab` as it's default style. This style change is visible in Chrome or another supported browser.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
