### PR TITLE
Remove canvas, update documentation and travis-ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
       python: '3.7'
       sudo: required
       before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y libgif-dev
         - python --version
         - python3 --version
         - nvm install 8.15.1
@@ -19,37 +17,19 @@ matrix:
       python: '3.7'
       sudo: required
       before_install:
-        - sudo apt-get update
-        - sudo apt-get install -y libgif-dev
         - python --version
         - python3 --version
         - nvm install lts/*
     - os: osx
       language: node_js
       node_js: '8.15.1'
-      before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config cairo libffi
-      before_cache:
-        - brew cleanup
-      cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
     - os: osx
       language: node_js
       node_js: lts/* # latest LTS Node.js release
-      before_install:
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config cairo libffi python3
-      before_cache:
-        - brew cleanup
-      cache:
-        directories:
-          - $HOME/Library/Caches/Homebrew
     - os: windows
       language: node_js
       node_js: '8.15.1'
       before_install:
-        - GTKDIR="c:/GTK"
-        - GTKFILE="$HOME/GTK_TEMP/gtk.zip"
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python --version
@@ -57,23 +37,15 @@ matrix:
         - pip install virtualenv
         - python -m venv $HOME/venv
         - source $HOME/venv/Scripts/activate
-        - if [ ! -f "$GTKFILE" ]; then curl -o $GTKFILE "http://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -O -J -L; fi
-        - if [ ! -d "$GTKDIR" ]; then mkdir $GTKDIR; fi
-        - if [ ! "$(ls -A $GTKDIR)" ]; then unzip $GTKFILE -d $GTKDIR; fi
       cache:
         directories:
-          - c:/GTK
-          - $HOME/GTK_TEMP
           - $HOME/venv
-          - $HOME/.node-gyp
           - c:/Python37
           - c:/Python37/Scripts
     - os: windows
       language: node_js
       node_js: lts/* # latest LTS Node.js release
       before_install:
-        - GTKDIR="c:/GTK"
-        - GTKFILE="$HOME/GTK_TEMP/gtk.zip"
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python --version
@@ -81,15 +53,9 @@ matrix:
         - pip install virtualenv
         - python -m venv $HOME/venv
         - source $HOME/venv/Scripts/activate
-        - if [ ! -f "$GTKFILE" ]; then curl -o $GTKFILE "http://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip" -O -J -L; fi
-        - if [ ! -d "$GTKDIR" ]; then mkdir $GTKDIR; fi
-        - if [ ! "$(ls -A $GTKDIR)" ]; then unzip $GTKFILE -d $GTKDIR; fi
       cache:
         directories:
-          - c:/GTK
-          - $HOME/GTK_TEMP
           - $HOME/venv
-          - $HOME/.node-gyp
           - c:/Python37
           - c:/Python37/Scripts
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ The following are required to install and run Worldview:
   - macOS users should use homebrew to install **Python v3**
     - `brew install python`
 
-- Necessary `node-canvas` [dependencies for your Operating System](https://github.com/Automattic/node-canvas#compiling)
-
 Windows users will also need the following:
 
 - [Git Bash](https://git-scm.com/downloads), or [MinGW-w64](https://sourceforge.net/projects/mingw-w64/files/External%20binary%20packages%20%28Win64%20hosted%29/MSYS%20%2832-bit%29/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4452,15 +4452,6 @@
       "integrity": "sha512-H6gK6kxUzG6oAwg/Jal279z8pHw0BzrpZfwo/CA9FFm/vA0l8IhDfkZtepyJNE2Y4V6Dp3P3ubz6czby1/Mgsw==",
       "dev": true
     },
-    "canvas": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.13.tgz",
-      "integrity": "sha512-XAfzfEOHZ3JIPjEV+WSI6PpISgUta3dgmndWbsajotz+0TQOX/jDpp2kawjRERatOGv9sMMzk5auB3GKEKA6hg==",
-      "dev": true,
-      "requires": {
-        "nan": "^2.10.0"
-      }
-    },
     "canvg-browser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/canvg-browser/-/canvg-browser-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "babel-loader": "^8.0.6",
     "browserstack-capabilities": "^0.7.0",
     "browserstack-local": "^1.4.2",
-    "canvas": "^1.6.11",
     "cheerio": "^1.0.0-rc.2",
     "chromedriver": "^76.0.0",
     "clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
## Description

Fixes #2181

Tested removing `canvas` by running unit, lint, e2e (and e2e headless) tests.

- Remove `canvas` devDependency
- Update documentation to exclude node-canvas prerequisites from installation
- Remove node-canvas prerequisites from travis-ci builds

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments
N/A

@nasa-gibs/worldview
