### PR TITLE
Updated wrap flag to work with snapshots across the dateline - rebase…

### DIFF
--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
@@ -14,7 +14,7 @@
             "palette": {
                 "immutable": true
             },
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
@@ -14,7 +14,7 @@
             "palette": {
                 "immutable": true
             },
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
@@ -11,7 +11,7 @@
               "goes"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
@@ -11,7 +11,7 @@
               "himawari"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
@@ -14,7 +14,7 @@
             "palette": {
                 "immutable": true
             },
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
@@ -11,7 +11,7 @@
               "himawari"
             ],
             "product":  "",
-            "wrapadjacentdays": true
+            "wrapX": true
         }
     }
 }


### PR DESCRIPTION
Added `wrapX` flag to all geostationary layers to support image snapshots across the anti-meridian.