### PR TITLE
Supercluster update from 3.0.2 to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10216,9 +10216,9 @@
       }
     },
     "kdbush": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz",
-      "integrity": "sha1-PL0D6d6tnA9vZszblkUOXOzGQOA="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "killable": {
       "version": "1.0.1",
@@ -17611,11 +17611,11 @@
       }
     },
     "supercluster": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-3.0.2.tgz",
-      "integrity": "sha512-3Fm2/9YcoCE26M4FlSkGU7xYYpDAFWlxaChdx31h0I08ywRhcF2W1NKbsi+APqaxxn8TSXH/HvMhl4nEf+9lJA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
       "requires": {
-        "kdbush": "^1.0.1"
+        "kdbush": "^3.0.0"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "redux-responsive": "^4.3.8",
     "redux-thunk": "^2.3.0",
     "simplebar-react": "^2.0.4",
-    "supercluster": "3.0.2",
+    "supercluster": "6.0.2",
     "web-streams-polyfill": "^1.3.2",
     "whatwg-fetch": "^3.0.0"
   },

--- a/web/js/map/natural-events/cluster.js
+++ b/web/js/map/natural-events/cluster.js
@@ -1,57 +1,41 @@
-import superCluster from 'supercluster';
+import Supercluster from 'supercluster';
 import lodashRound from 'lodash/round';
 
 /**
- * Create superCLuster Object - Uses map and reduce
+ * Create Supercluster Object - Uses map and reduce
  * operations to create a timespan on each clustered
  * object
  *
  * @return {void}
  */
-export function naturalEventsClusterCreateObject() {
-  return superCluster({
+export const naturalEventsClusterCreateObject = () => {
+  return new Supercluster({
     radius: 60, // pixel radius where points are clustered
     maxZoom: 12,
-    initial: function() {
-      return {
-        startDate: null,
-        endDate: null
-      };
-    },
-    map: function(props) {
-      return {
-        startDate: props.date,
-        endDate: props.date
-      };
-    },
-    reduce: function(accumulated, properties) {
-      var newDate = properties.startDate;
-      var pastStartDate = accumulated.startDate;
-      var pastEndDate = accumulated.endDate;
+    map: (props) => ({ startDate: props.date, endDate: props.date }),
+    reduce: (accumulated, properties) => {
+      const newDate = properties.startDate;
+      const pastStartDate = accumulated.startDate;
+      const pastEndDate = accumulated.endDate;
       if (!pastEndDate) {
         accumulated.startDate = newDate;
         accumulated.endDate = newDate;
       } else {
+        const newDateFormatted = new Date(newDate).getTime();
         accumulated.startDate =
-          Date.parse(new Date(pastStartDate)) > Date.parse(new Date(newDate))
+          new Date(pastStartDate).getTime() > newDateFormatted
             ? newDate
             : pastStartDate;
         accumulated.endDate =
-          Date.parse(new Date(pastEndDate)) < Date.parse(new Date(newDate))
+          new Date(pastEndDate).getTime() < newDateFormatted
             ? newDate
             : pastEndDate;
       }
     },
-    setPolar: function() {
-      this.radius = 30;
-      this.maxZoom = 7;
-    },
-    setGeo: function() {
-      this.radius = 60;
-      this.maxZoom = 12;
-    }
+    setPolar: () => ({ radius: 30, maxZoom: 7 }),
+    setGeo: () => ({ radius: 60, maxZoom: 12 })
   });
-}
+};
 /**
  * Create a geoJSON point out of a point
  *
@@ -60,7 +44,7 @@ export function naturalEventsClusterCreateObject() {
  * @param  {String} date
  * @return {Object} geoJSON point
  */
-export function naturalEventsClusterPointToGeoJSON(id, coordinates, date) {
+export const naturalEventsClusterPointToGeoJSON = (id, coordinates, date) => {
   return {
     type: 'Feature',
     properties: {
@@ -73,34 +57,34 @@ export function naturalEventsClusterPointToGeoJSON(id, coordinates, date) {
       coordinates: coordinates
     }
   };
-}
+};
 /**
  * @param  {Array}
  * @return {void}
  */
-export function naturalEventsClusterSort(clusterArray) {
-  const newArray = clusterArray.sort(function(a, b) {
-    var firstDate = a.properties.date || a.properties.startDate;
-    var secondDate = b.properties.date || b.properties.startDate;
+export const naturalEventsClusterSort = (clusterArray) => {
+  const newArray = clusterArray.sort((a, b) => {
+    const firstDate = a.properties.date || a.properties.startDate;
+    const secondDate = b.properties.date || b.properties.startDate;
 
     return new Date(secondDate) - new Date(firstDate);
   });
   return newArray;
-}
+};
 /**
- * Load points given superCluster Object
+ * Load points given Supercluster Object
  *
  * @param  {Object} superClusterObj
  * @param  {Array} pointArray
  * @param  {number} zoomLevel
  * @return {Object}
  */
-export function naturalEventsClusterGetPoints(
+export const naturalEventsClusterGetPoints = (
   superClusterObj,
   pointArray,
   zoomLevel,
   extent
-) {
+) => {
   superClusterObj.load(pointArray);
   return superClusterObj.getClusters(extent, lodashRound(zoomLevel));
-}
+};


### PR DESCRIPTION
## Description

Allows `supercluster` version bump from 3.0.2 to 6.0.2 - changes prompted from `dependabot` #2190  

- Revised `supercluster` class based implementation used in natural events clustering.
- Removed unused `initial` method and minor file cleanup.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
