### PR TITLE
Fix data-download endless loop on data tab click

### DIFF
--- a/web/js/containers/sidebar/data.js
+++ b/web/js/containers/sidebar/data.js
@@ -68,7 +68,7 @@ class Data extends React.Component {
     const dataArray = Object.entries(products);
     if (dataArray.length > 0 && !selectedProduct && isActive) {
       findProductToSelect(activeLayers, selectedProduct);
-    } else if (selectedProduct && !doesSelectedExist(activeLayers, selectedProduct)) {
+    } else if (selectedProduct && !doesSelectedExist(dataArray, selectedProduct)) {
       findProductToSelect(activeLayers, selectedProduct);
     }
     return (
@@ -76,7 +76,7 @@ class Data extends React.Component {
         <div id="wv-data">
           <div className="wv-datalist sidebar-panel content">
             <div id="wv-datacontent">
-              {dataArray.map(product => {
+              {dataArray.map((product, i) => {
                 return (
                   <Products
                     key={product[0]}
@@ -143,7 +143,6 @@ function mapStateToProps(state, ownProps) {
     config,
     proj.id
   );
-
   return {
     counts,
     selectedProduct,

--- a/web/js/containers/sidebar/data.js
+++ b/web/js/containers/sidebar/data.js
@@ -68,8 +68,7 @@ class Data extends React.Component {
     const dataArray = Object.entries(products);
     if (dataArray.length > 0 && !selectedProduct && isActive) {
       findProductToSelect(activeLayers, selectedProduct);
-    }
-    if (selectedProduct && !doesSelectedExist(activeLayers, selectedProduct)) {
+    } else if (selectedProduct && !doesSelectedExist(activeLayers, selectedProduct)) {
       findProductToSelect(activeLayers, selectedProduct);
     }
     return (
@@ -124,7 +123,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   },
   findProductToSelect: (products, selectedProduct) => {
     const newSelection = findAvailableProduct(products);
-
     if (newSelection) {
       dispatch(selectProduct(newSelection));
     }

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -26,7 +26,7 @@ import {
   expandSidebar
 } from '../../modules/sidebar/actions';
 
-const getActiveTabs = function (config) {
+const getActiveTabs = function(config) {
   const features = config.features;
   return {
     download: features.dataDownload,
@@ -34,7 +34,7 @@ const getActiveTabs = function (config) {
     events: features.naturalEvents
   };
 };
-const resetWorldview = function (e) {
+const resetWorldview = function(e) {
   e.preventDefault();
   if (window.location.search === '') return; // Nothing to reset
   var msg =
@@ -287,7 +287,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(changeTab(str));
   },
   onTabClick: (str, activeStr) => {
-    if(str === activeStr) return;
+    if (str === activeStr) return;
     googleTagManager.pushEvent({
       event: str + '_tab'
     });

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Layers from './layers';
 import Events from './events';
 import Data from './data';
+import { get as lodashGet } from 'lodash';
 import CompareCase from './compare';
 import FooterContent from './footer-content';
 import { TabContent, TabPane } from 'reactstrap';
@@ -25,7 +26,7 @@ import {
   expandSidebar
 } from '../../modules/sidebar/actions';
 
-const getActiveTabs = function(config) {
+const getActiveTabs = function (config) {
   const features = config.features;
   return {
     download: features.dataDownload,
@@ -33,7 +34,7 @@ const getActiveTabs = function(config) {
     events: features.naturalEvents
   };
 };
-const resetWorldview = function(e) {
+const resetWorldview = function (e) {
   e.preventDefault();
   if (window.location.search === '') return; // Nothing to reset
   var msg =
@@ -75,11 +76,11 @@ class Sidebar extends React.Component {
 
   updateDimensions() {
     const { subComponentHeight } = this.state;
+    const footerHeight = lodashGet(this, 'footerElement.clientHeight') || 20;
     const { isMobile, screenHeight } = this.props;
     if (!isMobile && this.iconElement) {
       const iconHeight = this.iconElement.clientHeight;
       const topOffset = Math.abs(this.iconElement.getBoundingClientRect().top);
-      const footerHeight = this.footerElement.clientHeight;
       const tabHeight = 32;
       const basePadding = 110;
       const newHeight =
@@ -96,7 +97,6 @@ class Sidebar extends React.Component {
       }
     } else {
       const tabHeight = 32;
-      const footerHeight = this.footerElement.clientHeight;
       const newHeight = screenHeight - (tabHeight + footerHeight);
       // See note above
       if (Math.abs(subComponentHeight - newHeight) > 1) {
@@ -286,7 +286,8 @@ const mapDispatchToProps = dispatch => ({
   changeTab: str => {
     dispatch(changeTab(str));
   },
-  onTabClick: str => {
+  onTabClick: (str, activeStr) => {
+    if(str === activeStr) return;
     googleTagManager.pushEvent({
       event: str + '_tab'
     });

--- a/web/js/map/data/ui.js
+++ b/web/js/map/data/ui.js
@@ -98,12 +98,15 @@ export function dataUi(store, ui, config) {
     const dataState = state.data;
     const { compare, layers, proj } = state;
     const activeLayers = getLayers(layers[compare.activeString], { proj: proj.id });
-
     if (state.sidebar.activeTab !== 'download') {
       return;
     }
-
-    if (!dataState.selectedProduct || (dataState.selectedProduct && !doesSelectedExist(activeLayers, dataState.selectedProduct))) {
+    const products = getDataProductsFromActiveLayers(
+      activeLayers,
+      config,
+      proj.id
+    );
+    if (!dataState.selectedProduct || (dataState.selectedProduct && !doesSelectedExist(Object.entries(products), dataState.selectedProduct))) {
       self.events.trigger(self.EVENT_QUERY_RESULTS, {
         meta: {},
         granules: []
@@ -273,7 +276,7 @@ export function dataUi(store, ui, config) {
     uiIndicator.hide(indicators);
     wvui.notify(
       'No results received yet. This may be due to a ' +
-        'connectivity issue. Please try again later.'
+      'connectivity issue. Please try again later.'
     );
   };
 
@@ -654,10 +657,10 @@ var dataUiDownloadListPanel = function(config, store) {
     $.each(links, function(index, link) {
       elements.push(
         "<li class='link'><a href='" +
-          link.href +
-          "' target='_blank'>" +
-          link.title +
-          '</a></li>'
+        link.href +
+        "' target='_blank'>" +
+        link.title +
+        '</a></li>'
       );
     });
     elements.push('</ul>');
@@ -670,24 +673,24 @@ var dataUiDownloadListPanel = function(config, store) {
       elements = [
         "<tr data-granule='" + granule.id + "'>",
         "<td><input type='button' class='remove' " +
-          "data-granule='" +
-          granule.id +
-          "' " +
-          "value='X'></input></td>",
+        "data-granule='" +
+        granule.id +
+        "' " +
+        "value='X'></input></td>",
         '<td><nobr><ul><li>' + granule.label + '</li></ul></nobr></td>',
         "<td class='wv-data-granule-link'>" +
-          linksText(granule.links) +
-          '</td>',
+        linksText(granule.links) +
+        '</td>',
         '</tr>'
       ];
     } else {
       elements = [
         "<tr data-granule='" + granule.id + "'>",
         "<td><input type='button' class='remove' " +
-          "data-granule='" +
-          granule.id +
-          "' " +
-          "value='X'></input></td>",
+        "data-granule='" +
+        granule.id +
+        "' " +
+        "value='X'></input></td>",
         "<td colspan='2'>" + linksText(granule.links) + '</td>',
         '</tr>'
       ];
@@ -848,17 +851,17 @@ var dataUiSelectionListPanel = function(dataUi, results, store) {
       var selected = dataState.selectedGranules[granule.id] ? "checked='true'" : '';
       elements.push(
         '<tr>' +
-          '<td>' +
-          "<input type='checkbox' value='" +
-          granule.id +
-          "' " +
-          selected +
-          '>' +
-          '</td>' +
-          "<td class='label'>" +
-          granule.label +
-          '</td>' +
-          '</tr>'
+        '<td>' +
+        "<input type='checkbox' value='" +
+        granule.id +
+        "' " +
+        selected +
+        '>' +
+        '</td>' +
+        "<td class='label'>" +
+        granule.label +
+        '</td>' +
+        '</tr>'
       );
     });
     var text = elements.join('\n');

--- a/web/js/modules/data/actions.js
+++ b/web/js/modules/data/actions.js
@@ -15,7 +15,7 @@ export function selectProduct(id) {
         id: id
       });
     }
-  }
+  };
 }
 export function dataQuery(location) {
   return (dispatch, getData) => {

--- a/web/js/modules/data/actions.js
+++ b/web/js/modules/data/actions.js
@@ -8,12 +8,15 @@ import { requestAction } from '../core/actions';
 import update from 'immutability-helper';
 
 export function selectProduct(id) {
-  return {
-    type: SELECT_PRODUCT,
-    id: id
-  };
+  return (dispatch, getState) => {
+    if (getState().data.selectedProduct !== id) {
+      dispatch({
+        type: SELECT_PRODUCT,
+        id: id
+      });
+    }
+  }
 }
-
 export function dataQuery(location) {
   return (dispatch, getData) => {
     return requestAction(dispatch, DATA_QUERY, location, 'application/json');

--- a/web/js/modules/data/selectors.js
+++ b/web/js/modules/data/selectors.js
@@ -89,10 +89,14 @@ export function groupByProducts(config, dataProducts) {
   }
   return results;
 }
-export function doesSelectedExist(activeLayers, selectedId) {
+export function doesSelectedExist(products, selectedId) {
   let exists = false;
-  lodashEach(activeLayers, function(layer) {
-    if (layer.product === selectedId) exists = true;
+  lodashEach(products, function(productItemArray) {
+    const id = productItemArray[0];
+    if (id === selectedId) {
+      exists = true;
+      return false;
+    }
   });
   return exists;
 }

--- a/web/js/modules/sidebar/actions.js
+++ b/web/js/modules/sidebar/actions.js
@@ -9,10 +9,14 @@ import {
 } from './constants';
 
 export function changeTab(str) {
-  return {
-    type: CHANGE_TAB,
-    activeTab: str
-  };
+  return (dispatch, getState) => {
+    if (getState().sidebar.activeTab !== str) {
+      dispatch({
+        type: CHANGE_TAB,
+        activeTab: str
+      });
+    }
+  }
 }
 export function toggleSidebarCollapse(str) {
   return (dispatch, getState) => {

--- a/web/js/modules/sidebar/actions.js
+++ b/web/js/modules/sidebar/actions.js
@@ -16,7 +16,7 @@ export function changeTab(str) {
         activeTab: str
       });
     }
-  }
+  };
 }
 export function toggleSidebarCollapse(str) {
   return (dispatch, getState) => {


### PR DESCRIPTION
## Description

Fixes #2332

When you click on the data download tab after clicking a fire event an endless loop breaks the app
- [x] Only dispatch tab event if new tab is different
- [x] Only dispatch new select product event if incoming product is new
- [x] fix doesSelectedExist method (the actual solution)


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
