### PR TITLE
Allow promise to resolve on no response for tilelayer grid building

### DIFF
--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -263,8 +263,8 @@ var promiseTileLayer = function(layer, extent, viewState, pixelRatio) {
               resolve();
             }
           } else {
-            reject(new Error('No response at this URL'));
-            // resolve();// some gibs data is not accurate and rejecting this will break the animation if tile doesn't exist
+            console.error('No response for tile request ' + layer.wv.key);
+            resolve(); // some gibs data is not accurate and rejecting this will break the animation if tile doesn't exist
           }
           this.un('tileloadend', loader); // remove event listeners from memory
           this.un('tileloaderror', loader);


### PR DESCRIPTION
## Description

Fixes #1707  .

- A rejected tile layer in the parent `Promise.all` resulted in animation hanging. This fix will display a console error, but resolve the `promise` even if no tiles are available. This will allow the animation to continue for layers with spotty coverage over animation date ranges.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

An alternative fix that I was going to put into place was a modified `Promise.all` that just returned `null` for errors and continued resolving successful requests, but this PR fix gave better user log feedback to know the layer/requested date causing the issue.

@nasa-gibs/worldview
