### PR TITLE
Fix Browserstack Integration

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -12,13 +12,20 @@
   },
   "extends": "standard",
   "rules": {
-    "semi": ["error", "always"],
-    "space-before-function-paren": "off",
-    "object-curly-spacing": ["warn", "always"],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "object-curly-spacing": [
+      "warn",
+      "always"
+    ],
   },
   "overrides": [
     {
-      "files": [ "*.js"],
+      "files": [
+        "*.js"
+      ],
       "rules": {
         "no-octal": "warn",
         "no-unused-vars": "warn",
@@ -51,6 +58,10 @@
         "no-useless-call": "warn",
         "no-trailing-spaces": "warn",
         "standard/computed-property-even-spacing": "warn",
+        "space-before-function-paren": [
+          "error",
+          "never"
+        ],
         "wrap-iife": "warn",
         "new-cap": "warn"
       }

--- a/e2e/browserstack.conf.js
+++ b/e2e/browserstack.conf.js
@@ -1,6 +1,7 @@
 const environments = require('./environments.js');
 const glob = require('glob');
 const files = glob.sync('./e2e/features/**/*-test.js');
+
 const nightwatchConfig = {
   output_folder: './e2e/reports',
   globals_path: './globals.js',
@@ -8,7 +9,6 @@ const nightwatchConfig = {
   src_folders: files,
   selenium: {
     start_process: false,
-    check_process_delay: 5000,
     host: 'hub-cloud.browserstack.com',
     port: 80
   },
@@ -17,10 +17,11 @@ const nightwatchConfig = {
     'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY,
     'browserstack.local': true,
     'browserstack.debug': true,
+    'browserstack.localIdentifier': ('wvtester19234' + process.env.BROWSERSTACK_USER).replace(/[^a-zA-Z0-9]/g, ''),
     build: 'nightwatch-browserstack',
     applicationCacheEnabled: false,
     webStorageEnabled: false,
-    marionette: true
+    "marionette": true
   },
   test_settings: {
     default: {},
@@ -33,14 +34,13 @@ const nightwatchConfig = {
       desiredCapabilities: {
         browser: 'chrome',
         marionette: true,
-        'browserstack.selenium_version': '2.53.0'
+        'browserstack.selenium_version': '3.5.2'
       }
     },
     safari: {
       desiredCapabilities: {
         browser: 'safari',
-        'browserstack.selenium_version': '3.5.2',
-        'browserstack.safari.driver': '2.45'
+        'browserstack.selenium_version': '3.5.2'
       }
     },
     firefox: {
@@ -50,7 +50,7 @@ const nightwatchConfig = {
         browserName: 'firefox',
         javascriptEnabled: true,
         'browserstack.selenium_version': '3.10.0',
-        'browserstack.geckodriver': '0.19.0'
+        'browserstack.geckodriver': '0.24.0'
       }
     },
     ie: {

--- a/e2e/browserstack.conf.js
+++ b/e2e/browserstack.conf.js
@@ -21,7 +21,7 @@ const nightwatchConfig = {
     build: 'nightwatch-browserstack',
     applicationCacheEnabled: false,
     webStorageEnabled: false,
-    "marionette": true
+    marionette: true
   },
   test_settings: {
     default: {},

--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -25,6 +25,7 @@ try {
   Nightwatch.bs_local = bs_local = new browserstack.Local();
   bs_local.start({
     key: process.env.BROWSERSTACK_ACCESS_KEY,
+    localIdentifier: ('wvtester19234' + process.env.BROWSERSTACK_USER).replace(/[^a-zA-Z0-9]/g, ''),
     force: 'true' // if you want to kill existing ports
   }, function (error) {
     if (error) throw new Error(error);
@@ -37,14 +38,20 @@ try {
       argv.env = envString;
       Nightwatch.CliRunner(argv)
         .setup(null, function () {
-          // Code to stop browserstack local after end of parallel test
           bs_local.stop(function () {
             process.exit();
           });
         })
         .runTests(function () {
-          // Code to stop browserstack local after end of single test
-          bs_local.stop(function () {});
+          bs_local.stop(function () {
+            if (bs_local.pid && process) {
+              // Code to stop browserstack local after end of parallel test
+              process.exit();
+            }
+          })
+        }).catch(err => {
+          console.error(err);
+          process.exit();
         });
     });
   });

--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -48,7 +48,7 @@ try {
               // Code to stop browserstack local after end of parallel test
               process.exit();
             }
-          })
+          });
         }).catch(err => {
           console.error(err);
           process.exit();

--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -27,23 +27,23 @@ try {
     key: process.env.BROWSERSTACK_ACCESS_KEY,
     localIdentifier: ('wvtester19234' + process.env.BROWSERSTACK_USER).replace(/[^a-zA-Z0-9]/g, ''),
     force: 'true' // if you want to kill existing ports
-  }, function (error) {
+  }, function(error) {
     if (error) throw new Error(error);
 
     console.log('Connected. Running tests...');
     console.log('Go to https://www.browserstack.com/automate to view tests in progress.');
-    Nightwatch.cli(function (argv) {
+    Nightwatch.cli(function(argv) {
       var envString = environment_names.join(',');
       argv.e = envString;
       argv.env = envString;
       Nightwatch.CliRunner(argv)
-        .setup(null, function () {
-          bs_local.stop(function () {
+        .setup(null, function() {
+          bs_local.stop(function() {
             process.exit();
           });
         })
-        .runTests(function () {
-          bs_local.stop(function () {
+        .runTests(function() {
+          bs_local.stop(function() {
             if (bs_local.pid && process) {
               // Code to stop browserstack local after end of parallel test
               process.exit();

--- a/e2e/custom-assertions/elementCountEquals.js
+++ b/e2e/custom-assertions/elementCountEquals.js
@@ -6,20 +6,20 @@
 //
 // for how to write custom assertions see
 // http://nightwatchjs.org/guide#writing-custom-assertions
-exports.assertion = function (selector, count) {
+exports.assertion = function(selector, count) {
   this.message = 'Testing if element <' + selector + '> has count: ' + count;
   this.expected = count;
-  this.pass = function (val) {
+  this.pass = function(val) {
     return val === this.expected;
   };
-  this.value = function (res) {
+  this.value = function(res) {
     return res.value;
   };
-  this.command = function (cb) {
+  this.command = function(cb) {
     var self = this;
-    return this.api.execute(function (selector) {
+    return this.api.execute(function(selector) {
       return document.querySelectorAll(selector).length;
-    }, [selector], function (res) {
+    }, [selector], function(res) {
       cb.call(self, res);
     });
   };

--- a/e2e/custom-assertions/elementCountGreater.js
+++ b/e2e/custom-assertions/elementCountGreater.js
@@ -6,20 +6,20 @@
 //
 // for how to write custom assertions see
 // http://nightwatchjs.org/guide#writing-custom-assertions
-exports.assertion = function (selector, count) {
+exports.assertion = function(selector, count) {
   this.message = 'Testing if element <' + selector + '> has count: ' + count;
   this.expected = count;
-  this.pass = function (val) {
+  this.pass = function(val) {
     return val >= this.expected;
   };
-  this.value = function (res) {
+  this.value = function(res) {
     return res.value;
   };
-  this.command = function (cb) {
+  this.command = function(cb) {
     var self = this;
-    return this.api.execute(function (selector) {
+    return this.api.execute(function(selector) {
       return document.querySelectorAll(selector).length;
-    }, [selector], function (res) {
+    }, [selector], function(res) {
       cb.call(self, res);
     });
   };

--- a/e2e/custom-assertions/urlParameterEquals.js
+++ b/e2e/custom-assertions/urlParameterEquals.js
@@ -1,9 +1,9 @@
 const { URL } = require('url');
 
-exports.assertion = function (parameter, value) {
+exports.assertion = function(parameter, value) {
   this.message = 'Testing if URL parameter "' + parameter + '" has value: ' + value;
   this.expected = `${parameter}=${value}`;
-  this.pass = function (value) {
+  this.pass = function(value) {
     const expected = this.expected.split('=');
     const expectedParam = expected[0];
     const expectedValue = expected[1];
@@ -12,11 +12,11 @@ exports.assertion = function (parameter, value) {
     }
     return value.get(expectedParam) === expectedValue;
   };
-  this.value = function (result) {
+  this.value = function(result) {
     const url = new URL(result.value);
     return url.searchParams;
   };
-  this.command = function (cb) {
+  this.command = function(cb) {
     this.api.url(cb);
     return this;
   };

--- a/e2e/environments.js
+++ b/e2e/environments.js
@@ -7,9 +7,9 @@ const createCapabilities = bsCapabilities(
 
 const capabilities = createCapabilities([{
   browser: 'firefox',
-  browser_version: ['59.0'],
-  os: ['Windows'],
-  os_version: ['10']
+  browser_version: ['69.0'],
+  os: ['Windows', 'OS X'],
+  os_version: ['10', 'Mojave']
 }, {
   browser: 'safari',
   browser_version: ['11.1'],
@@ -17,9 +17,9 @@ const capabilities = createCapabilities([{
   os_version: ['High Sierra']
 }, {
   browser: 'chrome',
-  browser_version: ['66.0'],
+  browser_version: ['76.0'],
   os: ['Windows', 'OS X'],
-  os_version: ['10', 'Sierra']
+  os_version: ['10', 'Mojave']
 }, {
   browser: 'ie',
   browser_version: ['11.0'],


### PR DESCRIPTION
## Description
Browserstack tests no longer running
Fixes #2030

- [x] Add local ID 
- [x] Update Browsers and operating systems to test

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
Not all tests are passing in all environments. This PR just makes the connecting with BrowserStack possible again.

Should we drop tests for `IE` and or `safari`? I believe that their selenium driver support is not at the level of Chrome or Firefox causing false positives that will be hard to avoid.

@nasa-gibs/worldview
