### PR TITLE
Set compare b dragger init flag to true on toggle

### DIFF
--- a/web/js/modules/compare/reducers.js
+++ b/web/js/modules/compare/reducers.js
@@ -24,7 +24,8 @@ export function compareReducer(state = initialCompareState, action) {
     }
     case TOGGLE_ON_OFF:
       return lodashAssign({}, state, {
-        active: !state.active
+        active: !state.active,
+        bStatesInitiated: true
       });
     case CHANGE_MODE:
       return lodashAssign({}, state, {


### PR DESCRIPTION
## Description

The compare mode b dragger init flag `bStatesInitiated` was only getting set to `true` when page loaded with compare mode already on in the permalink. A `false` causes the b dragger to re-initialize and not retain state on compare mode toggle.

Fixes #2303  .

- [x] This fix sets compare mode b dragger init flag `bStatesInitiated` to `true` on toggle.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
