### PR TITLE
Upgrade Core JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -851,6 +851,13 @@
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+        }
       }
     },
     "@babel/template": {
@@ -3485,6 +3492,12 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -3513,6 +3526,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -4737,9 +4756,10 @@
       }
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.4.tgz",
+      "integrity": "sha512-BtibooaAmSOptGLRccsuX/dqgPtXwNgqcvYA6kOTTMzonRxZ+pJS4e+6mvVutESfXMeTnK8m3M+aBu3bkJbR+w==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.3.3",
@@ -6910,6 +6930,12 @@
         "whatwg-url": "^6.5.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
         "path-to-regexp": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "cheerio": "^1.0.0-rc.2",
     "chromedriver": "^77.0.0",
     "clean-webpack-plugin": "^3.0.0",
-    "core-js": "^2.6.9",
+    "core-js": "^3.3.4",
     "cross-env": "^6.0.2",
     "css-hot-loader": "^1.4.1",
     "css-loader": "^3.2.0",

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,8 +1,6 @@
 /* global DEBUG */
 // IE11 corejs polyfills container
-import 'core-js/es5';
-import 'core-js/es6';
-import 'core-js/es7';
+import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 // IE11 corejs polyfills container
 import 'whatwg-fetch';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,7 +137,7 @@ module.exports = {
             compact: false // fixes https://stackoverflow.com/questions/29576341/what-does-the-code-generator-has-deoptimised-the-styling-of-some-file-as-it-e
           }
         },
-        exclude: [/\.test\.js$/, /fixtures\.js$/]
+        exclude: [/\.test\.js$/, /fixtures\.js$/, /core-js/]
       },
       {
         test: require.resolve('jquery'), // expose globally for jQuery plugins


### PR DESCRIPTION
## Description

Fixes #1842 

I ran browserstack a few times to get a sense for IE11 impact.  Unfortunately, IE11 is the flakiest when it comes to our E2E tests.  However, I manually checked the tests that I saw failing that differed from the tests that fail on develop and was not able to find anything broken after this update.


