### PR TITLE
Limit subdaily date range to one hour before and after current date

### DIFF
--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -22,6 +22,8 @@ var map,
 
 export function mapDateLineBuilder(models, config, store, ui) {
   var self = {};
+  // formatted YYYY-MM-DD (e.g., 2019-06-25) for checking daily change for dateline
+  self.date = {};
   /*
    * Sets globals and event listeners
    *
@@ -46,7 +48,11 @@ export function mapDateLineBuilder(models, config, store, ui) {
         const state = store.getState();
         const selectedDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
         const date = state.date[selectedDateStr];
-        return updateDate(date);
+        const isNewDay = compareDateStrings(date);
+        if (isNewDay) {
+          return updateDate(date);
+        }
+        break;
       case CHANGE_PROJECTION:
         proj = action.id;
     }
@@ -55,6 +61,7 @@ export function mapDateLineBuilder(models, config, store, ui) {
     var dimensions;
     map = olMap;
     drawDatelines(map, date);
+    self.date = date.toISOString().split('T')[0];
     proj = store.getState().proj.id;
 
     Parent.events.on('moveend', function() {
@@ -385,6 +392,27 @@ export function mapDateLineBuilder(models, config, store, ui) {
     });
     overlay.setPosition(coordinate);
     return overlay;
+  };
+
+  /*
+   * Check if YYYY-MM-DD changed or a subdaily drag occurred
+   *  to determine if new date lines are needed
+   *
+   * @method compareDateStrings
+   * @private
+   *
+   * @param {object} date
+   *
+   * @sets {string} self.date - if new date
+   * @returns {boolean}
+   */
+  const compareDateStrings = (date) => {
+    const dateString = date.toISOString().split('T')[0];
+    if (dateString !== self.date) {
+      self.date = dateString;
+      return true;
+    }
+    return false;
   };
 
   return self;

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -1188,10 +1188,16 @@ export default (function (self) {
           dateArray.push(new Date(minDate.getUTCFullYear(), minDate.getUTCMonth(), minDate.getUTCDate() + dateInterval, 0, 0, 0));
         }
       } else if (def.period === 'subdaily') {
+        const currentDateOffset = currentDate.getTimezoneOffset() * 60000;
         const minDateMinutes = minDate.getUTCMinutes();
         // only check an hour into past for min date
-        const hourBeforeCurrentDate = new Date(currentDate.setMinutes(minDateMinutes) - (currentDate.getTimezoneOffset() * 60000) - (60 * 60000));
+        const hourBeforeCurrentDate = new Date(currentDate.setMinutes(minDateMinutes) - currentDateOffset - (60 * 60000));
         minDate = hourBeforeCurrentDate < minDate ? minDate : hourBeforeCurrentDate;
+        // only check an hour into future for max date
+        const hourAfterCurrentDate = new Date(currentDate.setMinutes(minDateMinutes) - currentDateOffset + (60 * 60000));
+        maxMinuteDate = hourAfterCurrentDate > maxMinuteDate ? maxMinuteDate : hourAfterCurrentDate;
+
+        currentDate = new Date(currentDate.getTime() - currentDateOffset);
         // if containgeRange is true, check if date is between current dateRange.startDate && dateRange.endDate
         if (!containRange) {
           minuteDifference = self.minuteDiff(minDate, maxMinuteDate);

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -1188,6 +1188,10 @@ export default (function (self) {
           dateArray.push(new Date(minDate.getUTCFullYear(), minDate.getUTCMonth(), minDate.getUTCDate() + dateInterval, 0, 0, 0));
         }
       } else if (def.period === 'subdaily') {
+        const minDateMinutes = minDate.getUTCMinutes();
+        // only check an hour into past for min date
+        const hourBeforeCurrentDate = new Date(currentDate.setMinutes(minDateMinutes) - (currentDate.getTimezoneOffset() * 60000) - (60 * 60000));
+        minDate = hourBeforeCurrentDate < minDate ? minDate : hourBeforeCurrentDate;
         // if containgeRange is true, check if date is between current dateRange.startDate && dateRange.endDate
         if (!containRange) {
           minuteDifference = self.minuteDiff(minDate, maxMinuteDate);


### PR DESCRIPTION
## Description

Fixes:

- Limits subdaily available date range array to one hour before and after current date instead of entire range based on layer config definition `startDate` / `endDate`
- Prevents dateline updates for subdaily date changes

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
