### PR TITLE
Add leftsetoffleftOffsetFixedCoeff parameter for timeline axis update

### DIFF
--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -501,7 +501,7 @@ class TimelineAxis extends Component {
 
     // update scale if end time limit has changed (e.g. time has elapsed since the app was started)
     if (timelineEndDateLimit !== prevProps.timelineEndDateLimit && !isAnimationPlaying && !isDraggerDragging && !isTimelineDragging) {
-      this.updateScale(draggerDate, timeScale, null, null);
+      this.updateScale(draggerDate, timeScale, null, 0.50);
     }
 
     // handle switching A/B dragger axis focus if switched from A/B sidebar tabs


### PR DESCRIPTION
## Description

This parameter is necessary for axis updates when hover position is not being used. I removed this  in a previous fix for #2165 and need to add back (related to #2194 ).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
