### PR TITLE
Prevent event track from showing up when not in events mode

### DIFF
--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -35,7 +35,7 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
    */
   var init = function() {
     selectedMap.on('moveend', function(e) {
-      if (self.active) {
+      if (self.active && store.getState().events.active) {
         if (self.trackDetails.id) {
           addPointOverlays(selectedMap, self.trackDetails.pointArray);
         } else {


### PR DESCRIPTION
## Description

Fixes #1954 

Event tracks showing up when not in events mode

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

@ZachTRice Should we patch this right into master or put this into develop?

@nasa-gibs/worldview
