### PR TITLE
Only try to show running data values for active compare mode

### DIFF
--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -71,7 +71,7 @@ export function MapRunningData(models, compareUi, store) {
     const [lon, lat] = map.getCoordinateFromPixel(pixels);
     if (!(lon < -180 || lon > 180 || lat < -90 || lat > 90)) {
       map.forEachFeatureAtPixel(pixels, (feature, layer) => {
-        if (!layer.wv || !layer.wv.def) return;
+        if (!layer.wv || !layer.wv.def || !isFromActiveCompareRegion(map, pixels, layer.wv)) return;
         let color;
         const def = layer.wv.def;
         const identifier = def.palette.styleProperty;


### PR DESCRIPTION
## Description

Fixes #2439

- [x] Only try to show running data values for active compare mode
- [x] only show vector running data value in swipe mode

## Further comments
Prevents numerous breaks in compare mode

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
