### PR TITLE
Render metadata tooltips as HTML

### DIFF
--- a/web/js/components/vector-metadata/tooltip.js
+++ b/web/js/components/vector-metadata/tooltip.js
@@ -22,8 +22,15 @@ export default class VectorMetaTooltip extends React.Component {
     return (
       <Fragment key={this.props.index}>
         <span href="#" id={'tooltip-' + this.props.index}><i className="fa fa-info vector-info-icon"></i></span>
-        <Tooltip boundariesElement="window" placement="top" isOpen={this.state.tooltipOpen} target={'tooltip-' + this.props.index} toggle={this.toggle} fade={false}>
-          {this.props.description}
+        <Tooltip
+          dangerouslySetInnerHTML={{ __html: this.props.description }}
+          boundariesElement="window"
+          placement="top"
+          isOpen={this.state.tooltipOpen}
+          target={'tooltip-' + this.props.index}
+          toggle={this.toggle}
+          fade={false}
+        >
         </Tooltip>
       </Fragment>
     );


### PR DESCRIPTION
## Description

Fixes #1916

Renders vector metadata tooltips as HTML instead of plain text.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
