### PR TITLE
Fix vector layer ids with periods breaking vector styles/data

### DIFF
--- a/tasks/processVectorData.py
+++ b/tasks/processVectorData.py
@@ -33,7 +33,7 @@ def copy_file(file):
     if input_file.endswith('.json'):
         response_data = {}
         vector_layer_filename = file;
-        vector_layer_id = vector_layer_filename.split(".", 1)[0]
+        vector_layer_id = vector_layer_filename.split(".json", 1)[0]
         response_data["vectorData"] = {}
         response_data["vectorData"][vector_layer_id] = {}
         with open(input_file) as json_file:

--- a/tasks/processVectorStyles.py
+++ b/tasks/processVectorStyles.py
@@ -33,7 +33,7 @@ def copy_file(file):
     if input_file.endswith('.json'):
         response_data = {}
         vector_layer_filename = file;
-        vector_layer_id = vector_layer_filename.split(".", 1)[0]
+        vector_layer_id = vector_layer_filename.split(".json", 1)[0]
         response_data["vectorStyles"] = {}
         response_data["vectorStyles"][vector_layer_id] = {}
         with open(input_file) as json_file:


### PR DESCRIPTION
## Description

Fixes #2012

Splits layer identifiers at `.json` instead of at `.`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
