### PR TITLE
End tour to set isActive as false and close dialog

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -59,8 +59,13 @@ class Tour extends React.Component {
 
   toggleModalStart(e) {
     e.preventDefault();
+    const toggleModal = !this.state.modalStart;
+    // if closing modal
+    if (!toggleModal) {
+      this.props.endTour();
+    }
     this.setState({
-      modalStart: !this.state.modalStart
+      modalStart: toggleModal
     });
   }
 


### PR DESCRIPTION
## Description

Fixes #2039 .

- end tour to set `isActive` as `false` and close dialog

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
