### PR TITLE
Fix showing/hiding date stamp on gifs

### DIFF
--- a/web/js/components/animation-widget/gif-panel.js
+++ b/web/js/components/animation-widget/gif-panel.js
@@ -42,7 +42,7 @@ export default class GifPanel extends React.Component {
       startDate,
       endDate,
       onCheck,
-      checked,
+      showDates,
       numberOfFrames
     } = this.props;
     const { resolution } = this.state;
@@ -87,7 +87,7 @@ export default class GifPanel extends React.Component {
             id="wv-checkbox-gif"
             classNames="wv-checkbox-gif"
             title="Check box to remove dates from Animating GIF"
-            checked={checked}
+            checked={showDates}
             onCheck={onCheck}
             label="Include Date Stamps"
           />

--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -122,6 +122,7 @@ class GIF extends Component {
             startDate={startDate}
             endDate={endDate}
             onClick={this.createGIF.bind(this)}
+            onCheck={this.toggleShowDates.bind(this)}
             numberOfFrames={numberOfFrames}
           />
 
@@ -143,6 +144,10 @@ class GIF extends Component {
         </ModalBody>
       </Modal>
     );
+  }
+  toggleShowDates() {
+    const { showDates } = this.state;
+    this.setState({ showDates: !showDates });
   }
   createGIF(width, height) {
     const { getImageArray } = this.props;


### PR DESCRIPTION
## Description
Make sure that the toggle for showing dates is properly hooked  up to a fn to change state for `showDates`

Fixes #1909.

