### PR TITLE
Update event track projection handling 

### DIFF
--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -85,7 +85,7 @@ class Events extends React.Component {
       showAlert,
       selectedDate
     } = this.props;
-    if (selected.id && !visibleWithinMapExtent[selected.id]) {
+    if (selected.id && !visibleWithinMapExtent[selected.id] && events && events.length) {
       deselectEvent();
     }
     const errorOrLoadingText = isLoading

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -74,6 +74,7 @@ class Events extends React.Component {
       isLoading,
       selectEvent,
       selected,
+      visibleWithinMapExtent,
       visibleEvents,
       sources,
       height,
@@ -84,6 +85,9 @@ class Events extends React.Component {
       showAlert,
       selectedDate
     } = this.props;
+    if (selected.id && !visibleWithinMapExtent[selected.id]) {
+      deselectEvent();
+    }
     const errorOrLoadingText = isLoading
       ? 'Loading...'
       : hasRequestError
@@ -153,7 +157,6 @@ const mapDispatchToProps = dispatch => ({
       dispatch(collapseSidebar());
     }
     if (dateStr) {
-      console.log(dateStr);
       dispatch(selectDate(new Date(dateStr)));
     }
   },
@@ -209,7 +212,15 @@ function mapStateToProps(state) {
   const events = lodashGet(requestedEvents, 'response');
   const sources = lodashGet(requestedEventSources, 'response');
   const mapExtent = lodashGet(state, 'map.extent');
+  let visibleWithinMapExtent = {};
   if (events && mapExtent) {
+    visibleWithinMapExtent = getEventsWithinExtent(
+      events,
+      selected,
+      proj.selected.maxExtent,
+      proj.selected,
+      true
+    );
     let extent = showAll ? proj.selected.maxExtent : mapExtent;
     visibleEvents = getEventsWithinExtent(
       events,
@@ -234,6 +245,7 @@ function mapStateToProps(state) {
     hasRequestError,
     sources,
     selected,
+    visibleWithinMapExtent,
     visibleEvents,
     apiURL,
     config,
@@ -267,5 +279,6 @@ Events.propTypes = {
   showAlert: PropTypes.bool,
   showAll: PropTypes.bool,
   sources: PropTypes.array,
-  visibleEvents: PropTypes.object
+  visibleEvents: PropTypes.object,
+  visibleWithinMapExtent: PropTypes.object
 };

--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -172,13 +172,13 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
         callback
       );
       selectedMap.addLayer(newTrackDetails.track);
-      self.active = true;
     }
+    self.active = true;
     self.trackDetails = newTrackDetails;
   };
 
   var debounceTrackUpdate = lodashDebounce(() => {
-    const selectedEvent = store.getState().events.selected;
+    const selectedEvent = ui.naturalEvents.selected;
 
     if (!selectedEvent.id || !selectedEvent.date) {
       return;

--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -7,8 +7,6 @@ import OlStyleStyle from 'ol/style/Style';
 import * as olExtent from 'ol/extent';
 import OlGeomMultiLineString from 'ol/geom/MultiLineString';
 import * as olProj from 'ol/proj';
-import { CHANGE_PROJECTION } from '../../modules/projection/constants';
-import { CHANGE_TAB as CHANGE_SIDEBAR_TAB } from '../../modules/sidebar/constants';
 import {
   find as lodashFind,
   each as lodashEach,
@@ -32,27 +30,24 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
   var self = {};
   self.trackDetails = {};
   self.active = false;
-
   /**
    * @return {void}
    */
   var init = function() {
-    const map = ui.map.selected;
-    store.subscribe(subscribeToStore);
-    map.on('moveend', function(e) {
+    selectedMap.on('moveend', function(e) {
       if (self.active) {
         if (self.trackDetails.id) {
-          addPointOverlays(map, self.trackDetails.pointArray);
+          addPointOverlays(selectedMap, self.trackDetails.pointArray);
         } else {
           debounceTrackUpdate();
         }
       }
     });
     // reset track on change to resolution or rotation
-    map.getView().on('propertychange', function(e) {
+    selectedMap.getView().on('propertychange', function(e) {
       if (e.key === 'resolution' || e.key === 'rotation') {
         self.trackDetails = self.trackDetails.id
-          ? self.removeTrack(map, self.trackDetails)
+          ? self.removeTrack(selectedMap, self.trackDetails)
           : {};
       } else if (e.key === 'center') {
         if (self.active) {
@@ -76,34 +71,18 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
             isNewTarget = oldLon !== targetLon || oldLat !== targetLat;
           }
           if (isNewTarget) {
-            removeOldPoints(map, self.trackDetails.pointArray);
+            removeOldPoints(selectedMap, self.trackDetails.pointArray);
           }
         }
       }
     });
   };
 
-  /**
-   * Suscribe to redux store and listen for
-   * specific action types
-   */
-  const subscribeToStore = function() {
-    const state = store.getState();
-    const action = state.lastAction;
-    switch (action.type) {
-      case CHANGE_SIDEBAR_TAB:
-        return onSidebarChange(action.activeTab);
-      case CHANGE_PROJECTION:
-        // update/remove track on projection change
-        if (self.trackDetails.id) return self.update(null, selectedMap);
-    }
-  };
-  const onSidebarChange = function(tab) {
-    const map = ui.map.selected;
+  self.onSidebarChange = function(tab) {
     if (tab === 'events') {
       debounceTrackUpdate();
     } else {
-      if (self.trackDetails.id) self.update(null, map);
+      if (self.trackDetails.id) self.update(null);
     }
   };
   /**
@@ -129,7 +108,7 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
    * @param  {Function} callback event change callback
    * @return {[type]}
    */
-  self.update = function(event, map, selectedDate, callback) {
+  self.update = function(event, selectedDate, callback) {
     const proj = store.getState().proj;
     var newTrackDetails;
     var trackDetails = self.trackDetails;
@@ -137,7 +116,7 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
       // If track exists remove it.
       // Else return empty Object
       newTrackDetails = trackDetails.id
-        ? self.removeTrack(map, trackDetails)
+        ? self.removeTrack(selectedMap, trackDetails)
         : {};
       self.active = false;
     } else if (trackDetails.id) {
@@ -151,15 +130,15 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
           // If New Date is in cluster
           // build new track
           if (isClusteredSelection) {
-            newTrackDetails = self.removeTrack(map, trackDetails);
+            newTrackDetails = self.removeTrack(selectedMap, trackDetails);
             newTrackDetails = createTrack(
               proj,
               event,
-              map,
+              selectedMap,
               selectedDate,
               callback
             );
-            map.addLayer(newTrackDetails.track);
+            selectedMap.addLayer(newTrackDetails.track);
           } else {
             newTrackDetails = trackDetails;
             updateSelection(selectedDate);
@@ -172,40 +151,46 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
         }
       } else {
         // Remove old DOM Elements
-        newTrackDetails = self.removeTrack(map, trackDetails);
-        newTrackDetails = createTrack(proj, event, map, selectedDate, callback);
-        map.addLayer(newTrackDetails.track);
+        newTrackDetails = self.removeTrack(selectedMap, trackDetails);
+        newTrackDetails = createTrack(
+          proj,
+          event,
+          selectedMap,
+          selectedDate,
+          callback
+        );
+        selectedMap.addLayer(newTrackDetails.track);
       }
     } else {
       // If no track element currenlty exists,
       // but there is a multiday event, build a new track
-      newTrackDetails = createTrack(proj, event, map, selectedDate, callback);
-      map.addLayer(newTrackDetails.track);
+      newTrackDetails = createTrack(
+        proj,
+        event,
+        selectedMap,
+        selectedDate,
+        callback
+      );
+      selectedMap.addLayer(newTrackDetails.track);
       self.active = true;
     }
     self.trackDetails = newTrackDetails;
   };
 
-  var debounceTrackUpdate = lodashDebounce(
-    () => {
-      const selectedEvent = ui.naturalEvents.selected;
-      const map = ui.map.selected;
+  var debounceTrackUpdate = lodashDebounce(() => {
+    const selectedEvent = store.getState().events.selected;
 
-      if (!selectedEvent || !selectedEvent.date) {
-        return;
-      }
-      let event = naturalEventsUtilGetEventById(
-        ui.naturalEvents.eventsData,
-        selectedEvent.id
-      );
-      self.update(event, map, selectedEvent.date, (id, date) => {
-        store.dispatch(
-          selectEventAction(id, date)
-        );
-      });
-    },
-    250
-  );
+    if (!selectedEvent.id || !selectedEvent.date) {
+      return;
+    }
+    let event = naturalEventsUtilGetEventById(
+      ui.naturalEvents.eventsData,
+      selectedEvent.id
+    );
+    self.update(event, selectedEvent.date, (id, date) => {
+      store.dispatch(selectEventAction(id, date));
+    });
+  }, 250);
 
   init();
   return self;
@@ -350,6 +335,7 @@ var createTrack = function(proj, eventObj, map, selectedDate, callback) {
     proj.selected.id === 'geographic'
       ? [-250, -90, 250, 90]
       : [-180, -90, 180, 90];
+
   const selectedCoords = lodashFind(eventObj.geometries, function(geometry) {
     return geometry.date.split('T')[0] === selectedDate;
   }).coordinates;

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -1,7 +1,6 @@
-import lodashFind from 'lodash/find';
 import * as olExtent from 'ol/extent';
 import * as olProj from 'ol/proj';
-
+import { forOwn as lodashForOwn, find as lodashFind } from 'lodash';
 import markers from './markers';
 import track from './track';
 import wvui from '../../ui/ui';
@@ -31,7 +30,8 @@ export default function naturalEventsUI(ui, config, store, models) {
   self.selected = {};
   self.selecting = false;
   var naturalEventMarkers = markers(ui, store);
-  var naturalEventsTrack = track(ui, store);
+  var naturalEventsTracks = {};
+  var naturalEventsTrack;
   /**
    * Suscribe to redux store and listen for
    * specific action types
@@ -120,6 +120,7 @@ export default function naturalEventsUI(ui, config, store, models) {
     } else {
       naturalEventMarkers.remove(self.markers);
     }
+    naturalEventsTrack.onSidebarChange(tab);
   };
 
   /**
@@ -131,7 +132,8 @@ export default function naturalEventsUI(ui, config, store, models) {
     map = ui.map.selected;
     view = map.getView();
     naturalEventMarkers = markers(ui, store, map);
-    naturalEventsTrack = track(ui, store, map);
+    if (naturalEventsTrack.trackDetails.id) naturalEventsTrack.update(null);
+    naturalEventsTrack = naturalEventsTracks[id];
     // filter events within projection view extent
     self.filterEventList();
 
@@ -168,17 +170,6 @@ export default function naturalEventsUI(ui, config, store, models) {
         if (!findSelectedInProjection) {
           self.deselectEvent();
           self.filterEventList();
-        } else {
-          let event = naturalEventsUtilGetEventById(
-            self.eventsData,
-            self.selected.id
-          );
-          naturalEventsTrack.update(
-            event,
-            map,
-            self.selected.date,
-            self.selectEvent
-          );
         }
       }
     }
@@ -217,6 +208,10 @@ export default function naturalEventsUI(ui, config, store, models) {
   };
   var init = function() {
     map = ui.map.selected;
+    lodashForOwn(ui.map.proj, (projMap, key) => {
+      naturalEventsTracks[key] = track(ui, store, projMap);
+    });
+    naturalEventsTrack = naturalEventsTracks[store.getState().proj.id];
     // Display loading information for user feedback on slow network
     view = map.getView();
     ui.events.on('last-action', subscribeToStore);
@@ -254,9 +249,10 @@ export default function naturalEventsUI(ui, config, store, models) {
       wvui.notify('The event with an id of ' + id + ' is no longer active.');
       return;
     }
+    date = date || self.getDefaultEventDate(event);
     self.selected = {
       id,
-      date: date || self.getDefaultEventDate(event)
+      date: date
     };
 
     const zoomPromise = getZoomPromise(
@@ -301,7 +297,7 @@ export default function naturalEventsUI(ui, config, store, models) {
       } else {
         ui.map.updateDate();
       }
-      naturalEventsTrack.update(event, ui.map.selected, date, self.selectEvent);
+      naturalEventsTrack.update(event, date, self.selectEvent);
     });
   };
 
@@ -309,7 +305,7 @@ export default function naturalEventsUI(ui, config, store, models) {
     self.selected = {};
     naturalEventMarkers.remove(self.markers);
     self.markers = naturalEventMarkers.draw();
-    naturalEventsTrack.update(null, ui.map.selected);
+    naturalEventsTrack.update(null);
     store.dispatch(deselectEventAction);
     self.events.trigger('change');
   };

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -171,6 +171,10 @@ export default function naturalEventsUI(ui, config, store, models) {
           self.deselectEvent();
           self.filterEventList();
         }
+        if (self.selected.date) {
+          var event = naturalEventsUtilGetEventById(self.eventsData, self.selected.id);
+          naturalEventsTrack.update(event, self.selected.date, self.selectEvent);
+        };
       }
     }
   };

--- a/web/js/modules/natural-events/selectors.js
+++ b/web/js/modules/natural-events/selectors.js
@@ -60,7 +60,6 @@ export function getEventsWithinExtent(
       isSelectedEvent &&
       olExtent.containsCoordinate(maxExtent, coordinates)
     ) {
-      console.log(maxExtent, coordinates);
       visibleListEvents[naturalEvent.id] = true;
     }
   });


### PR DESCRIPTION

## Description
Updated the way event tracks handle proj changes. Now 3 instances are created at initialization and we toggle between on the 3 on proj change.

Fixes #1898
- [x] added deselection of point if not in projection as it works on production

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
This one should be tested pretty thoroughly as it's a pretty significant change.

@nasa-gibs/worldview
