### PR TITLE
Date time snapping for subdaily "future" times

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -130,7 +130,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
   /**
    * For subdaily layers, round the time down to nearest interval.
    * NOTE: Assumes intervals are the same for all ranges!
-   * @param {*} date
+   * @param {object} def
+   * @param {date} date
+   * @return {date}
    */
   const nearestInterval = function(def, date) {
     const dateInterval = lodashGet(def, 'dateRanges[0].dateInterval');

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -44,6 +44,7 @@ import {
   getLayers,
   isRenderable as isRenderableLayer
 } from '../modules/layers/selectors';
+import { datesinDateRanges } from '../modules/layers/util';
 import {
   get as lodashGet,
   debounce as lodashDebounce,
@@ -525,7 +526,7 @@ export function mapui(models, config, store, ui) {
     if (isGraticule(def, proj.id)) {
       addGraticule(def.opacity, activeLayerStr);
     } else {
-      def.availableDates = util.datesinDateRanges(def, date, true);
+      def.availableDates = datesinDateRanges(def, date);
       if (firstLayer && firstLayer.get('group')) {
         // Find which map layer-group is the active LayerGroup
         // and add layer to layerGroup in correct location

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -277,7 +277,7 @@ export function dateRange(spec, activeLayers, config) {
   var range = false;
   var maxDates = [];
 
-  // Use the minute ceiling of the currne titme so that we don't run into an issue where
+  // Use the minute ceiling of the current time so that we don't run into an issue where
   // seconds value of current appNow time is greater than a layer's available time range
   const minuteCeilingCurrentTime = util.now().setSeconds(59);
 


### PR DESCRIPTION
## Description

Fixes #2041.

Makes sure that times requested that fall outside a subdaily layer's date ranges still snap to the interval.

* Should NOT send tile requests when date/time is before layer's `startDate`
* Should NOT send request when date/time is after layers `endDate` only if layer is marked `inactive`
* Should send request when date/time is after layers `endDate` if layer is NOT marked `inactive`
* Request time should always snap to the layers `dateInterval` (usually 10 minutes)
* For subdaily layers with 10 minute interval:
  * Should NOT send request when minutes are incremented/decremented until passing a 10 minute boundary
* For daily layers:
  * Should NOT send request when hours/minutes are incremented
  * Should only send requests when day/month/year is changed (if there is availability)
* Time snapping for other layer time periods are not currently working as expected.  Some changes to the related code were made in order to clean up/simplify things but another open ticket exists for implementing the full fix.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
