### PR TITLE
fix broken e2e tests

### DIFF
--- a/e2e/features/animation/animation-test.js
+++ b/e2e/features/animation/animation-test.js
@@ -28,8 +28,8 @@ module.exports = {
           .click('.wv-animation-widget-header .timeline-interval #interval-custom-static');
         client.pause(1000);
         client.useCss().assert.elementPresent('#wv-animation-widget .custom-interval-widget');
-        client.useCss().assert.containsText('.wv-animation-widget-header #current-interval', 'CUSTOM');
-        client.useCss().assert.containsText('#timeline #current-interval', 'CUSTOM');
+        client.useCss().assert.containsText('.wv-animation-widget-header #current-interval', '1 DAY');
+        client.useCss().assert.containsText('#timeline #current-interval', '1 DAY');
       }
     );
   },

--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -105,6 +105,8 @@ module.exports = {
       globalSelectors.notifyMessage,
       TIME_LIMIT,
       function() {
+        // Close the geostationary alert since it obscures the event alert
+        client.click('#geostationary-alert-close').pause(500);
         client.assert.containsText(
           globalSelectors.notifyMessage,
           'Events may not be visible at all times'

--- a/web/js/components/feature-alert/alert.js
+++ b/web/js/components/feature-alert/alert.js
@@ -29,6 +29,7 @@ class FeaturedAlert extends React.Component {
     const { showAlert } = this.state;
     return (
       <AlertUtil
+        id={'geostationary-alert'}
         isOpen={showAlert}
         iconClassName='fa fa-layer-group fa-fw'
         onClick={this.props.showModal.bind(this)}

--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -40,7 +40,11 @@ export default class AlertComponent extends React.Component {
     } = this.props;
     return (
       <Portal node={document && document.getElementById('wv-content')}>
-        <Alert className="wv-alert" isOpen={isOpen}>
+        <Alert
+          id={this.props.id}
+          className="wv-alert"
+          isOpen={isOpen}
+        >
           <div
             className="alert-content"
             title={title}
@@ -54,7 +58,7 @@ export default class AlertComponent extends React.Component {
             </div>
           </div>
           {onDismiss && (
-            <div className="close-alert" onClick={onDismiss}>
+            <div id={`${this.props.id}-close`} className="close-alert" onClick={onDismiss}>
               <i className="fa fa-times exit fa-1x" />
             </div>
           )}
@@ -69,6 +73,7 @@ AlertComponent.defaultProps = {
 };
 AlertComponent.propTypes = {
   iconClassName: PropTypes.string,
+  id: PropTypes.string,
   isOpen: PropTypes.bool,
   message: PropTypes.string,
   onClick: PropTypes.func,

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -110,6 +110,7 @@ class Events extends React.Component {
       <React.Fragment>
         {showAlert && this.state.showAlert ? (
           <AlertUtil
+            id={'event-alert'}
             isOpen={true}
             onClick={openAlertModal}
             onDismiss={this.dismissAlert}


### PR DESCRIPTION
## Description

Fixes #2268 

Fix tests that were broken due to:

* interval selector no longer shows "CUSTOM" when you select custom, instead retains default interval, e.g. 1 DAY, until you make a custom selection
* new geostationary alert obscures the event alert.  the test for this now closes the geostationary alert before trying to open the event alert.