### PR TITLE
Fix tour modal scroll area cut-off

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -46,18 +46,13 @@
 /* .tour-start */
 .tour-start .modal {
   overflow-y: auto;
-  height: 830px;
   margin-left: auto;
   margin-right: auto;
-  top: 20px;
-  bottom: 20px;
 }
 
 .tour-start .modal-dialog {
   overflow-y: initial;
   border: 1px solid #333;
-  margin-top: 0;
-  margin-bottom: 0;
 }
 
 .tour-start .modal.fade .modal-dialog {


### PR DESCRIPTION
## Description

Fixes #2096

- Removes fixed height on worldview tour modal

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
