### PR TITLE
remove screenHeight update on browsers less than medium

### DIFF
--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -171,6 +171,7 @@ function mapStateToProps(state) {
     bodyTemplate = state[template];
     isTemplateModal = true;
   }
+  const isMobile = state.browser.lessThan.medium;
 
   return {
     isOpen: isOpen,
@@ -178,8 +179,8 @@ function mapStateToProps(state) {
     headerText,
     isCustom,
     id,
-    isMobile: state.browser.lessThan.medium,
-    screenHeight: state.browser.screenHeight,
+    isMobile,
+    screenHeight: isMobile ? undefined : state.browser.screenHeight,
     bodyTemplate,
     isTemplateModal,
     customProps


### PR DESCRIPTION
## Description

Fixes #2234  .

- The update to `screenHeight` when opening the keyboard in mobile causes a re-render that results in the keyboard closing. This fix prevents `screenHeight` from being returned in `mapStateToProps`.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


@nasa-gibs/worldview
