### PR TITLE
E2E in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ script: npm test
 matrix:
   allow_failures:
     - os: windows
+
   include:
     - os: osx
-      name: 'Node.js lts/* - Chrome E2E'
+      name: 'Node.js lts/* Chrome E2E'
       language: node_js
       node_js: lts/* # latest LTS Node.js release
       addons:
@@ -34,7 +35,7 @@ matrix:
       node_js: '8.15.1'
 
     - os: linux
-      name: 'Node.js lts/* - Firefox E2E'
+      name: 'Node.js lts/* Firefox E2E'
       dist: xenial
       language: python
       node_js: 'lts/*'
@@ -79,7 +80,7 @@ matrix:
           - c:/Python37
           - c:/Python37/Scripts
 
-  - os: windows
+    - os: windows
       language: node_js
       node_js: '8.15.1'
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   npm: true
   pip: true
 
-install: npm install
+install: npm ci
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 env:
   global:
     - MOZ_HEADLESS=1
+cache:
+  directories:
+    - node_modules
+    - .python
+  npm: true
+  pip: true
+
+install: npm install
+
+script: npm test
+
 matrix:
   allow_failures:
     - os: windows
-
   include:
-
     - os: osx
       name: 'Node.js lts/* - Chrome E2E'
       language: node_js
@@ -86,14 +95,3 @@ matrix:
           - $HOME/venv
           - c:/Python37
           - c:/Python37/Scripts
-
-cache:
-  directories:
-    - node_modules
-    - .python
-  npm: true
-  pip: true
-
-install: npm install
-
-script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
       language: node_js
       node_js: lts/* # latest LTS Node.js release
       before_install:
-        - choco install python3
+        - choco install python --version 3.7.5
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python --version
         - python -m ensurepip
@@ -84,7 +84,7 @@ matrix:
       language: node_js
       node_js: '8.15.1'
       before_install:
-        - choco install python3
+        - choco install python --version 3.7.5
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python --version
         - python -m ensurepip

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,16 @@ install: npm install
 script: npm test
 
 matrix:
+  fast_finish: true # don't wait for allowed failures to determine overall build status
   allow_failures:
     - os: windows
+    - node_js: lts/*
 
   include:
     - os: osx
-      name: 'Node.js lts/* Chrome E2E'
+      name: 'Node.js 10.16.3 - Chrome E2E'
       language: node_js
-      node_js: lts/* # latest LTS Node.js release
+      node_js: '10.16.3'
       addons:
         chrome: stable
       before_install:
@@ -32,13 +34,20 @@ matrix:
 
     - os: osx
       language: node_js
+      node_js: lts/* # latest LTS Node.js release
+      script:
+        - npm test
+        - npm run build
+
+    - os: osx
+      language: node_js
       node_js: '8.15.1'
 
     - os: linux
-      name: 'Node.js lts/* Firefox E2E'
+      name: 'Node.js 10.16.3 - Firefox E2E'
       dist: xenial
       language: python
-      node_js: 'lts/*'
+      node_js: '10.16.3'
       python: '3.7'
       sudo: required
       addons:
@@ -46,11 +55,25 @@ matrix:
       before_install:
         - python --version
         - python3 --version
-        - nvm install lts/*
+        - nvm install 10.16.3
       script:
         - npm run build
         - npm run start &
         - npm run e2e:headless:firefox
+
+    - os: linux
+      dist: xenial
+      language: python
+      node_js: 'lts/*'
+      python: '3.7'
+      sudo: required
+      before_install:
+        - python --version
+        - python3 --version
+        - nvm install lts/*
+      script:
+        - npm test
+        - npm run build
 
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,46 @@
+env:
+  global:
+    - MOZ_HEADLESS=1
 matrix:
+  allow_failures:
+    - os: windows
+
   include:
+
+    - os: osx
+      name: 'Node.js lts/* - E2E'
+      language: node_js
+      node_js: lts/* # latest LTS Node.js release
+      addons:
+        chrome: stable
+      before_install:
+         - "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
+      script:
+        - npm run build
+        - npm run start &
+        - npm run e2e:headless:chrome
+
+    - os: osx
+      language: node_js
+      node_js: '8.15.1'
+
+    - os: linux
+      dist: xenial
+      language: python
+      node_js: 'lts/*'
+      python: '3.7'
+      sudo: required
+      addons:
+        firefox: latest
+      before_install:
+        - python --version
+        - python3 --version
+        - nvm install lts/*
+      script:
+        - npm run build
+        - npm run start &
+        - npm run e2e:headless:firefox
+
     - os: linux
       dist: xenial
       language: python
@@ -10,22 +51,7 @@ matrix:
         - python --version
         - python3 --version
         - nvm install 8.15.1
-    - os: linux
-      dist: xenial
-      language: python
-      node_js: 'lts/*'
-      python: '3.7'
-      sudo: required
-      before_install:
-        - python --version
-        - python3 --version
-        - nvm install lts/*
-    - os: osx
-      language: node_js
-      node_js: '8.15.1'
-    - os: osx
-      language: node_js
-      node_js: lts/* # latest LTS Node.js release
+
     - os: windows
       language: node_js
       node_js: '8.15.1'
@@ -42,6 +68,7 @@ matrix:
           - $HOME/venv
           - c:/Python37
           - c:/Python37/Scripts
+
     - os: windows
       language: node_js
       node_js: lts/* # latest LTS Node.js release

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ cache:
 
 install: npm install
 
-script: npm test
+script:
+  - npm test
+  - npm run build
 
 matrix:
   fast_finish: true # don't wait for allowed failures to determine overall build status
@@ -35,9 +37,6 @@ matrix:
     - os: osx
       language: node_js
       node_js: lts/* # latest LTS Node.js release
-      script:
-        - npm test
-        - npm run build
 
     - os: osx
       language: node_js
@@ -71,9 +70,6 @@ matrix:
         - python --version
         - python3 --version
         - nvm install lts/*
-      script:
-        - npm test
-        - npm run build
 
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
 
     - os: osx
-      name: 'Node.js lts/* - E2E'
+      name: 'Node.js lts/* - Chrome E2E'
       language: node_js
       node_js: lts/* # latest LTS Node.js release
       addons:
@@ -25,6 +25,7 @@ matrix:
       node_js: '8.15.1'
 
     - os: linux
+      name: 'Node.js lts/* - Firefox E2E'
       dist: xenial
       language: python
       node_js: 'lts/*'
@@ -54,7 +55,7 @@ matrix:
 
     - os: windows
       language: node_js
-      node_js: '8.15.1'
+      node_js: lts/* # latest LTS Node.js release
       before_install:
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
@@ -69,9 +70,9 @@ matrix:
           - c:/Python37
           - c:/Python37/Scripts
 
-    - os: windows
+  - os: windows
       language: node_js
-      node_js: lts/* # latest LTS Node.js release
+      node_js: '8.15.1'
       before_install:
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"

--- a/e2e/browserstack.conf.js
+++ b/e2e/browserstack.conf.js
@@ -23,7 +23,8 @@ const nightwatchConfig = {
     build: 'wv-nightwatch-' + timeStamp,
     applicationCacheEnabled: false,
     webStorageEnabled: false,
-    marionette: true
+    marionette: true,
+    project: 'Worldview'
   },
   test_settings: {
     default: {},

--- a/e2e/browserstack.conf.js
+++ b/e2e/browserstack.conf.js
@@ -1,6 +1,8 @@
 const environments = require('./environments.js');
 const glob = require('glob');
 const files = glob.sync('./e2e/features/**/*-test.js');
+const now = new Date();
+const timeStamp = `${now.getMonth() + 1}/${now.getDate()} @ ${now.getHours()}:${now.getMinutes()}`;
 
 const nightwatchConfig = {
   output_folder: './e2e/reports',
@@ -18,7 +20,7 @@ const nightwatchConfig = {
     'browserstack.local': true,
     'browserstack.debug': true,
     'browserstack.localIdentifier': ('wvtester19234' + process.env.BROWSERSTACK_USER).replace(/[^a-zA-Z0-9]/g, ''),
-    build: 'nightwatch-browserstack',
+    build: 'wv-nightwatch-' + timeStamp,
     applicationCacheEnabled: false,
     webStorageEnabled: false,
     marionette: true

--- a/e2e/browserstack.js
+++ b/e2e/browserstack.js
@@ -29,34 +29,33 @@ try {
     force: 'true' // if you want to kill existing ports
   }, function(error) {
     if (error) throw new Error(error);
-
     console.log('Connected. Running tests...');
     console.log('Go to https://www.browserstack.com/automate to view tests in progress.');
-    Nightwatch.cli(function(argv) {
+
+    Nightwatch.cli(argv => {
       var envString = environment_names.join(',');
       argv.e = envString;
       argv.env = envString;
       Nightwatch.CliRunner(argv)
-        .setup(null, function() {
-          bs_local.stop(function() {
-            process.exit();
+        .setup(null, () => {
+          bs_local.stop(() => {
+            process.exitCode = 0;
           });
         })
-        .runTests(function() {
-          bs_local.stop(function() {
+        .runTests(() => {
+          bs_local.stop(() => {
             if (bs_local.pid && process) {
-              // Code to stop browserstack local after end of parallel test
-              process.exit();
+              process.exitCode = 0;
             }
           });
         }).catch(err => {
           console.error(err);
-          process.exit();
+          process.exitCode = 1;
         });
     });
   });
 } catch (ex) {
   console.log('There was an error while starting the test runner:\n\n');
   process.stderr.write(ex.stack + '\n');
-  process.exit(2);
+  process.exitCode = 1;
 }

--- a/e2e/environments.js
+++ b/e2e/environments.js
@@ -5,27 +5,28 @@ const createCapabilities = bsCapabilities(
   process.env.BROWSERSTACK_ACCESS_KEY
 ).create;
 
-const capabilities = createCapabilities([{
-  browser: 'firefox',
-  browser_version: ['69.0'],
-  os: ['Windows', 'OS X'],
-  os_version: ['10', 'Mojave']
-}, {
-  browser: 'safari',
-  browser_version: ['11.1'],
-  os: ['OS X'],
-  os_version: ['High Sierra']
-}, {
-  browser: 'chrome',
-  browser_version: ['76.0'],
-  os: ['Windows', 'OS X'],
-  os_version: ['10', 'Mojave']
-}, {
-  browser: 'ie',
-  browser_version: ['11.0'],
-  os: ['Windows'],
-  os_version: ['10']
-}]);
+const capabilities = createCapabilities(
+  [
+    {
+      browser: 'firefox',
+      browser_version: ['69.0'],
+      os: ['OS X'],
+      os_version: ['High Sierra']
+    },
+    {
+      browser: 'chrome',
+      browser_version: ['76.0'],
+      os: ['OS X'],
+      os_version: ['Mojave']
+    },
+    {
+      browser: 'ie',
+      browser_version: ['11.0'],
+      os: ['Windows'],
+      os_version: ['10']
+    }
+  ]
+);
 
 capabilities.forEach((capability) => {
   capability.resolution = '1280x1024';

--- a/e2e/features/measure/measure-test.js
+++ b/e2e/features/measure/measure-test.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   'Initiating a measurement causes an alert to show and sidebar to collapse': function(client) {
     client.useCss().click(measureDistanceBtn);
-    client.waitForElementVisible('.wv-alert', TIME_LIMIT);
+    client.waitForElementVisible('#measurement-alert', TIME_LIMIT);
     client.useCss().assert.elementPresent(sidebarContainer);
     client.useCss().assert.cssProperty(
       sidebarContainer,
@@ -42,7 +42,7 @@ module.exports = {
           .mouseButtonDown(2)
           .mouseButtonUp(2);
         client.pause(300);
-        client.expect.element('.wv-alert').to.not.be.present;
+        client.expect.element('#measurement-alert').to.not.be.present;
         client.expect.element(sidebarContainer)
           .to.have.css('max-height').which.does.not.equal('0px');
       });
@@ -53,7 +53,7 @@ module.exports = {
     client.waitForElementVisible(measureMenu, TIME_LIMIT, (el) => {
       client.useCss().click(measureDistanceBtn);
       client.pause(300);
-      client.waitForElementVisible('.wv-alert', TIME_LIMIT);
+      client.waitForElementVisible('#measurement-alert', TIME_LIMIT);
       client.moveToElement('#wv-map-geographic', 300, 100)
         .mouseButtonClick(0);
       client.pause(300);

--- a/e2e/reuseables/querystrings.js
+++ b/e2e/reuseables/querystrings.js
@@ -20,7 +20,7 @@ module.exports = {
   knownDate: '?t=2019-07-22',
 
   // timeline
-  subdailyLayerIntervalTimescale: '?t=2019-10-04-T09%3A46%3A32Z&z=4&i=4&l=GOES-East_ABI_Band2_Red_Visible,Reference_Labels(hidden),Reference_Features(hidden),Coastlines,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor',
+  subdailyLayerIntervalTimescale: '?t=2019-10-04-T09%3A46%3A32Z&z=4&i=4&l=GOES-East_ABI_Band2_Red_Visible_1km,Reference_Labels(hidden),Reference_Features(hidden),Coastlines,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor',
 
   // events
   eventsTabActive: '?e=true',

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -58,6 +58,7 @@ class MeasureButton extends React.Component {
     return (
       <>
         {showAlert && <AlertUtil
+          id={'measurement-alert'}
           isOpen={true}
           iconClassName='fa fa-ruler fa-fw'
           title='Measure Tool'


### PR DESCRIPTION
## Description

E2E tests will now run on every build!  If your build isn't passing, see if you broke any tests.

**Travis**
* Update travis config to run e2e tests in headless mode:
  * One OSX build with Node LTS will run with Chrome
  * One Linux build with Node LTS will run with Firefox
* Tests will run on every build
* See ticket comments for more details on why we aren't running browserstack at this time
* Allow Windows builds to fail for now since they are in beta and fairly often will fail
* Fix recent issue with Windows builds that was causing an older version of Python to be installed which meant they would _always_ fail
* Fix a few broken E2E tests so that everything _should_ be passing on build

**Browserstack**
* attempt to address an issue where process exited before logs could be received by parent process
* reduce the build configures to only three OS/browser combos
* give the build a name with timestamp so each run can be differentiated in the Browserstack dashboard
