### PR TITLE
Animation breaks when permalink has ab='on' without animation start and end dates

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -93,8 +93,7 @@ class App extends React.Component {
     document.removeEventListener('keypress', this.handleKeyPress);
   }
   render() {
-    const { isAnimationWidgetActive, isTourActive } = this.props;
-
+    const { isAnimationWidgetActive, isTourActive, locationKey } = this.props;
     return (
       <div className="wv-content" id="wv-content" data-role="content">
         <Toolbar />
@@ -106,7 +105,7 @@ class App extends React.Component {
         <div id="eventsHolder" />
         <div id="imagedownload" />
         <div id="dlMap" />
-        <Timeline />
+        <Timeline key={locationKey || '1'} />
         <div id="wv-animation-widet-case">
           {isAnimationWidgetActive ? <AnimationWidget /> : null}
         </div>
@@ -166,10 +165,12 @@ function mapStateToProps(state, ownProps) {
     state: state,
     isAnimationWidgetActive: state.animation.isActive,
     isTourActive: state.tour.active,
+    tour: state.tour,
     config: state.config,
     parameters: state.parameters,
     models: ownProps.models,
-    mapMouseEvents: ownProps.mapMouseEvents
+    mapMouseEvents: ownProps.mapMouseEvents,
+    locationKey: state.location.key
   };
 }
 const mapDispatchToProps = dispatch => ({
@@ -189,6 +190,7 @@ App.propTypes = {
   isAnimationWidgetActive: PropTypes.bool,
   isTourActive: PropTypes.bool,
   keyPressAction: PropTypes.func,
+  locationKey: PropTypes.string,
   mapMouseEvents: PropTypes.object,
   parameters: PropTypes.object,
   state: PropTypes.object

--- a/web/js/modules/animation/util.js
+++ b/web/js/modules/animation/util.js
@@ -123,7 +123,10 @@ export function mapLocationToAnimationState(
     stateFromLocation = update(stateFromLocation, {
       animation: { isPlaying: { $set: true } }
     });
-  } else if (!parameters.ae || (!parameters.as && (!!endDate || !!startDate))) {
+  } else if (
+    parameters.ab !== 'on' &&
+    (!parameters.ae || (!parameters.as && (!!endDate || !!startDate)))
+  ) {
     // wipe anim start & end dates on tour change
 
     stateFromLocation = update(stateFromLocation, {

--- a/web/js/modules/combine-reducers.js
+++ b/web/js/modules/combine-reducers.js
@@ -35,8 +35,9 @@ import {
   getInitialVectorStyleState
 } from './vector-styles/reducers';
 import dataDownloadReducer from './data/reducers';
-import { get as lodashGet } from 'lodash';
+import { get as lodashGet, assign as lodashAssign } from 'lodash';
 import { imageDownloadReducer } from './image-download/reducers';
+import { LOCATION_POP_ACTION } from '../redux-location-state-customs';
 
 function lastAction(state = null, action) {
   return action;
@@ -88,6 +89,13 @@ export function getInitialState(models, config, parameters) {
     vectorStyles: getInitialVectorStyleState(config)
   };
 }
+const locationReducer = (state = { key: '' }, action) => {
+  if (action.type === LOCATION_POP_ACTION) {
+    return lodashAssign({}, state, { key: action.payload.key });
+  } else {
+    return state;
+  }
+};
 const defaultReducer = (state = {}) => state;
 const reducers = {
   proj: projectionReducer,
@@ -116,7 +124,8 @@ const reducers = {
   modalAboutPage,
   shortLink,
   notificationsRequest,
-  lastAction: lastAction
+  lastAction: lastAction,
+  location: locationReducer
 };
 const appReducer = combineReducers(reducers);
 /**


### PR DESCRIPTION
## Description

Fixes #1903 
- [x] Fix animation break when permalink loads with `ab='on'`, without animation start and end dates
- [x] Fix rendering of range selectors on tour change

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
