### PR TITLE
Fix image/gif download crop boxes

### DIFF
--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -15,9 +15,7 @@ import {
 } from '../modules/image-download/constants';
 import {
   imageUtilCalculateResolution,
-  imageUtilGetCoordsFromPixelValues,
-  getPercentageFromPixel,
-  getPixelFromPercentage
+  imageUtilGetCoordsFromPixelValues
 } from '../modules/image-download/util';
 import { Progress, Modal, ModalBody, ModalHeader } from 'reactstrap';
 import { timeScaleFromNumberKey } from '../modules/date/constants';
@@ -134,12 +132,12 @@ class GIF extends Component {
           />
 
           <Crop
-            x={getPercentageFromPixel(screenWidth, x)}
-            y={getPercentageFromPixel(screenHeight, y)}
+            x={x}
+            y={y}
+            width={x2 - x}
+            height={y2 - y}
             maxHeight={screenHeight}
             maxWidth={screenWidth}
-            width={getPercentageFromPixel(screenWidth, x2 - x)}
-            height={getPercentageFromPixel(screenHeight, y2 - y)}
             onChange={lodashDebounce(this.onBoundaryChange, 5)}
             onClose={onClose}
             coordinates={{
@@ -291,22 +289,20 @@ class GIF extends Component {
   }
 
   onBoundaryChange(cropBounds) {
-    const {
-      screenWidth,
-      screenHeight,
-      onBoundaryChange
-    } = this.props;
-    const x = getPixelFromPercentage(screenWidth, cropBounds.x);
-    const y = getPixelFromPercentage(screenHeight, cropBounds.y);
-    const x2 = x + getPixelFromPercentage(screenWidth, cropBounds.width);
-    const y2 = y + getPixelFromPercentage(screenHeight, cropBounds.height);
-    const boundaries = { x, y, x2, y2 };
-    const { offsetLeft, offsetTop } = this.getModalOffsets(boundaries);
-    onBoundaryChange(boundaries);
+    const { onBoundaryChange } = this.props;
+    const { x, y, width, height } = cropBounds;
+    const newBoundaries = {
+      x,
+      y,
+      x2: x + width,
+      y2: y + height
+    };
+    const { offsetLeft, offsetTop } = this.getModalOffsets(newBoundaries);
+    onBoundaryChange(newBoundaries);
     this.setState({
       offsetLeft,
       offsetTop,
-      boundaries
+      boundaries: newBoundaries
     });
   }
 

--- a/web/js/containers/image-download.js
+++ b/web/js/containers/image-download.js
@@ -9,9 +9,7 @@ import * as olProj from 'ol/proj';
 import { debounce as lodashDebounce } from 'lodash';
 import {
   imageUtilCalculateResolution,
-  imageUtilGetCoordsFromPixelValues,
-  getPercentageFromPixel,
-  getPixelFromPercentage
+  imageUtilGetCoordsFromPixelValues
 } from '../modules/image-download/util';
 import util from '../util/util';
 import { getLayers } from '../modules/layers/selectors';
@@ -33,16 +31,15 @@ class ImageDownloadContainer extends Component {
     super(props);
     const screenHeight = props.screenHeight;
     const screenWidth = props.screenWidth;
-    const boundaryProps = props.boundaries;
     this.state = {
       fileType: props.fileType,
       resolution: props.resolution,
       isWorldfile: props.isWorldfile,
-      boundaries: {
-        x: boundaryProps.x || screenWidth / 2 - 100,
-        y: boundaryProps.y || screenHeight / 2 - 100,
-        x2: boundaryProps.x2 || screenWidth / 2 + 100,
-        y2: boundaryProps.y2 || screenHeight / 2 + 100
+      boundaries: props.boundaries || {
+        x: screenWidth / 2 - 100,
+        y: screenHeight / 2 - 100,
+        x2: screenWidth / 2 + 100,
+        y2: screenHeight / 2 + 100
       }
     };
     this.debounceBoundaryUpdate = lodashDebounce(
@@ -53,21 +50,15 @@ class ImageDownloadContainer extends Component {
   }
 
   onBoundaryChange(boundaries) {
-    const { screenWidth, screenHeight } = this.props;
-    const x = getPixelFromPercentage(screenWidth, boundaries.x);
-    const y = getPixelFromPercentage(screenHeight, boundaries.y);
-    const x2 = x + getPixelFromPercentage(screenWidth, boundaries.width);
-    const y2 = y + getPixelFromPercentage(screenHeight, boundaries.height);
+    const { x, y, width, height } = boundaries;
     const newBoundaries = {
-      x: x,
-      y: y,
-      x2: x2,
-      y2: y2
+      x,
+      y,
+      x2: x + width,
+      y2: y + height
     };
 
-    this.setState({
-      boundaries: newBoundaries
-    });
+    this.setState({ boundaries: newBoundaries });
     this.debounceBoundaryUpdate(newBoundaries);
   }
 
@@ -120,12 +111,12 @@ class ImageDownloadContainer extends Component {
           onPanelChange={onPanelChange}
         />
         <Crop
-          x={getPercentageFromPixel(screenWidth, x)}
-          y={getPercentageFromPixel(screenHeight, y)}
+          x={x}
+          y={y}
+          width={x2 - x}
+          height={y2 - y}
           maxHeight={screenHeight}
           maxWidth={screenWidth}
-          width={getPercentageFromPixel(screenWidth, x2 - x)}
-          height={getPercentageFromPixel(screenHeight, y2 - y)}
           onChange={this.onBoundaryChange}
           onClose={onClose}
           bottomLeftStyle={{

--- a/web/js/modules/image-download/reducers.js
+++ b/web/js/modules/image-download/reducers.js
@@ -9,7 +9,7 @@ import { CHANGE_PROJECTION } from '../projection/constants';
 import { assign as lodashAssign, find as lodashFind } from 'lodash';
 export const defaultState = {
   fileType: 'image/jpeg',
-  boundaries: {},
+  boundaries: undefined,
   isWorldfile: false,
   resolution: ''
 };


### PR DESCRIPTION
## Description
Fixes #2032 

Update image and gif download crop props to be pixel based instead of percentage based, to work with new version if react-image-crop

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

