### PR TITLE
Don't change interval until a selection has actually been made in the…

### DIFF
--- a/web/js/components/timeline/timeline-controls/interval-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/interval-timescale-change.js
@@ -33,11 +33,11 @@ class TimeScaleIntervalChange extends PureComponent {
   }
 
   // handle click of timescale intervals
-  handleClickInterval = (timescale, openDialog = false) => {
+  handleClickInterval = (timescale, openModal = false) => {
     // send props function to change timescale interval throughout app
     this.setState({
       toolTipHovered: false
-    }, this.props.setTimeScaleIntervalChangeUnit(timescale, openDialog));
+    }, this.props.setTimeScaleIntervalChangeUnit(timescale, openModal));
   }
 
   // individual linking timescale handlers

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -199,10 +199,15 @@ class AnimationWidget extends React.Component {
    * @return {void}
    */
 
-  onIntervalSelect(timeScale, modalOpen) {
+  onIntervalSelect(timeScale, openModal) {
     let delta;
     const { customInterval, customDelta } = this.props;
     const customSelected = timeScale === 'custom';
+
+    if (openModal) {
+      this.toggleCustomIntervalModal(openModal);
+      return;
+    }
 
     if (customSelected && customInterval && customDelta) {
       timeScale = customInterval;
@@ -212,7 +217,6 @@ class AnimationWidget extends React.Component {
       delta = 1;
     }
     this.props.onIntervalSelect(delta, timeScale, customSelected);
-    this.toggleCustomIntervalModal(modalOpen);
   }
 
   /*

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -458,10 +458,15 @@ class Timeline extends React.Component {
   * @param {Boolean} modalOpen - is custom interval modal open
   * @returns {void}
   */
-  setTimeScaleIntervalChangeUnit = (timeScale, modalOpen) => {
+  setTimeScaleIntervalChangeUnit = (timeScale, openModal) => {
     let delta;
     const { customIntervalZoomLevel, customIntervalValue } = this.props;
     const customSelected = timeScale === 'custom';
+
+    if (openModal) {
+      this.toggleCustomIntervalModal(openModal);
+      return;
+    }
 
     if (customSelected && customIntervalZoomLevel && customIntervalValue) {
       timeScale = customIntervalZoomLevel;
@@ -471,7 +476,6 @@ class Timeline extends React.Component {
       delta = 1;
     }
     this.props.selectInterval(delta, timeScale, customSelected);
-    this.toggleCustomIntervalModal(modalOpen);
   };
 
   /**


### PR DESCRIPTION
## Description

Fixes #2220.

Update to not select the custom interval until a selection has actually been made in the dialog so that timeline/animation widget can't end up in broken state

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

@nasa-gibs/worldview
