### PR TITLE
give flex-basis property in IE a value so it will flex properly

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -428,9 +428,9 @@
 .tour-in-progress .modal-body {
   color: #fff;
   padding: 16px 20px;
-  height: 248px;
   overflow-y: scroll;
   border-bottom: 2px solid #fff;
+  -ms-flex: 1 1 25px;
 }
 
 .tour-in-progress .modal-body p {


### PR DESCRIPTION
## Description

Fixes # 2256.

IE 11 requires a unit to be added to the third argument, the `flex-basis` property (third value of `flex` or `-ms-flex` in this case)


