### PR TITLE
Updated wrap flag to work with snapshots across the dateline

### DIFF
--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
@@ -10,8 +10,7 @@
             "layergroup": [
               "goes"
             ],
-            "product":  "",
-            "wrapadjacentdays": true
+            "product":  ""
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
@@ -10,8 +10,7 @@
             "layergroup": [
               "goes"
             ],
-            "product":  "",
-            "wrapadjacentdays": true
+            "product":  ""
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible.json
@@ -10,8 +10,7 @@
             "layergroup": [
               "goes"
             ],
-            "product":  "",
-            "wrapadjacentdays": true
+            "product":  ""
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
@@ -11,7 +11,7 @@
               "himawari"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
@@ -11,7 +11,7 @@
               "himawari"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible.json
@@ -11,7 +11,7 @@
               "himawari"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }


### PR DESCRIPTION
Updated layer wrap flag to `wrapX` (from `wrapadjacentdays`) for GOES-West and Himawari-8 layers and removed `wrapadjacentdays` flag from GOES-East layers since they won't ever wrap.

Fixes some issues with image snapshots across the dateline, though there are still issues under certain circumstances which appear to be a problem with the backend.
