### PR TITLE
Fix imagery not loading after build date

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -24,9 +24,7 @@ import {
   setStyleFunction
 } from '../modules/vector-styles/selectors';
 import {
-  nearestInterval,
-  datesinDateRanges,
-  prevDateInDateRange
+  nearestInterval
 } from '../modules/layers/util';
 
 export function mapLayerBuilder(models, config, cache, ui, store) {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -141,11 +141,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
   self.closestDate = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
-    const dateArray = def.availableDates || [];
     let date = options.date || new Date(state.date[activeDateStr]);
-    const zoomGreaterThanEqPeriod = (def.period === 'daily' && state.date.selectedZoom >= 3) ||
-                                  (def.period === 'monthly' && state.date.selectedZoom >= 2) ||
-                                  (def.period === 'yearly' && state.date.selectedZoom >= 1);
 
     if (def.period === 'subdaily') {
       date = nearestInterval(def, date);
@@ -155,22 +151,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
         : util.clearTimeUTC(date);
     }
 
-    if (
-      !options.precache &&
-      state.animation.isPlaying === false &&
-      state.date.selectedZoom !== 0 &&
-      zoomGreaterThanEqPeriod
-    ) {
-      date = prevDateInDateRange(def, date, dateArray);
-      // Is current "rounded" previous date in the array of available dates
-      const dateInArray = dateArray.some((arrDate) => date.getTime() === arrDate.getTime());
-
-      if (date && !dateInArray) {
-        // Then, update layer object with new array of dates
-        def.availableDates = datesinDateRanges(def, date);
-        date = prevDateInDateRange(def, date, def.availableDates);
-      }
-    }
     return date;
   };
 


### PR DESCRIPTION
## To test 
Change [this line](https://github.com/nasa-gibs/worldview/blob/master/tasks/python3/processTemporalLayer.py#L43) to `endDateParse = datetime(2019, 10, 19)` to simulate a build date in the past

## Notes
* Removed code around trying to handle date snapping which was trying to snap dates for active layers back in time based on build date
* Removed any date snapping (excluding subdaily) based on layer interval since I was unable to quickly get it working while also fixing this bug.  Only monthly and subdaily intervals appeared to be working as intended anyway.
* Date snapping should be overhauled/re-implemented under issue #2129.  Appears to have been broken since at least v3.0.0