### PR TITLE
Calculate layer extent from tile matrix limits

### DIFF
--- a/tasks/python3/extractConfigFromWMTS.py
+++ b/tasks/python3/extractConfigFromWMTS.py
@@ -90,11 +90,11 @@ def process_layer(gc_layer, wv_layers, colormaps):
         mappedSetLimits = []
         for setLimit in matrixSetLimits:
             mappedSetLimits.append({
-                "TileMatrix": setLimit["TileMatrix"],
-                "MinTileRow": int(setLimit["MinTileRow"]),
-                "MaxTileRow": int(setLimit["MaxTileRow"]),
-                "MinTileCol": int(setLimit["MinTileCol"]),
-                "MaxTileCol": int(setLimit["MaxTileCol"]),
+                "tileMatrix": setLimit["TileMatrix"],
+                "minTileRow": int(setLimit["MinTileRow"]),
+                "maxTileRow": int(setLimit["MaxTileRow"]),
+                "minTileCol": int(setLimit["MinTileCol"]),
+                "maxTileCol": int(setLimit["MaxTileCol"]),
             })
         wv_layer["projections"][entry["projection"]]["matrixSetLimits"] = mappedSetLimits;
 
@@ -211,9 +211,18 @@ def process_entry(entry, colormaps):
         ident = gc_matrix_set["ows:Identifier"]
         zoom_levels = len(tileMatrixArr)
         resolutions = []
+        formattedTileMatrixArr = []
         max_resolution = entry["maxResolution"]
         for zoom in range(0, zoom_levels):
             resolutions = resolutions + [max_resolution / (2 ** zoom)]
+
+        # We are assuming that width/heights are the same for every matrix and excluding
+        # the "TileWidth", "TileHeight" properties here
+        for tileMatrix in tileMatrixArr:
+            formattedTileMatrixArr.append({
+                "matrixWidth": int(tileMatrix["MatrixWidth"]),
+                "matrixHeight": int(tileMatrix["MatrixHeight"]),
+            })
 
         wv_matrix_sets[ident] = {
             "id": ident,
@@ -223,7 +232,7 @@ def process_entry(entry, colormaps):
                 int(tileMatrixArr[0]["TileWidth"]),
                 int(tileMatrixArr[0]["TileHeight"])
             ],
-            "tileMatrices": tileMatrixArr
+            "tileMatrices": formattedTileMatrixArr
         }
 
     if(type(gc_contents["TileMatrixSet"]) is OrderedDict):

--- a/tasks/python3/extractConfigFromWMTS.py
+++ b/tasks/python3/extractConfigFromWMTS.py
@@ -87,7 +87,16 @@ def process_layer(gc_layer, wv_layers, colormaps):
 
     if "TileMatrixSetLimits" in matrixSetLink and matrixSetLink["TileMatrixSetLimits"] is not None:
         matrixSetLimits = matrixSetLink["TileMatrixSetLimits"]["TileMatrixLimits"]
-        wv_layer["projections"][entry["projection"]]["matrixSetLimits"] = matrixSetLimits
+        mappedSetLimits = []
+        for setLimit in matrixSetLimits:
+            mappedSetLimits.append({
+                "TileMatrix": setLimit["TileMatrix"],
+                "MinTileRow": int(setLimit["MinTileRow"]),
+                "MaxTileRow": int(setLimit["MaxTileRow"]),
+                "MinTileCol": int(setLimit["MinTileCol"]),
+                "MaxTileCol": int(setLimit["MaxTileCol"]),
+            })
+        wv_layer["projections"][entry["projection"]]["matrixSetLimits"] = mappedSetLimits;
 
     # Vector data links
     if "ows:Metadata" in gc_layer and gc_layer["ows:Metadata"] is not None:
@@ -198,8 +207,9 @@ def process_entry(entry, colormaps):
                         ident, str(e)))
 
     def process_matrix_set(gc_matrix_set):
+        tileMatrixArr = gc_matrix_set["TileMatrix"]
         ident = gc_matrix_set["ows:Identifier"]
-        zoom_levels = len(gc_matrix_set["TileMatrix"])
+        zoom_levels = len(tileMatrixArr)
         resolutions = []
         max_resolution = entry["maxResolution"]
         for zoom in range(0, zoom_levels):
@@ -210,10 +220,10 @@ def process_entry(entry, colormaps):
             "maxResolution": max_resolution,
             "resolutions": resolutions,
             "tileSize": [
-                int(gc_matrix_set["TileMatrix"][0]["TileWidth"]),
-                int(gc_matrix_set["TileMatrix"][0]["TileHeight"])
+                int(tileMatrixArr[0]["TileWidth"]),
+                int(tileMatrixArr[0]["TileHeight"])
             ],
-            "raw": gc_matrix_set
+            "tileMatrices": tileMatrixArr
         }
 
     if(type(gc_contents["TileMatrixSet"]) is OrderedDict):

--- a/tasks/python3/extractConfigFromWMTS.py
+++ b/tasks/python3/extractConfigFromWMTS.py
@@ -86,7 +86,7 @@ def process_layer(gc_layer, wv_layers, colormaps):
     }
 
     if "TileMatrixSetLimits" in matrixSetLink and matrixSetLink["TileMatrixSetLimits"] is not None:
-        matrixSetLimits = matrixSetLink["TileMatrixSetLimits"]
+        matrixSetLimits = matrixSetLink["TileMatrixSetLimits"]["TileMatrixLimits"]
         wv_layer["projections"][entry["projection"]]["matrixSetLimits"] = matrixSetLimits
 
     # Vector data links

--- a/tasks/python3/extractConfigFromWMTS.py
+++ b/tasks/python3/extractConfigFromWMTS.py
@@ -57,6 +57,18 @@ json_options["separators"] = (',', ': ')
 class SkipException(Exception):
     pass
 
+def process_matrix_set_limits(matrix_set_limits):
+    limitsList = [];
+    for set_limit in matrix_set_limits:
+        limitsList.append({
+            "tileMatrix": set_limit["TileMatrix"],
+            "minTileRow": set_limit["MinTileRow"],
+            "maxTileRow": set_limit["MaxTileRow"],
+            "minTileCol": set_limit["MinTileCol"],
+            "maxTileCol": set_limit["MaxTileCol"]
+        })
+    return limitsList
+
 def process_layer(gc_layer, wv_layers, colormaps):
     ident = gc_layer["ows:Identifier"]
     if ident in skip:
@@ -75,11 +87,15 @@ def process_layer(gc_layer, wv_layers, colormaps):
         if dimension["ows:Identifier"] == "Time":
             wv_layer = process_temporal(wv_layer, dimension["Value"])
     # Extract matrix set
-    matrixSet = gc_layer["TileMatrixSetLink"]["TileMatrixSet"]
+    matrixSetLink = gc_layer["TileMatrixSetLink"]
+    matrixSet = matrixSetLink["TileMatrixSet"]
+    matrixSetLimits = matrixSetLink["TileMatrixSetLimits"]["TileMatrixLimits"]
+
     wv_layer["projections"] = {
         entry["projection"]: {
             "source": entry["source"],
-            "matrixSet": matrixSet
+            "matrixSet": matrixSet,
+            "matrixSetLimits": process_matrix_set_limits(matrixSetLimits)
         }
     }
 

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -219,7 +219,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
   const calcExtentsFromLimits = (matrixSet, matrixSetLimits, day, proj) => {
     let extent = proj.maxExtent;
     let origin = [extent[0], extent[3]];
-
     if (day && day === 1) {
       extent = [-250, -90, -180, 90];
       origin = [-540, 90];
@@ -232,7 +231,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     }
     const resolutionLen = matrixSet.resolutions.length;
     const setlimitsLen = matrixSetLimits.length;
-
     if (setlimitsLen !== resolutionLen) {
       console.error('Mismatching levels of matrix set and matrix set limits!');
       return { origin, extent };
@@ -245,9 +243,11 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     const minY = extent[3] - (minSetLimits.minTileRow * pixelHeight);
     const maxX = extent[0] + ((minSetLimits.maxTileCol + 1) * pixelWidth);
     const maxY = extent[3] - ((minSetLimits.maxTileRow + 1) * pixelHeight);
-    console.log(minX, maxY, maxX, minY);
-    extent = [minX, maxY, maxX, minY];
-    return { origin, extent };
+
+    return {
+      origin,
+      extent: [minX, maxY, maxX, minY]
+    };
   };
 
   /**

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-duplicates */
 import util from '../util/util';
 import OlTileGridWMTS from 'ol/tilegrid/WMTS';
-import { createFromCapabilitiesMatrixSet } from 'ol/tilegrid/WMTS';
 import OlSourceWMTS from 'ol/source/WMTS';
 import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlLayerGroup from 'ol/layer/Group';

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -222,10 +222,26 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
 
     if (def.matrixSetLimits) {
       const rawMatrixSet = {};
+      def.matrixSetLimits.forEach((matrix) => {
+        for (const key in matrix) {
+          if (key !== 'Identifier') {
+            matrix[key] = Number(matrix[key]);
+          }
+        }
+      });
+
       rawMatrixSet.Identifier = matrixSet.raw['ows:Identifier'];
       rawMatrixSet.SupportedCRS = matrixSet.raw['ows:SupportedCRS'];
       rawMatrixSet.TileMatrix = matrixSet.raw.TileMatrix.map((matrix) => {
         matrix.Identifier = matrix['ows:Identifier'];
+        for (const key in matrix) {
+          if (key !== 'Identifier' && key !== 'ows:Identifier') {
+            matrix[key] = Number(matrix[key]);
+          }
+          if (key === 'TopLeftCorner') {
+            matrix[key] = [-180, 90];
+          }
+        }
         return matrix;
       });
       wmtsTileGrid = createFromCapabilitiesMatrixSet(rawMatrixSet, extent, def.matrixSetLimits);


### PR DESCRIPTION
## Description

Fixes #1680.

Currently does not handle layers that cross the antimeridian since these layers have two discrete sets of limits that don't overlap, which we can't calculate a single extent from.  It may be possible to work around this by creating multiple layers but I would suggest we investigate that in another ticket.

The branch [`subdaily-test-config`](https://github.com/nasa-gibs/worldview/compare/subdaily-test-config) can be used to build the `wv.json` with the necessary set limits to test these changes.

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
