### PR TITLE
Scroll layer descriptions

### DIFF
--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -503,6 +503,10 @@
 }
 
 /* Layer Options */
+.layer-info-wrap {
+  position: fixed;
+}
+
 .layer-info-settings-modal {
   margin-left: auto;
   margin-right: auto;

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -363,8 +363,8 @@ const mapDispatchToProps = dispatch => ({
         headerText: title || 'Layer Description',
         backdrop: false,
         bodyComponent: LayerInfo,
-        wrapClassName: 'clickable-behind-modal',
-        modalClassName: ' layer-info-settings-modal layer-info-modal ',
+        wrapClassName: 'clickable-behind-modal layer-info-wrap',
+        modalClassName: ' layer-info-settings-modal ',
         timeout: 150,
         bodyComponentProps: {
           layer: layer


### PR DESCRIPTION
## Description

Fixes # 2054.

Allows layer description modals to be scrolled as they are intended.

@nasa-gibs/worldview
