### PR TITLE
Default to geographic selected projection if not specified for location pop action

### DIFF
--- a/web/js/modules/projection/util.js
+++ b/web/js/modules/projection/util.js
@@ -42,6 +42,11 @@ export function mapLocationToProjState(parameters, stateFromLocation, state) {
         proj: { $set: newProjState }
       });
     }
+  } else {
+    const selected = lodashGet(state, 'config.projections.geographic');
+    stateFromLocation = update(stateFromLocation, {
+      proj: { selected: { $set: selected } }
+    });
   }
   return stateFromLocation;
 }


### PR DESCRIPTION
## Description

Fixes #2356  .

- The `REDUX-LOCATION-POP-ACTION` being used for stories wasn't defaulting to `geographic` projection in the event that a projection wasn't specified in the first stepLink of the story. This only caused a selected map related issue when starting in `arctic`/`antarctic` and starting a story that switched to `geographic`. 

This fix will default to `geographic` as the selected projection if not specified.



## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
