### PR TITLE
update CSS to prevent event title wrapping

### DIFF
--- a/web/css/events.css
+++ b/web/css/events.css
@@ -4,7 +4,7 @@
 
 .wv-eventslist li.item .event-icon {
   float: left;
-  margin: 0 8px 1px 5px;
+  margin: 0 8px 13px 5px;
 }
 
 .map-item-list li.item {

--- a/web/css/events.css
+++ b/web/css/events.css
@@ -4,7 +4,7 @@
 
 .wv-eventslist li.item .event-icon {
   float: left;
-  margin: 0 8px 13px 5px;
+  margin: 0 8px 1px 5px;
 }
 
 .map-item-list li.item {
@@ -24,6 +24,7 @@
   font-size: 0.85em;
   color: #ccc;
   padding: 0 3px;
+  left-margin: 40px; 
 }
 
 .map-item-list li.item p,

--- a/web/css/events.css
+++ b/web/css/events.css
@@ -24,7 +24,7 @@
   font-size: 0.85em;
   color: #ccc;
   padding: 0 3px;
-  left-margin: 40px; 
+  margin-left: 40px; 
 }
 
 .map-item-list li.item p,


### PR DESCRIPTION
## Description

Fixes #2299.

- Increased the bottom-margin for event icons to prevent long titles from wrapping beneath it.

## Further comments

This fix does increase the space between the events (pictured below; original on the left and my version on the right). 

<img width="601" alt="Screen Shot 2019-10-20 at 12 24 44 AM" src="https://user-images.githubusercontent.com/34118418/67243560-d8d02e00-f425-11e9-9c7e-3f683527e4ea.png">

If this is not preferred, please let me know and I will try a different solution.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview