### PR TITLE
Empty ows:Metadata, part 2

### DIFF
--- a/tasks/extractConfigFromWMTS.py
+++ b/tasks/extractConfigFromWMTS.py
@@ -85,7 +85,7 @@ def process_layer(gc_layer, wv_layers, colormaps):
     }
 
     # Vector data links
-    if "ows:Metadata" in gc_layer:
+    if "ows:Metadata" in gc_layer and gc_layer["ows:Metadata"] is not None:
         for item in gc_layer["ows:Metadata"]:
             if "@xlink:role" not in item:
                 raise KeyError("No xlink:role")

--- a/tasks/getCapabilities.py
+++ b/tasks/getCapabilities.py
@@ -52,7 +52,7 @@ with open(config_file) as fp:
     config = json.load(fp)
 
 def process_vector_data(layer):
-    if "ows:Metadata" in layer:
+    if "ows:Metadata" in layer and layer["ows:Metadata"] is not None:
         for item in layer["ows:Metadata"]:
             schema_version = item["@xlink:role"]
             if schema_version == "http://earthdata.nasa.gov/gibs/metadata-type/layer/1.0":


### PR DESCRIPTION
## Description

Fixes a bug where the config generator crashes if a GC document contains an empty ows:Metadata element.

[Description of the bug or feature]

- [ ]
- [ ]
- [ ]

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
