### PR TITLE
Bump browserstack-capabilities from 0.4.0 to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2669,21 +2669,13 @@
       }
     },
     "browserstack-capabilities": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserstack-capabilities/-/browserstack-capabilities-0.4.0.tgz",
-      "integrity": "sha1-osaFKf1qgStR1K2aSr4fU2o5uSM=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/browserstack-capabilities/-/browserstack-capabilities-0.7.0.tgz",
+      "integrity": "sha512-XnMn74P3h9wybp9yJLv5Y7wNHPmLmXpLaIO9zP4WPWPZrjSnXmcrvFktItRFFBhvzFzBHaJI4/0fIIMOnjaBzQ==",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1",
+        "lodash": "4.17.15",
         "sync-request": "4.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
       }
     },
     "browserstack-local": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",
-    "browserstack-capabilities": "^0.4.0",
+    "browserstack-capabilities": "^0.7.0",
     "browserstack-local": "^1.3.0",
     "canvas": "^1.6.11",
     "cheerio": "^1.0.0-rc.2",


### PR DESCRIPTION
## Description

- Bump `browserstack-capabilities` from 0.4.0 to 0.7.0

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

Browserstack tests are currently breaking and need to be refactored. To test this, just ensure that the local client is still able to connect to browserstack. The broken tests will be fixed in another update.

@nasa-gibs/worldview
