### PR TITLE
Add initial height for tour modal content

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -65,6 +65,11 @@
   border: 0;
   border-radius: 0;
 }
+
+.tour-in-progress .modal-content {
+  height: 350px;
+}
+
 .tour-start .scrollbar-visible .modal-body {
   padding-right: 10px;
 }


### PR DESCRIPTION
## Description

Fixes #2231  .

- [x] Add initial height for tour modal content to address IE11 overflowing into scale below.

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
