### PR TITLE
Fix vector style not being applied when changing date

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -38,6 +38,7 @@ import * as layerConstants from '../modules/layers/constants';
 import * as compareConstants from '../modules/compare/constants';
 import * as paletteConstants from '../modules/palettes/constants';
 import * as vectorStyleConstants from '../modules/vector-styles/constants';
+import { setStyleFunction } from '../modules/vector-styles/selectors';
 import {
   getLayers,
   isRenderable as isRenderableLayer
@@ -592,6 +593,8 @@ export function mapui(models, config, store, ui) {
       }
     }
     lodashEach(activeLayers, function(def) {
+      const layerName = def.layer || def.id;
+
       if (!['subdaily', 'daily', 'monthly', 'yearly'].includes(def.period)) {
         return;
       }
@@ -611,6 +614,21 @@ export function mapui(models, config, store, ui) {
       } else {
         let index = findLayerIndex(def);
         self.selected.getLayers().setAt(index, createLayer(def));
+      }
+      if (config.vectorStyles && def.vectorStyle && def.vectorStyle.id) {
+        var vectorStyles = config.vectorStyles;
+        var vectorStyleId;
+
+        vectorStyleId = def.vectorStyle.id;
+        if (state.layers[activeLayerStr]) {
+          let layers = state.layers[activeLayerStr];
+          layers.forEach(layer => {
+            if (layer.id === layerName && layer.custom) {
+              vectorStyleId = layer.custom;
+            }
+          });
+        }
+        setStyleFunction(def, vectorStyleId, vectorStyles, null, state);
       }
     });
     updateLayerVisibilities();


### PR DESCRIPTION
## Description

Fixes an issue where a vector style loaded outside of it's date range does not have it's style applied when changing to a visible date. There was no method to update styles (i.e. `setStyleFunction`) when `updateDate` was being ran.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
