### PR TITLE
v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## Layer Updates
- IMERG Precipitation rate #1977
- MODIS Atmosphere layers #2010

## Technical Updates / Bug Fixes
- Add multiple node versions and windows distro to .travis.yml #1946
- Add options to fix copy-to-clipboard copied text format $1947
- Prevent event track from showing up when not in events mode #1955
- Refactor import to fix console error #1957
- Scroll to selected event in sidebar on click #1958
- Remove unused variable #1963
- Optimize static imagery for page load time savings #1967
- Update postcss / cssnano dependencies & webpack config #1970
- Add basic jest code coverage #1974
- Bring in postcss-nesting plugin #1978
- Optimize travis-ci builds #1979
- Use zeroed times for data download time filtering #1988
- Prevent disabled data download or natural events feature components from building #1995
- Antimeridian crossing image/GIF download #1998
- Empty ows:Metadata, part 2 #2005
- Allow configuration to have no products defined #2011
- Render metadata tooltips as HTML #2014
- Fix layerIds that have dot notation to allow object property selection #2018
- Fix eslint errors #2021
- Headless e2e testing #2022
- Fix image/gif download crop boxes #2033
- Fix B-state layer & date init #2036
- Show event title on hover #2037
- Make esc button exit tour #2040
- Limit subdaily date range to one hour before and after current date #2044
- Add empty format options to clipboard copy for IE11 #2049
- End tour to set isActive as false and close dialog #2050
- Allow subdaily layer image download to retain subdaily time and prevent zeroing #2052
- Put tics around MODIS product names #2056
- Add projection param to all stepLinks for new fires tour #2059
- Remove any href attrs from anchor elements where the value included 'javascript:' #2060
- Make sure we check to see if localStorage is accessible before trying to access it #2061
- Scroll layer descriptions #2065
- Fixed SSS descriptions and product names #2066
- Prevent gif download with too many frames #2067

## Update Dependencies
- Bump react from 16.4.2 to 16.8.6 #1932
- Bump lodash.mergewith from 4.6.1 to 4.6.2 #1933
- Bump lodash.template from 4.4.0 to 4.5.0 #1934
- Bump clean-webpack-plugin from 0.1.19 to 3.0.0 #1935
- Bump webpack from 4.35.0 to 4.38.0 #1936
- Bump chromedriver from 2.46.0 to 76.0.0 #1937
- Bump lodash from 4.17.11 to 4.17.13 #1942
- Bump redux-location-state from `050ab73` to `4e81314` #1943
- Bump uglifyjs-webpack-plugin from 1.3.0 to 2.2.0 #1944
- Bump copy-webpack-plugin from 4.6.0 to 5.0.4 #1945
- Bump fetch-mock from 7.3.3 to 7.3.9 #1951
- Bump @fortawesome/fontawesome-free from 5.9.0 to 5.10.1 #1952
- Bump postcss-import from 11.1.0 to 12.0.1 #1960
- Bump promise-queue from 2.2.3 to 2.2.5 #1961
- Bump css-loader from 1.0.1 to 3.2.0 #1971
- Bump webpack from 4.38.0 to 4.39.1 #1972
- Bump react-beautiful-dnd from 9.0.2 to 11.0.5 #1982
- Bump url-loader from 1.1.2 to 2.1.0 #1983
- Bump postcss-cli from 4.1.1 to 6.1.3 #1984
- Bump regenerator-runtime from 0.13.2 to 0.13.3 #1985
- Bump lodash from 4.17.13 to 4.17.15 #1986
- Bump express from 4.15.2 to 4.17.1 #1989
- Bump nightwatch from 0.9.16 to 1.1.13 #1990
- Bump file-loader from 1.1.11 to 4.2.0 #1992
- Bump browserstack-capabilities from 0.4.0 to 0.7.0 #2019