### PR TITLE
Fix supercluster overlays sometimes not being removed when zooming in

### DIFF
--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -634,7 +634,7 @@ function getClusterPointEl(proj, cluster, map, pointClusterObj, callback) {
     positioning: 'center-center',
     element: overlayEl,
     stopEvent: false,
-    id: clusterId
+    id: clusterId + properties.startDate + properties.endDate
   });
 }
 function addOverlayIfIsVisible(map, overlay) {


### PR DESCRIPTION
## Description

Fixes #1885.

There was an issue where an overlay representing a cluster could easily be assigned the same id as another overlay representing a different cluster.  This is easily remedied by appending the start/end dates to the cluster id so that we end up with a unique layer id.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
