### PR TITLE
Make animation start range dynamic

### DIFF
--- a/web/js/modules/animation/actions.js
+++ b/web/js/modules/animation/actions.js
@@ -12,25 +12,32 @@ import {
   TOGGLE_GIF
 } from './constants';
 import util from '../../util/util';
+import { timeScaleFromNumberKey } from '../date/constants';
 
 export function onActivate() {
   return (dispatch, getState) => {
     const { compare, date, animation } = getState();
+    const { customSelected, customDelta, delta, customInterval, interval } = date;
     const dateStr = compare.isCompareA ? 'selected' : 'selectedB';
     const activeDate = date[dateStr];
     if (!animation.startDate || !animation.endDate) {
-      const sevenDaysBefore = util.dateAdd(activeDate, 'day', -7);
-      const sevenDaysAfter = util.dateAdd(activeDate, 'day', 7);
+      const timeScaleChangeUnit = customSelected
+        ? timeScaleFromNumberKey[customInterval]
+        : timeScaleFromNumberKey[interval];
+      const deltaChangeAmt = customSelected ? customDelta : delta;
+      const sevenFrameDelta = 7 * deltaChangeAmt;
+      const sevenFramesBefore = util.dateAdd(activeDate, timeScaleChangeUnit, -(sevenFrameDelta));
+      const sevenFramesAfter = util.dateAdd(activeDate, timeScaleChangeUnit, sevenFrameDelta);
       const startDate = animation.startDate
         ? animation.startDate
-        : date.appNow < sevenDaysAfter
-          ? sevenDaysBefore
+        : date.appNow < sevenFramesAfter
+          ? sevenFramesBefore
           : activeDate;
       const endDate = animation.endDate
         ? animation.endDate
-        : date.appNow < sevenDaysAfter
+        : date.appNow < sevenFramesAfter
           ? activeDate
-          : sevenDaysAfter;
+          : sevenFramesAfter;
       dispatch({ type: UPDATE_START_AND_END_DATE, startDate, endDate });
     }
     dispatch({ type: OPEN_ANIMATION });

--- a/web/js/modules/animation/actions.js
+++ b/web/js/modules/animation/actions.js
@@ -25,19 +25,19 @@ export function onActivate() {
         ? timeScaleFromNumberKey[customInterval]
         : timeScaleFromNumberKey[interval];
       const deltaChangeAmt = customSelected ? customDelta : delta;
-      const sevenFrameDelta = 7 * deltaChangeAmt;
-      const sevenFramesBefore = util.dateAdd(activeDate, timeScaleChangeUnit, -(sevenFrameDelta));
-      const sevenFramesAfter = util.dateAdd(activeDate, timeScaleChangeUnit, sevenFrameDelta);
+      const tenFrameDelta = 10 * deltaChangeAmt;
+      const tenFramesBefore = util.dateAdd(activeDate, timeScaleChangeUnit, -(tenFrameDelta));
+      const tenFramesAfter = util.dateAdd(activeDate, timeScaleChangeUnit, tenFrameDelta);
       const startDate = animation.startDate
         ? animation.startDate
-        : date.appNow < sevenFramesAfter
-          ? sevenFramesBefore
+        : date.appNow < tenFramesAfter
+          ? tenFramesBefore
           : activeDate;
       const endDate = animation.endDate
         ? animation.endDate
-        : date.appNow < sevenFramesAfter
+        : date.appNow < tenFramesAfter
           ? activeDate
-          : sevenFramesAfter;
+          : tenFramesAfter;
       dispatch({ type: UPDATE_START_AND_END_DATE, startDate, endDate });
     }
     dispatch({ type: OPEN_ANIMATION });

--- a/web/js/modules/animation/actions.test.js
+++ b/web/js/modules/animation/actions.test.js
@@ -58,8 +58,8 @@ describe('Open, play, stop, close and toggle actions', () => {
   );
   test(
     'toggleComponentGifActive action returns ' +
-      constants.TOGGLE_GIF +
-      ' action type',
+    constants.TOGGLE_GIF +
+    ' action type',
     () => {
       const expectedAction = {
         type: constants.TOGGLE_GIF
@@ -73,8 +73,8 @@ describe('Animation Datechange actions', () => {
   const then = util.dateAdd(now, 'day', -7);
   test(
     'changeStartDate action returns ' +
-      constants.UPDATE_START_DATE +
-      ' action type and current date as value',
+    constants.UPDATE_START_DATE +
+    ' action type and current date as value',
     () => {
       const expectedAction = {
         type: constants.UPDATE_START_DATE,
@@ -87,8 +87,8 @@ describe('Animation Datechange actions', () => {
   );
   test(
     'changeEndDate action returns ' +
-      constants.UPDATE_END_DATE +
-      ' action type and current date as value',
+    constants.UPDATE_END_DATE +
+    ' action type and current date as value',
     () => {
       const response = changeEndDate(now);
       expect(response.type).toEqual(constants.UPDATE_END_DATE);
@@ -97,8 +97,8 @@ describe('Animation Datechange actions', () => {
   );
   test(
     'changeStartAndEndDate action returns ' +
-      constants.UPDATE_START_AND_END_DATE +
-      ' action type and current date as value',
+    constants.UPDATE_START_AND_END_DATE +
+    ' action type and current date as value',
     () => {
       const response = changeStartAndEndDate(then, now);
       expect(response.type).toEqual(constants.UPDATE_START_AND_END_DATE);
@@ -110,8 +110,8 @@ describe('Animation Datechange actions', () => {
 
 test(
   'changeFrameRate action returns ' +
-    constants.UPDATE_FRAME_RATE +
-    ' action type and number value',
+  constants.UPDATE_FRAME_RATE +
+  ' action type and number value',
   () => {
     const response = changeFrameRate(2);
     expect(response.type).toEqual(constants.UPDATE_FRAME_RATE);
@@ -120,8 +120,8 @@ test(
 );
 test(
   'onActivate action returns ' +
-    constants.OPEN_ANIMATION +
-    ' action type and current dateValue',
+  constants.OPEN_ANIMATION +
+  ' action type and current dateValue',
   () => {
     const mockStore = configureMockStore(middlewares);
     const store = mockStore(state);
@@ -131,7 +131,7 @@ test(
     expect(response1.type).toEqual(constants.UPDATE_START_AND_END_DATE);
     expect(response1.endDate).toEqual(state.date.selected);
     expect(response1.startDate).toEqual(
-      util.dateAdd(state.date.selected, 'day', -7)
+      util.dateAdd(state.date.selected, 'day', -10)
     );
     expect(response2.type).toEqual(constants.OPEN_ANIMATION);
   }


### PR DESCRIPTION
## Description

Fixes #1735

Make animation start range dynamic. Currently when the animation widget is initiated it defaults to a 7-day range no matter the selected time interval.

- [x] Make animation widget default to a ten frames

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
