### PR TITLE
match sources before merging config with wtms from gc

### DIFF
--- a/tasks/buildOptions.sh
+++ b/tasks/buildOptions.sh
@@ -68,7 +68,7 @@ fi
 # Run extractConfigFromWMTS.py script with config.json
 if [ -e "$BUILD_DIR/config.json" ] ; then
     "$PYTHON_SCRIPTS_DIR/extractConfigFromWMTS.py" "$BUILD_DIR/config.json" "$BUILD_DIR/gc" \
-        "$BUILD_DIR/config/wv.json/_wmts" "$BUILD_DIR/colormaps"
+        "$BUILD_DIR/_wmts" "$BUILD_DIR/colormaps"
 fi
 
 # # Run processVectorStyles.py and move vectorstyles where we want them
@@ -129,6 +129,8 @@ for config in $configs; do
     esac
 done
 
+"$PYTHON_SCRIPTS_DIR/mergeConfigWithWMTS.py" "$BUILD_DIR/_wmts" \
+    "$DEST_DIR/config/wv.json"
 # Copy brand files from build to dest
 cp -r "$BUILD_DIR/brand" "$DEST_DIR"
 cp "$BUILD_DIR/brand.json" "$DEST_DIR"

--- a/tasks/python3/mergeConfig.py
+++ b/tasks/python3/mergeConfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from copy import deepcopy
+from util import dict_merge
 from optparse import OptionParser
 import os
 import sys
@@ -12,27 +12,6 @@ version = "2.0.0"
 help_description = """\
 Concatenates all configuration items a directory into one configuration file.
 """
-
-# dict_merge from
-# http://blog.impressiver.com/post/31434674390/deep-merge-multiple-python-dicts
-def dict_merge(target, *args):
-  # Merge multiple dicts
-  if len(args) > 1:
-    for obj in args:
-      dict_merge(target, obj)
-    return target
-
-  # Recursively merge dicts and set non-dict values
-  obj = args[0]
-  if not isinstance(obj, dict):
-    return obj
-  for k, v in obj.items():
-    if k in target and isinstance(target[k], dict):
-      dict_merge(target[k], v)
-    else:
-      target[k] = deepcopy(v)
-  return target
-
 
 # MAIN
 parser = OptionParser(usage="Usage: %s <input_dir> <output_file>" % prog,

--- a/tasks/python3/mergeConfigWithWMTS.py
+++ b/tasks/python3/mergeConfigWithWMTS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from util import dict_merge
 from copy import deepcopy
@@ -31,14 +31,12 @@ def wmts_dict_merge(target, *args):
           if projectionKey in conf_projections:
             if 'source' in conf_projections[projectionKey]:
               if source != conf_projections[projectionKey]['source']:
-                print(output_file, "Skipping", k, "merge because of source mismatch")
-                return target
+                print(prog, "Skipping", k, "merge because of source mismatch")
+                continue
       if k in target and isinstance(target[k], dict):
           dict_merge(target[k], v, conf[k])
       else:
           target[k] = dict_merge(v, conf[k])
-    else:
-      target[k] = deepcopy(v)
   return target
 
 # MAIN
@@ -65,7 +63,7 @@ for file in os.listdir(input_dir):
       file_count += 1
       with open(os.path.join(input_dir, file)) as fp:
           data = json.load(fp)
-      wmts_dict_merge(new_conf['layers'], data, output_data)
+      new_conf['layers'] = wmts_dict_merge(new_conf['layers'], data, output_data)
       dict_merge(new_conf["sources"], data['sources'], output_data['sources'])
   except Exception as e:
       sys.stderr.write("ERROR: %s: %s\n" %

--- a/tasks/python3/mergeConfigWithWMTS.py
+++ b/tasks/python3/mergeConfigWithWMTS.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from util import dict_merge
+from copy import deepcopy
+from optparse import OptionParser
+import os
+import sys
+import json
+
+prog = os.path.basename(__file__)
+base_dir = os.path.join(os.path.dirname(__file__), "..")
+version = "2.0.0"
+help_description = """\
+Concatenates all configuration items a directory into one configuration file.
+"""
+
+def wmts_dict_merge(target, *args):
+  # Merge multiple dicts
+  # Recursively merge dicts and set non-dict values
+  obj = args[0]['layers']
+  conf = args[1]['layers']
+
+  if not isinstance(obj, dict):
+    return obj
+  for k, v in obj.items():
+    if k in conf and isinstance(conf[k], dict):
+      if 'projections' in v and 'projections' in conf[k]:
+        conf_projections = conf[k]['projections']
+        for projectionKey, projection in v['projections'].items():
+          source = projection['source']
+          if projectionKey in conf_projections:
+            if 'source' in conf_projections[projectionKey]:
+              if source != conf_projections[projectionKey]['source']:
+                print(output_file, "Skipping", k, "merge because of source mismatch")
+                return target
+      if k in target and isinstance(target[k], dict):
+          dict_merge(target[k], v, conf[k])
+      else:
+          target[k] = dict_merge(v, conf[k])
+    else:
+      target[k] = deepcopy(v)
+  return target
+
+# MAIN
+parser = OptionParser(usage="Usage: %s <input_dir> <output_file>" % prog,
+                      version="%s version %s" % (prog, version),
+                      epilog=help_description)
+
+(options, args) = parser.parse_args()
+if len(args) != 2:
+    parser.error("Invalid number of arguments")
+input_dir = args[0]
+output_file = args[1]
+new_conf = {}
+new_conf["layers"] = {}
+new_conf["sources"] = {}
+
+with open(output_file) as fp:
+  output_data = json.load(fp)
+file_count = 0
+for file in os.listdir(input_dir):
+  try:
+      if not file.endswith(".json"):
+        continue
+      file_count += 1
+      with open(os.path.join(input_dir, file)) as fp:
+          data = json.load(fp)
+      wmts_dict_merge(new_conf['layers'], data, output_data)
+      dict_merge(new_conf["sources"], data['sources'], output_data['sources'])
+  except Exception as e:
+      sys.stderr.write("ERROR: %s: %s\n" %
+                        (os.path.join(input_dir, file), str(e)))
+      sys.exit(1)
+dict_merge(new_conf, output_data)
+json_options = {}
+json_options["indent"] = 2
+json_options["separators"] = (',', ': ')
+
+with open(output_file, "w") as fp:
+    json.dump(new_conf, fp, **json_options)
+
+print("%s: %s file(s) merged into %s" % (prog, file_count,
+    os.path.basename(output_file)))

--- a/tasks/python3/util.py
+++ b/tasks/python3/util.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+# dict_merge from
+# http://blog.impressiver.com/post/31434674390/deep-merge-multiple-python-dicts
 def dict_merge(target, *args):
   # Merge multiple dicts
   if len(args) > 1:

--- a/tasks/python3/util.py
+++ b/tasks/python3/util.py
@@ -1,0 +1,23 @@
+from copy import deepcopy
+
+def dict_merge(target, *args):
+  # Merge multiple dicts
+  if len(args) > 1:
+    for obj in args:
+      dict_merge(target, obj)
+    return target
+
+  # Recursively merge dicts and set non-dict values
+  obj = args[0]
+  if not isinstance(obj, dict):
+    return obj
+  for k, v in obj.items():
+
+    if k in target and isinstance(target[k], dict):
+      if 'type' in v and 'type' in target[k]:
+        if v['type'] != target[k]['type']:
+          return target
+      dict_merge(target[k], v)
+    else:
+      target[k] = deepcopy(v)
+  return target


### PR DESCRIPTION
## Description

Fixes #2132 Auto-config via GC document should match layers by source

When there is a wms layer in the config and a wmts later with the same id in the GC, the GC overwrites layerconfig with wmts info

- [x] Merge config into one file before merging with wmts
- [x] check that sources between layerconfig and wmts match before merging two dicts


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
