### PR TITLE
Allow subdaily layer image download to retain subdaily time and prevent zeroing

### DIFF
--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -50,12 +50,13 @@ export default class ImageResSelection extends React.Component {
     const { getLayers, url, lonlats, crs, projection, date } = this.props;
     const { fileType, isWorldfile, resolution } = this.state;
     const time = new Date(date.getTime());
-    time.setUTCHours(0, 0, 0, 0);
+    if (!this.props.hasSubdailyLayers) {
+      time.setUTCHours(0, 0, 0, 0);
+    }
     const layerList = getLayers();
     const layerWraps = imageUtilGetLayerWrap(layerList);
     const layers = imageUtilGetLayers(layerList, projection.id);
     const opacities = imageUtilGetLayerOpacities(layerList);
-
     const params = [
       'REQUEST=GetSnapshot',
       `TIME=${util.toISOStringSeconds(time)}`,
@@ -216,6 +217,7 @@ ImageResSelection.propTypes = {
   fileTypes: PropTypes.object,
   firstLabel: PropTypes.string,
   getLayers: PropTypes.func,
+  hasSubdailyLayers: PropTypes.bool,
   isWorldfile: PropTypes.bool,
   lonlats: PropTypes.array,
   maxImageSize: PropTypes.string,

--- a/web/js/containers/image-download.js
+++ b/web/js/containers/image-download.js
@@ -12,7 +12,10 @@ import {
   imageUtilGetCoordsFromPixelValues
 } from '../modules/image-download/util';
 import util from '../util/util';
-import { getLayers } from '../modules/layers/selectors';
+import {
+  hasSubDaily as hasSubDailySelector,
+  getLayers
+} from '../modules/layers/selectors';
 import {
   resolutionsGeo,
   resolutionsPolar,
@@ -72,6 +75,7 @@ class ImageDownloadContainer extends Component {
       screenHeight,
       date,
       getLayers,
+      hasSubdailyLayers,
       onPanelChange
     } = this.props;
     const { boundaries, resolution, isWorldfile, fileType } = this.state;
@@ -104,6 +108,7 @@ class ImageDownloadContainer extends Component {
           lonlats={lonlats}
           resolution={newResolution}
           isWorldfile={isWorldfile}
+          hasSubdailyLayers={hasSubdailyLayers}
           date={date}
           url={url}
           crs={crs}
@@ -154,6 +159,8 @@ function mapStateToProps(state) {
   const { isWorldfile, fileType, resolution, boundaries } = imageDownload;
   const { screenWidth, screenHeight } = browser;
   const activeDateStr = compare.isCompareA ? 'selected' : 'selectedB';
+  const activeStr = compare.activeString;
+  const hasSubdailyLayers = hasSubDailySelector(layers[activeStr]);
   let url = DEFAULT_URL;
   if (config.features.imageDownload && config.features.imageDownload.url) {
     url = config.features.imageDownload.url;
@@ -173,6 +180,7 @@ function mapStateToProps(state) {
     fileType,
     resolution,
     boundaries,
+    hasSubdailyLayers,
     date: date[activeDateStr],
     getLayers: () => {
       return getLayers(
@@ -217,6 +225,7 @@ ImageDownloadContainer.propTypes = {
   boundaries: PropTypes.object,
   date: PropTypes.object,
   getLayers: PropTypes.func,
+  hasSubdailyLayers: PropTypes.bool,
   isWorldfile: PropTypes.bool,
   resolution: PropTypes.string,
   screenHeight: PropTypes.number,


### PR DESCRIPTION
## Description

Fixes #2051  .

- Conditionally zeroes time parameter for image download request only if no subdaily layers are present

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

There may be some WVS server side image request handling that negates this fix in the future.

@nasa-gibs/worldview
