### PR TITLE
Render legendEntries as legend instead of colormapEntries

### DIFF
--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodashDebounce from 'lodash/debounce';
 import { Range as RangeInput } from 'rc-slider';
-import { getFirstIndexFromRef } from '../../../modules/palettes/util';
 import { Checkbox } from '../../util/checkbox';
 
 class ThresholdSelect extends React.Component {
@@ -10,8 +9,8 @@ class ThresholdSelect extends React.Component {
     super(props);
     const { start, end, palette, legend } = props;
     this.state = {
-      start: start ? getFirstIndexFromRef(palette.entries.refs[start], legend.refs) : start,
-      end: end ? getFirstIndexFromRef(palette.entries.refs[end], legend.refs) : start,
+      start: start ? legend.refs.indexOf(palette.entries.refs[start]) : start,
+      end: end ? legend.refs.indexOf(palette.entries.refs[end]) : start,
       squashed: props.squashed,
       activeDragger: 'start'
     };
@@ -31,8 +30,8 @@ class ThresholdSelect extends React.Component {
 
     setRange(
       layerId,
-      parseFloat(getFirstIndexFromRef(startIndex, palette.entries.refs)),
-      parseFloat(getFirstIndexFromRef(endIndex, palette.entries.refs)),
+      parseFloat(palette.entries.refs.indexOf(startIndex)),
+      parseFloat(palette.entries.refs.indexOf(endIndex)),
       isSquashed,
       index,
       groupName
@@ -72,8 +71,8 @@ class ThresholdSelect extends React.Component {
 
     this.debounceSetRange(
       layerId,
-      parseFloat(getFirstIndexFromRef(startRef, palette.entries.refs)),
-      parseFloat(getFirstIndexFromRef(endRef, palette.entries.refs)),
+      parseFloat(palette.entries.refs.indexOf(startRef)),
+      parseFloat(palette.entries.refs.indexOf(endRef)),
       this.state.squashed,
       index,
       groupName

--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -2,15 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodashDebounce from 'lodash/debounce';
 import { Range as RangeInput } from 'rc-slider';
-
+import { getFirstIndexFromRef } from '../../../modules/palettes/util'
 import { Checkbox } from '../../util/checkbox';
 
 class ThresholdSelect extends React.Component {
   constructor(props) {
     super(props);
+    const { start, end, palette, legend } = props;
     this.state = {
-      start: props.start,
-      end: props.end,
+      start: start ? getFirstIndexFromRef(palette.entries.refs[start], legend.refs) : start,
+      end: end ? getFirstIndexFromRef(palette.entries.refs[end], legend.refs) : start,
       squashed: props.squashed,
       activeDragger: 'start'
     };
@@ -22,13 +23,16 @@ class ThresholdSelect extends React.Component {
    * @param {Boolean} boo
    */
   updateSquash(boo) {
-    const { setRange, layerId, index, groupName } = this.props;
+    const { setRange, layerId, index, groupName, palette, legend } = this.props;
     const { start, end, squashed } = this.state;
     const isSquashed = !squashed;
+    const startIndex = legend.refs[start];
+    const endIndex = legend.refs[end];
+
     setRange(
       layerId,
-      parseFloat(start),
-      parseFloat(end),
+      parseFloat(getFirstIndexFromRef(startIndex, palette.entries.refs)),
+      parseFloat(getFirstIndexFromRef(endIndex, palette.entries.refs)),
       isSquashed,
       index,
       groupName
@@ -41,11 +45,13 @@ class ThresholdSelect extends React.Component {
    * @param {Array} thresholdArray | Array of start/end indexs for colormap
    */
   updateThreshold(thresholdArray) {
-    const { layerId, index, groupName } = this.props;
+    const { layerId, index, groupName, palette, legend } = this.props;
     const { start, end } = this.state;
-
     const newStart = Math.ceil(Number(thresholdArray[0]));
     const newEnd = Math.ceil(Number(thresholdArray[1]));
+    const startRef = legend.refs[newStart];
+    const endRef = legend.refs[newEnd];
+
     if (newStart !== start && newEnd !== end) {
       this.setState({
         start: newStart,
@@ -63,10 +69,11 @@ class ThresholdSelect extends React.Component {
       return;
     }
     // Update local state on every range-selector change but debounce threshold model update
+
     this.debounceSetRange(
       layerId,
-      parseFloat(newStart),
-      parseFloat(newEnd),
+      parseFloat(getFirstIndexFromRef(startRef, palette.entries.refs)),
+      parseFloat(getFirstIndexFromRef(endRef, palette.entries.refs)),
       this.state.squashed,
       index,
       groupName

--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodashDebounce from 'lodash/debounce';
 import { Range as RangeInput } from 'rc-slider';
-import { getFirstIndexFromRef } from '../../../modules/palettes/util'
+import { getFirstIndexFromRef } from '../../../modules/palettes/util';
 import { Checkbox } from '../../util/checkbox';
 
 class ThresholdSelect extends React.Component {

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -110,10 +110,11 @@ class LayerSettings extends React.Component {
                 layerId={layer.id}
                 squashed={!!palette.squash}
                 index={i}
+                palette={palette}
               />
             ) : (
-              ''
-            )}
+                ''
+              )}
             <Palette
               setCustomPalette={setCustomPalette}
               groupName={groupName}
@@ -189,6 +190,7 @@ class LayerSettings extends React.Component {
             squashed={!!palette.squash}
             groupName={groupName}
             index={0}
+            palette={palette}
           />
         }
         <Palette

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -113,8 +113,8 @@ class LayerSettings extends React.Component {
                 palette={palette}
               />
             ) : (
-                ''
-              )}
+              ''
+            )}
             <Palette
               setCustomPalette={setCustomPalette}
               groupName={groupName}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -253,8 +253,8 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-            ''
-          )}
+          ''
+        )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
@@ -375,8 +375,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                  ''
-                )}
+                ''
+              )}
             </React.Fragment>
           );
         })}

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../util/util';
-import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas, getFirstIndexFromRef } from '../../modules/palettes/util';
+import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
 import lodashIsNumber from 'lodash/isNumber';
 
 class PaletteLegend extends React.Component {
@@ -237,8 +237,8 @@ class PaletteLegend extends React.Component {
     }
     var min = legend.minLabel || legend.tooltips[0];
     var max = legend.maxLabel || legend.tooltips[toolTipLength];
-    min = palette.min ? legend.tooltips[getFirstIndexFromRef(palette.entries.refs[palette.min], legend.refs)] : min;
-    max = palette.max ? legend.tooltips[getFirstIndexFromRef(palette.entries.refs[palette.max], legend.refs)] : max;
+    min = palette.min ? legend.tooltips[legend.refs.indexOf(palette.entries.refs[palette.min])] : min;
+    max = palette.max ? legend.tooltips[legend.refs.indexOf(palette.entries.refs[palette.max])] : max;
 
     min = legend.units ? min + ' ' + legend.units : min;
     max = legend.units ? max + ' ' + legend.units : max;

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import util from '../../util/util';
-import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
+import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas, getFirstIndexFromRef } from '../../modules/palettes/util';
 import lodashIsNumber from 'lodash/isNumber';
 
 class PaletteLegend extends React.Component {
@@ -237,8 +237,8 @@ class PaletteLegend extends React.Component {
     }
     var min = legend.minLabel || legend.tooltips[0];
     var max = legend.maxLabel || legend.tooltips[toolTipLength];
-    min = palette.min ? legend.tooltips[palette.min] : min;
-    max = palette.max ? legend.tooltips[palette.max] : max;
+    min = palette.min ? legend.tooltips[getFirstIndexFromRef(palette.entries.refs[palette.min], legend.refs)] : min;
+    max = palette.max ? legend.tooltips[getFirstIndexFromRef(palette.entries.refs[palette.max], legend.refs)] : max;
 
     min = legend.units ? min + ' ' + legend.units : min;
     max = legend.units ? max + ' ' + legend.units : max;
@@ -253,8 +253,8 @@ class PaletteLegend extends React.Component {
         {isMoreThanOneColorBar ? (
           <div className="wv-palettes-title">{legend.title}</div>
         ) : (
-          ''
-        )}
+            ''
+          )}
         <div className="colorbar-case">
           <canvas
             className="wv-palettes-colorbar"
@@ -375,8 +375,8 @@ class PaletteLegend extends React.Component {
                     )}
                 </div>
               ) : (
-                ''
-              )}
+                  ''
+                )}
             </React.Fragment>
           );
         })}

--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -14,7 +14,7 @@ var fixtures = {
   light_blue: 'f0f0ffff',
   dark_blue: '000040'
 };
-fixtures.getState = function () {
+fixtures.getState = function() {
   return {
     compare: initialCompareState,
     config: fixtures.config(),
@@ -37,6 +37,7 @@ fixtures.getState = function () {
               },
               legend: {
                 tooltips: ['0', '1', '2'],
+                colors: [fixtures.green, fixtures.yellow, fixtures.red],
                 minLabel: '0',
                 maxLabel: '2',
                 refs: ['0', '1', '2']
@@ -56,6 +57,7 @@ fixtures.getState = function () {
               },
               legend: {
                 tooltips: ['0', '1', '2'],
+                colors: [fixtures.green, fixtures.yellow, fixtures.red],
                 minLabel: '0',
                 maxLabel: '2',
                 refs: ['0', '1', '2']
@@ -184,7 +186,7 @@ fixtures.getState = function () {
   };
 };
 
-fixtures.config = function () {
+fixtures.config = function() {
   return {
     pageLoadTime: new Date(),
     now: new Date(),
@@ -365,12 +367,15 @@ fixtures.config = function () {
               entries: {
                 type: 'scale',
                 colors: [fixtures.green, fixtures.yellow, fixtures.red],
-                values: [0, 1, 2]
+                values: [0, 1, 2],
+                refs: ['0', '1', '2']
+
               },
               legend: {
                 tooltips: ['0', '1', '2'],
                 minLabel: '0',
-                maxLabel: '2'
+                maxLabel: '2',
+                refs: ['0', '1', '2']
               }
             }
           ]
@@ -382,12 +387,15 @@ fixtures.config = function () {
               entries: {
                 type: 'scale',
                 colors: [fixtures.green, fixtures.yellow, fixtures.red],
-                values: [0, 1, 2]
+                values: [0, 1, 2],
+                refs: ['0', '1', '2']
+
               },
               legend: {
                 tooltips: ['0', '1', '2'],
                 minLabel: '0',
-                maxLabel: '2'
+                maxLabel: '2',
+                refs: ['0', '1', '2']
               }
             }
           ]

--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -14,7 +14,7 @@ var fixtures = {
   light_blue: 'f0f0ffff',
   dark_blue: '000040'
 };
-fixtures.getState = function() {
+fixtures.getState = function () {
   return {
     compare: initialCompareState,
     config: fixtures.config(),
@@ -32,12 +32,14 @@ fixtures.getState = function() {
               entries: {
                 type: 'scale',
                 colors: [fixtures.green, fixtures.yellow, fixtures.red],
-                values: [0, 1, 2]
+                values: [0, 1, 2],
+                refs: ['0', '1', '2']
               },
               legend: {
                 tooltips: ['0', '1', '2'],
                 minLabel: '0',
-                maxLabel: '2'
+                maxLabel: '2',
+                refs: ['0', '1', '2']
               }
             }
           ]
@@ -49,12 +51,14 @@ fixtures.getState = function() {
               entries: {
                 type: 'scale',
                 colors: [fixtures.green, fixtures.yellow, fixtures.red],
-                values: [0, 1, 2]
+                values: [0, 1, 2],
+                refs: ['0', '1', '2']
               },
               legend: {
                 tooltips: ['0', '1', '2'],
                 minLabel: '0',
-                maxLabel: '2'
+                maxLabel: '2',
+                refs: ['0', '1', '2']
               }
             }
           ]
@@ -180,7 +184,7 @@ fixtures.getState = function() {
   };
 };
 
-fixtures.config = function() {
+fixtures.config = function () {
   return {
     pageLoadTime: new Date(),
     now: new Date(),

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -109,10 +109,10 @@ export function getCustomPalette(paletteId, customsPaletteConfig) {
   }
   return palette;
 }
-var useLookup = function (layerId, palettesObj, state) {
+var useLookup = function(layerId, palettesObj, state) {
   var use = false;
   var active = palettesObj[layerId].maps;
-  lodashEach(active, function (palette, index) {
+  lodashEach(active, function(palette, index) {
     if (palette.custom) {
       use = true;
       return false;
@@ -138,7 +138,7 @@ export function getLookup(layerId, groupstr, state) {
   groupstr = groupstr || state.compare.activeString;
   return state.palettes[groupstr][layerId].lookup;
 }
-var updateLookup = function (layerId, palettesObj, state) {
+var updateLookup = function(layerId, palettesObj, state) {
   let newPalettes = palettesObj;
   if (!useLookup(layerId, newPalettes, state)) {
     delete newPalettes[layerId];
@@ -146,7 +146,7 @@ var updateLookup = function (layerId, palettesObj, state) {
   }
   var lookup = {};
   var active = newPalettes[layerId].maps;
-  lodashEach(active, function (palette, index) {
+  lodashEach(active, function(palette, index) {
     var oldLegend = palette.legend;
     var entries = palette.entries;
     const refs = oldLegend.refs;
@@ -172,7 +172,7 @@ var updateLookup = function (layerId, palettesObj, state) {
     var sourceCount = source.length;
     var targetCount = target.length;
     var appliedLegends = [];
-    lodashEach(source, function (color, index) {
+    lodashEach(source, function(color, index) {
       var targetColor;
       if (index < min || index > max) {
         targetColor = '00000000';
@@ -230,7 +230,7 @@ export function findIndex(layerId, type, value, index, groupStr, state) {
   index = index || 0;
   var values = getPalette(layerId, index, groupStr, state).entries.values;
   var result;
-  lodashEach(values, function (check, index) {
+  lodashEach(values, function(check, index) {
     var min = getMinValue(check);
     var max = getMaxValue(check);
     if (type === 'min' && value === min) {
@@ -335,12 +335,12 @@ export function clearCustomSelector(layerId, index, palettes, state) {
   }); // remove custom key
   return updateLookup(layerId, newPalettes, state);
 }
-var prepare = function (layerId, palettesObj, state) {
+var prepare = function(layerId, palettesObj, state) {
   var newPalettes = lodashCloneDeep(palettesObj);
   if (!newPalettes[layerId]) newPalettes[layerId] = {};
   var active = newPalettes[layerId];
   active.maps = active.maps || [];
-  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function (
+  lodashEach(getRenderedPalette(layerId, undefined, state).maps, function(
     palette,
     index
   ) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -219,9 +219,6 @@ export function isSupported() {
   var browser = util.browser;
   return !(browser.ie || !browser.webWorkers || !browser.cors);
 }
-export function getFirstIndexFromRef(ref, array) {
-  return array.indexOf(ref);
-}
 /**
  * Serialize palette info for layer
  *

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -45,7 +45,7 @@ export function getCheckerboard() {
 
 export function palettesTranslate(source, target) {
   var translation = [];
-  lodashEach(source, function (color, index) {
+  lodashEach(source, function(color, index) {
     var sourcePercent = index / source.length;
     var targetIndex = Math.floor(sourcePercent * target.length);
     translation.push(target[targetIndex]);
@@ -134,7 +134,7 @@ export function drawTicksOnCanvas(ctx, legend, width) {
 }
 export function lookup(sourcePalette, targetPalette) {
   var lookup = {};
-  lodashEach(sourcePalette.colors, function (sourceColor, index) {
+  lodashEach(sourcePalette.colors, function(sourceColor, index) {
     var source =
       parseInt(sourceColor.substring(0, 2), 16) +
       ',' +
@@ -296,7 +296,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
     return [];
   }
 }
-const createPaletteAttributeObject = function (def, value, attrObj, count) {
+const createPaletteAttributeObject = function(def, value, attrObj, count) {
   const key = attrObj.key;
   const attrArray = attrObj.array;
   let hasAtLeastOnePair = attrObj.isActive;
@@ -333,7 +333,7 @@ export function loadPalettes(permlinkState, state) {
     ];
   }
   lodashEach(stateArray, stateObj => {
-    lodashEach(state.layers[stateObj.groupStr], function (layerDef) {
+    lodashEach(state.layers[stateObj.groupStr], function(layerDef) {
       if (layerDef.palette) {
         var layerId = layerDef.id;
         var min = [];
@@ -341,7 +341,7 @@ export function loadPalettes(permlinkState, state) {
         var squash = [];
         var count = 0;
         if (layerDef.custom) {
-          lodashEach(layerDef.custom, function (value, index) {
+          lodashEach(layerDef.custom, function(value, index) {
             try {
               const newPalettes = setCustomSelector(
                 layerId,
@@ -359,7 +359,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.min) {
-          lodashEach(layerDef.min, function (value, index) {
+          lodashEach(layerDef.min, function(value, index) {
             try {
               min.push(
                 findPaletteExtremeIndex(
@@ -377,7 +377,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.max) {
-          lodashEach(layerDef.max, function (value, index) {
+          lodashEach(layerDef.max, function(value, index) {
             try {
               max.push(
                 findPaletteExtremeIndex(

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -45,7 +45,7 @@ export function getCheckerboard() {
 
 export function palettesTranslate(source, target) {
   var translation = [];
-  lodashEach(source, function(color, index) {
+  lodashEach(source, function (color, index) {
     var sourcePercent = index / source.length;
     var targetIndex = Math.floor(sourcePercent * target.length);
     translation.push(target[targetIndex]);
@@ -134,7 +134,7 @@ export function drawTicksOnCanvas(ctx, legend, width) {
 }
 export function lookup(sourcePalette, targetPalette) {
   var lookup = {};
-  lodashEach(sourcePalette.colors, function(sourceColor, index) {
+  lodashEach(sourcePalette.colors, function (sourceColor, index) {
     var source =
       parseInt(sourceColor.substring(0, 2), 16) +
       ',' +
@@ -219,6 +219,9 @@ export function isSupported() {
   var browser = util.browser;
   return !(browser.ie || !browser.webWorkers || !browser.cors);
 }
+export function getFirstIndexFromRef(ref, array) {
+  return array.indexOf(ref);
+}
 /**
  * Serialize palette info for layer
  *
@@ -293,7 +296,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
     return [];
   }
 }
-const createPaletteAttributeObject = function(def, value, attrObj, count) {
+const createPaletteAttributeObject = function (def, value, attrObj, count) {
   const key = attrObj.key;
   const attrArray = attrObj.array;
   let hasAtLeastOnePair = attrObj.isActive;
@@ -330,7 +333,7 @@ export function loadPalettes(permlinkState, state) {
     ];
   }
   lodashEach(stateArray, stateObj => {
-    lodashEach(state.layers[stateObj.groupStr], function(layerDef) {
+    lodashEach(state.layers[stateObj.groupStr], function (layerDef) {
       if (layerDef.palette) {
         var layerId = layerDef.id;
         var min = [];
@@ -338,7 +341,7 @@ export function loadPalettes(permlinkState, state) {
         var squash = [];
         var count = 0;
         if (layerDef.custom) {
-          lodashEach(layerDef.custom, function(value, index) {
+          lodashEach(layerDef.custom, function (value, index) {
             try {
               const newPalettes = setCustomSelector(
                 layerId,
@@ -356,7 +359,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.min) {
-          lodashEach(layerDef.min, function(value, index) {
+          lodashEach(layerDef.min, function (value, index) {
             try {
               min.push(
                 findPaletteExtremeIndex(
@@ -374,7 +377,7 @@ export function loadPalettes(permlinkState, state) {
           });
         }
         if (layerDef.max) {
-          lodashEach(layerDef.max, function(value, index) {
+          lodashEach(layerDef.max, function (value, index) {
             try {
               max.push(
                 findPaletteExtremeIndex(


### PR DESCRIPTION
## Description
Fixes #2216

Render legends with legendEntries instead of colormapEntries. This became necessary because of the `showTick` feature to prevent rendering ticks on colormaps that have multiple colormapEntires with the same ids (e.g. Cloud Top Pressure - Day)

- [x] Render legendEntries  instead of colormapEntries
- [x] add references to legends & entries for custom mapping
- [x] Update rendering in sidebar and settings modals

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable)



@nasa-gibs/worldview
