### PR TITLE
Update grid axis drag sentinel count with boundsDiff taken into account

### DIFF
--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -643,7 +643,13 @@ class TimelineAxis extends Component {
   * @returns {void}
   */
   updateScaleWithOffset = (date, timeScale, draggerCheck) => {
-    let leftOffsetFixedCoeff = draggerCheck.newDraggerDiff > 5 ? 0.5 : draggerCheck.newDateInThePast ? 0.25 : 0.75;
+    let leftOffsetFixedCoeff = draggerCheck.newDraggerDiff > 5
+      ? 0.5
+      : draggerCheck.newDateInThePast
+        ? !draggerCheck.withinRange
+          ? 0.5
+          : 0.25
+        : 0.75;
     this.updateScale(date, timeScale, null, leftOffsetFixedCoeff);
   }
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -374,7 +374,7 @@ class Timeline extends React.Component {
   */
   handleKeyDown = (e) => {
     // prevent left/right arrows changing date within inputs
-    if (e.target.tagName !== 'INPUT' && !e.ctrlKey && !e.metaKey) {
+    if (e.target.tagName !== 'INPUT' && !e.ctrlKey && !e.metaKey && !this.state.isTimelineDragging) {
       // left arrow
       if (e.keyCode === 37) {
         e.preventDefault();


### PR DESCRIPTION
## Description

Bug can be best seen when dragging axis to expose past dates when in `MONTH` timescale axis zoom level and the leading updated axis tiles are blank.

Fixes #1914  .

- Primary fix addressed in this fix is updating the `dragSentinelCount` used in determining when the timeline axis needs to updated based on dragging (if accumulated `dragSentinelCount` exceeds `dragSentinelChangeNumber`, the axis updates)
- Clean up variable names, props/state destructuring, and comments

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
