### PR TITLE
Run browserstack on dependabot branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ matrix:
         - npm run start &
         - |
           # Run when PR opened with 'dependabot' in branch name
-          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ||  $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
+          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ || $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
             travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome
           fi
+        after_script:
+          - sleep 10
 
     - os: osx
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,11 @@ matrix:
         - npm run start &
         - |
           # Run when PR opened with 'dependabot' in branch name
-          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]]; then
-            travis_wait 60 npm run browserstack
-          elif [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
-            travis_wait 60 npm run browserstack
+          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]] || [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
+            travis_wait 60 npm run browserstack && sleep 30
           else
             npm run e2e:headless:chrome
           fi
-      after_script:
         - sleep 10
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ matrix:
         - npm run start &
         - |
           # Run when PR opened with 'dependabot' in branch name
-          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ || $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
+          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]]; then
+            travis_wait 60 npm run browserstack
+          elif [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
             travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome
           fi
-        after_script:
-          - sleep 10
+        - sleep 10
 
     - os: osx
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
         - npm run build
         - npm run start &
         - |
-          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]]; then
+          if [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
             travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome
@@ -29,17 +29,6 @@ matrix:
     - os: linux
       dist: xenial
       language: python
-      node_js: '8.15.1'
-      python: '3.7'
-      sudo: required
-      before_install:
-        - python --version
-        - python3 --version
-        - nvm install 8.15.1
-
-    - os: linux
-      dist: xenial
-      language: python
       node_js: 'lts/*'
       python: '3.7'
       sudo: required
@@ -47,6 +36,17 @@ matrix:
         - python --version
         - python3 --version
         - nvm install lts/*
+
+    - os: linux
+      dist: xenial
+      language: python
+      node_js: '8.15.1'
+      python: '3.7'
+      sudo: required
+      before_install:
+        - python --version
+        - python3 --version
+        - nvm install 8.15.1
 
     - os: windows
       language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       before_install:
          - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
       script:
-        - npm run build
+        - IGNORE_ERRORS=true npm run build
         - npm run start &
         - |
           # Run when PR opened with 'dependabot' in branch name

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
           else
             npm run e2e:headless:chrome
           fi
+      after_script:
         - sleep 10
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,28 @@
 matrix:
   include:
+
+    - os: osx
+      name: 'Node.js lts/* - E2E / Browserstack'
+      language: node_js
+      node_js: lts/* # latest LTS Node.js release
+      addons:
+        chrome: stable
+      before_install:
+         - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
+      script:
+        - npm run build
+        - npm run start &
+        - |
+          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]]; then
+            npm run browserstack
+          else
+            npm run e2e:headless:chrome
+          fi
+
+    - os: osx
+      language: node_js
+      node_js: '8.15.1'
+
     - os: linux
       dist: xenial
       language: python
@@ -10,6 +33,7 @@ matrix:
         - python --version
         - python3 --version
         - nvm install 8.15.1
+
     - os: linux
       dist: xenial
       language: python
@@ -20,12 +44,7 @@ matrix:
         - python --version
         - python3 --version
         - nvm install lts/*
-    - os: osx
-      language: node_js
-      node_js: '8.15.1'
-    - os: osx
-      language: node_js
-      node_js: lts/* # latest LTS Node.js release
+
     - os: windows
       language: node_js
       node_js: '8.15.1'
@@ -42,6 +61,7 @@ matrix:
           - $HOME/venv
           - c:/Python37
           - c:/Python37/Scripts
+
     - os: windows
       language: node_js
       node_js: lts/* # latest LTS Node.js release

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - npm run start &
         - |
           if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]]; then
-            npm run browserstack
+            travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - |
           # Run when PR opened with 'dependabot' in branch name
           if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]] || [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
-            travis_wait 60 npm run browserstack | pv -q -L 3k && sleep 30
+            travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 matrix:
+  allow_failures:
+    - os: windows
+
   include:
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ matrix:
         - npm run build
         - npm run start &
         - |
-          if [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
+          # Run when PR opened with 'dependabot' in branch name
+          if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ||  $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
             travis_wait 60 npm run browserstack
           else
             npm run e2e:headless:chrome

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ matrix:
         - |
           # Run when PR opened with 'dependabot' in branch name
           if [[ $TRAVIS_PULL_REQUEST_BRANCH =~ ^dependabot\/ ]] || [[ $TRAVIS_BRANCH =~ ^dependabot\/ ]]; then
-            travis_wait 60 npm run browserstack && sleep 30
+            travis_wait 60 npm run browserstack | pv -q -L 3k && sleep 30
           else
             npm run e2e:headless:chrome
           fi
+        # https://github.com/travis-ci/travis-ci/issues/6018
         - sleep 10
 
     - os: osx

--- a/e2e/browserstack.conf.js
+++ b/e2e/browserstack.conf.js
@@ -1,6 +1,6 @@
 const environments = require('./environments.js');
 const glob = require('glob');
-const files = glob.sync('./e2e/features/**/*-test.js');
+const files = glob.sync('./e2e/features/animation/*-test.js');
 
 const nightwatchConfig = {
   output_folder: './e2e/reports',

--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -27,31 +27,37 @@ try {
     key: process.env.BROWSERSTACK_ACCESS_KEY,
     localIdentifier: ('wvtester19234' + process.env.BROWSERSTACK_USER).replace(/[^a-zA-Z0-9]/g, ''),
     force: 'true' // if you want to kill existing ports
-  }, function(error) {
+  }, (error) => {
     if (error) throw new Error(error);
-
     console.log('Connected. Running tests...');
     console.log('Go to https://www.browserstack.com/automate to view tests in progress.');
-    Nightwatch.cli(function(argv) {
+
+    Nightwatch.cli((argv) => {
       var envString = environment_names.join(',');
+      console.log(envString);
       argv.e = envString;
       argv.env = envString;
+
       Nightwatch.CliRunner(argv)
-        .setup(null, function() {
-          bs_local.stop(function() {
-            process.exit();
+        .setup(null, () => {
+          // Code to stop browserstack local after end of parallel test
+          console.log('Ran setup');
+          bs_local.stop(() => {
+            process.exitCode = 0;
           });
         })
-        .runTests(function() {
-          bs_local.stop(function() {
+        .runTests(() => {
+          // Code to stop browserstack local after end of single test
+          console.log('Ran runTests');
+          bs_local.stop(() => {
             if (bs_local.pid && process) {
-              // Code to stop browserstack local after end of parallel test
-              process.exit();
+              process.exitCode = 0;
             }
           });
-        }).catch(err => {
+        })
+        .catch(err => {
           console.error(err);
-          process.exit();
+          process.exitCode = 1;
         });
     });
   });

--- a/e2e/environments.js
+++ b/e2e/environments.js
@@ -10,8 +10,8 @@ const capabilities = createCapabilities(
     {
       browser: 'firefox',
       browser_version: ['69.0'],
-      os: ['Windows', 'OS X'],
-      os_version: ['10', 'Mojave']
+      os: ['OS X'],
+      os_version: ['Mojave']
     }
     // {
     //   browser: 'safari',

--- a/e2e/environments.js
+++ b/e2e/environments.js
@@ -5,27 +5,34 @@ const createCapabilities = bsCapabilities(
   process.env.BROWSERSTACK_ACCESS_KEY
 ).create;
 
-const capabilities = createCapabilities([{
-  browser: 'firefox',
-  browser_version: ['69.0'],
-  os: ['Windows', 'OS X'],
-  os_version: ['10', 'Mojave']
-}, {
-  browser: 'safari',
-  browser_version: ['11.1'],
-  os: ['OS X'],
-  os_version: ['High Sierra']
-}, {
-  browser: 'chrome',
-  browser_version: ['76.0'],
-  os: ['Windows', 'OS X'],
-  os_version: ['10', 'Mojave']
-}, {
-  browser: 'ie',
-  browser_version: ['11.0'],
-  os: ['Windows'],
-  os_version: ['10']
-}]);
+const capabilities = createCapabilities(
+  [
+    {
+      browser: 'firefox',
+      browser_version: ['69.0'],
+      os: ['Windows', 'OS X'],
+      os_version: ['10', 'Mojave']
+    }
+    // {
+    //   browser: 'safari',
+    //   browser_version: ['11.1'],
+    //   os: ['OS X'],
+    //   os_version: ['High Sierra']
+    // },
+    // {
+    //   browser: 'chrome',
+    //   browser_version: ['76.0'],
+    //   os: ['Windows', 'OS X'],
+    //   os_version: ['10', 'Mojave']
+    // },
+    // {
+    //   browser: 'ie',
+    //   browser_version: ['11.0'],
+    //   os: ['Windows'],
+    //   os_version: ['10']
+    // }
+  ]
+);
 
 capabilities.forEach((capability) => {
   capability.resolution = '1280x1024';


### PR DESCRIPTION
## Description

Fixes #1966.

* If a PR branch name contains `dependabot/`, run browserstack E2E tests.  This specifically has to be a branch that has on open PR against it, not just any branch with `dependabot/` in the name.
* Else, run Chrome headless e2e locally in Travis on every branch push
* Adding E2E to a single OSX build only increases the build time by about 6-7 minutes so seems worth running on every build
* Running browserstack seems to take about 45 minutes on average so I set a timeout of 60 minutes to get Travis to allow that process to finish.
* Currently a number of tests fail on browserstack (about 14 errors, 35 assertions total), almost entirely on IE11.  For the purposes of dependabot branches, we may want to look at the output and see if most tests are passing in other browsers/environments to determine if we think it's safe to update a dependency, at least until we can get these tests passing.


