### PR TITLE
Fix animation dragger range selection to allow subdaily time units

### DIFF
--- a/web/js/components/range-selection/dragger-range.js
+++ b/web/js/components/range-selection/dragger-range.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
+import { timeScaleOptions } from '../../modules/date/constants';
 /*
  * A react component, is a draggable svg
  * rect element
@@ -69,114 +70,81 @@ class TimelineDraggerRange extends PureComponent {
   handleDrag(e, d) {
     e.preventDefault();
     e.stopPropagation();
+    const {
+      endLocation,
+      max,
+      startLocation,
+      timelineEndDateLimit,
+      timeScale
+    } = this.props;
+    let endLocationDate = this.props.endLocationDate;
+    let timelineEndDate = new Date(timelineEndDateLimit);
+
+    // milliseconds to determine # of time units from end based on timeScale
+    let scaleMs = timeScaleOptions[timeScale].timeAxis.scaleMs;
+    // threshold for scaleMs to buffer if below
+    let bufferCoeff = 20;
+
+    // used to determine when to init buffer for variable MS month/year time units
+    if (!scaleMs) {
+      if (timeScale === 'month') {
+        // 12 months
+        scaleMs = 86400000 * 31;
+        bufferCoeff = 12;
+      }
+      if (timeScale === 'year') {
+        // 5 years
+        scaleMs = 86400000 * 365;
+        bufferCoeff = 5;
+      }
+    }
+
     // +/- {number} - change in x - set to 0 to 'stop' dragger movement - min/max of -55/55 to prevent overdrag
     let deltaX = d.deltaX < -55 ? -55 : d.deltaX > 55 ? 55 : d.deltaX;
     // +/- {number} - start position
     const deltaStart = d.x;
-    const startLocationDate = this.props.startLocationDate;
-    let endLocationDate = this.props.endLocationDate;
-    const timelineEndDate = new Date(this.props.timelineEndDateLimit);
-    // used to determine and buffer large monthly/yearly ranges
-    let startDateToEndDifference = this.dateDifferenceInDays(
-      startLocationDate,
-      endLocationDate
-    );
-    if (startDateToEndDifference > 100) {
-      startDateToEndDifference = 300;
-    }
-    // difference between last date on timeline (current day/now) and end date dragger
-    const endDateToLimitDifference = Math.min(
-      startDateToEndDifference,
-      this.dateDifferenceInDays(endLocationDate, timelineEndDate)
-    );
-    // match end date precise time units to dragging end date
-    let timelineEndDateLimitMatch = new Date(
-      timelineEndDate.getFullYear(),
-      timelineEndDate.getMonth(),
-      timelineEndDate.getDate(),
-      endLocationDate.getHours(),
-      endLocationDate.getMinutes()
-    );
-    // match buffer date precise time units to dragging end date - calculated endDateToLimitDifference used dynamically
-    // to change buffer dates of when to limit deltaX and therefore slow down dragger speed
-    let timelineMaxDateBufferMatch = new Date(
-      timelineEndDate.getFullYear(),
-      timelineEndDate.getMonth(),
-      timelineEndDate.getDate() - Math.abs(endDateToLimitDifference),
-      endLocationDate.getHours(),
-      endLocationDate.getMinutes()
-    );
+
+    // difference between end dragger and end of timeline in MS
+    const endDateToLimitDifference = timelineEndDate.getTime() - endLocationDate.getTime();
+    // determine if needs to be throttled
+    const timeUnitsTillEnd = endDateToLimitDifference / scaleMs;
+    const needDeltaThrottle = timeUnitsTillEnd < bufferCoeff;
 
     // format dates to ISO for comparison
     endLocationDate = endLocationDate.toISOString().split('.')[0] + 'Z';
-    timelineEndDateLimitMatch =
-      timelineEndDateLimitMatch.toISOString().split('.')[0] + 'Z';
-    timelineMaxDateBufferMatch =
-      timelineMaxDateBufferMatch.toISOString().split('.')[0] + 'Z';
+    timelineEndDate = timelineEndDate.toISOString().split('.')[0] + 'Z';
 
     // timeline dragger dragged into the future (to the right)
     if (deltaX > 0) {
       // stop dragger if reached end date
-      if (endLocationDate >= timelineEndDateLimitMatch) {
+      if (endLocationDate >= timelineEndDate) {
         deltaX = 0;
       } else {
         // if end of timeline date is within view - rely on max
-        if (this.props.max.end) {
+        if (max.end) {
           // timeline dragger dragged to max future of current viewable timeline
-          if (this.props.endLocation >= this.props.max.width) {
-            deltaX = 0;
-          }
-          if (this.props.endLocation > this.props.max.width - deltaX) {
+          if (endLocation >= max.width || endLocation > max.width - deltaX) {
             deltaX = 0;
           }
           // end of timeline date is not within view - rely on dates
         } else {
           // use buffer to start slowing down allowed deltaX to prevent overdrag
-          if (endLocationDate >= timelineMaxDateBufferMatch) {
-            deltaX = Math.min(deltaX, Math.abs(endDateToLimitDifference * 2));
+          if (needDeltaThrottle) {
+            deltaX = Math.min(deltaX, Math.abs(timeUnitsTillEnd * 2));
           }
         }
       }
       // timeline dragger dragged into the past (to the left)
     } else {
-      if (this.props.max.start) {
+      if (max.start) {
         // timeline dragger dragged to min past of current viewable timeline
-        if (
-          this.props.startLocation + deltaX - this.props.max.startOffset <=
-          0
-        ) {
+        if (startLocation + deltaX - max.startOffset <= 0) {
           deltaX = 0;
         }
       }
     }
-    this.props.onDrag(deltaX, deltaStart, this.props.id);
-  }
 
-  /*
-   * Utility function to caculate difference between two dates
-   * put cutoff date as dateA for min (dateA hours & minutes used for both), and dateB for max
-   *
-   * @method dateDifferenceInDays
-   *
-   * @return {number}
-   */
-  dateDifferenceInDays(dateA, dateB) {
-    const msPerDay = 1000 * 60 * 60 * 24;
-    // Discard the time and time-zone information.
-    const utc1 = Date.UTC(
-      dateA.getFullYear(),
-      dateA.getMonth(),
-      dateA.getDate()
-    );
-    const utc2 = Date.UTC(
-      dateB.getFullYear(),
-      dateB.getMonth(),
-      dateB.getDate(),
-      dateA.getHours(),
-      dateA.getMinutes()
-    );
-
-    return Math.floor((utc2 - utc1) / msPerDay);
+    this.props.onDrag(deltaX, deltaStart);
   }
 
   /*
@@ -284,6 +252,7 @@ TimelineDraggerRange.propTypes = {
   startLocation: PropTypes.number,
   startLocationDate: PropTypes.object,
   timelineEndDateLimit: PropTypes.string,
+  timeScale: PropTypes.string,
   width: PropTypes.number
 };
 

--- a/web/js/components/range-selection/range-selection.js
+++ b/web/js/components/range-selection/range-selection.js
@@ -13,9 +13,6 @@ import { timeScaleOptions } from '../../modules/date/constants';
  * @class TimelineRangeSelector
  */
 class TimelineRangeSelector extends React.Component {
-  /*
-   * @constructor
-   */
   constructor(props) {
     super(props);
     this.state = {
@@ -23,10 +20,6 @@ class TimelineRangeSelector extends React.Component {
       endLocation: props.endLocation,
       deltaStart: 0
     };
-
-    this.onRangeDrag = this.onRangeDrag.bind(this);
-    this.onItemDrag = this.onItemDrag.bind(this);
-    this.onDragStop = this.onDragStop.bind(this);
   }
 
   /*
@@ -43,36 +36,38 @@ class TimelineRangeSelector extends React.Component {
    *
    * @return {void}
    */
-  onItemDrag(deltaX, id) {
-    var startX;
-    var endX;
+  onItemDrag = (deltaX, id) => {
+    const { endLocation, startLocation } = this.state;
+    const { max, pinWidth } = this.props;
+    let startX;
+    let endX;
 
     if (id === 'start') {
-      startX = deltaX + this.state.startLocation;
-      endX = this.state.endLocation;
+      startX = deltaX + startLocation;
+      endX = endLocation;
       if (startX < 0 || startX > endX) {
         return;
       }
-      if (startX + this.props.pinWidth >= endX) {
-        if (startX + this.props.pinWidth >= this.props.max.width) {
+      if (startX + pinWidth >= endX) {
+        if (startX + pinWidth >= max.width) {
           return;
         } else {
-          endX = startX + this.props.pinWidth;
+          endX = startX + pinWidth;
         }
       }
     } else if (id === 'end') {
-      startX = this.state.startLocation;
-      endX = deltaX + this.state.endLocation;
-      if (endX > this.props.max.width || startX > endX) {
+      startX = startLocation;
+      endX = deltaX + endLocation;
+      if (endX > max.width || startX > endX) {
         return;
       }
-      if (startX + 2 * this.props.pinWidth >= endX) {
-        startX = endX - this.props.pinWidth;
+      if (startX + 2 * pinWidth >= endX) {
+        startX = endX - pinWidth;
       }
     } else {
-      startX = deltaX + this.state.startLocation;
-      endX = deltaX + this.state.endLocation;
-      if (endX >= this.props.max.width || startX < 0) {
+      startX = deltaX + startLocation;
+      endX = deltaX + endLocation;
+      if (endX >= max.width || startX < 0) {
         return;
       }
     }
@@ -91,8 +86,9 @@ class TimelineRangeSelector extends React.Component {
    *
    * @return {void}
    */
-  onDragStop() {
-    this.animationDraggerPositionUpdate(this.state.startLocation, this.state.endLocation, false);
+  onDragStop = () => {
+    const { endLocation, startLocation } = this.state;
+    this.animationDraggerPositionUpdate(startLocation, endLocation, false);
   }
 
   /*
@@ -105,7 +101,7 @@ class TimelineRangeSelector extends React.Component {
    *
    * @return {void}
    */
-  onRangeDrag(d, deltaStart) {
+  onRangeDrag = (d, deltaStart) => {
     const startLocation = this.state.startLocation + d;
     const endLocation = this.state.endLocation + d;
     this.setState({
@@ -258,61 +254,89 @@ class TimelineRangeSelector extends React.Component {
    * @method render
    */
   render() {
+    const { endLocation, deltaStart, startLocation } = this.state;
+    const {
+      axisWidth,
+      endColor,
+      endLocationDate,
+      endTriangleColor,
+      max,
+      pinWidth,
+      rangeColor,
+      rangeOpacity,
+      startColor,
+      startLocationDate,
+      startTriangleColor,
+      timelineEndDateLimit,
+      timelineStartDateLimit,
+      timeScale
+    } = this.props;
     return (
       <svg
         id="wv-timeline-range-selector"
         className="wv-timeline-range-selector"
-        width={this.props.axisWidth}
+        width={axisWidth}
         height={75}
       >
         <DraggerRange
-          opacity={this.props.rangeOpacity}
-          startLocation={this.state.startLocation}
-          endLocation={this.state.endLocation}
-          startLocationDate={this.props.startLocationDate}
-          endLocationDate={this.props.endLocationDate}
-          timelineStartDateLimit={this.props.timelineStartDateLimit}
-          timelineEndDateLimit={this.props.timelineEndDateLimit}
-          deltaStart={this.state.deltaStart}
-          max={this.props.max}
+          opacity={rangeOpacity}
+          startLocation={startLocation}
+          endLocation={endLocation}
+          startLocationDate={startLocationDate}
+          endLocationDate={endLocationDate}
+          timelineStartDateLimit={timelineStartDateLimit}
+          timelineEndDateLimit={timelineEndDateLimit}
+          timeScale={timeScale}
+          deltaStart={deltaStart}
+          max={max}
           height={64}
-          width={this.props.pinWidth}
-          color={this.props.rangeColor}
+          width={pinWidth}
+          color={rangeColor}
           draggerID="range-selector-range"
           onDrag={this.onRangeDrag}
           onStop={this.onDragStop}
           id="range"
         />
         <Dragger
-          position={this.state.startLocation}
-          color={this.props.startColor}
-          width={this.props.pinWidth}
+          position={startLocation}
+          color={startColor}
+          width={pinWidth}
           height={45}
           onDrag={this.onItemDrag}
           onStop={this.onDragStop}
-          max={this.props.max.width}
+          max={max.width}
           draggerID="range-selector-dragger-1"
-          backgroundColor={this.props.startTriangleColor}
+          backgroundColor={startTriangleColor}
           first={true}
           id="start"
         />
         <Dragger
-          max={this.props.max.width}
-          position={this.state.endLocation}
-          color={this.props.endColor}
-          width={this.props.pinWidth}
+          max={max.width}
+          position={endLocation}
+          color={endColor}
+          width={pinWidth}
           height={45}
           first={false}
           draggerID="range-selector-dragger-2"
           onDrag={this.onItemDrag}
           onStop={this.onDragStop}
-          backgroundColor={this.props.endTriangleColor}
+          backgroundColor={endTriangleColor}
           id="end"
         />
       </svg>
     );
   }
 }
+
+TimelineRangeSelector.defaultProps = {
+  pinWidth: 5,
+  rangeOpacity: 0.3,
+  rangeColor: '#45bdff',
+  startColor: '#40a9db',
+  startTriangleColor: '#fff',
+  endColor: '#295f92',
+  endTriangleColor: '#4b7aab'
+};
 
 TimelineRangeSelector.propTypes = {
   axisWidth: PropTypes.number,

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -79,6 +79,7 @@ const RangeHandle = props => {
 
 const widgetWidth = 334;
 const subdailyWidgetWidth = 460;
+const maxFrames = 40;
 
 /*
  * A react component, Builds a rather specific
@@ -200,7 +201,7 @@ class AnimationWidget extends React.Component {
       endDate
     } = this.zeroDates();
 
-    if (numberOfFrames >= 40) {
+    if (numberOfFrames >= maxFrames) {
       return;
     }
 
@@ -374,7 +375,7 @@ class AnimationWidget extends React.Component {
     const { numberOfFrames } = this.props;
     const { hoverGif } = this.state;
     const elemExists = document.querySelector('#create-gif-button');
-    const showTooltip = elemExists && hoverGif && numberOfFrames >= 40;
+    const showTooltip = elemExists && hoverGif && numberOfFrames >= maxFrames;
     return (
       <Tooltip
         placement="right"
@@ -436,7 +437,7 @@ class AnimationWidget extends React.Component {
       hasSubdailyLayers
     } = this.props;
     const { speed } = this.state;
-    const gifDisabled = numberOfFrames >= 40;
+    const gifDisabled = numberOfFrames >= maxFrames;
     return (
       <Draggable
         bounds="body"
@@ -669,7 +670,8 @@ function mapStateToProps(state) {
     startDate,
     endDate,
     timeScaleFromNumberKey[useInterval],
-    customSelected && customDelta ? customDelta : delta
+    customSelected && customDelta ? customDelta : delta,
+    maxFrames
   );
 
   return {

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1027,13 +1027,7 @@ class Timeline extends React.Component {
                       endLocationDate={animationEndLocationDate}
                       updateAnimationDateAndLocation={this.updateAnimationDateAndLocation}
                       max={rangeSelectorMax}
-                      pinWidth={5}
-                      rangeOpacity={0.3}
-                      rangeColor={'#45bdff'}
-                      startColor={'#40a9db'}
-                      startTriangleColor={'#fff'}
-                      endColor={'#295f92'}
-                      endTriangleColor={'#4b7aab'} />
+                    />
                     : null
                   }
 

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -444,13 +444,17 @@ export default (function(self) {
     return newDate;
   };
 
-  self.getNumberOfDays = function(start, end, interval, increment) {
+  self.getNumberOfDays = function(start, end, interval, increment, maxToCheck) {
     increment = increment || 1;
     var i = 1;
     var currentDate = start;
     while (currentDate < end) {
       i++;
       currentDate = self.dateAdd(currentDate, interval, increment);
+      // if checking for a max number limit, break out after reaching it
+      if (maxToCheck && i >= maxToCheck) {
+        return i;
+      }
     }
     return i;
   };


### PR DESCRIPTION
## Description

Fixes #2390  .

- Refactor animation dragger range selection to allow for subdaily units. This includes changes in the delta drag buffer (to prevent fast overdragging) that is now timescale time unit dependent vs previously calculated based on number of days.
- Add max limit for `getNumberOfDays` util function for large day spans that could slow down range selector drag (`year` timescale zoom level over a large span with `minute` timescale interval selected is an example).
- Refactor/cleanup related functions, state, and props.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
