### PR TITLE
Change subdaily props name to allow TAB action in date selector

### DIFF
--- a/web/js/components/date-selector/date-selector.js
+++ b/web/js/components/date-selector/date-selector.js
@@ -33,7 +33,7 @@ class DateSelector extends Component {
   changeTab(index) {
     var nextTab = index;
     var maxTab;
-    if (this.props.hasSubdailyLayers) {
+    if (this.props.subDailyMode) {
       maxTab = 5;
     } else {
       maxTab = 3;
@@ -197,7 +197,6 @@ DateSelector.defaultProps = {
 DateSelector.propTypes = {
   date: PropTypes.object,
   fontSize: PropTypes.number,
-  hasSubdailyLayers: PropTypes.bool,
   id: PropTypes.string,
   idSuffix: PropTypes.string,
   maxDate: PropTypes.object,


### PR DESCRIPTION
## Description

Fixes #2131  .

- Change subdaily props name to allow TAB action in date selector

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
