### PR TITLE
Snap layer times to previous available dates to prevent unnecessary network requests

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -89,6 +89,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     options = options || {};
     const group = options.group || null;
     let date = self.closestDate(def, options);
+    if (date) {
+      options.date = date;
+    }
     const key = self.layerKey(def, options, state);
     const proj = state.proj.selected;
     let layer = cache.getItem(key);
@@ -140,7 +143,8 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
   self.closestDate = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
-    let date = options.date || new Date(state.date[activeDateStr]);
+    const stateCurrentDate = new Date(state.date[activeDateStr]);
+    let date = options.date || stateCurrentDate;
 
     // need to get previous available date to prevent unecessary requests
     let dateRange;

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -19,8 +19,6 @@ import closestIndexTo from 'date-fns/closest_index_to';
 import isBefore from 'date-fns/is_before';
 import isEqual from 'date-fns/is_equal';
 import isFirstDayOfMonth from 'date-fns/is_first_day_of_month';
-import isLastDayOfMonth from 'date-fns/is_last_day_of_month';
-import lastDayOfYear from 'date-fns/last_day_of_year';
 
 /**
    * For subdaily layers, round the time down to nearest interval.
@@ -55,10 +53,11 @@ export function nearestInterval(def, date) {
 export function prevDateInDateRange(def, date, dateArray) {
   const closestAvailableDates = [];
   const currentDate = new Date(date.getTime());
+  const currentDateOffsetCheck = new Date(currentDate.getTime() + (currentDate.getTimezoneOffset() * 60000));
 
   if (!dateArray ||
-      (def.period === 'monthly' && (isFirstDayOfMonth(currentDate) || isLastDayOfMonth(currentDate))) ||
-      (def.period === 'yearly' && ((currentDate.getDate() === 1 && currentDate.getMonth() === 0) || (currentDate === lastDayOfYear(currentDate))))) {
+      (def.period === 'monthly' && isFirstDayOfMonth(currentDateOffsetCheck)) ||
+      (def.period === 'yearly' && (currentDateOffsetCheck.getDate() === 1 && currentDateOffsetCheck.getMonth() === 0))) {
     return date;
   }
 
@@ -68,7 +67,7 @@ export function prevDateInDateRange(def, date, dateArray) {
     }
   });
 
-  // use closet date index to find closest date in filtered closestAvailableDates
+  // use closest date index to find closest date in filtered closestAvailableDates
   const closestDateIndex = closestIndexTo(currentDate, closestAvailableDates);
   const closestDate = closestAvailableDates[closestDateIndex];
   def.previousDate = closestDate || null;

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -54,8 +54,7 @@ export function nearestInterval(def, date) {
    */
 export function prevDateInDateRange(def, date, dateArray) {
   const closestAvailableDates = [];
-  // const currentDate = new Date(date.getTime());
-  const currentDate = new Date(date.getTime() + (date.getTimezoneOffset() * 60000));
+  const currentDate = new Date(date.getTime());
 
   if (!dateArray ||
       (def.period === 'monthly' && (isFirstDayOfMonth(currentDate) || isLastDayOfMonth(currentDate))) ||
@@ -77,8 +76,6 @@ export function prevDateInDateRange(def, date, dateArray) {
   // check for potential next date in function passed dateArray
   const nextClosestDate = dateArray[closestDateIndex + 1];
   def.nextDate = nextClosestDate || null;
-
-  console.log(currentDate, closestDate, nextClosestDate)
 
   return closestDate ? new Date(closestDate.getTime()) : date;
 };
@@ -102,59 +99,59 @@ export function datesinDateRanges(def, date) {
     let monthDifference;
     let dayDifference;
     let minuteDifference;
-    // default to startDate/endDate if defined in the layer def
-    let minDate = new Date(def.startDate || dateRange.startDate);
-    let maxDate = new Date(def.endDate || dateRange.endDate);
-    // Offset timezone
-    if (def.period !== 'yearly') {
-      minDate = new Date(minDate.getTime() - (minDate.getTimezoneOffset() * 60000));
-      maxDate = new Date(maxDate.getTime() - (maxDate.getTimezoneOffset() * 60000));
-    }
+    let minDate = new Date(dateRange.startDate);
+    const maxDate = new Date(dateRange.endDate);
+
     const maxYear = maxDate.getUTCFullYear();
     const maxMonth = maxDate.getUTCMonth();
     const maxDay = maxDate.getUTCDate();
-    const maxHours = maxDate.getUTCHours();
-    const maxMinutes = maxDate.getUTCMinutes();
     const minYear = minDate.getUTCFullYear();
     const minMonth = minDate.getUTCMonth();
     const minDay = minDate.getUTCDate();
-    const minMinutes = minDate.getUTCMinutes();
-
-    const maxYearDate = new Date(maxYear + 1, maxMonth, maxDay);
-    const maxMonthDate = new Date(maxYear, maxMonth + 1, maxDay);
-    const maxDayDate = new Date(maxYear, maxMonth, maxDay + 1);
-    let maxMinuteDate = new Date(maxYear, maxMonth, maxDay, maxHours, maxMinutes + dateInterval);
 
     let i;
     // Yearly layers
     if (def.period === 'yearly') {
+      const maxYearDate = new Date(maxYear + dateInterval, maxMonth, maxDay);
       if (currentDate >= minDate && currentDate <= maxYearDate) {
         yearDifference = util.yearDiff(minDate, maxYearDate);
       }
       for (i = 0; i <= (yearDifference + 1); i++) {
-        dateArray.push(new Date(minYear + i * dateInterval, minMonth, minDay));
+        let year = new Date(minYear + i * dateInterval, minMonth, minDay);
+        year = new Date(year.getTime() - (year.getTimezoneOffset() * 60000));
+        dateArray.push(year);
       }
     // Monthly layers
     } else if (def.period === 'monthly') {
+      const maxMonthDate = new Date(maxYear, maxMonth + dateInterval, maxDay);
       if (currentDate >= minDate && currentDate <= maxMonthDate) {
         monthDifference = util.monthDiff(minDate, maxMonthDate);
       }
       for (i = 0; i <= (monthDifference + 1); i++) {
-        dateArray.push(new Date(minYear, minMonth + i * dateInterval, minDay));
+        let month = new Date(minYear, minMonth + i * dateInterval, minDay);
+        month = new Date(month.getTime() - (month.getTimezoneOffset() * 60000));
+        dateArray.push(month);
       }
     // Daily layers
     } else if (def.period === 'daily') {
+      const maxDayDate = new Date(maxYear, maxMonth, maxDay + dateInterval);
       if (currentDate >= minDate && currentDate <= maxDayDate) {
         dayDifference = util.dayDiff(minDate, maxDayDate);
         // handle non-1 day intervals to prevent over pushing unused dates to dateArray
         dayDifference = Math.ceil(dayDifference / dateInterval);
       }
-      console.log(dateInterval, dayDifference)
       for (i = 0; i <= (dayDifference + 1); i++) {
-        dateArray.push(new Date(minYear, minMonth, minDay + i * dateInterval));
+        let day = new Date(minYear, minMonth, minDay + i * dateInterval);
+        day = new Date(day.getTime() - (day.getTimezoneOffset() * 60000));
+        dateArray.push(day);
       }
     // Subdaily layers
     } else if (def.period === 'subdaily') {
+      const maxHours = maxDate.getUTCHours();
+      const maxMinutes = maxDate.getUTCMinutes();
+      const minMinutes = minDate.getUTCMinutes();
+      let maxMinuteDate = new Date(maxYear, maxMonth, maxDay, maxHours, maxMinutes + dateInterval);
+
       const currentDateOffset = currentDate.getTimezoneOffset() * 60000;
       const hourBeforeCurrentDate = new Date(currentDate.setMinutes(minMinutes) - currentDateOffset - (60 * 60000));
       const hourAfterCurrentDate = new Date(currentDate.setMinutes(minMinutes) - currentDateOffset + (60 * 60000));
@@ -180,7 +177,6 @@ export function datesinDateRanges(def, date) {
       }
     }
   });
-  console.log(def, dateArray)
   return dateArray;
 };
 


### PR DESCRIPTION
## Description

Fixes #2129  .

- [x] Add a `def.previousDate` and `def.nextDate` based on the `closestDate` determined from `prevDateInDateRange`. This allows for layers with longer ranges to not make requests if the current date is between `def.previousDate` and `def.nextDate`.
- [x] If a `closestDate` is found, it will be saved onto the layer building `options`.
- [x] Within `datesinDateRanges`, move how timezone offsets are handled as these will vary, base max dates and pushed dates on respective `dateInterval`, and minor refactor to only create certain constants if necessary for a given `def.period`.

## Further comments

I suggest future optimizations:
- [ ] Shorten date range when creating `dateArray` in `datesinDateRanges`. This can be costly CPU for slower machines with long 7000+ day interval arrays being created, for example.
- [ ] Adjust animation precache/layer fetching to tackle the problem handled in this PR (currently day animation increment will request each day even for monthly layers, which shouldn't be necessary).
- [ ] Determine use case for `def.startDate` and `def.endDate` and check if these ever conflict with the dates found in `def.dateRanges`, and if there are conflicts does any date take precedence.


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
