### PR TITLE
Prevent ctrl or cmd plus left/right timeline arrows from invoking change date function

### DIFF
--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -373,7 +373,7 @@ class Timeline extends React.Component {
   */
   handleKeyDown = (e) => {
     // prevent left/right arrows changing date within inputs
-    if (e.target.tagName !== 'INPUT') {
+    if (e.target.tagName !== 'INPUT' && !e.ctrlKey && !e.metaKey) {
       // left arrow
       if (e.keyCode === 37) {
         e.preventDefault();


### PR DESCRIPTION
## Description

Fixes #1899  .

- Prevent combination `ctrl` or `cmd` plus left/right arrow on timeline from invoking change date function which was overriding native browser functionality

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
