### PR TITLE
Prevent axis update if dragging timeline or dragger

### DIFF
--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -475,6 +475,7 @@ class TimelineAxis extends Component {
       axisWidth,
       isAnimationPlaying,
       isCompareModeActive,
+      isTimelineDragging,
       draggerTimeState,
       draggerTimeStateB,
       timelineEndDateLimit
@@ -499,7 +500,7 @@ class TimelineAxis extends Component {
     }
 
     // update scale if end time limit has changed (e.g. time has elapsed since the app was started)
-    if (timelineEndDateLimit !== prevProps.timelineEndDateLimit && !isAnimationPlaying) {
+    if (timelineEndDateLimit !== prevProps.timelineEndDateLimit && !isAnimationPlaying && !isDraggerDragging && !isTimelineDragging) {
       this.updateScale(draggerDate, timeScale, null, null);
     }
 


### PR DESCRIPTION
## Description

Fixes #2165  .

Additional conditional props to prevent axis update if timeline or dragger is dragging when timeline end date limit is updated. This is a follow up to PR  [#2168 ](https://github.com/nasa-gibs/worldview/pull/2168)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
