### PR TITLE
Allow configuration to have no products defined

### DIFF
--- a/web/js/modules/data/selectors.js
+++ b/web/js/modules/data/selectors.js
@@ -43,6 +43,11 @@ export function getDataSelectionSize(selectedGranules) {
 }
 export function groupByProducts(config, dataProducts) {
   let products = {};
+  // If no products have been defined in the configuration, return
+  // the empty object.
+  if (!config.products) {
+    return products;
+  }
   for (let layer of dataProducts) {
     // If products is a list, use it. If a single item, convert to a list.
     // If no products are defined, add it to the no product group.


### PR DESCRIPTION
## Description

If no products have been defined, return an empty object. 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
