### PR TITLE
v3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## New Features
### Measure Tool (#2099)
- Measure distance or area, or area in either kilometers or miles
- Switch between normal or great circle measurements

### Geostationary Imagery (#2176, #2177, #2178)
- Adds 9 Geostationary imagery layers from GOES East, GOES West and Himawari-8 - Red Visible, Clean Infrared and Air Mass.
- Ability to view geostationary layers in sub-daily (hour and minute) increments
- Adds featured tab in product picker for geostationary layers (and more)
- Adds geostationary notice modal

## New Tour Story
- Dorian hurricane tour story #2179

## Layer Updates
- Add MODIS L3 Cryosphere descriptions; other fixes #2089
- Add wdpa layer #2091
- Update text to include daily and new layer number #2092
- Fix modis cloud #2112
- Add LSR descriptions #2118
- Add Airs l2 nrt layers #2154
- Remove inactive flag from oco-2 layers #2158
- Fix incorrect snow product #2171

## Technical Updates / Bug Fixes
- Allow tour startup to show more than 9 stories #2080
- Retain compare opacity value in permalink #2086
- Fix CI build errors related to python3 #2088
- Add python3 to docker build #2097
- Add Colormap ticks #2100
- Add validation check for image download to see if available layers is an empty array #2107
- Delete get-pip.py #2109
- Make animation start range dynamic #2110
- Update timeline scale with current time every minute #2113
- Allow promise to resolve on no response for tilelayer grid building #2116
- Fix tour modal scroll area cut-off #2119
- Update npm config used for CI/CD #2121
- Add space-before-function-paren never eslint rule #2124
- Date time snapping for subdaily "future" times #2130
- Subdaily img/gif download #2133
- Fix Browserstack Integration #2134
- Fix broken e2e tests #2137
- Change subdaily props name to allow TAB action in date selector #2153
- Fix worldfile option for image download #2156
- Update layer cache for subdaily layers if their datetime is recent #2161
- Match sources before merging config with wtms from gc #2167
- Prevent timeline scale update from new timelineEndDateLimit if animation is playing #2168
- Remove canvas, update documentation and travis-ci tests #2182
- Prevent axis update if dragging timeline or dragger #2194
- Fix conditional vector style legend rendering #2195
- Add leftsetoffleftOffsetFixedCoeff parameter for timeline axis update #2199
- Calculate layer extent from tile matrix limits #2151
- Fix tour scroll #2198
- Animations layer caching #2202
- Fix issue with calculating extents from set limits #2205
- Interval in permalink #2208
- Only show gif creation button tooltip on button hover #2212
- Fix NaN left property #2213
- Fix jumpy slider #2219
- Fix measure tool modal styles so it aligns properly in ie11 #2222
- Fix measurements wrapping on map #2223
- Don't change interval until a selection has actually been made in the… #2225
- Restart tour on arriving via permalink to a specific step (other than the first) #2228
- Make sure image behaves responsively even in IE11 #2230
- Allow click behind animation preload modal #2235
- Center bar in running data triangle (firefox) #2236
- Use the clickable-behind-modal class and remove invalid prop #2239
- Add flex styling and minor changes to alert notification for consistent mobile/desktop style #2245
- Measure tool modal on mobile #2251
- Fix no results text cut off #2252
- Close layer settings modal on tab switch #2253
- Add initial height for tour modal content #2255
- Clear animation queue when animation stops #2257
- Remove temporary sources that pointed to GIBS UAT for subdaily #2258
- Give flex-basis property in IE a value so it will flex properly #2260
- Remove screenHeight update on browsers less than medium #2261
- Render legendEntries as legend instead of colormapEntries #2263
- Revised date change arrow intervals using higher scope and conditional flags #2267 
- Fixed broken e2e tests #2269
- Updated resolution text - #2277 
- Added GOES hyphen and updated tour article link #2278 
- Updated Red Visible filename #2292 
- Disabled thresholding and palette adjustment for the clean infrared layers #2293 
- Updated screenshot #2294
- Allow custom interval widget to open when timeline is collapsed #2295 
- Updated wrap flag to work with snapshots across the dateline #2296 
- Activate imerg precipitation #2298
- Remove dust storm story #2304
- Set compare b dragger init flag to true on toggle #2307
- Allow multiple alerts to show at once #2310
- Time snapping backwards when geostationary layers added #2312

## Update Dependencies
- Bump eslint-config-standard from 13.0.1 to 14.0.1 #2078
- Bump sass-loader from 7.2.0 to 7.3.1 #2084
- Bump eslint-plugin-node from 9.1.0 to 10.0.0 #2093
- Bump rc-slider from 8.6.3 to 8.7.1 #2094
- Bump react-draggable from 3.3.0 to 4.0.3 #2114
- Bump jest from 24.8.0 to 24.9.0 #2120
- Bump cross-env from 5.2.0 to 6.0.0 #2135
- Bump write-file-webpack-plugin from 4.5.0 to 4.5.1 #2138
- Bump browserstack-local from 1.4.0 to 1.4.2 #2139
- Bump postcss-preset-env from 6.6.0 to 6.7.0 #2140
- Bump @fortawesome/fontawesome-free from 5.10.1 to 5.11.2 #2152
- Bump webpack-dev-server from 3.7.2 to 3.8.1 #2160
- Bump @babel/plugin-proposal-class-properties from 7.4.4 to 7.5.5 #2169
- Bump tar from 4.4.10 to 5.0.2 #2172
- Bump eslint from 6.1.0 to 6.5.1 #2173
- Bump fetch-mock from 7.3.9 to 7.4.0 #2174
- Bump redux from 4.0.1 to 4.0.4 #2175
- Bump cross-env from 6.0.0 to 6.0.2 #2183
