### PR TITLE
Add empty format options to clipboard copy for IE11

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -182,7 +182,7 @@ class ShareLinkContainer extends Component {
             />
 
             <CopyToClipboard
-              options={{ format: 'text/plain' }}
+              options={window.clipboardData ? {} : { format: 'text/plain' } }
               text={value}
               onCopy={() => {
                 this.setState({ tooltipOpen: true });


### PR DESCRIPTION
## Description

Fixes #2046 
Caused from #1947 format options change

- If `window.clipboardData` (IE11) - pass empty options to prevent format issues and fix copying to clipboard

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
