### PR TITLE
Prevent timeline scale update from new timelineEndDateLimit if animation is playing

### DIFF
--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -499,8 +499,8 @@ class TimelineAxis extends Component {
     }
 
     // update scale if end time limit has changed (e.g. time has elapsed since the app was started)
-    if (timelineEndDateLimit !== prevProps.timelineEndDateLimit) {
-      this.updateScale(draggerDate, timeScale, null, null, true);
+    if (timelineEndDateLimit !== prevProps.timelineEndDateLimit && !isAnimationPlaying) {
+      this.updateScale(draggerDate, timeScale, null, null);
     }
 
     // handle switching A/B dragger axis focus if switched from A/B sidebar tabs


### PR DESCRIPTION
## Description

Fixes #2165  .

- Prevent `updateScale` from new `timelineEndDateLimit` if animation is playing which can cause bad update that results in missing timeline axis grids.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
