### PR TITLE
Close layer settings modal on tab switch

### DIFF
--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -344,7 +344,9 @@ const mapDispatchToProps = dispatch => ({
         headerText: title || 'Layer Options',
         backdrop: false,
         bodyComponent: LayerSettings,
-        clickableBehindModal: true,
+        // Using clickableBehindModal: true here causes an issue where switching sidebar
+        // tabs does not close this modal
+        wrapClassName: 'clickable-behind-modal',
         modalClassName: ' layer-info-settings-modal layer-settings-modal',
         timeout: 150,
         bodyComponentProps: {
@@ -363,7 +365,9 @@ const mapDispatchToProps = dispatch => ({
         headerText: title || 'Layer Description',
         backdrop: false,
         bodyComponent: LayerInfo,
-        clickableBehindModal: true,
+        // Using clickableBehindModal: true here causes an issue where switching sidebar
+        // tabs does not close this modal
+        wrapClassName: 'clickable-behind-modal',
         modalClassName: ' layer-info-settings-modal layer-info-modal',
         timeout: 150,
         bodyComponentProps: {


### PR DESCRIPTION
## Description

Fixes # 2240.

Setting `clickableBehindModal: true` was causing `DetectOuterClick` to be enabled which prevented the sidebar tab click from closing the modal. 




