### PR TITLE
Allow custom interval widget to open when timeline is collapsed

### DIFF
--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1057,16 +1057,16 @@ class Timeline extends React.Component {
                     />
                     : null
                   }
-
-                  {/* custom interval selector */}
-                  <CustomIntervalSelectorWidget
-                    customDelta={customIntervalValue}
-                    customIntervalZoomLevel={customIntervalZoomLevel}
-                    changeCustomInterval={this.changeCustomInterval}
-                    customIntervalModalOpen={timelineCustomModalOpen}
-                    hasSubdailyLayers={hasSubdailyLayers}
-                  />
                 </div>
+
+                {/* custom interval selector */}
+                <CustomIntervalSelectorWidget
+                  customDelta={customIntervalValue}
+                  customIntervalZoomLevel={customIntervalZoomLevel}
+                  changeCustomInterval={this.changeCustomInterval}
+                  customIntervalModalOpen={timelineCustomModalOpen}
+                  hasSubdailyLayers={hasSubdailyLayers}
+                />
 
                 {/* Zoom Level Change */}
                 <AxisTimeScaleChange


### PR DESCRIPTION
## Description

Fixes #2283  .

- [x] Move custom interval widget outside of timeline footer to allow opening it while timeline is collapsed.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
