### PR TITLE
Add Colormap ticks 67

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,10 +1436,10 @@
       "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
       "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
       "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/area": {
@@ -1447,8 +1447,8 @@
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
       "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/bbox": {
@@ -1456,8 +1456,8 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
       "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/bbox-clip": {
@@ -1465,9 +1465,9 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
       "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "lineclip": "^1.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "lineclip": "1.1.5"
       }
     },
     "@turf/bbox-polygon": {
@@ -1475,7 +1475,7 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
       "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/bearing": {
@@ -1483,8 +1483,8 @@
       "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
       "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/bezier-spline": {
@@ -1492,8 +1492,8 @@
       "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
       "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/boolean-clockwise": {
@@ -1501,8 +1501,8 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
       "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/boolean-contains": {
@@ -1510,11 +1510,11 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
       "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/boolean-crosses": {
@@ -1522,11 +1522,11 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
       "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5"
       }
     },
     "@turf/boolean-disjoint": {
@@ -1534,11 +1534,11 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz",
       "integrity": "sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/polygon-to-line": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/polygon-to-line": "5.1.5"
       }
     },
     "@turf/boolean-equal": {
@@ -1546,9 +1546,9 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
       "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
       "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
         "geojson-equality": "0.1.6"
       }
     },
@@ -1557,11 +1557,11 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
       "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-overlap": "^5.1.5",
-        "@turf/meta": "^5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/meta": "5.1.6",
         "geojson-equality": "0.1.6"
       }
     },
@@ -1570,10 +1570,10 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
       "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
       "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5"
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5"
       }
     },
     "@turf/boolean-point-in-polygon": {
@@ -1581,8 +1581,8 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
       "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/boolean-point-on-line": {
@@ -1590,8 +1590,8 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
       "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/boolean-within": {
@@ -1599,11 +1599,11 @@
       "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
       "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/buffer": {
@@ -1611,13 +1611,13 @@
       "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
       "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/projection": "^5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/projection": "5.1.5",
         "d3-geo": "1.7.1",
-        "turf-jsts": "*"
+        "turf-jsts": "1.2.3"
       }
     },
     "@turf/center": {
@@ -1625,8 +1625,8 @@
       "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
       "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/center-mean": {
@@ -1634,9 +1634,9 @@
       "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
       "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/center-median": {
@@ -1644,11 +1644,11 @@
       "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
       "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
       "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/center-mean": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/center-of-mass": {
@@ -1656,11 +1656,11 @@
       "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
       "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
       "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/convex": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/centroid": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/centroid": {
@@ -1668,8 +1668,8 @@
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
       "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/circle": {
@@ -1677,8 +1677,8 @@
       "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
       "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
       "requires": {
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/clean-coords": {
@@ -1686,8 +1686,8 @@
       "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
       "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/clone": {
@@ -1695,7 +1695,7 @@
       "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
       "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/clusters": {
@@ -1703,8 +1703,8 @@
       "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
       "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/clusters-dbscan": {
@@ -1712,11 +1712,11 @@
       "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
       "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
         "density-clustering": "1.3.0"
       }
     },
@@ -1725,10 +1725,10 @@
       "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
       "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
         "skmeans": "0.9.7"
       }
     },
@@ -1737,10 +1737,10 @@
       "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
       "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "rbush": "^2.0.1"
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "rbush": "2.0.2"
       }
     },
     "@turf/combine": {
@@ -1748,8 +1748,8 @@
       "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
       "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/concave": {
@@ -1757,14 +1757,14 @@
       "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
       "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/tin": "^5.1.5",
-        "topojson-client": "3.x",
-        "topojson-server": "3.x"
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/tin": "5.1.5",
+        "topojson-client": "3.0.1",
+        "topojson-server": "3.0.1"
       }
     },
     "@turf/convex": {
@@ -1772,9 +1772,9 @@
       "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
       "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "concaveman": "*"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "concaveman": "1.1.1"
       }
     },
     "@turf/destination": {
@@ -1782,8 +1782,8 @@
       "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
       "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/difference": {
@@ -1791,11 +1791,11 @@
       "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
       "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
       "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "turf-jsts": "*"
+        "@turf/area": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "turf-jsts": "1.2.3"
       }
     },
     "@turf/dissolve": {
@@ -1803,15 +1803,15 @@
       "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
       "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
       "requires": {
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
         "geojson-rbush": "2.1.0",
-        "get-closest": "*"
+        "get-closest": "0.0.4"
       }
     },
     "@turf/distance": {
@@ -1819,8 +1819,8 @@
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
       "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/ellipse": {
@@ -1828,10 +1828,10 @@
       "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
       "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/transform-rotate": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/transform-rotate": "5.1.5"
       }
     },
     "@turf/envelope": {
@@ -1839,9 +1839,9 @@
       "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
       "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/explode": {
@@ -1849,8 +1849,8 @@
       "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
       "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/flatten": {
@@ -1858,8 +1858,8 @@
       "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
       "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/flip": {
@@ -1867,9 +1867,9 @@
       "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
       "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/great-circle": {
@@ -1877,8 +1877,8 @@
       "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
       "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/helpers": {
@@ -1891,10 +1891,10 @@
       "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
       "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
       "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.6",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/interpolate": {
@@ -1902,17 +1902,17 @@
       "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
       "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/hex-grid": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/point-grid": "^5.1.5",
-        "@turf/square-grid": "^5.1.5",
-        "@turf/triangle-grid": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/point-grid": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/triangle-grid": "5.1.5"
       }
     },
     "@turf/intersect": {
@@ -1920,11 +1920,11 @@
       "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.6.tgz",
       "integrity": "sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==",
       "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
-        "turf-jsts": "*"
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "turf-jsts": "1.2.3"
       }
     },
     "@turf/invariant": {
@@ -1932,7 +1932,7 @@
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
       "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/isobands": {
@@ -1940,13 +1940,13 @@
       "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
       "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
       "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/bbox": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/isolines": {
@@ -1954,10 +1954,10 @@
       "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
       "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/kinks": {
@@ -1965,7 +1965,7 @@
       "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
       "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/length": {
@@ -1973,9 +1973,9 @@
       "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
       "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
       "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/line-arc": {
@@ -1983,9 +1983,9 @@
       "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
       "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
       "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/circle": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/line-chunk": {
@@ -1993,10 +1993,10 @@
       "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
       "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/length": "^5.1.5",
-        "@turf/line-slice-along": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/line-intersect": {
@@ -2004,10 +2004,10 @@
       "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
       "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
         "geojson-rbush": "2.1.0"
       }
     },
@@ -2016,9 +2016,9 @@
       "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
       "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/line-overlap": {
@@ -2026,12 +2026,12 @@
       "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
       "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
       "requires": {
-        "@turf/boolean-point-on-line": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
         "geojson-rbush": "2.1.0"
       }
     },
@@ -2040,9 +2040,9 @@
       "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
       "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/line-slice": {
@@ -2050,9 +2050,9 @@
       "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
       "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5"
       }
     },
     "@turf/line-slice-along": {
@@ -2060,10 +2060,10 @@
       "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
       "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
       "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/line-split": {
@@ -2071,15 +2071,15 @@
       "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
       "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/line-segment": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/nearest-point-on-line": "^5.1.5",
-        "@turf/square": "^5.1.5",
-        "@turf/truncate": "^5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/truncate": "5.1.5",
         "geojson-rbush": "2.1.0"
       }
     },
@@ -2088,9 +2088,9 @@
       "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
       "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/mask": {
@@ -2098,11 +2098,11 @@
       "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
       "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/union": "^5.1.5",
-        "rbush": "^2.0.1"
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
+        "rbush": "2.0.2"
       }
     },
     "@turf/meta": {
@@ -2110,7 +2110,7 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
       "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/midpoint": {
@@ -2118,10 +2118,10 @@
       "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
       "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
       "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/nearest-point": {
@@ -2129,10 +2129,10 @@
       "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
       "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/nearest-point-on-line": {
@@ -2140,13 +2140,13 @@
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
       "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
       "requires": {
-        "@turf/bearing": "^5.1.5",
-        "@turf/destination": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-intersect": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/nearest-point-to-line": {
@@ -2154,11 +2154,11 @@
       "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz",
       "integrity": "sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==",
       "requires": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/point-to-line-distance": "^5.1.5",
-        "object-assign": "*"
+        "@turf/helpers": "6.1.4",
+        "@turf/invariant": "6.1.2",
+        "@turf/meta": "6.0.2",
+        "@turf/point-to-line-distance": "5.1.6",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "@turf/helpers": {
@@ -2171,7 +2171,7 @@
           "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
           "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
           "requires": {
-            "@turf/helpers": "6.x"
+            "@turf/helpers": "6.1.4"
           }
         },
         "@turf/meta": {
@@ -2179,7 +2179,7 @@
           "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
           "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
           "requires": {
-            "@turf/helpers": "6.x"
+            "@turf/helpers": "6.1.4"
           }
         }
       }
@@ -2189,8 +2189,8 @@
       "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
       "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/point-grid": {
@@ -2198,10 +2198,10 @@
       "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
       "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
       "requires": {
-        "@turf/boolean-within": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/boolean-within": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/point-on-feature": {
@@ -2209,11 +2209,11 @@
       "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
       "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/explode": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/nearest-point": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/nearest-point": "5.1.5"
       }
     },
     "@turf/point-to-line-distance": {
@@ -2221,14 +2221,14 @@
       "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz",
       "integrity": "sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==",
       "requires": {
-        "@turf/bearing": "6.x",
-        "@turf/distance": "6.x",
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x",
-        "@turf/meta": "6.x",
-        "@turf/projection": "6.x",
-        "@turf/rhumb-bearing": "6.x",
-        "@turf/rhumb-distance": "6.x"
+        "@turf/bearing": "6.0.1",
+        "@turf/distance": "6.0.1",
+        "@turf/helpers": "6.1.4",
+        "@turf/invariant": "6.1.2",
+        "@turf/meta": "6.0.2",
+        "@turf/projection": "6.0.1",
+        "@turf/rhumb-bearing": "6.0.1",
+        "@turf/rhumb-distance": "6.0.1"
       },
       "dependencies": {
         "@turf/bearing": {
@@ -2236,8 +2236,8 @@
           "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.0.1.tgz",
           "integrity": "sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==",
           "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
+            "@turf/helpers": "6.1.4",
+            "@turf/invariant": "6.1.2"
           }
         },
         "@turf/clone": {
@@ -2245,7 +2245,7 @@
           "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.0.2.tgz",
           "integrity": "sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==",
           "requires": {
-            "@turf/helpers": "6.x"
+            "@turf/helpers": "6.1.4"
           }
         },
         "@turf/distance": {
@@ -2253,8 +2253,8 @@
           "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.0.1.tgz",
           "integrity": "sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==",
           "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
+            "@turf/helpers": "6.1.4",
+            "@turf/invariant": "6.1.2"
           }
         },
         "@turf/helpers": {
@@ -2267,7 +2267,7 @@
           "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
           "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
           "requires": {
-            "@turf/helpers": "6.x"
+            "@turf/helpers": "6.1.4"
           }
         },
         "@turf/meta": {
@@ -2275,7 +2275,7 @@
           "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
           "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
           "requires": {
-            "@turf/helpers": "6.x"
+            "@turf/helpers": "6.1.4"
           }
         },
         "@turf/projection": {
@@ -2283,9 +2283,9 @@
           "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.0.1.tgz",
           "integrity": "sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==",
           "requires": {
-            "@turf/clone": "6.x",
-            "@turf/helpers": "6.x",
-            "@turf/meta": "6.x"
+            "@turf/clone": "6.0.2",
+            "@turf/helpers": "6.1.4",
+            "@turf/meta": "6.0.2"
           }
         },
         "@turf/rhumb-bearing": {
@@ -2293,8 +2293,8 @@
           "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz",
           "integrity": "sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==",
           "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
+            "@turf/helpers": "6.1.4",
+            "@turf/invariant": "6.1.2"
           }
         },
         "@turf/rhumb-distance": {
@@ -2302,8 +2302,8 @@
           "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz",
           "integrity": "sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==",
           "requires": {
-            "@turf/helpers": "6.x",
-            "@turf/invariant": "6.x"
+            "@turf/helpers": "6.1.4",
+            "@turf/invariant": "6.1.2"
           }
         }
       }
@@ -2313,9 +2313,9 @@
       "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
       "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/polygon-tangents": {
@@ -2323,8 +2323,8 @@
       "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
       "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/polygon-to-line": {
@@ -2332,8 +2332,8 @@
       "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
       "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/polygonize": {
@@ -2341,11 +2341,11 @@
       "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
       "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/envelope": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/projection": {
@@ -2353,9 +2353,9 @@
       "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
       "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/random": {
@@ -2363,7 +2363,7 @@
       "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
       "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/rewind": {
@@ -2371,11 +2371,11 @@
       "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
       "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
       "requires": {
-        "@turf/boolean-clockwise": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/rhumb-bearing": {
@@ -2383,8 +2383,8 @@
       "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
       "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/rhumb-destination": {
@@ -2392,8 +2392,8 @@
       "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
       "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/rhumb-distance": {
@@ -2401,8 +2401,8 @@
       "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
       "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/sample": {
@@ -2410,7 +2410,7 @@
       "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
       "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/sector": {
@@ -2418,11 +2418,11 @@
       "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
       "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
       "requires": {
-        "@turf/circle": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/line-arc": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/shortest-path": {
@@ -2430,15 +2430,15 @@
       "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
       "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/bbox-polygon": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/transform-scale": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/transform-scale": "5.1.5"
       }
     },
     "@turf/simplify": {
@@ -2446,10 +2446,10 @@
       "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
       "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
       "requires": {
-        "@turf/clean-coords": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/square": {
@@ -2457,8 +2457,8 @@
       "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
       "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
       "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5"
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/square-grid": {
@@ -2466,12 +2466,12 @@
       "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
       "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
       "requires": {
-        "@turf/boolean-contains": "^5.1.5",
-        "@turf/boolean-overlap": "^5.1.5",
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.6",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/standard-deviational-ellipse": {
@@ -2479,12 +2479,12 @@
       "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
       "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
       "requires": {
-        "@turf/center-mean": "^5.1.5",
-        "@turf/ellipse": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/points-within-polygon": "^5.1.5"
+        "@turf/center-mean": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/points-within-polygon": "5.1.5"
       }
     },
     "@turf/tag": {
@@ -2492,10 +2492,10 @@
       "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
       "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
       "requires": {
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/tesselate": {
@@ -2503,8 +2503,8 @@
       "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
       "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "earcut": "^2.0.0"
+        "@turf/helpers": "5.1.5",
+        "earcut": "2.1.5"
       }
     },
     "@turf/tin": {
@@ -2512,7 +2512,7 @@
       "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
       "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
       "requires": {
-        "@turf/helpers": "^5.1.5"
+        "@turf/helpers": "5.1.5"
       }
     },
     "@turf/transform-rotate": {
@@ -2520,14 +2520,14 @@
       "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
       "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
       "requires": {
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
       }
     },
     "@turf/transform-scale": {
@@ -2535,16 +2535,16 @@
       "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
       "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
       "requires": {
-        "@turf/bbox": "^5.1.5",
-        "@turf/center": "^5.1.5",
-        "@turf/centroid": "^5.1.5",
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-bearing": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5",
-        "@turf/rhumb-distance": "^5.1.5"
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
       }
     },
     "@turf/transform-translate": {
@@ -2552,11 +2552,11 @@
       "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
       "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
       "requires": {
-        "@turf/clone": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "@turf/rhumb-destination": "^5.1.5"
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-destination": "5.1.5"
       }
     },
     "@turf/triangle-grid": {
@@ -2564,10 +2564,10 @@
       "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
       "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
       "requires": {
-        "@turf/distance": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/intersect": "^5.1.5",
-        "@turf/invariant": "^5.1.5"
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.6",
+        "@turf/invariant": "5.1.5"
       }
     },
     "@turf/truncate": {
@@ -2575,8 +2575,8 @@
       "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
       "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
       }
     },
     "@turf/turf": {
@@ -2584,106 +2584,106 @@
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
       "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
       "requires": {
-        "@turf/along": "5.1.x",
-        "@turf/area": "5.1.x",
-        "@turf/bbox": "5.1.x",
-        "@turf/bbox-clip": "5.1.x",
-        "@turf/bbox-polygon": "5.1.x",
-        "@turf/bearing": "5.1.x",
-        "@turf/bezier-spline": "5.1.x",
-        "@turf/boolean-clockwise": "5.1.x",
-        "@turf/boolean-contains": "5.1.x",
-        "@turf/boolean-crosses": "5.1.x",
-        "@turf/boolean-disjoint": "5.1.x",
-        "@turf/boolean-equal": "5.1.x",
-        "@turf/boolean-overlap": "5.1.x",
-        "@turf/boolean-parallel": "5.1.x",
-        "@turf/boolean-point-in-polygon": "5.1.x",
-        "@turf/boolean-point-on-line": "5.1.x",
-        "@turf/boolean-within": "5.1.x",
-        "@turf/buffer": "5.1.x",
-        "@turf/center": "5.1.x",
-        "@turf/center-mean": "5.1.x",
-        "@turf/center-median": "5.1.x",
-        "@turf/center-of-mass": "5.1.x",
-        "@turf/centroid": "5.1.x",
-        "@turf/circle": "5.1.x",
-        "@turf/clean-coords": "5.1.x",
-        "@turf/clone": "5.1.x",
-        "@turf/clusters": "5.1.x",
-        "@turf/clusters-dbscan": "5.1.x",
-        "@turf/clusters-kmeans": "5.1.x",
-        "@turf/collect": "5.1.x",
-        "@turf/combine": "5.1.x",
-        "@turf/concave": "5.1.x",
-        "@turf/convex": "5.1.x",
-        "@turf/destination": "5.1.x",
-        "@turf/difference": "5.1.x",
-        "@turf/dissolve": "5.1.x",
-        "@turf/distance": "5.1.x",
-        "@turf/ellipse": "5.1.x",
-        "@turf/envelope": "5.1.x",
-        "@turf/explode": "5.1.x",
-        "@turf/flatten": "5.1.x",
-        "@turf/flip": "5.1.x",
-        "@turf/great-circle": "5.1.x",
-        "@turf/helpers": "5.1.x",
-        "@turf/hex-grid": "5.1.x",
-        "@turf/interpolate": "5.1.x",
-        "@turf/intersect": "5.1.x",
-        "@turf/invariant": "5.1.x",
-        "@turf/isobands": "5.1.x",
-        "@turf/isolines": "5.1.x",
-        "@turf/kinks": "5.1.x",
-        "@turf/length": "5.1.x",
-        "@turf/line-arc": "5.1.x",
-        "@turf/line-chunk": "5.1.x",
-        "@turf/line-intersect": "5.1.x",
-        "@turf/line-offset": "5.1.x",
-        "@turf/line-overlap": "5.1.x",
-        "@turf/line-segment": "5.1.x",
-        "@turf/line-slice": "5.1.x",
-        "@turf/line-slice-along": "5.1.x",
-        "@turf/line-split": "5.1.x",
-        "@turf/line-to-polygon": "5.1.x",
-        "@turf/mask": "5.1.x",
-        "@turf/meta": "5.1.x",
-        "@turf/midpoint": "5.1.x",
-        "@turf/nearest-point": "5.1.x",
-        "@turf/nearest-point-on-line": "5.1.x",
-        "@turf/nearest-point-to-line": "5.1.x",
-        "@turf/planepoint": "5.1.x",
-        "@turf/point-grid": "5.1.x",
-        "@turf/point-on-feature": "5.1.x",
-        "@turf/point-to-line-distance": "5.1.x",
-        "@turf/points-within-polygon": "5.1.x",
-        "@turf/polygon-tangents": "5.1.x",
-        "@turf/polygon-to-line": "5.1.x",
-        "@turf/polygonize": "5.1.x",
-        "@turf/projection": "5.1.x",
-        "@turf/random": "5.1.x",
-        "@turf/rewind": "5.1.x",
-        "@turf/rhumb-bearing": "5.1.x",
-        "@turf/rhumb-destination": "5.1.x",
-        "@turf/rhumb-distance": "5.1.x",
-        "@turf/sample": "5.1.x",
-        "@turf/sector": "5.1.x",
-        "@turf/shortest-path": "5.1.x",
-        "@turf/simplify": "5.1.x",
-        "@turf/square": "5.1.x",
-        "@turf/square-grid": "5.1.x",
-        "@turf/standard-deviational-ellipse": "5.1.x",
-        "@turf/tag": "5.1.x",
-        "@turf/tesselate": "5.1.x",
-        "@turf/tin": "5.1.x",
-        "@turf/transform-rotate": "5.1.x",
-        "@turf/transform-scale": "5.1.x",
-        "@turf/transform-translate": "5.1.x",
-        "@turf/triangle-grid": "5.1.x",
-        "@turf/truncate": "5.1.x",
-        "@turf/union": "5.1.x",
-        "@turf/unkink-polygon": "5.1.x",
-        "@turf/voronoi": "5.1.x"
+        "@turf/along": "5.1.5",
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-clip": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/bearing": "5.1.5",
+        "@turf/bezier-spline": "5.1.5",
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-crosses": "5.1.5",
+        "@turf/boolean-disjoint": "5.1.6",
+        "@turf/boolean-equal": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/boolean-parallel": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/boolean-within": "5.1.5",
+        "@turf/buffer": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/center-mean": "5.1.5",
+        "@turf/center-median": "5.1.5",
+        "@turf/center-of-mass": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/circle": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/clusters": "5.1.5",
+        "@turf/clusters-dbscan": "5.1.5",
+        "@turf/clusters-kmeans": "5.1.5",
+        "@turf/collect": "5.1.5",
+        "@turf/combine": "5.1.5",
+        "@turf/concave": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/difference": "5.1.5",
+        "@turf/dissolve": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/flatten": "5.1.5",
+        "@turf/flip": "5.1.5",
+        "@turf/great-circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/interpolate": "5.1.5",
+        "@turf/intersect": "5.1.6",
+        "@turf/invariant": "5.1.5",
+        "@turf/isobands": "5.1.5",
+        "@turf/isolines": "5.1.5",
+        "@turf/kinks": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/line-chunk": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-offset": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/line-slice": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/line-split": "5.1.5",
+        "@turf/line-to-polygon": "5.1.5",
+        "@turf/mask": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/midpoint": "5.1.5",
+        "@turf/nearest-point": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/nearest-point-to-line": "5.1.6",
+        "@turf/planepoint": "5.1.5",
+        "@turf/point-grid": "5.1.5",
+        "@turf/point-on-feature": "5.1.5",
+        "@turf/point-to-line-distance": "5.1.6",
+        "@turf/points-within-polygon": "5.1.5",
+        "@turf/polygon-tangents": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5",
+        "@turf/polygonize": "5.1.5",
+        "@turf/projection": "5.1.5",
+        "@turf/random": "5.1.5",
+        "@turf/rewind": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5",
+        "@turf/sample": "5.1.5",
+        "@turf/sector": "5.1.5",
+        "@turf/shortest-path": "5.1.5",
+        "@turf/simplify": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/standard-deviational-ellipse": "5.1.5",
+        "@turf/tag": "5.1.5",
+        "@turf/tesselate": "5.1.5",
+        "@turf/tin": "5.1.5",
+        "@turf/transform-rotate": "5.1.5",
+        "@turf/transform-scale": "5.1.5",
+        "@turf/transform-translate": "5.1.5",
+        "@turf/triangle-grid": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "@turf/union": "5.1.5",
+        "@turf/unkink-polygon": "5.1.5",
+        "@turf/voronoi": "5.1.5"
       }
     },
     "@turf/union": {
@@ -2691,8 +2691,8 @@
       "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
       "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "turf-jsts": "*"
+        "@turf/helpers": "5.1.5",
+        "turf-jsts": "1.2.3"
       }
     },
     "@turf/unkink-polygon": {
@@ -2700,11 +2700,11 @@
       "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
       "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
       "requires": {
-        "@turf/area": "^5.1.5",
-        "@turf/boolean-point-in-polygon": "^5.1.5",
-        "@turf/helpers": "^5.1.5",
-        "@turf/meta": "^5.1.5",
-        "rbush": "^2.0.1"
+        "@turf/area": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.2"
       }
     },
     "@turf/voronoi": {
@@ -2712,8 +2712,8 @@
       "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
       "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
       "requires": {
-        "@turf/helpers": "^5.1.5",
-        "@turf/invariant": "^5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
         "d3-voronoi": "1.1.2"
       }
     },
@@ -3206,7 +3206,7 @@
       "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
       "dev": true,
       "requires": {
-        "object-assign": "4.x"
+        "object-assign": "4.1.1"
       }
     },
     "adm-zip": {
@@ -4937,11 +4937,11 @@
       "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
       "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
       "requires": {
-        "monotone-convex-hull-2d": "^1.0.1",
-        "point-in-polygon": "^1.0.1",
-        "rbush": "^2.0.1",
-        "robust-orientation": "^1.1.3",
-        "tinyqueue": "^1.1.0"
+        "monotone-convex-hull-2d": "1.0.1",
+        "point-in-polygon": "1.0.1",
+        "rbush": "2.0.2",
+        "robust-orientation": "1.1.3",
+        "tinyqueue": "1.2.3"
       }
     },
     "configstore": {
@@ -5282,8 +5282,8 @@
       "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.x",
-        "component-classes": "^1.2.5"
+        "babel-runtime": "6.26.0",
+        "component-classes": "1.2.6"
       }
     },
     "css-blank-pseudo": {
@@ -5835,7 +5835,7 @@
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
       "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
       "requires": {
-        "d3-array": "1"
+        "d3-array": "1.2.4"
       }
     },
     "d3-voronoi": {
@@ -5858,13 +5858,13 @@
       "integrity": "sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.53"
+        "@types/node": "8.10.54"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.53",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.53.tgz",
-          "integrity": "sha512-aOmXdv1a1/vYUn1OT1CED8ftbkmmYbKhKGSyMDeJiidLvKRKvZUQOdXwG/wcNY7T1Qb0XTlVdiYjIq00U7pLrQ==",
+          "version": "8.10.54",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.54.tgz",
+          "integrity": "sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==",
           "dev": true
         }
       }
@@ -7815,8 +7815,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7840,15 +7839,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -7865,22 +7862,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8011,8 +8005,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8026,7 +8019,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -8043,7 +8035,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -8052,15 +8043,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2",
             "yallist": "3.0.3"
@@ -8081,7 +8070,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8170,8 +8158,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8185,7 +8172,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -8281,8 +8267,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8324,7 +8309,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -8346,7 +8330,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -8395,15 +8378,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8555,7 +8536,7 @@
       "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
       "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
       "requires": {
-        "deep-equal": "^1.0.0"
+        "deep-equal": "1.0.1"
       }
     },
     "geojson-rbush": {
@@ -8563,9 +8544,9 @@
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
       "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
       "requires": {
-        "@turf/helpers": "*",
-        "@turf/meta": "*",
-        "rbush": "*"
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.2"
       }
     },
     "get-caller-file": {
@@ -9667,6 +9648,12 @@
       "requires": {
         "loose-envify": "1.4.0"
       }
+    },
+    "invert-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-color/-/invert-color-2.0.0.tgz",
+      "integrity": "sha512-9s6IATlhOAr0/0MPUpLdMpk81ixIu8IqwPwORssXBauFT/4ff/iyEOcojd0UYuPwkDbJvL1+blIZGhqVIaAm5Q==",
+      "dev": true
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -12012,7 +11999,7 @@
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
       "requires": {
-        "robust-orientation": "^1.1.3"
+        "robust-orientation": "1.1.3"
       }
     },
     "move-concurrently": {
@@ -17064,7 +17051,7 @@
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "dev": true,
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       }
     },
     "raf-schd": {
@@ -17150,10 +17137,10 @@
       "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "dom-align": "^1.7.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4"
+        "babel-runtime": "6.26.0",
+        "dom-align": "1.10.2",
+        "prop-types": "15.7.2",
+        "rc-util": "4.11.0"
       }
     },
     "rc-animate": {
@@ -17162,13 +17149,13 @@
       "integrity": "sha512-gZM3WteZO0e3X8B71KP0bs95EY2tAPRuiZyKnlhdLpOjTX/64SrhDZM3pT2Z8mJjKWNiiB5q2SSSf+BD8ljwVw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "css-animation": "^1.3.2",
-        "prop-types": "15.x",
-        "raf": "^3.4.0",
-        "rc-util": "^4.8.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
+        "css-animation": "1.6.1",
+        "prop-types": "15.7.2",
+        "raf": "3.4.1",
+        "rc-util": "4.11.0",
+        "react-lifecycles-compat": "3.0.4"
       }
     },
     "rc-slider": {
@@ -17177,14 +17164,14 @@
       "integrity": "sha512-WMT5mRFUEcrLWwTxsyS8jYmlaMsTVCZIGENLikHsNv+tE8ThU2lCoPfi/xFNUfJFNFSBFP3MwPez9ZsJmNp13g==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.5",
-        "prop-types": "^15.5.4",
-        "rc-tooltip": "^3.7.0",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "warning": "^4.0.3"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
+        "prop-types": "15.7.2",
+        "rc-tooltip": "3.7.3",
+        "rc-util": "4.11.0",
+        "react-lifecycles-compat": "3.0.4",
+        "shallowequal": "1.1.0",
+        "warning": "4.0.3"
       }
     },
     "rc-tooltip": {
@@ -17193,9 +17180,9 @@
       "integrity": "sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.2"
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.7.2",
+        "rc-trigger": "2.6.5"
       }
     },
     "rc-trigger": {
@@ -17204,13 +17191,13 @@
       "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "15.x",
-        "rc-align": "^2.4.0",
-        "rc-animate": "2.x",
-        "rc-util": "^4.4.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.6",
+        "prop-types": "15.7.2",
+        "rc-align": "2.4.5",
+        "rc-animate": "2.10.0",
+        "rc-util": "4.11.0",
+        "react-lifecycles-compat": "3.0.4"
       }
     },
     "rc-util": {
@@ -17219,11 +17206,11 @@
       "integrity": "sha512-nB29kXOXsSVjBkWfH+Z1GVh6tRg7XGZtZ0Yfie+OI0stCDixGQ1cPrS6iYxlg+AV2St6COCK5MFrCmpTgghh0w==",
       "dev": true,
       "requires": {
-        "add-dom-event-listener": "^1.1.0",
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^0.2.2"
+        "add-dom-event-listener": "1.1.0",
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.7.2",
+        "react-lifecycles-compat": "3.0.4",
+        "shallowequal": "0.2.2"
       },
       "dependencies": {
         "shallowequal": {
@@ -17232,7 +17219,7 @@
           "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
           "dev": true,
           "requires": {
-            "lodash.keys": "^3.1.2"
+            "lodash.keys": "3.1.2"
           }
         }
       }
@@ -17647,7 +17634,6 @@
     },
     "redux-location-state": {
       "version": "github:nasa-gibs/redux-location-state#4e81314253e61ee0f4eaffdc0a5ba0a89194253f",
-      "from": "github:nasa-gibs/redux-location-state#4e81314253e61ee0f4eaffdc0a5ba0a89194253f",
       "dev": true,
       "requires": {
         "lodash": "4.17.15"
@@ -18132,10 +18118,10 @@
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
       "requires": {
-        "robust-scale": "^1.0.2",
-        "robust-subtract": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.2"
+        "robust-scale": "1.0.2",
+        "robust-subtract": "1.0.0",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
       }
     },
     "robust-scale": {
@@ -18143,8 +18129,8 @@
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
       "requires": {
-        "two-product": "^1.0.2",
-        "two-sum": "^1.0.0"
+        "two-product": "1.0.2",
+        "two-sum": "1.0.0"
       }
     },
     "robust-subtract": {
@@ -20918,19 +20904,19 @@
       "dev": true
     },
     "topojson-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
-      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.1.tgz",
+      "integrity": "sha512-rfGGzyqefpxOaxvV9OTF9t+1g+WhjGEbAIuCcmKYrQkxr0nttjMMyzZsK+NhLW4cTl2g1bz2jQczPUtEshpbVQ==",
       "requires": {
-        "commander": "2"
+        "commander": "2.17.1"
       }
     },
     "topojson-server": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
-      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
       "requires": {
-        "commander": "2"
+        "commander": "2.17.1"
       }
     },
     "toposort": {
@@ -21748,7 +21734,7 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9649,12 +9649,6 @@
         "loose-envify": "1.4.0"
       }
     },
-    "invert-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-color/-/invert-color-2.0.0.tgz",
-      "integrity": "sha512-9s6IATlhOAr0/0MPUpLdMpk81ixIu8IqwPwORssXBauFT/4ff/iyEOcojd0UYuPwkDbJvL1+blIZGhqVIaAm5Q==",
-      "dev": true
-    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "glob": "^7.1.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "invert-color": "^2.0.0",
     "jest": "^24.8.0",
     "mini-css-extract-plugin": "^0.4.1",
     "moment": "^2.19.3",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "glob": "^7.1.2",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
-    "invert-color": "^2.0.0",
     "jest": "^24.8.0",
     "mini-css-extract-plugin": "^0.4.1",
     "moment": "^2.19.3",

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -132,6 +132,7 @@ def process_entries(colormap):
     legends = to_list(colormap["Legend"]["LegendEntry"])
     colors = []
     values = []
+    ticks = []
     tooltips = []
     matches = []
 
@@ -153,6 +154,8 @@ def process_entries(colormap):
                 if (map_type == "continuous") or (map_type == "discrete"):
                     matches += [entry["@rgb"]]
         tooltips += [tooltip]
+        if "@showTick" in legend:
+            ticks.append(index)
         if (map_type == "continuous") or (map_type == "discrete"):
             items = re.sub(r"[\(\)\[\]]", "", entry["@value"]).split(",")
             try:
@@ -179,7 +182,8 @@ def process_entries(colormap):
         "legend": {
             "tooltips": tooltips,
             "colors": colors,
-            "type": map_type
+            "type": map_type,
+            "ticks": ticks
         }
     }
     if (map_type == "continuous") or (map_type == "discrete"):

--- a/web/css/palettes.css
+++ b/web/css/palettes.css
@@ -178,8 +178,7 @@
 
 .wv-palettes-colorbar {
   width: 231px;
-  height: 12px;
-  border: 1px solid #404040;
+  height: 24px;
   margin-bottom: 13px;
   max-width: 231px;
   margin-left: 5px;

--- a/web/css/palettes.css
+++ b/web/css/palettes.css
@@ -51,7 +51,7 @@
 .wv-palettes-title,
 .wv-running-category-label,
 .wv-running-label {
-  font-size: 0.7em;
+  font-size: 10px;
   bottom: 0;
   width: auto;
 }
@@ -77,7 +77,7 @@
 .layer-hidden .wv-running-category-label,
 .layer-hidden .wv-running-label {
   color: #999;
-  font-size: 0.7em;
+  font-size: 10px;
 }
 
 .wv-palettes-title {

--- a/web/css/palettes.css
+++ b/web/css/palettes.css
@@ -143,19 +143,18 @@
 }
 
 .wv-palettes-panel .wv-running-bar::before {
-  top: 6px;
-  left: -5px;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 5.5px solid #000;
+  top: -1px;
+  left: -4.25px;
+  border-left: 5.5px solid transparent;
+  border-right: 5.5px solid transparent;
+  border-top: 5.5px solid #000;
 }
 
 .wv-palettes-panel .wv-running-bar::after {
-  top: 7px;
-  left: -4px;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-bottom: 4px solid #dedede;
+  left: -3.25px;
+  border-left: 4.5px solid transparent;
+  border-right: 4.5px solid transparent;
+  border-top: 4px solid #dedede;
 }
 
 .wv-palettes-legend.wv-running .wv-palettes-max,

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -31,7 +31,7 @@ class MeasureButton extends React.Component {
     this.dismissAlert = this.dismissAlert.bind(this);
   }
 
-  onButtonClick (evt) {
+  onButtonClick(evt) {
     const { openModal } = this.props;
     const isTouchDevice = evt.type === 'touchend';
     evt.stopPropagation();

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -253,8 +253,8 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-            ''
-          )}
+          ''
+        )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
@@ -375,8 +375,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                  ''
-                )}
+                ''
+              )}
             </React.Fragment>
           );
         })}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../util/util';
-import { drawPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
+import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
 import lodashIsNumber from 'lodash/isNumber';
 
 class PaletteLegend extends React.Component {
@@ -137,7 +137,7 @@ class PaletteLegend extends React.Component {
             this.setState({ width: newWidth });
           }
           const ctx = this[ctxStr].current.getContext('2d');
-          drawPaletteOnCanvas(
+          drawSidebarPaletteOnCanvas(
             ctx,
             checkerBoardPattern,
             colorMap.colors,

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -99,7 +99,7 @@ class PaletteLegend extends React.Component {
       if (util.hexColorDelta(legend.colors[i], hex) < acceptableDifference) {
         // If the two colors are close
         return {
-          label: legend.tooltips[i] + ' ' + units,
+          label: units ? legend.tooltips[i] + ' ' + units : legend.tooltips[i],
           len: len,
           index: i
         };
@@ -212,7 +212,7 @@ class PaletteLegend extends React.Component {
     } else if (xOffset + halfTextWidth > width) {
       return { right: '0' };
     }
-    return { left: xOffset - halfTextWidth + 'px' };
+    return { left: Math.floor(xOffset - halfTextWidth) + 'px' };
   }
 
   /**
@@ -231,7 +231,7 @@ class PaletteLegend extends React.Component {
       legendObj = this.getLegendObject(legend, colorHex, 5); // {label,len,index}
       if (legendObj) {
         percent = this.getPercent(legendObj.len, legendObj.index);
-        textWidth = util.getTextWidth(legendObj.label, 'Lucida Sans');
+        textWidth = util.getTextWidth(legendObj.label, '10px Open Sans');
         xOffset = Math.floor(this.state.width * percent);
       }
     }

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -273,7 +273,8 @@ class PaletteLegend extends React.Component {
           <div
             className="wv-running-bar"
             style={{
-              left: isHoveringLegend ? 0 : xOffset,
+              top: 7,
+              left: isHoveringLegend ? 0 : xOffset + 1,
               visibility: legendObj && !isHoveringLegend ? 'visible' : 'hidden'
             }}
           />

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -253,14 +253,14 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-          ''
-        )}
+            ''
+          )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
             id={layer.id + '-' + legend.id + index + 'colorbar'}
             width={width}
-            height={12}
+            height={24}
             ref={this['canvas_' + index]}
             onMouseEnter={!isMobile ? this.onMouseEnter.bind(this) : null}
             onMouseLeave={!isMobile ? this.hideValue.bind(this) : null}
@@ -374,8 +374,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                ''
-              )}
+                  ''
+                )}
             </React.Fragment>
           );
         })}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../util/util';
 import { drawPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
-import lodashIsEqual from 'lodash/isEqual';
 import lodashIsNumber from 'lodash/isNumber';
 
 class PaletteLegend extends React.Component {
@@ -137,7 +136,7 @@ class PaletteLegend extends React.Component {
             // This value is needed for calculating running data offsets
             this.setState({ width: newWidth });
           }
-          let ctx = this[ctxStr].current.getContext('2d');
+          const ctx = this[ctxStr].current.getContext('2d');
           drawPaletteOnCanvas(
             ctx,
             checkerBoardPattern,
@@ -254,8 +253,8 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-            ''
-          )}
+          ''
+        )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
@@ -375,8 +374,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                  ''
-                )}
+                ''
+              )}
             </React.Fragment>
           );
         })}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../util/util';
-import { drawPaletteOnCanvas } from '../../modules/palettes/util';
+import { drawPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
+import lodashIsEqual from 'lodash/isEqual';
 import lodashIsNumber from 'lodash/isNumber';
 
 class PaletteLegend extends React.Component {
@@ -136,10 +137,17 @@ class PaletteLegend extends React.Component {
             // This value is needed for calculating running data offsets
             this.setState({ width: newWidth });
           }
+          let ctx = this[ctxStr].current.getContext('2d');
           drawPaletteOnCanvas(
-            this[ctxStr].current.getContext('2d'),
+            ctx,
             checkerBoardPattern,
             colorMap.colors,
+            width,
+            height
+          );
+          drawTicksOnCanvas(
+            ctx,
+            colorMap,
             width,
             height
           );
@@ -246,8 +254,8 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-          ''
-        )}
+            ''
+          )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
@@ -347,9 +355,9 @@ class PaletteLegend extends React.Component {
               {isEndOfRow ? (
                 <div className="wv-running-category-label-case">
                   {isRunningData &&
-                  legendObj &&
-                  (legendObj.index >= rowEndIndex && // legend is in this row
-                    legendObj.index <= index) ? (
+                    legendObj &&
+                    (legendObj.index >= rowEndIndex && // legend is in this row
+                      legendObj.index <= index) ? (
                       <span
                         className="wv-running-category-label"
                         style={this.getClassLabelStyle(
@@ -367,8 +375,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                ''
-              )}
+                  ''
+                )}
             </React.Fragment>
           );
         })}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -232,7 +232,7 @@ class PaletteLegend extends React.Component {
       if (legendObj) {
         percent = this.getPercent(legendObj.len, legendObj.index);
         textWidth = util.getTextWidth(legendObj.label, 'Lucida Sans');
-        xOffset = this.state.width * percent;
+        xOffset = Math.floor(this.state.width * percent);
       }
     }
     var min = legend.minLabel || legend.tooltips[0];
@@ -274,7 +274,7 @@ class PaletteLegend extends React.Component {
             className="wv-running-bar"
             style={{
               top: 7,
-              left: isHoveringLegend ? 0 : xOffset + 1,
+              left: isHoveringLegend ? 0 : xOffset + 0.5,
               visibility: legendObj && !isHoveringLegend ? 'visible' : 'hidden'
             }}
           />

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -731,7 +731,7 @@ class Timeline extends React.Component {
   checkAndUpdateAppNow() {
     const { updateAppNow } = this.props;
     const self = this;
-    const ensureCanUpdate = function () {
+    const ensureCanUpdate = function() {
       return new Promise(function(resolve, reject) {
         (function waitForSafeUpdate() {
           const {

--- a/web/js/map/measure/ui.js
+++ b/web/js/map/measure/ui.js
@@ -21,7 +21,7 @@ import {
 } from './util.js';
 import { toggleMeasureActive } from '../../modules/measure/actions';
 
-export function measure (map, mapUiEvents, store) {
+export function measure(map, mapUiEvents, store) {
   let draw;
   let sketch;
   let measureTooltipElement;
@@ -116,7 +116,7 @@ export function measure (map, mapUiEvents, store) {
     map.addOverlay(measureTooltip);
   }
 
-  function drawStartCallback (evt) {
+  function drawStartCallback(evt) {
     let tooltipCoord;
     mapUiEvents.trigger('disable-click-zoom');
     sketch = evt.feature;
@@ -132,7 +132,7 @@ export function measure (map, mapUiEvents, store) {
     });
   };
 
-  function drawEndCallback (evt) {
+  function drawEndCallback(evt) {
     const featureGeom = evt.feature.getGeometry();
     allGeometries[featureGeom.ol_uid] = featureGeom;
     measureTooltipElement.className = 'tooltip-measure tooltip-static';
@@ -146,7 +146,7 @@ export function measure (map, mapUiEvents, store) {
    * lines and polygon edges.  Otherwise pass through unaffected.
    * @param {*} feature
    */
-  function styleGeometryFn (feature) {
+  function styleGeometryFn(feature) {
     const geometry = feature.getGeometry();
     if (!useGreatCircle) {
       return geometry;
@@ -181,7 +181,7 @@ export function measure (map, mapUiEvents, store) {
    * Go through every tooltip and recalculate the measurement based on
    * current settings of unit of measurement and great circle
    */
-  function recalculateAllMeasurements () {
+  function recalculateAllMeasurements() {
     for (const id in allMeasureTooltips) {
       const geomForTooltip = allGeometries[id];
       const tooltipElement = allMeasureTooltips[id].element.children[0];

--- a/web/js/map/measure/util.js
+++ b/web/js/map/measure/util.js
@@ -31,7 +31,7 @@ const getArcLine = (p1, p2) => {
  * applying a great circle arc transformation
  * @param {*} geom - the geometry object to apply great circle arc transformation to
  */
-export function transformLineStringArc (geom, projection) {
+export function transformLineStringArc(geom, projection) {
   const coords = [];
   const transformedGeom = geom.clone().transform(projection, referenceProjection);
 
@@ -48,7 +48,7 @@ export function transformLineStringArc (geom, projection) {
  * great circle arc
  * @param {*} geom - the geometry object to apply great circle arc transformation to
  */
-export function transformPolygonArc (geom, projection) {
+export function transformPolygonArc(geom, projection) {
   let coords = [];
   const transformedGeom = geom.clone().transform(projection, referenceProjection);
   const polyCoords = transformedGeom.getCoordinates()[0];
@@ -146,7 +146,7 @@ export function getRhumbLineArea(polygon, projection) {
  * @param {*} factor
  * @return {String} - The measurement, converted based on factor and locale
  */
-export function roundAndLocale (measurement, factor) {
+export function roundAndLocale(measurement, factor) {
   factor = factor || 1;
   return (Math.round(measurement / factor * 100) / 100).toLocaleString();
 };

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -109,10 +109,10 @@ export function getCustomPalette(paletteId, customsPaletteConfig) {
   }
   return palette;
 }
-var useLookup = function(layerId, palettesObj, state) {
+var useLookup = function (layerId, palettesObj, state) {
   var use = false;
   var active = palettesObj[layerId].maps;
-  lodashEach(active, function(palette, index) {
+  lodashEach(active, function (palette, index) {
     if (palette.custom) {
       use = true;
       return false;
@@ -138,7 +138,7 @@ export function getLookup(layerId, groupstr, state) {
   groupstr = groupstr || state.compare.activeString;
   return state.palettes[groupstr][layerId].lookup;
 }
-var updateLookup = function(layerId, palettesObj, state) {
+var updateLookup = function (layerId, palettesObj, state) {
   let newPalettes = palettesObj;
   if (!useLookup(layerId, newPalettes, state)) {
     delete newPalettes[layerId];
@@ -146,7 +146,7 @@ var updateLookup = function(layerId, palettesObj, state) {
   }
   var lookup = {};
   var active = newPalettes[layerId].maps;
-  lodashEach(active, function(palette, index) {
+  lodashEach(active, function (palette, index) {
     var oldLegend = palette.legend;
     var entries = palette.entries;
     var legend = {
@@ -154,6 +154,7 @@ var updateLookup = function(layerId, palettesObj, state) {
       minLabel: oldLegend.minLabel,
       maxLabel: oldLegend.maxLabel,
       tooltips: oldLegend.tooltips,
+      ticks: oldLegend.ticks,
       units: oldLegend.units,
       type: entries.type,
       title: entries.title,
@@ -169,7 +170,7 @@ var updateLookup = function(layerId, palettesObj, state) {
 
     var sourceCount = source.length;
     var targetCount = target.length;
-    lodashEach(source, function(color, index) {
+    lodashEach(source, function (color, index) {
       var targetColor;
       if (index < min || index > max) {
         targetColor = '00000000';
@@ -221,7 +222,7 @@ export function findIndex(layerId, type, value, index, groupStr, state) {
   index = index || 0;
   var values = getPalette(layerId, index, groupStr, state).entries.values;
   var result;
-  lodashEach(values, function(check, index) {
+  lodashEach(values, function (check, index) {
     var min = getMinValue(check);
     var max = getMaxValue(check);
     if (type === 'min' && value === min) {
@@ -326,12 +327,12 @@ export function clearCustomSelector(layerId, index, palettes, state) {
   }); // remove custom key
   return updateLookup(layerId, newPalettes, state);
 }
-var prepare = function(layerId, palettesObj, state) {
+var prepare = function (layerId, palettesObj, state) {
   var newPalettes = lodashCloneDeep(palettesObj);
   if (!newPalettes[layerId]) newPalettes[layerId] = {};
   var active = newPalettes[layerId];
   active.maps = active.maps || [];
-  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function(
+  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function (
     palette,
     index
   ) {

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -109,10 +109,10 @@ export function getCustomPalette(paletteId, customsPaletteConfig) {
   }
   return palette;
 }
-var useLookup = function (layerId, palettesObj, state) {
+var useLookup = function(layerId, palettesObj, state) {
   var use = false;
   var active = palettesObj[layerId].maps;
-  lodashEach(active, function (palette, index) {
+  lodashEach(active, function(palette, index) {
     if (palette.custom) {
       use = true;
       return false;
@@ -138,7 +138,7 @@ export function getLookup(layerId, groupstr, state) {
   groupstr = groupstr || state.compare.activeString;
   return state.palettes[groupstr][layerId].lookup;
 }
-var updateLookup = function (layerId, palettesObj, state) {
+var updateLookup = function(layerId, palettesObj, state) {
   let newPalettes = palettesObj;
   if (!useLookup(layerId, newPalettes, state)) {
     delete newPalettes[layerId];
@@ -146,7 +146,7 @@ var updateLookup = function (layerId, palettesObj, state) {
   }
   var lookup = {};
   var active = newPalettes[layerId].maps;
-  lodashEach(active, function (palette, index) {
+  lodashEach(active, function(palette, index) {
     var oldLegend = palette.legend;
     var entries = palette.entries;
     var legend = {
@@ -170,7 +170,7 @@ var updateLookup = function (layerId, palettesObj, state) {
 
     var sourceCount = source.length;
     var targetCount = target.length;
-    lodashEach(source, function (color, index) {
+    lodashEach(source, function(color, index) {
       var targetColor;
       if (index < min || index > max) {
         targetColor = '00000000';
@@ -222,7 +222,7 @@ export function findIndex(layerId, type, value, index, groupStr, state) {
   index = index || 0;
   var values = getPalette(layerId, index, groupStr, state).entries.values;
   var result;
-  lodashEach(values, function (check, index) {
+  lodashEach(values, function(check, index) {
     var min = getMinValue(check);
     var max = getMaxValue(check);
     if (type === 'min' && value === min) {
@@ -327,12 +327,12 @@ export function clearCustomSelector(layerId, index, palettes, state) {
   }); // remove custom key
   return updateLookup(layerId, newPalettes, state);
 }
-var prepare = function (layerId, palettesObj, state) {
+var prepare = function(layerId, palettesObj, state) {
   var newPalettes = lodashCloneDeep(palettesObj);
   if (!newPalettes[layerId]) newPalettes[layerId] = {};
   var active = newPalettes[layerId];
   active.maps = active.maps || [];
-  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function (
+  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function(
     palette,
     index
   ) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -99,8 +99,6 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
       ctx.stroke();
       ctx.closePath();
     });
-
-
   }
 }
 export function lookup(sourcePalette, targetPalette) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -15,7 +15,6 @@ import {
   findIndex as findPaletteExtremeIndex
 } from './selectors';
 import util from '../../util/util';
-import invertColor from 'invert-color';
 import Promise from 'bluebird';
 
 /**
@@ -63,12 +62,40 @@ export function drawPaletteOnCanvas(
   ctx,
   checkerBoardPattern,
   colors,
-  width
+  width,
+  height
 ) {
   ctx.fillStyle = checkerBoardPattern;
   ctx.fillRect(0, 0, width, height);
+
+  if (colors) {
+    var bins = colors.length;
+    var binWidth = width / bins;
+    var drawWidth = Math.ceil(binWidth);
+    colors.forEach((color, i) => {
+      ctx.fillStyle = util.hexToRGBA(color);
+      ctx.fillRect(Math.floor(binWidth * i), 0, drawWidth, height);
+    });
+  }
+}
+/**
+ * Redraw canvas with selected colormap
+ * @param {String} ctxStr | String of wanted cavnas
+ * @param {Object} checkerBoardPattern | Background for canvas threshold
+ * @param {Array} colors | array of color values
+ */
+export function drawSidebarPaletteOnCanvas(
+  ctx,
+  checkerBoardPattern,
+  colors,
+  width
+) {
   const height = 24;
   const barHeight = 12;
+  const colorbarStartY = barHeight - 5;
+  ctx.fillStyle = checkerBoardPattern;
+  ctx.fillRect(1, colorbarStartY, width - 1, barHeight);
+
   if (colors) {
     var bins = colors.length;
     var binWidth = (width - 2) / bins;
@@ -78,12 +105,11 @@ export function drawPaletteOnCanvas(
 
     colors.forEach((color, i) => {
       ctx.fillStyle = util.hexToRGBA(color);
-      ctx.fillRect(Math.floor((binWidth * i) + 1), barHeight - 5, drawWidth, barHeight);
+      ctx.fillRect(Math.floor((binWidth * i) + 1), colorbarStartY, drawWidth, barHeight);
     });
-    ctx.rect(2 - (thickness), (7) - (thickness), width - 3 + (thickness * 2), (barHeight) + (thickness * 2));
+    ctx.rect(2 - (thickness), (colorbarStartY) - (thickness), width - 3 + (thickness * 2), (barHeight) + (thickness * 2));
     ctx.stroke();
   }
-
 }
 export function drawTicksOnCanvas(ctx, legend, width, height) {
   const ticks = legend.ticks;
@@ -94,7 +120,7 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const yValue2 = parseFloat(12 * 0.3);
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
-  if (ticks && ticks.length > 0 && bins > 12) {
+  if (ticks && ticks.length > 0 && bins > 100) {
     ctx.beginPath();
     ticks.forEach(tick => {
       const start = binWidth * tick;

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -84,7 +84,8 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const colors = legend.colors;
   const bins = colors.length;
   const binWidth = width / bins;
-  const yValue = height * 0.70;
+  const yValue = parseFloat(height * 0.70);
+  const yValue2 = parseFloat(height * 0.3);
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
   if (ticks && ticks.length > 0) {
@@ -92,10 +93,19 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
       const start = binWidth * tick;
       const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331
       ctx.beginPath();
-      ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
+      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
+      ctx.strokeStyle = '#000'
       ctx.lineWidth = 0.8;
-      ctx.moveTo(midpoint, parseFloat(yValue));
-      ctx.lineTo(midpoint, parseFloat(height));
+      ctx.moveTo(midpoint, yValue);
+      ctx.lineTo(midpoint, height);
+      ctx.stroke();
+      ctx.closePath();
+      ctx.beginPath();
+      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
+      ctx.strokeStyle = '#fff'
+      ctx.lineWidth = 0.8;
+      ctx.moveTo(midpoint, 0);
+      ctx.lineTo(midpoint, yValue2);
       ctx.stroke();
       ctx.closePath();
     });

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -94,7 +94,7 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const yValue2 = parseFloat(12 * 0.3);
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
-  if (ticks && ticks.length > 0) {
+  if (ticks && ticks.length > 0 && bins > 12) {
     ticks.forEach(tick => {
       const start = binWidth * tick;
       const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -90,7 +90,6 @@ export function drawSidebarPaletteOnCanvas(
   colors,
   width
 ) {
-  const height = 24;
   const barHeight = 12;
   const colorbarStartY = barHeight - 5;
   ctx.fillStyle = checkerBoardPattern;
@@ -111,13 +110,12 @@ export function drawSidebarPaletteOnCanvas(
     ctx.stroke();
   }
 }
-export function drawTicksOnCanvas(ctx, legend, width, height) {
+export function drawTicksOnCanvas(ctx, legend, width) {
+  const canvasHeight = 24;
   const ticks = legend.ticks;
   const colors = legend.colors;
   const bins = colors.length;
   const binWidth = width / bins;
-  const yValue = parseFloat(height * 0.70);
-  const yValue2 = parseFloat(12 * 0.3);
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
   if (ticks && ticks.length > 0 && bins > 100) {
@@ -125,10 +123,10 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
     ticks.forEach(tick => {
       const start = binWidth * tick;
       const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331
-      ctx.strokeStyle = '#000'
+      ctx.strokeStyle = '#000';
       ctx.lineWidth = 0.8;
-      ctx.moveTo(midpoint, 24 - 4);
-      ctx.lineTo(midpoint, 23);
+      ctx.moveTo(midpoint, canvasHeight - 4);
+      ctx.lineTo(midpoint, canvasHeight - 1);
     });
     ctx.stroke();
     ctx.closePath();

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -45,7 +45,7 @@ export function getCheckerboard() {
 
 export function palettesTranslate(source, target) {
   var translation = [];
-  lodashEach(source, function (color, index) {
+  lodashEach(source, function(color, index) {
     var sourcePercent = index / source.length;
     var targetIndex = Math.floor(sourcePercent * target.length);
     translation.push(target[targetIndex]);
@@ -134,7 +134,7 @@ export function drawTicksOnCanvas(ctx, legend, width) {
 }
 export function lookup(sourcePalette, targetPalette) {
   var lookup = {};
-  lodashEach(sourcePalette.colors, function (sourceColor, index) {
+  lodashEach(sourcePalette.colors, function(sourceColor, index) {
     var source =
       parseInt(sourceColor.substring(0, 2), 16) +
       ',' +
@@ -293,7 +293,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
     return [];
   }
 }
-const createPaletteAttributeObject = function (def, value, attrObj, count) {
+const createPaletteAttributeObject = function(def, value, attrObj, count) {
   const key = attrObj.key;
   const attrArray = attrObj.array;
   let hasAtLeastOnePair = attrObj.isActive;
@@ -330,7 +330,7 @@ export function loadPalettes(permlinkState, state) {
     ];
   }
   lodashEach(stateArray, stateObj => {
-    lodashEach(state.layers[stateObj.groupStr], function (layerDef) {
+    lodashEach(state.layers[stateObj.groupStr], function(layerDef) {
       if (layerDef.palette) {
         var layerId = layerDef.id;
         var min = [];
@@ -338,7 +338,7 @@ export function loadPalettes(permlinkState, state) {
         var squash = [];
         var count = 0;
         if (layerDef.custom) {
-          lodashEach(layerDef.custom, function (value, index) {
+          lodashEach(layerDef.custom, function(value, index) {
             try {
               const newPalettes = setCustomSelector(
                 layerId,
@@ -356,7 +356,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.min) {
-          lodashEach(layerDef.min, function (value, index) {
+          lodashEach(layerDef.min, function(value, index) {
             try {
               min.push(
                 findPaletteExtremeIndex(
@@ -374,7 +374,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.max) {
-          lodashEach(layerDef.max, function (value, index) {
+          lodashEach(layerDef.max, function(value, index) {
             try {
               max.push(
                 findPaletteExtremeIndex(

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -78,9 +78,9 @@ export function drawPaletteOnCanvas(
 
     colors.forEach((color, i) => {
       ctx.fillStyle = util.hexToRGBA(color);
-      ctx.fillRect(Math.floor((binWidth * i) + 1), barHeight - 2, drawWidth, barHeight);
+      ctx.fillRect(Math.floor((binWidth * i) + 1), barHeight - 5, drawWidth, barHeight);
     });
-    ctx.rect(2 - (thickness), (10) - (thickness), width - 3 + (thickness * 2), (barHeight) + (thickness * 2));
+    ctx.rect(2 - (thickness), (7) - (thickness), width - 3 + (thickness * 2), (barHeight) + (thickness * 2));
     ctx.stroke();
   }
 
@@ -95,26 +95,17 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
   if (ticks && ticks.length > 0 && bins > 12) {
+    ctx.beginPath();
     ticks.forEach(tick => {
       const start = binWidth * tick;
       const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331
-      ctx.beginPath();
-      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
-      // ctx.strokeStyle = '#000'
-      // ctx.lineWidth = 0.8;
-      // ctx.moveTo(midpoint, yValue);
-      // ctx.lineTo(midpoint, height);
-      // ctx.stroke();
-      // ctx.closePath();
-      // ctx.beginPath();
-      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
       ctx.strokeStyle = '#000'
       ctx.lineWidth = 0.8;
-      ctx.moveTo(midpoint, 3);
-      ctx.lineTo(midpoint, 10);
-      ctx.stroke();
-      ctx.closePath();
+      ctx.moveTo(midpoint, 24 - 4);
+      ctx.lineTo(midpoint, 23);
     });
+    ctx.stroke();
+    ctx.closePath();
   }
 }
 export function lookup(sourcePalette, targetPalette) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -15,6 +15,7 @@ import {
   findIndex as findPaletteExtremeIndex
 } from './selectors';
 import util from '../../util/util';
+import invertColor from 'invert-color';
 import Promise from 'bluebird';
 
 /**
@@ -83,16 +84,23 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const colors = legend.colors;
   const bins = colors.length;
   const binWidth = width / bins;
-  const yValue = height * 0.5;
+  const yValue = height * 0.70;
   const drawWidth = Math.ceil(binWidth);
-
+  const halfWidth = drawWidth / 2;
   if (ticks && ticks.length > 0) {
     ticks.forEach(tick => {
-      const start = Math.floor(binWidth * tick);
-      const midpoint = start + drawWidth / 2;
-      ctx.fillStyle = util.hexToRGBA('000000ff');
-      ctx.fillRect(midpoint - 0.25, yValue, 0.5, height);
+      const start = binWidth * tick;
+      const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331
+      ctx.beginPath();
+      ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
+      ctx.lineWidth = 0.8;
+      ctx.moveTo(midpoint, parseFloat(yValue));
+      ctx.lineTo(midpoint, parseFloat(height));
+      ctx.stroke();
+      ctx.closePath();
     });
+
+
   }
 }
 export function lookup(sourcePalette, targetPalette) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -63,21 +63,27 @@ export function drawPaletteOnCanvas(
   ctx,
   checkerBoardPattern,
   colors,
-  width,
-  height
+  width
 ) {
   ctx.fillStyle = checkerBoardPattern;
   ctx.fillRect(0, 0, width, height);
-
+  const height = 24;
+  const barHeight = 12;
   if (colors) {
     var bins = colors.length;
-    var binWidth = width / bins;
+    var binWidth = (width - 2) / bins;
     var drawWidth = Math.ceil(binWidth);
+    var thickness = 0.5;
+    ctx.strokeStyle = '#000';
+
     colors.forEach((color, i) => {
       ctx.fillStyle = util.hexToRGBA(color);
-      ctx.fillRect(Math.floor(binWidth * i), 0, drawWidth, height);
+      ctx.fillRect(Math.floor((binWidth * i) + 1), barHeight - 2, drawWidth, barHeight);
     });
+    ctx.rect(2 - (thickness), (10) - (thickness), width - 3 + (thickness * 2), (barHeight) + (thickness * 2));
+    ctx.stroke();
   }
+
 }
 export function drawTicksOnCanvas(ctx, legend, width, height) {
   const ticks = legend.ticks;
@@ -85,7 +91,7 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
   const bins = colors.length;
   const binWidth = width / bins;
   const yValue = parseFloat(height * 0.70);
-  const yValue2 = parseFloat(height * 0.3);
+  const yValue2 = parseFloat(12 * 0.3);
   const drawWidth = Math.ceil(binWidth);
   const halfWidth = drawWidth / 2;
   if (ticks && ticks.length > 0) {
@@ -94,18 +100,18 @@ export function drawTicksOnCanvas(ctx, legend, width, height) {
       const midpoint = Math.floor((start + halfWidth)) + 0.5; // https://stackoverflow.com/a/8696641/4589331
       ctx.beginPath();
       // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
+      // ctx.strokeStyle = '#000'
+      // ctx.lineWidth = 0.8;
+      // ctx.moveTo(midpoint, yValue);
+      // ctx.lineTo(midpoint, height);
+      // ctx.stroke();
+      // ctx.closePath();
+      // ctx.beginPath();
+      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
       ctx.strokeStyle = '#000'
       ctx.lineWidth = 0.8;
-      ctx.moveTo(midpoint, yValue);
-      ctx.lineTo(midpoint, height);
-      ctx.stroke();
-      ctx.closePath();
-      ctx.beginPath();
-      // ctx.strokeStyle = invertColor(util.hexToRGB(legend.colors[tick], true), { black: '#333333', white: '#c0c0c0' });
-      ctx.strokeStyle = '#fff'
-      ctx.lineWidth = 0.8;
-      ctx.moveTo(midpoint, 0);
-      ctx.lineTo(midpoint, yValue2);
+      ctx.moveTo(midpoint, 3);
+      ctx.lineTo(midpoint, 10);
       ctx.stroke();
       ctx.closePath();
     });

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -45,7 +45,7 @@ export function getCheckerboard() {
 
 export function palettesTranslate(source, target) {
   var translation = [];
-  lodashEach(source, function(color, index) {
+  lodashEach(source, function (color, index) {
     var sourcePercent = index / source.length;
     var targetIndex = Math.floor(sourcePercent * target.length);
     translation.push(target[targetIndex]);
@@ -78,9 +78,26 @@ export function drawPaletteOnCanvas(
     });
   }
 }
+export function drawTicksOnCanvas(ctx, legend, width, height) {
+  const ticks = legend.ticks;
+  const colors = legend.colors;
+  const bins = colors.length;
+  const binWidth = width / bins;
+  const yValue = height * 0.5;
+  const drawWidth = Math.ceil(binWidth);
+
+  if (ticks && ticks.length > 0) {
+    ticks.forEach(tick => {
+      const start = Math.floor(binWidth * tick);
+      const midpoint = start + drawWidth / 2;
+      ctx.fillStyle = util.hexToRGBA('000000ff');
+      ctx.fillRect(midpoint - 0.25, yValue, 0.5, height);
+    });
+  }
+}
 export function lookup(sourcePalette, targetPalette) {
   var lookup = {};
-  lodashEach(sourcePalette.colors, function(sourceColor, index) {
+  lodashEach(sourcePalette.colors, function (sourceColor, index) {
     var source =
       parseInt(sourceColor.substring(0, 2), 16) +
       ',' +
@@ -239,7 +256,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
     return [];
   }
 }
-const createPaletteAttributeObject = function(def, value, attrObj, count) {
+const createPaletteAttributeObject = function (def, value, attrObj, count) {
   const key = attrObj.key;
   const attrArray = attrObj.array;
   let hasAtLeastOnePair = attrObj.isActive;
@@ -276,7 +293,7 @@ export function loadPalettes(permlinkState, state) {
     ];
   }
   lodashEach(stateArray, stateObj => {
-    lodashEach(state.layers[stateObj.groupStr], function(layerDef) {
+    lodashEach(state.layers[stateObj.groupStr], function (layerDef) {
       if (layerDef.palette) {
         var layerId = layerDef.id;
         var min = [];
@@ -284,7 +301,7 @@ export function loadPalettes(permlinkState, state) {
         var squash = [];
         var count = 0;
         if (layerDef.custom) {
-          lodashEach(layerDef.custom, function(value, index) {
+          lodashEach(layerDef.custom, function (value, index) {
             try {
               const newPalettes = setCustomSelector(
                 layerId,
@@ -302,7 +319,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.min) {
-          lodashEach(layerDef.min, function(value, index) {
+          lodashEach(layerDef.min, function (value, index) {
             try {
               min.push(
                 findPaletteExtremeIndex(
@@ -320,7 +337,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.max) {
-          lodashEach(layerDef.max, function(value, index) {
+          lodashEach(layerDef.max, function (value, index) {
             try {
               max.push(
                 findPaletteExtremeIndex(

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -22,7 +22,7 @@ import isFirstDayOfMonth from 'date-fns/is_first_day_of_month';
 import isLastDayOfMonth from 'date-fns/is_last_day_of_month';
 import lastDayOfYear from 'date-fns/last_day_of_year';
 
-export default (function(self) {
+export default (function (self) {
   var canvas = null;
 
   // Export other util methods
@@ -58,7 +58,7 @@ export default (function(self) {
     }
   };
 
-  self.repeat = function(value, length) {
+  self.repeat = function (value, length) {
     var result = '';
     for (var i = 0; i < length; i++) {
       result += value;
@@ -66,7 +66,7 @@ export default (function(self) {
     return result;
   };
 
-  self.pad = function(value, width, padding) {
+  self.pad = function (value, width, padding) {
     value = '' + value;
     if (value.length < width) {
       var add = width - value.length;
@@ -74,7 +74,7 @@ export default (function(self) {
     }
     return value;
   };
-  self.preventPinch = function(e) {
+  self.preventPinch = function (e) {
     if (e.deltaY && !Number.isInteger(e.deltaY)) {
       e.stopPropagation();
       e.preventDefault();
@@ -100,7 +100,7 @@ export default (function(self) {
    * object.
    * @return {object} object representation of the query string.
    */
-  self.fromQueryString = function(queryString) {
+  self.fromQueryString = function (queryString) {
     if (!queryString) {
       return {};
     }
@@ -117,7 +117,7 @@ export default (function(self) {
     }
     return result;
   };
-  self.elapsed = function(message, startTime, parameters) {
+  self.elapsed = function (message, startTime, parameters) {
     if (parameters && !parameters.elapsed) return;
     var t = new Date().getTime() - startTime;
     console.log(t, message);
@@ -144,12 +144,12 @@ export default (function(self) {
    *     "format=image/png"
    * @return {String} converted query string
    */
-  self.toQueryString = function(kvps, exceptions) {
+  self.toQueryString = function (kvps, exceptions) {
     exceptions = exceptions || {};
     var parts = [];
-    lodashEach(kvps, function(value, key) {
+    lodashEach(kvps, function (value, key) {
       var part = key + '=' + encodeURIComponent(value);
-      lodashEach(exceptions, function(exception) {
+      lodashEach(exceptions, function (exception) {
         var regexp = new RegExp(exception, 'ig');
         var decoded = decodeURIComponent(exception);
         part = part.replace(regexp, decoded);
@@ -173,7 +173,7 @@ export default (function(self) {
    * @return {Date} converted string as a datetime object, throws an
    * exception if the string is invalid.
    */
-  self.parseTimestampUTC = function(str) {
+  self.parseTimestampUTC = function (str) {
     return self.parseDateUTC(str);
   };
 
@@ -187,7 +187,7 @@ export default (function(self) {
    * @return y {Number} Y value on canvas
    * @return {Object} Canvas image data.
    */
-  self.getCanvasPixelData = function(canvas, x, y) {
+  self.getCanvasPixelData = function (canvas, x, y) {
     var context = canvas.getContext('2d');
     return context.getImageData(x, y, 1, 1)
       .data;
@@ -203,7 +203,7 @@ export default (function(self) {
    * the string is invalid
    */
   // NOTE: Older Safari doesn't like Date.parse
-  self.parseDateUTC = function(dateAsString) {
+  self.parseDateUTC = function (dateAsString) {
     var dateTimeArr = dateAsString.split(/T/);
 
     var yyyymmdd = dateTimeArr[0].split(/[\s-]+/);
@@ -233,12 +233,12 @@ export default (function(self) {
     }
     return date;
   };
-  self.appendAttributesForURL = function(item) {
+  self.appendAttributesForURL = function (item) {
     if (lodashIsObject(item)) {
       let part = item.id || '';
       const attributes = [];
       if (item.attributes && item.attributes.length > 0) {
-        lodashEach(item.attributes, function(attribute) {
+        lodashEach(item.attributes, function (attribute) {
           if (attribute.value) {
             attributes.push(attribute.id + '=' + attribute.value);
           } else {
@@ -256,7 +256,7 @@ export default (function(self) {
    * Test if is valid Date
    * @param {Object} d | Date object
    */
-  self.isValidDate = function(d) {
+  self.isValidDate = function (d) {
     return d instanceof Date && !isNaN(d);
   };
   /**
@@ -268,7 +268,7 @@ export default (function(self) {
    * @return {Date} converted string as a non UTC date object, throws an exception if
    * the string is invalid
    */
-  self.parseDate = function(dateAsString) {
+  self.parseDate = function (dateAsString) {
     var dateTimeArr = dateAsString.split(/T/);
 
     var yyyymmdd = dateTimeArr[0].split(/[\s-]+/);
@@ -307,7 +307,7 @@ export default (function(self) {
    *
    * @see http://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
    */
-  self.getTextWidth = function(text, font) {
+  self.getTextWidth = function (text, font) {
     // re-use canvas object for better performance
     canvas = canvas || document.createElement('canvas');
     var context = canvas.getContext('2d');
@@ -323,7 +323,7 @@ export default (function(self) {
    * @param  {Date} date {Date} the date to convert
    * @return {string} Julian date string in the form of `YYYYDDD`
    */
-  self.toJulianDate = function(date) {
+  self.toJulianDate = function (date) {
     var jStart, jDate;
     jStart = self.parseDateUTC(date.getUTCFullYear() + '-01-01');
     jDate = '00' + (1 + Math.ceil((date.getTime() - jStart) / 86400000));
@@ -338,7 +338,7 @@ export default (function(self) {
    * @param date {Date} the date to convert
    * @return {string} ISO string in the form of ``YYYY-MM-DD``.
    */
-  self.toISOStringDate = function(date) {
+  self.toISOStringDate = function (date) {
     return date.toISOString()
       .split('T')[0];
   };
@@ -351,7 +351,7 @@ export default (function(self) {
    * @param  {Date} date the date to convert
    * @return {string} ISO string in the form of `YYYY-MM-DDThh:mm:ssZ`.
    */
-  self.toISOStringSeconds = function(date) {
+  self.toISOStringSeconds = function (date) {
     return date.toISOString().split('.')[0] + 'Z';
   };
 
@@ -363,7 +363,7 @@ export default (function(self) {
    * @param  {Date} date the date to convert
    * @return {string} ISO string in the form of `YYYY-MM-DDThh:mmZ`.
    */
-  self.toISOStringMinutes = function(date) {
+  self.toISOStringMinutes = function (date) {
     const parts = date.toISOString().split(':');
     return parts[0] + ':' + parts[1] + 'Z';
   };
@@ -376,7 +376,7 @@ export default (function(self) {
    * @param date {Date} the date to convert
    * @return {string} ISO string in the form of HH:MM`.
    */
-  self.toHourMinutes = function(date) {
+  self.toHourMinutes = function (date) {
     var time = date.toISOString()
       .split('T')[1];
     var parts = time.split('.')[0].split(':');
@@ -391,7 +391,7 @@ export default (function(self) {
    * @param time {Date} date
    * @return {number} rounded date
    */
-  self.roundTimeOneMinute = function(time) {
+  self.roundTimeOneMinute = function (time) {
     var timeToReturn = new Date(time);
 
     timeToReturn.setMilliseconds(Math.round(timeToReturn.getMilliseconds() / 1000) * 1000);
@@ -409,7 +409,7 @@ export default (function(self) {
    * to zero.
    * @return {Date} the date object
    */
-  self.clearTimeUTC = function(date) {
+  self.clearTimeUTC = function (date) {
     date.setUTCHours(0);
     date.setUTCMinutes(0);
     date.setUTCSeconds(0);
@@ -418,7 +418,7 @@ export default (function(self) {
     return date;
   };
 
-  self.dateAdd = function(date, interval, amount) {
+  self.dateAdd = function (date, interval, amount) {
     var month, maxDay, year;
     var newDate = new Date(date);
     switch (interval) {
@@ -450,7 +450,7 @@ export default (function(self) {
     return newDate;
   };
 
-  self.getNumberOfDays = function(start, end, interval, increment) {
+  self.getNumberOfDays = function (start, end, interval, increment) {
     increment = increment || 1;
     var i = 1;
     var currentDate = start;
@@ -461,7 +461,7 @@ export default (function(self) {
     return i;
   };
 
-  self.daysInMonth = function(d) {
+  self.daysInMonth = function (d) {
     var year;
     var month;
     if (d.getUTCFullYear) {
@@ -475,14 +475,14 @@ export default (function(self) {
     return lastDay.getUTCDate();
   };
 
-  self.daysInYear = function(date) {
+  self.daysInYear = function (date) {
     var jStart, jDate;
     jStart = self.parseDateUTC(date.getUTCFullYear() + '-01-01');
     jDate = '00' + (Math.ceil((date.getTime() - jStart) / 86400000) + 1);
     return (jDate).substr((jDate.length) - 3);
   };
 
-  self.objectLength = function(obj) {
+  self.objectLength = function (obj) {
     return Object.keys(obj)
       .length;
   };
@@ -495,7 +495,7 @@ export default (function(self) {
    * @param date {Date} date object of which to determine week day
    * @return {String} the full name of the day of the week
    */
-  self.giveWeekDay = function(d) {
+  self.giveWeekDay = function (d) {
     var day = [
       'Sunday',
       'Monday',
@@ -517,7 +517,7 @@ export default (function(self) {
    * @param date {Date} date object of which to determine the Month name
    * @return {String} the full name of the month
    */
-  self.giveMonth = function(d) {
+  self.giveMonth = function (d) {
     var month = [
       'January',
       'February',
@@ -536,7 +536,7 @@ export default (function(self) {
     return month[d.getUTCMonth()];
   };
 
-  self.clamp = function(val, min, max) {
+  self.clamp = function (val, min, max) {
     if (val < min) {
       return min;
     }
@@ -546,7 +546,7 @@ export default (function(self) {
     return val;
   };
 
-  self.roll = function(val, min, max) {
+  self.roll = function (val, min, max) {
     if (val < min) {
       return max - (min - val) + 1;
     }
@@ -556,15 +556,15 @@ export default (function(self) {
     return val;
   };
 
-  self.minDate = function() {
+  self.minDate = function () {
     return new Date(Date.UTC(1000, 0, 1, 0, 0));
   };
 
-  self.maxDate = function() {
+  self.maxDate = function () {
     return new Date(Date.UTC(3000, 11, 30, 23, 59));
   };
 
-  self.rollRange = function(date, interval, minDate, maxDate) {
+  self.rollRange = function (date, interval, minDate, maxDate) {
     var year = date.getUTCFullYear();
     var month = date.getUTCMonth();
     var first, last;
@@ -616,7 +616,7 @@ export default (function(self) {
     };
   };
 
-  self.rollDate = function(date, interval, amount, minDate, maxDate) {
+  self.rollDate = function (date, interval, amount, minDate, maxDate) {
     minDate = minDate || self.minDate();
     maxDate = maxDate || self.maxDate();
     var range = self.rollRange(date, interval, minDate, maxDate);
@@ -669,7 +669,7 @@ export default (function(self) {
    * @return {String} string representation in the form of
    * ``YYYYMMDDHHMMSSsss``
    */
-  self.toCompactTimestamp = function(date) {
+  self.toCompactTimestamp = function (date) {
     return date.toISOString()
       .replace(/[-:TZ.]/g, '');
   };
@@ -683,7 +683,7 @@ export default (function(self) {
    * ``YYYYMMDDHHMMSSsss``.
    * @return {Date} the converted date object.
    */
-  self.fromCompactTimestamp = function(str) {
+  self.fromCompactTimestamp = function (str) {
     var v = str.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})/);
     if (lodashIsNull(v)) {
       throw new Error('Invalid timestamp:' + str);
@@ -706,13 +706,13 @@ export default (function(self) {
    * @static
    * @return {Date} The current time or an overriden value.
    */
-  var now = function() {
+  var now = function () {
     return new Date();
   };
 
   self.now = now;
 
-  self.resetNow = function() {
+  self.resetNow = function () {
     self.now = now;
   };
 
@@ -725,7 +725,7 @@ export default (function(self) {
    * @return {Date} The current time with the UTC hours, minutes, and seconds
    * fields set to zero or an overriden value.
    */
-  self.today = function() {
+  self.today = function () {
     return self.now();
   };
 
@@ -741,7 +741,7 @@ export default (function(self) {
    * @param {string} message Message to display to the end user.
    * @param {Exception} cause The exception object that caused the error
    */
-  self.error = function(message, cause) {
+  self.error = function (message, cause) {
     wvui.error(message, cause);
   };
 
@@ -755,16 +755,16 @@ export default (function(self) {
    * @param {object*} messages Messages to display to the end user.
    */
   self.warn = (console && console.warn && console.warn.bind)
-    ? console.warn.bind(console) : function() {};
+    ? console.warn.bind(console) : function () { };
 
-  self.hexToRGB = function(str) {
+  self.hexToRGB = function (str) {
     return 'rgb(' +
       parseInt(str.substring(0, 2), 16) + ',' +
       parseInt(str.substring(2, 4), 16) + ',' +
       parseInt(str.substring(4, 6), 16) + ')';
   };
 
-  self.hexToRGBA = function(str) {
+  self.hexToRGBA = function (str) {
     return 'rgba(' +
       parseInt(str.substring(0, 2), 16) + ',' +
       parseInt(str.substring(2, 4), 16) + ',' +
@@ -772,7 +772,7 @@ export default (function(self) {
       parseInt(str.substring(6, 8), 16) + ')';
   };
 
-  self.rgbaToHex = function(r, g, b) {
+  self.rgbaToHex = function (r, g, b) {
     function hex(c) {
       var strHex = c.toString(16);
       return strHex.length === 1 ? '0' + strHex : strHex;
@@ -780,7 +780,7 @@ export default (function(self) {
     return hex(r) + hex(g) + hex(b) + 'ff';
   };
 
-  self.hexColorDelta = function(hex1, hex2) {
+  self.hexColorDelta = function (hex1, hex2) {
     var r1 = parseInt(hex1.substring(0, 2), 16);
     var g1 = parseInt(hex1.substring(2, 4), 16);
     var b1 = parseInt(hex1.substring(4, 6), 16);
@@ -790,18 +790,18 @@ export default (function(self) {
     // calculate differences in 3D Space
     return Math.sqrt(Math.pow((r1 - r2), 2) + Math.pow((g1 - g2), 2) + Math.pow((b1 - b2), 2));
   };
-  self.fetch = function(url, mimeType) {
+  self.fetch = function (url, mimeType) {
     return new Promise((resolve, reject) => {
       return fetch(url)
-        .then(function(response) {
+        .then(function (response) {
           return mimeType === 'application/json'
             ? response.json()
             : response.text();
         })
-        .then(function(data) {
+        .then(function (data) {
           resolve(data);
         })
-        .catch(function(error) {
+        .catch(function (error) {
           reject(error);
         });
     });
@@ -817,7 +817,7 @@ export default (function(self) {
    * @param {Object} [spec.options] options to pass to jscache on setItem.
    *
    */
-  self.ajaxCache = function(spec) {
+  self.ajaxCache = function (spec) {
     spec = spec || {};
     var size = spec.size || null;
     var options = spec.options || {};
@@ -835,7 +835,7 @@ export default (function(self) {
        * when the query returns, or resolves immedately if the results
        * are cached.
        */
-      submit: function(parameters) {
+      submit: function (parameters) {
         var key = 'url=' + parameters.url;
         if (parameters.data) {
           key += '&query=' + $.param(parameters.data, true);
@@ -848,7 +848,7 @@ export default (function(self) {
             .promise();
         } else {
           var promise = $.ajax(parameters);
-          promise.done(function(results) {
+          promise.done(function (results) {
             cache.setItem(key, results, options);
           });
           return promise;
@@ -856,9 +856,9 @@ export default (function(self) {
       }
     };
   };
-  self.errorReport = function(errors) {
+  self.errorReport = function (errors) {
     var layersRemoved = 0;
-    lodashEach(errors, function(error) {
+    lodashEach(errors, function (error) {
       var cause = error.cause ? ': ' + error.cause : '';
       self.warn(error.message + cause);
       if (error.layerRemoved) {
@@ -873,8 +873,8 @@ export default (function(self) {
    * @param {function} func the function to wrap
    * @return the function wrapped in a try/catch block.
    */
-  self.wrap = function(func) {
-    return function() {
+  self.wrap = function (func) {
+    return function () {
       try {
         return func.apply(func, arguments);
       } catch (error) {
@@ -891,14 +891,14 @@ export default (function(self) {
    * @param {url} func the function to wrap
    * @return {object} Promise
    */
-  self.get = function(url) {
+  self.get = function (url) {
     // Return a new promise.
-    return new Promise(function(resolve, reject) {
+    return new Promise(function (resolve, reject) {
       // Do the usual XHR stuff
       var req = new XMLHttpRequest();
       req.open('GET', url);
 
-      req.onload = function() {
+      req.onload = function () {
         // This is called even on 404 etc
         // so check the status
         if (req.status === 200) {
@@ -911,7 +911,7 @@ export default (function(self) {
         }
       };
       // Handle network errors
-      req.onerror = function() {
+      req.onerror = function () {
         reject(Error('Network Error'));
       };
       // Make the request
@@ -920,20 +920,20 @@ export default (function(self) {
   };
 
   // FIXME: Should be replaced with $.when
-  self.ajaxJoin = function(calls) {
+  self.ajaxJoin = function (calls) {
     var completed = 0;
     var result = {};
     var deferred = $.Deferred();
 
-    $.each(calls, function(index, call) {
-      call.promise.done(function(data) {
+    $.each(calls, function (index, call) {
+      call.promise.done(function (data) {
         result[call.item] = data;
         completed += 1;
         if (completed === calls.length) {
           deferred.resolve(result);
         }
       })
-        .fail(function(jqXHR, textStatus, errorThrown) {
+        .fail(function (jqXHR, textStatus, errorThrown) {
           deferred.reject(jqXHR, textStatus, errorThrown);
         });
     });
@@ -956,21 +956,21 @@ export default (function(self) {
   // The original plan was to escape the special characters but that
   // became confusing as element attributes would need one escape character
   // but the selector would need two (\. vs \\.)
-  self.encodeId = function(str) {
+  self.encodeId = function (str) {
     return str.replace(/[.:]/g, (match) => {
       return '__' + match.charCodeAt(0).toString(16).toUpperCase() + '__';
     });
   };
 
   // Converts an encoded identifier back to its original value.
-  self.decodeId = function(str) {
+  self.decodeId = function (str) {
     return str.replace(/__[0-9A-Fa-f]{2}__/g, (match) => {
       const charCode = Number.parseInt(match.substring(2, 4), 16);
       return String.fromCharCode(charCode);
     });
   };
 
-  self.metrics = function() {
+  self.metrics = function () {
     if (window.ntptEventTag) {
       ntptEventTag.apply(null, arguments);
     } else {
@@ -1020,7 +1020,7 @@ export default (function(self) {
   self.formatDMS = (value, type) => formatDegrees(value, type, true);
   self.formatDM = (value, type) => formatDegrees(value, type, false);
 
-  self.setCoordinateFormat = function(type) {
+  self.setCoordinateFormat = function (type) {
     if (!browser.localStorage) return;
     if (type !== 'latlon-dd' && type !== 'latlon-dms' && type !== 'latlon-dm') {
       throw new Error('Invalid coordinate format: ' + type);
@@ -1028,12 +1028,12 @@ export default (function(self) {
     localStorage.setItem('coordinateFormat', type);
   };
 
-  self.getCoordinateFormat = function() {
+  self.getCoordinateFormat = function () {
     if (!browser.localStorage) return 'latlon-dd';
     return localStorage.getItem('coordinateFormat') || 'latlon-dd';
   };
 
-  self.formatCoordinate = function(coord, format) {
+  self.formatCoordinate = function (coord, format) {
     var type = format || self.getCoordinateFormat();
     if (type === 'latlon-dms') {
       return self.formatDMS(coord[1], 'latitude') + ', ' +
@@ -1051,7 +1051,7 @@ export default (function(self) {
   // arguments array contains all args passed. String must be formatted
   // so that first replacement starts with "{1}"
   // usage example: wv.util.format("{1}{2}",'World','view')
-  self.format = function() {
+  self.format = function () {
     var formatted = arguments[0];
     for (var i = 1; i < arguments.length; i++) {
       var regexp = new RegExp('\\{' + i + '\\}', 'gi');
@@ -1060,7 +1060,7 @@ export default (function(self) {
     return formatted;
   };
 
-  self.toArray = function(value) {
+  self.toArray = function (value) {
     if (!value) {
       return [];
     }
@@ -1071,14 +1071,14 @@ export default (function(self) {
   };
 
   // Returns the number of months between two dates
-  self.yearDiff = function(startDate, endDate) {
+  self.yearDiff = function (startDate, endDate) {
     var year1 = startDate.getFullYear();
     var year2 = endDate.getFullYear();
     return year2 - year1;
   };
 
   // Returns the number of months between two dates
-  self.monthDiff = function(startDate, endDate) {
+  self.monthDiff = function (startDate, endDate) {
     var year1 = startDate.getFullYear();
     var year2 = endDate.getFullYear();
     var month1 = startDate.getMonth();
@@ -1091,7 +1091,7 @@ export default (function(self) {
     return numberOfMonths;
   };
 
-  self.dayDiff = function(startDate, endDate) {
+  self.dayDiff = function (startDate, endDate) {
     var date1 = new Date(startDate);
     var date2 = new Date(endDate);
     var timeDiff = Math.abs(date2.getTime() - date1.getTime());
@@ -1099,7 +1099,7 @@ export default (function(self) {
     return dayDiff;
   };
 
-  self.minuteDiff = function(startDate, endDate) {
+  self.minuteDiff = function (startDate, endDate) {
     var date1 = new Date(startDate);
     var date2 = new Date(endDate);
     var timeDiff = Math.abs(date2.getTime() - date1.getTime());
@@ -1117,10 +1117,10 @@ export default (function(self) {
    *                                If false, only return the dates from the range the current date falls in.
    * @return {array}                An array of dates with normalized timezones
    */
-  self.datesinDateRanges = function(def, date, containRange) {
+  self.datesinDateRanges = function (def, date, containRange) {
     var dateArray = [];
     var currentDate = new Date(date.getTime());
-    lodashEach(def.dateRanges, function(dateRange) {
+    lodashEach(def.dateRanges, function (dateRange) {
       var yearDifference;
       var monthDifference;
       var dayDifference;
@@ -1220,7 +1220,7 @@ export default (function(self) {
    * @param {String} value | String to return index of
    * @return {Number}
    */
-  self.stringInArray = function(arra, value) {
+  self.stringInArray = function (arra, value) {
     for (var i = 0, len = arra.length; i < len; i++) {
       if (arra[i] === value) {
         return i;
@@ -1237,15 +1237,15 @@ export default (function(self) {
    * @param  {array} dateArray  An array of dates
    * @return {object}           The date object with normalized timeszone.
    */
-  self.prevDateInDateRange = function(def, date, dateArray) {
+  self.prevDateInDateRange = function (def, date, dateArray) {
     var currentDate = new Date(date.getTime());
     if (!dateArray) return date;
     if ((def.period === 'monthly' && (isFirstDayOfMonth(currentDate) || isLastDayOfMonth(currentDate))) ||
-        (def.period === 'yearly' && ((currentDate.getDate() === 1 &&
-          currentDate.getMonth() === 0) || (currentDate === lastDayOfYear(currentDate))))) return date;
+      (def.period === 'yearly' && ((currentDate.getDate() === 1 &&
+        currentDate.getMonth() === 0) || (currentDate === lastDayOfYear(currentDate))))) return date;
     // Return an array of the closest available dates within the range
     var closestAvailableDates = [];
-    lodashEach(dateArray, function(rangeDate) {
+    lodashEach(dateArray, function (rangeDate) {
       if (isBefore(rangeDate, currentDate) || isEqual(rangeDate, currentDate)) {
         closestAvailableDates.push(rangeDate);
       }
@@ -1265,7 +1265,7 @@ export default (function(self) {
    * @param  {array} comment seperated list of objects
    * @return {bool}
    */
-  self.objectsHaveSameKeys = function(...objects) {
+  self.objectsHaveSameKeys = function (...objects) {
     const allKeys = objects.reduce((keys, object) => keys.concat(Object.keys(object)), []);
     const union = new Set(allKeys);
     return objects.every(object => union.size === Object.keys(object).length);

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -22,7 +22,7 @@ import isFirstDayOfMonth from 'date-fns/is_first_day_of_month';
 import isLastDayOfMonth from 'date-fns/is_last_day_of_month';
 import lastDayOfYear from 'date-fns/last_day_of_year';
 
-export default (function (self) {
+export default (function(self) {
   var canvas = null;
 
   // Export other util methods
@@ -58,7 +58,7 @@ export default (function (self) {
     }
   };
 
-  self.repeat = function (value, length) {
+  self.repeat = function(value, length) {
     var result = '';
     for (var i = 0; i < length; i++) {
       result += value;
@@ -66,7 +66,7 @@ export default (function (self) {
     return result;
   };
 
-  self.pad = function (value, width, padding) {
+  self.pad = function(value, width, padding) {
     value = '' + value;
     if (value.length < width) {
       var add = width - value.length;
@@ -74,7 +74,7 @@ export default (function (self) {
     }
     return value;
   };
-  self.preventPinch = function (e) {
+  self.preventPinch = function(e) {
     if (e.deltaY && !Number.isInteger(e.deltaY)) {
       e.stopPropagation();
       e.preventDefault();
@@ -100,7 +100,7 @@ export default (function (self) {
    * object.
    * @return {object} object representation of the query string.
    */
-  self.fromQueryString = function (queryString) {
+  self.fromQueryString = function(queryString) {
     if (!queryString) {
       return {};
     }
@@ -117,7 +117,7 @@ export default (function (self) {
     }
     return result;
   };
-  self.elapsed = function (message, startTime, parameters) {
+  self.elapsed = function(message, startTime, parameters) {
     if (parameters && !parameters.elapsed) return;
     var t = new Date().getTime() - startTime;
     console.log(t, message);
@@ -144,12 +144,12 @@ export default (function (self) {
    *     "format=image/png"
    * @return {String} converted query string
    */
-  self.toQueryString = function (kvps, exceptions) {
+  self.toQueryString = function(kvps, exceptions) {
     exceptions = exceptions || {};
     var parts = [];
-    lodashEach(kvps, function (value, key) {
+    lodashEach(kvps, function(value, key) {
       var part = key + '=' + encodeURIComponent(value);
-      lodashEach(exceptions, function (exception) {
+      lodashEach(exceptions, function(exception) {
         var regexp = new RegExp(exception, 'ig');
         var decoded = decodeURIComponent(exception);
         part = part.replace(regexp, decoded);
@@ -173,7 +173,7 @@ export default (function (self) {
    * @return {Date} converted string as a datetime object, throws an
    * exception if the string is invalid.
    */
-  self.parseTimestampUTC = function (str) {
+  self.parseTimestampUTC = function(str) {
     return self.parseDateUTC(str);
   };
 
@@ -187,7 +187,7 @@ export default (function (self) {
    * @return y {Number} Y value on canvas
    * @return {Object} Canvas image data.
    */
-  self.getCanvasPixelData = function (canvas, x, y) {
+  self.getCanvasPixelData = function(canvas, x, y) {
     var context = canvas.getContext('2d');
     return context.getImageData(x, y, 1, 1)
       .data;
@@ -203,7 +203,7 @@ export default (function (self) {
    * the string is invalid
    */
   // NOTE: Older Safari doesn't like Date.parse
-  self.parseDateUTC = function (dateAsString) {
+  self.parseDateUTC = function(dateAsString) {
     var dateTimeArr = dateAsString.split(/T/);
 
     var yyyymmdd = dateTimeArr[0].split(/[\s-]+/);
@@ -233,12 +233,12 @@ export default (function (self) {
     }
     return date;
   };
-  self.appendAttributesForURL = function (item) {
+  self.appendAttributesForURL = function(item) {
     if (lodashIsObject(item)) {
       let part = item.id || '';
       const attributes = [];
       if (item.attributes && item.attributes.length > 0) {
-        lodashEach(item.attributes, function (attribute) {
+        lodashEach(item.attributes, function(attribute) {
           if (attribute.value) {
             attributes.push(attribute.id + '=' + attribute.value);
           } else {
@@ -256,7 +256,7 @@ export default (function (self) {
    * Test if is valid Date
    * @param {Object} d | Date object
    */
-  self.isValidDate = function (d) {
+  self.isValidDate = function(d) {
     return d instanceof Date && !isNaN(d);
   };
   /**
@@ -268,7 +268,7 @@ export default (function (self) {
    * @return {Date} converted string as a non UTC date object, throws an exception if
    * the string is invalid
    */
-  self.parseDate = function (dateAsString) {
+  self.parseDate = function(dateAsString) {
     var dateTimeArr = dateAsString.split(/T/);
 
     var yyyymmdd = dateTimeArr[0].split(/[\s-]+/);
@@ -307,7 +307,7 @@ export default (function (self) {
    *
    * @see http://stackoverflow.com/questions/118241/calculate-text-width-with-javascript/21015393#21015393
    */
-  self.getTextWidth = function (text, font) {
+  self.getTextWidth = function(text, font) {
     // re-use canvas object for better performance
     canvas = canvas || document.createElement('canvas');
     var context = canvas.getContext('2d');
@@ -323,7 +323,7 @@ export default (function (self) {
    * @param  {Date} date {Date} the date to convert
    * @return {string} Julian date string in the form of `YYYYDDD`
    */
-  self.toJulianDate = function (date) {
+  self.toJulianDate = function(date) {
     var jStart, jDate;
     jStart = self.parseDateUTC(date.getUTCFullYear() + '-01-01');
     jDate = '00' + (1 + Math.ceil((date.getTime() - jStart) / 86400000));
@@ -338,7 +338,7 @@ export default (function (self) {
    * @param date {Date} the date to convert
    * @return {string} ISO string in the form of ``YYYY-MM-DD``.
    */
-  self.toISOStringDate = function (date) {
+  self.toISOStringDate = function(date) {
     return date.toISOString()
       .split('T')[0];
   };
@@ -351,7 +351,7 @@ export default (function (self) {
    * @param  {Date} date the date to convert
    * @return {string} ISO string in the form of `YYYY-MM-DDThh:mm:ssZ`.
    */
-  self.toISOStringSeconds = function (date) {
+  self.toISOStringSeconds = function(date) {
     return date.toISOString().split('.')[0] + 'Z';
   };
 
@@ -363,7 +363,7 @@ export default (function (self) {
    * @param  {Date} date the date to convert
    * @return {string} ISO string in the form of `YYYY-MM-DDThh:mmZ`.
    */
-  self.toISOStringMinutes = function (date) {
+  self.toISOStringMinutes = function(date) {
     const parts = date.toISOString().split(':');
     return parts[0] + ':' + parts[1] + 'Z';
   };
@@ -376,7 +376,7 @@ export default (function (self) {
    * @param date {Date} the date to convert
    * @return {string} ISO string in the form of HH:MM`.
    */
-  self.toHourMinutes = function (date) {
+  self.toHourMinutes = function(date) {
     var time = date.toISOString()
       .split('T')[1];
     var parts = time.split('.')[0].split(':');
@@ -391,7 +391,7 @@ export default (function (self) {
    * @param time {Date} date
    * @return {number} rounded date
    */
-  self.roundTimeOneMinute = function (time) {
+  self.roundTimeOneMinute = function(time) {
     var timeToReturn = new Date(time);
 
     timeToReturn.setMilliseconds(Math.round(timeToReturn.getMilliseconds() / 1000) * 1000);
@@ -409,7 +409,7 @@ export default (function (self) {
    * to zero.
    * @return {Date} the date object
    */
-  self.clearTimeUTC = function (date) {
+  self.clearTimeUTC = function(date) {
     date.setUTCHours(0);
     date.setUTCMinutes(0);
     date.setUTCSeconds(0);
@@ -418,7 +418,7 @@ export default (function (self) {
     return date;
   };
 
-  self.dateAdd = function (date, interval, amount) {
+  self.dateAdd = function(date, interval, amount) {
     var month, maxDay, year;
     var newDate = new Date(date);
     switch (interval) {
@@ -450,7 +450,7 @@ export default (function (self) {
     return newDate;
   };
 
-  self.getNumberOfDays = function (start, end, interval, increment) {
+  self.getNumberOfDays = function(start, end, interval, increment) {
     increment = increment || 1;
     var i = 1;
     var currentDate = start;
@@ -461,7 +461,7 @@ export default (function (self) {
     return i;
   };
 
-  self.daysInMonth = function (d) {
+  self.daysInMonth = function(d) {
     var year;
     var month;
     if (d.getUTCFullYear) {
@@ -475,14 +475,14 @@ export default (function (self) {
     return lastDay.getUTCDate();
   };
 
-  self.daysInYear = function (date) {
+  self.daysInYear = function(date) {
     var jStart, jDate;
     jStart = self.parseDateUTC(date.getUTCFullYear() + '-01-01');
     jDate = '00' + (Math.ceil((date.getTime() - jStart) / 86400000) + 1);
     return (jDate).substr((jDate.length) - 3);
   };
 
-  self.objectLength = function (obj) {
+  self.objectLength = function(obj) {
     return Object.keys(obj)
       .length;
   };
@@ -495,7 +495,7 @@ export default (function (self) {
    * @param date {Date} date object of which to determine week day
    * @return {String} the full name of the day of the week
    */
-  self.giveWeekDay = function (d) {
+  self.giveWeekDay = function(d) {
     var day = [
       'Sunday',
       'Monday',
@@ -517,7 +517,7 @@ export default (function (self) {
    * @param date {Date} date object of which to determine the Month name
    * @return {String} the full name of the month
    */
-  self.giveMonth = function (d) {
+  self.giveMonth = function(d) {
     var month = [
       'January',
       'February',
@@ -536,7 +536,7 @@ export default (function (self) {
     return month[d.getUTCMonth()];
   };
 
-  self.clamp = function (val, min, max) {
+  self.clamp = function(val, min, max) {
     if (val < min) {
       return min;
     }
@@ -546,7 +546,7 @@ export default (function (self) {
     return val;
   };
 
-  self.roll = function (val, min, max) {
+  self.roll = function(val, min, max) {
     if (val < min) {
       return max - (min - val) + 1;
     }
@@ -556,15 +556,15 @@ export default (function (self) {
     return val;
   };
 
-  self.minDate = function () {
+  self.minDate = function() {
     return new Date(Date.UTC(1000, 0, 1, 0, 0));
   };
 
-  self.maxDate = function () {
+  self.maxDate = function() {
     return new Date(Date.UTC(3000, 11, 30, 23, 59));
   };
 
-  self.rollRange = function (date, interval, minDate, maxDate) {
+  self.rollRange = function(date, interval, minDate, maxDate) {
     var year = date.getUTCFullYear();
     var month = date.getUTCMonth();
     var first, last;
@@ -616,7 +616,7 @@ export default (function (self) {
     };
   };
 
-  self.rollDate = function (date, interval, amount, minDate, maxDate) {
+  self.rollDate = function(date, interval, amount, minDate, maxDate) {
     minDate = minDate || self.minDate();
     maxDate = maxDate || self.maxDate();
     var range = self.rollRange(date, interval, minDate, maxDate);
@@ -669,7 +669,7 @@ export default (function (self) {
    * @return {String} string representation in the form of
    * ``YYYYMMDDHHMMSSsss``
    */
-  self.toCompactTimestamp = function (date) {
+  self.toCompactTimestamp = function(date) {
     return date.toISOString()
       .replace(/[-:TZ.]/g, '');
   };
@@ -683,7 +683,7 @@ export default (function (self) {
    * ``YYYYMMDDHHMMSSsss``.
    * @return {Date} the converted date object.
    */
-  self.fromCompactTimestamp = function (str) {
+  self.fromCompactTimestamp = function(str) {
     var v = str.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})/);
     if (lodashIsNull(v)) {
       throw new Error('Invalid timestamp:' + str);
@@ -706,13 +706,13 @@ export default (function (self) {
    * @static
    * @return {Date} The current time or an overriden value.
    */
-  var now = function () {
+  var now = function() {
     return new Date();
   };
 
   self.now = now;
 
-  self.resetNow = function () {
+  self.resetNow = function() {
     self.now = now;
   };
 
@@ -725,7 +725,7 @@ export default (function (self) {
    * @return {Date} The current time with the UTC hours, minutes, and seconds
    * fields set to zero or an overriden value.
    */
-  self.today = function () {
+  self.today = function() {
     return self.now();
   };
 
@@ -741,7 +741,7 @@ export default (function (self) {
    * @param {string} message Message to display to the end user.
    * @param {Exception} cause The exception object that caused the error
    */
-  self.error = function (message, cause) {
+  self.error = function(message, cause) {
     wvui.error(message, cause);
   };
 
@@ -755,16 +755,16 @@ export default (function (self) {
    * @param {object*} messages Messages to display to the end user.
    */
   self.warn = (console && console.warn && console.warn.bind)
-    ? console.warn.bind(console) : function () { };
+    ? console.warn.bind(console) : function() { };
 
-  self.hexToRGB = function (str) {
+  self.hexToRGB = function(str) {
     return 'rgb(' +
       parseInt(str.substring(0, 2), 16) + ',' +
       parseInt(str.substring(2, 4), 16) + ',' +
       parseInt(str.substring(4, 6), 16) + ')';
   };
 
-  self.hexToRGBA = function (str) {
+  self.hexToRGBA = function(str) {
     return 'rgba(' +
       parseInt(str.substring(0, 2), 16) + ',' +
       parseInt(str.substring(2, 4), 16) + ',' +
@@ -772,7 +772,7 @@ export default (function (self) {
       parseInt(str.substring(6, 8), 16) + ')';
   };
 
-  self.rgbaToHex = function (r, g, b) {
+  self.rgbaToHex = function(r, g, b) {
     function hex(c) {
       var strHex = c.toString(16);
       return strHex.length === 1 ? '0' + strHex : strHex;
@@ -780,7 +780,7 @@ export default (function (self) {
     return hex(r) + hex(g) + hex(b) + 'ff';
   };
 
-  self.hexColorDelta = function (hex1, hex2) {
+  self.hexColorDelta = function(hex1, hex2) {
     var r1 = parseInt(hex1.substring(0, 2), 16);
     var g1 = parseInt(hex1.substring(2, 4), 16);
     var b1 = parseInt(hex1.substring(4, 6), 16);
@@ -790,18 +790,18 @@ export default (function (self) {
     // calculate differences in 3D Space
     return Math.sqrt(Math.pow((r1 - r2), 2) + Math.pow((g1 - g2), 2) + Math.pow((b1 - b2), 2));
   };
-  self.fetch = function (url, mimeType) {
+  self.fetch = function(url, mimeType) {
     return new Promise((resolve, reject) => {
       return fetch(url)
-        .then(function (response) {
+        .then(function(response) {
           return mimeType === 'application/json'
             ? response.json()
             : response.text();
         })
-        .then(function (data) {
+        .then(function(data) {
           resolve(data);
         })
-        .catch(function (error) {
+        .catch(function(error) {
           reject(error);
         });
     });
@@ -817,7 +817,7 @@ export default (function (self) {
    * @param {Object} [spec.options] options to pass to jscache on setItem.
    *
    */
-  self.ajaxCache = function (spec) {
+  self.ajaxCache = function(spec) {
     spec = spec || {};
     var size = spec.size || null;
     var options = spec.options || {};
@@ -835,7 +835,7 @@ export default (function (self) {
        * when the query returns, or resolves immedately if the results
        * are cached.
        */
-      submit: function (parameters) {
+      submit: function(parameters) {
         var key = 'url=' + parameters.url;
         if (parameters.data) {
           key += '&query=' + $.param(parameters.data, true);
@@ -848,7 +848,7 @@ export default (function (self) {
             .promise();
         } else {
           var promise = $.ajax(parameters);
-          promise.done(function (results) {
+          promise.done(function(results) {
             cache.setItem(key, results, options);
           });
           return promise;
@@ -856,9 +856,9 @@ export default (function (self) {
       }
     };
   };
-  self.errorReport = function (errors) {
+  self.errorReport = function(errors) {
     var layersRemoved = 0;
-    lodashEach(errors, function (error) {
+    lodashEach(errors, function(error) {
       var cause = error.cause ? ': ' + error.cause : '';
       self.warn(error.message + cause);
       if (error.layerRemoved) {
@@ -873,8 +873,8 @@ export default (function (self) {
    * @param {function} func the function to wrap
    * @return the function wrapped in a try/catch block.
    */
-  self.wrap = function (func) {
-    return function () {
+  self.wrap = function(func) {
+    return function() {
       try {
         return func.apply(func, arguments);
       } catch (error) {
@@ -891,14 +891,14 @@ export default (function (self) {
    * @param {url} func the function to wrap
    * @return {object} Promise
    */
-  self.get = function (url) {
+  self.get = function(url) {
     // Return a new promise.
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       // Do the usual XHR stuff
       var req = new XMLHttpRequest();
       req.open('GET', url);
 
-      req.onload = function () {
+      req.onload = function() {
         // This is called even on 404 etc
         // so check the status
         if (req.status === 200) {
@@ -911,7 +911,7 @@ export default (function (self) {
         }
       };
       // Handle network errors
-      req.onerror = function () {
+      req.onerror = function() {
         reject(Error('Network Error'));
       };
       // Make the request
@@ -920,20 +920,20 @@ export default (function (self) {
   };
 
   // FIXME: Should be replaced with $.when
-  self.ajaxJoin = function (calls) {
+  self.ajaxJoin = function(calls) {
     var completed = 0;
     var result = {};
     var deferred = $.Deferred();
 
-    $.each(calls, function (index, call) {
-      call.promise.done(function (data) {
+    $.each(calls, function(index, call) {
+      call.promise.done(function(data) {
         result[call.item] = data;
         completed += 1;
         if (completed === calls.length) {
           deferred.resolve(result);
         }
       })
-        .fail(function (jqXHR, textStatus, errorThrown) {
+        .fail(function(jqXHR, textStatus, errorThrown) {
           deferred.reject(jqXHR, textStatus, errorThrown);
         });
     });
@@ -956,21 +956,21 @@ export default (function (self) {
   // The original plan was to escape the special characters but that
   // became confusing as element attributes would need one escape character
   // but the selector would need two (\. vs \\.)
-  self.encodeId = function (str) {
+  self.encodeId = function(str) {
     return str.replace(/[.:]/g, (match) => {
       return '__' + match.charCodeAt(0).toString(16).toUpperCase() + '__';
     });
   };
 
   // Converts an encoded identifier back to its original value.
-  self.decodeId = function (str) {
+  self.decodeId = function(str) {
     return str.replace(/__[0-9A-Fa-f]{2}__/g, (match) => {
       const charCode = Number.parseInt(match.substring(2, 4), 16);
       return String.fromCharCode(charCode);
     });
   };
 
-  self.metrics = function () {
+  self.metrics = function() {
     if (window.ntptEventTag) {
       ntptEventTag.apply(null, arguments);
     } else {
@@ -1020,7 +1020,7 @@ export default (function (self) {
   self.formatDMS = (value, type) => formatDegrees(value, type, true);
   self.formatDM = (value, type) => formatDegrees(value, type, false);
 
-  self.setCoordinateFormat = function (type) {
+  self.setCoordinateFormat = function(type) {
     if (!browser.localStorage) return;
     if (type !== 'latlon-dd' && type !== 'latlon-dms' && type !== 'latlon-dm') {
       throw new Error('Invalid coordinate format: ' + type);
@@ -1028,12 +1028,12 @@ export default (function (self) {
     localStorage.setItem('coordinateFormat', type);
   };
 
-  self.getCoordinateFormat = function () {
+  self.getCoordinateFormat = function() {
     if (!browser.localStorage) return 'latlon-dd';
     return localStorage.getItem('coordinateFormat') || 'latlon-dd';
   };
 
-  self.formatCoordinate = function (coord, format) {
+  self.formatCoordinate = function(coord, format) {
     var type = format || self.getCoordinateFormat();
     if (type === 'latlon-dms') {
       return self.formatDMS(coord[1], 'latitude') + ', ' +
@@ -1051,7 +1051,7 @@ export default (function (self) {
   // arguments array contains all args passed. String must be formatted
   // so that first replacement starts with "{1}"
   // usage example: wv.util.format("{1}{2}",'World','view')
-  self.format = function () {
+  self.format = function() {
     var formatted = arguments[0];
     for (var i = 1; i < arguments.length; i++) {
       var regexp = new RegExp('\\{' + i + '\\}', 'gi');
@@ -1060,7 +1060,7 @@ export default (function (self) {
     return formatted;
   };
 
-  self.toArray = function (value) {
+  self.toArray = function(value) {
     if (!value) {
       return [];
     }
@@ -1071,14 +1071,14 @@ export default (function (self) {
   };
 
   // Returns the number of months between two dates
-  self.yearDiff = function (startDate, endDate) {
+  self.yearDiff = function(startDate, endDate) {
     var year1 = startDate.getFullYear();
     var year2 = endDate.getFullYear();
     return year2 - year1;
   };
 
   // Returns the number of months between two dates
-  self.monthDiff = function (startDate, endDate) {
+  self.monthDiff = function(startDate, endDate) {
     var year1 = startDate.getFullYear();
     var year2 = endDate.getFullYear();
     var month1 = startDate.getMonth();
@@ -1091,7 +1091,7 @@ export default (function (self) {
     return numberOfMonths;
   };
 
-  self.dayDiff = function (startDate, endDate) {
+  self.dayDiff = function(startDate, endDate) {
     var date1 = new Date(startDate);
     var date2 = new Date(endDate);
     var timeDiff = Math.abs(date2.getTime() - date1.getTime());
@@ -1099,7 +1099,7 @@ export default (function (self) {
     return dayDiff;
   };
 
-  self.minuteDiff = function (startDate, endDate) {
+  self.minuteDiff = function(startDate, endDate) {
     var date1 = new Date(startDate);
     var date2 = new Date(endDate);
     var timeDiff = Math.abs(date2.getTime() - date1.getTime());
@@ -1117,10 +1117,10 @@ export default (function (self) {
    *                                If false, only return the dates from the range the current date falls in.
    * @return {array}                An array of dates with normalized timezones
    */
-  self.datesinDateRanges = function (def, date, containRange) {
+  self.datesinDateRanges = function(def, date, containRange) {
     var dateArray = [];
     var currentDate = new Date(date.getTime());
-    lodashEach(def.dateRanges, function (dateRange) {
+    lodashEach(def.dateRanges, function(dateRange) {
       var yearDifference;
       var monthDifference;
       var dayDifference;
@@ -1220,7 +1220,7 @@ export default (function (self) {
    * @param {String} value | String to return index of
    * @return {Number}
    */
-  self.stringInArray = function (arra, value) {
+  self.stringInArray = function(arra, value) {
     for (var i = 0, len = arra.length; i < len; i++) {
       if (arra[i] === value) {
         return i;
@@ -1237,7 +1237,7 @@ export default (function (self) {
    * @param  {array} dateArray  An array of dates
    * @return {object}           The date object with normalized timeszone.
    */
-  self.prevDateInDateRange = function (def, date, dateArray) {
+  self.prevDateInDateRange = function(def, date, dateArray) {
     var currentDate = new Date(date.getTime());
     if (!dateArray) return date;
     if ((def.period === 'monthly' && (isFirstDayOfMonth(currentDate) || isLastDayOfMonth(currentDate))) ||
@@ -1245,7 +1245,7 @@ export default (function (self) {
         currentDate.getMonth() === 0) || (currentDate === lastDayOfYear(currentDate))))) return date;
     // Return an array of the closest available dates within the range
     var closestAvailableDates = [];
-    lodashEach(dateArray, function (rangeDate) {
+    lodashEach(dateArray, function(rangeDate) {
       if (isBefore(rangeDate, currentDate) || isEqual(rangeDate, currentDate)) {
         closestAvailableDates.push(rangeDate);
       }
@@ -1265,7 +1265,7 @@ export default (function (self) {
    * @param  {array} comment seperated list of objects
    * @return {bool}
    */
-  self.objectsHaveSameKeys = function (...objects) {
+  self.objectsHaveSameKeys = function(...objects) {
     const allKeys = objects.reduce((keys, object) => keys.concat(Object.keys(object)), []);
     const union = new Set(allKeys);
     return objects.every(object => union.size === Object.keys(object).length);


### PR DESCRIPTION
## Description

Fixes #67
Show tick marks along color bar so that log scales are apparent
- [x] Prevent ticks in layers < 100 color bins
- [x] Draw tick marks under bar
- [x] Flip running data triangle to point towards ticks
- [x] Center running data labels
- [x] Enlarge color bar labels  

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
