### PR TITLE
Fix jumpy slider

### DIFF
--- a/web/css/rc-slider-overrides.css
+++ b/web/css/rc-slider-overrides.css
@@ -1,5 +1,4 @@
 .rc-slider-handle {
-  margin-left: -11px;
   margin-top: -9px;
   width: 22px;
   height: 22px;


### PR DESCRIPTION
## Description

Fixes # 2217.
Removes a negative left margin which caused the slider drag handle to be positioned further left than it should be after the latest rc-slider dependency update.


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
