### PR TITLE
Add validation check for image download to see if available layers is an empty array

### DIFF
--- a/web/js/components/image-download/grid.js
+++ b/web/js/components/image-download/grid.js
@@ -12,7 +12,7 @@ import Button from '../util/button';
 export default class ResolutionTable extends React.Component {
   renderImageSize() {
     var size = this.props.fileSize;
-    if (!this.props.valid) {
+    if (!this.props.validSize) {
       return (
         <div
           id="wv-image-size"
@@ -33,7 +33,7 @@ export default class ResolutionTable extends React.Component {
 
   render() {
     const imageSize = this.renderImageSize();
-    const { width, height, onClick, valid } = this.props;
+    const { width, height, maxImageSize, onClick, validLayers, validSize } = this.props;
     return (
       <div className="wv-image-download-grid">
         <div className="grid-child grid-head">
@@ -45,12 +45,12 @@ export default class ResolutionTable extends React.Component {
         {imageSize}
         <div
           className={
-            this.props.valid
+            validSize
               ? 'grid-child wv-image-max-size'
               : 'grid-child wv-image-max-size wv-image-size-invalid'
           }
         >
-          <span>{this.props.maxImageSize}</span>
+          <span>{maxImageSize}</span>
         </div>
         <div
           className="grid-child wv-image-dimensions"
@@ -65,7 +65,7 @@ export default class ResolutionTable extends React.Component {
             onClick={() => {
               onClick(width, height);
             }}
-            valid={valid}
+            valid={validSize && validLayers}
           />
         </div>
       </div>
@@ -77,6 +77,7 @@ ResolutionTable.propTypes = {
   height: PropTypes.number,
   maxImageSize: PropTypes.string,
   onClick: PropTypes.func,
-  valid: PropTypes.bool,
+  validLayers: PropTypes.bool,
+  validSize: PropTypes.bool,
   width: PropTypes.number
 };

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -156,13 +156,14 @@ export default class ImageResSelection extends React.Component {
   }
 
   render() {
-    const { projection, lonlats, resolutions, maxImageSize } = this.props;
+    const { getLayers, projection, lonlats, resolutions, maxImageSize } = this.props;
     const { resolution, debugUrl } = this.state;
     const dimensions = getDimensions(projection.id, lonlats, resolution);
     const height = dimensions.height;
     const width = dimensions.width;
     const filetypeSelect = this._renderFileTypeSelect();
     const worldfileSelect = this._renderWorldfileSelect();
+    const layerList = getLayers();
     return (
       <div className="wv-re-pick-wrapper wv-image">
         <div
@@ -187,7 +188,8 @@ export default class ImageResSelection extends React.Component {
           height={height}
           fileSize={((width * height * 24) / 8388608).toFixed(2)}
           maxImageSize={maxImageSize}
-          valid={imageSizeValid(height, width, MAX_DIMENSION_SIZE)}
+          validSize={imageSizeValid(height, width, MAX_DIMENSION_SIZE)}
+          validLayers={layerList.length > 0}
           onClick={this.onDownload.bind(this)}
         />
       </div>


### PR DESCRIPTION
## Description

Fixes #1661  .

- Add validation check for image download button to see if available layers is an empty array - an empty array will be returned from a higher function that checks for valid layers

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
