### PR TITLE
automatically add the bug label to issues created via the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+labels: bug
 
 ---
 


### PR DESCRIPTION
## Description

Automatically apply the `bug` label to issues created with that template.  

We should also decide on whether it makes sense to automatically apply the `new feature` or `enhancement` labels to issues created with other templates. The `enhancement` label looks to be the more frequently used label currently.  If we want to more easily distinguish between enhancements to existing features, and entirely new features, we should probably just make slightly different templates for each and apply the appropriate default labels to them.

Let me know your preference and I'll update this PR.

