### PR TITLE
Use zeroed times for data download time filtering

### DIFF
--- a/web/js/map/data/results.js
+++ b/web/js/map/data/results.js
@@ -797,8 +797,9 @@ export function dataResultsTimeFilter(spec) {
   self.name = 'TimeFilter';
 
   var init = function() {
-    westZone = new Date(spec.time.getTime()).setUTCMinutes(spec.westZone);
-    eastZone = new Date(spec.time.getTime()).setUTCMinutes(spec.eastZone);
+    let zeroedTime = spec.time.setUTCHours(0);
+    westZone = new Date(zeroedTime).setUTCMinutes(spec.westZone);
+    eastZone = new Date(zeroedTime).setUTCMinutes(spec.eastZone);
     maxDistance = spec.maxDistance;
     timeOffset = spec.timeOffset || 0;
   };
@@ -849,7 +850,7 @@ export function dataResultsTimeLabel(time) {
     }
 
     var diff = Math.floor(
-      (timeStart.getTime() - time.getTime()) / (1000 * 60 * 60 * 24)
+      (timeStart.getTime() - time.setUTCHours(0)) / (1000 * 60 * 60 * 24)
     );
 
     var suffix = '';


### PR DESCRIPTION
## Description

Data download time filtering relied on a zeroed out time to calculate valid granules/labels. With the introduction of subdaily times, this needed to be revised using zeroed out times.

Fixes #1980   .

- Zero west and east meridian time cutoffs used to filter granules within valid times
- Change time used in data results labeling to use zeroed time for correct diffs (+1 day, -1 day)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

Time managed in data download may need to be revisited in the event that we offer partial subdaily cmr requests. In that event, a more concise refactor outside of just time filtering would be required.

@nasa-gibs/worldview
