### PR TITLE
Fix running data tooltip in compare mode

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -311,7 +311,7 @@ class PaletteLegend extends React.Component {
    */
   renderClasses(legend, legendIndex) {
     const { isRunningData, colorHex } = this.state;
-    const { layer, parentLayer } = this.props;
+    const { layer, parentLayer, layerGroupName } = this.props;
     const activeKeyObj = isRunningData && colorHex && this.getLegendObject(legend, colorHex, 5);
     const legendClass = activeKeyObj
       ? 'wv-running wv-palettes-legend wv-palettes-classes'
@@ -329,7 +329,7 @@ class PaletteLegend extends React.Component {
           const palletteClass = isActiveKey ? 'wv-active wv-palettes-class' : 'wv-palettes-class';
           const isSubLayer = !!parentLayer;
           const parentLayerId = isSubLayer ? parentLayer.id : '';
-          const keyId = layer.id + '-' + legend.id + '-color-' + keyIndex + parentLayerId;
+          const keyId = layer.id + '-' + legend.id + '-color-' + keyIndex + parentLayerId + layerGroupName;
           const keyLabel = activeKeyObj ? activeKeyObj.label : '';
 
           return (
@@ -421,6 +421,7 @@ PaletteLegend.propTypes = {
   isRunningDataEnabled: PropTypes.bool,
   isSubLayer: PropTypes.bool,
   layer: PropTypes.object,
+  layerGroupName: PropTypes.string,
   paletteId: PropTypes.string,
   paletteLegends: PropTypes.array,
   parentLayer: PropTypes.object,

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -331,6 +331,9 @@ class PaletteLegend extends React.Component {
           const parentLayerId = isSubLayer ? parentLayer.id : '';
           const keyId = layer.id + '-' + legend.id + '-color-' + keyIndex + parentLayerId + layerGroupName;
           const keyLabel = activeKeyObj ? activeKeyObj.label : '';
+          const tooltipText = singleKey
+            ? layer.track ? trackLabel : legendTooltip
+            : keyLabel;
 
           return (
             <React.Fragment key={keyId}>
@@ -344,21 +347,22 @@ class PaletteLegend extends React.Component {
                 dangerouslySetInnerHTML={{ __html: '&nbsp' }}
               />
 
-              {singleKey && !isSubLayer
-                ? (
-                  <div className="wv-running-category-label-case">
-                    <span className="wv-running-category-label">
-                      {layer.track ? trackLabel : legend.title}
-                    </span>
-                  </div>
-                ) : (
-                  <Tooltip
-                    placement="bottom"
-                    isOpen={isActiveKey}
-                    target={keyId}>
-                    {keyLabel}
-                  </Tooltip>
-                )}
+              {singleKey && !isSubLayer && (
+                <div className="wv-running-category-label-case">
+                  <span className="wv-running-category-label">
+                    {layer.track ? trackLabel : legendTooltip}
+                  </span>
+                </div>
+              )}
+
+              {(
+                <Tooltip
+                  placement={singleKey ? 'right' : 'bottom'}
+                  isOpen={isActiveKey}
+                  target={keyId}>
+                  {tooltipText}
+                </Tooltip>
+              )}
             </React.Fragment>
           );
         })}

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -41,7 +41,9 @@ class Layer extends React.Component {
 
   getPaletteLegend = () => {
     const {
+      compare,
       layer,
+      layerGroupName,
       runningObject,
       paletteLegends,
       checkerBoardPattern,
@@ -54,11 +56,14 @@ class Layer extends React.Component {
       isMobile
     } = this.props;
     if (!lodashIsEmpty(renderedPalette)) {
-      const isRunningData = !!runningObject;
+      const isRunningData = compare.active
+        ? (runningObject || {}).layerGroupName === layerGroupName
+        : !!runningObject;
       const colorHex = isRunningData ? runningObject.paletteHex : null;
       return (
         <PaletteLegend
           layer={layer}
+          layerGroupName={layerGroupName}
           paletteId={palette.id}
           getPalette={getPalette}
           paletteLegends={paletteLegends}
@@ -280,6 +285,7 @@ Layer.defaultProps = {
 };
 Layer.propTypes = {
   checkerBoardPattern: PropTypes.object,
+  compare: PropTypes.object,
   getPalette: PropTypes.func,
   hasPalette: PropTypes.bool,
   hover: PropTypes.func,
@@ -316,7 +322,7 @@ function mapStateToProps(state, ownProps) {
     index,
     layerGroupName
   } = ownProps;
-  const { palettes, config, map, layers } = state;
+  const { palettes, config, map, layers, compare } = state;
   const hasPalette = !lodashIsEmpty(layer.palette);
   const renderedPalettes = palettes.rendered;
   const paletteName = lodashGet(config, `layers['${layer.id}'].palette.id`);
@@ -329,6 +335,7 @@ function mapStateToProps(state, ownProps) {
   });
 
   return {
+    compare,
     tracksForLayer,
     layer,
     isDisabled,

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -57,7 +57,7 @@ class Layer extends React.Component {
     } = this.props;
     if (!lodashIsEmpty(renderedPalette)) {
       const isRunningData = compare.active
-        ? (runningObject || {}).layerGroupName === layerGroupName
+        ? compare.activeString === layerGroupName && !!runningObject
         : !!runningObject;
       const colorHex = isRunningData ? runningObject.paletteHex : null;
       return (

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -67,8 +67,6 @@ export function MapRunningData(models, compareUi, store) {
    */
   self.newPoint = function(pixels, map) {
     const state = store.getState();
-    const compareState = state.compare || {};
-    const layerGroupName = compareState.active && compareState.activeString;
     const activeLayerObj = {};
     const [lon, lat] = map.getCoordinateFromPixel(pixels);
     if (!(lon < -180 || lon > 180 || lat < -90 || lat > 90)) {
@@ -94,8 +92,7 @@ export function MapRunningData(models, compareUi, store) {
         }
         activeLayerObj[layerId] = {
           paletteLegends,
-          paletteHex: color,
-          layerGroupName
+          paletteHex: color
         };
       });
     }
@@ -106,8 +103,7 @@ export function MapRunningData(models, compareUi, store) {
       if (def.palette && !lodashGet(layer, 'wv.def.disableHoverValue')) {
         activeLayerObj[def.id] = {
           paletteLegends: getPalette(def.id, undefined, undefined, state),
-          paletteHex: util.rgbaToHex(data[0], data[1], data[2], data[3]),
-          layerGroupName
+          paletteHex: util.rgbaToHex(data[0], data[1], data[2], data[3])
         };
       }
     });

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -71,7 +71,7 @@ export function MapRunningData(models, compareUi, store) {
     const [lon, lat] = map.getCoordinateFromPixel(pixels);
     if (!(lon < -180 || lon > 180 || lat < -90 || lat > 90)) {
       map.forEachFeatureAtPixel(pixels, (feature, layer) => {
-        if (!layer.wv || !layer.wv.def) return;
+        if (!layer.wv || !layer.wv.def || !isFromActiveCompareRegion(map, pixels, layer.wv)) return;
         let color;
         const def = layer.wv.def;
         const identifier = def.palette.styleProperty;


### PR DESCRIPTION
## Description

Fixes #2438 
Fixes #2437 

* Only show tooltip for a palette item in compare mode if user is hovering over the active side of the A/B divide
* Show tooltip for single item palettes when running data for that item is active (more easily distinguish if & what you are pointing at in certain situations)

A good set of layers to test with:
http://localhost:3000/?v=-23.84371974109054,10.409624626741433,18.16799900890946,57.44868712674143&t=2017-01-16-T00%3A00%3A00Z&t1=2017-01-09-T00%3A00%3A00Z&l=AIRS_CO_Total_Column_Day,GRanD_Dams,Last_of_the_Wild_1995-2004,VIIRS_SNPP_Thermal_Anomalies_375m_Night,VIIRS_SNPP_Thermal_Anomalies_375m_Day,MODIS_Terra_CorrectedReflectance_TrueColor,Coastlines&l1=AIRS_CO_Total_Column_Day,GRanD_Dams,Last_of_the_Wild_1995-2004,VIIRS_SNPP_Thermal_Anomalies_375m_Night,VIIRS_SNPP_Thermal_Anomalies_375m_Day,MODIS_Terra_CorrectedReflectance_TrueColor,Coastlines&ca=true
