### PR TITLE
Remove any href attrs from anchor elements where the value included 'javascript:'

### DIFF
--- a/web/css/dataDownload.css
+++ b/web/css/dataDownload.css
@@ -29,6 +29,10 @@
   margin-left: 10px;
 }
 
+ul.BulkDownload li a.link {
+  color: #7bf;
+}
+
 #wv-data-selection h3 {
   font-size: 16px;
   line-height: 16px;

--- a/web/js/components/animation-widget/loop-button.js
+++ b/web/js/components/animation-widget/loop-button.js
@@ -9,7 +9,6 @@ class LoopButton extends React.Component {
   render() {
     return (
       <a
-        href="javascript:void(null)"
         title={this.props.looping ? 'Stop Loop' : 'Loop video'}
         className={
           this.props.looping

--- a/web/js/components/animation-widget/play-button.js
+++ b/web/js/components/animation-widget/play-button.js
@@ -9,7 +9,6 @@ class PlayButton extends React.Component {
   render() {
     return (
       <a
-        href="javascript:void(null)"
         title={this.props.playing ? 'Pause video' : 'Play video'}
         className="wv-anim-play-case wv-icon-case"
         onClick={this.props.playing ? this.props.pause : this.props.play}

--- a/web/js/components/tour/widget-steps.js
+++ b/web/js/components/tour/widget-steps.js
@@ -6,7 +6,6 @@ class Steps extends React.Component {
     return (
       <div className="step-container">
         <a
-          href="javascript:void(0);"
           className={'step-previous'}
           aria-label="Previous"
           onClick={this.props.decreaseStep}
@@ -20,7 +19,6 @@ class Steps extends React.Component {
           </p>
         </div>
         <a
-          href="javascript:void(0);"
           className="step-next"
           aria-label="Next"
           onClick={this.props.incrementStep}

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -389,7 +389,6 @@ class AnimationWidget extends React.Component {
               <span className="wv-slider-label">{sliderLabel}</span>
             </div>
             <a
-              href="javascript:void(null)"
               title={
                 !isCompareActive
                   ? 'Create Animated GIF'

--- a/web/js/map/data/ui.js
+++ b/web/js/map/data/ui.js
@@ -740,10 +740,10 @@ var dataUiDownloadListPanel = function(config, store) {
       "<div class='bulk dd-collapse'>" +
       '<h5>Bulk Download</h5>' +
       "<ul class='BulkDownload'>" +
-      "<li><a class='wget' href='javascript:void(null)'>List of Links</a>: " +
+      "<li><a class='link wget'>List of Links</a>: " +
       'for wget or download managers that accept a list of ' +
       'URLs</li>' +
-      "<li><a class='curl' href='javascript:void(null)'>List of cURL Commands</a>: " +
+      "<li><a class='link curl''>List of cURL Commands</a>: " +
       'can be copied and pasted to ' +
       'a terminal window to download using cURL.</li>' +
       '</ul>' +


### PR DESCRIPTION
## Description

Fixes #2047

Removed `href` attributes from anchor elements in these places:
* Animation Play button
* Animation Pause button
* Tour step forward/back buttons
* wget/curl data download links

@nasa-gibs/worldview
