### PR TITLE
Conditionally use default date for animations rather then time snapping

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -140,24 +140,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param  {object} options Layer options
    * @return {object}         Closest date
    */
-
-
-  // self.closestDate = function(def, options) {
-  //   const state = store.getState();
-  //   const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
-  //   let date = options.date || new Date(state.date[activeDateStr]);
-
-  //   if (def.period === 'subdaily') {
-  //     date = nearestInterval(def, date);
-  //   } else {
-  //     date = options.date
-  //       ? util.clearTimeUTC(new Date(date.getTime()))
-  //       : util.clearTimeUTC(date);
-  //   }
-
-  //   return date;
-  // };
-
   self.closestDate = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
@@ -165,7 +147,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     let date = options.date || stateCurrentDate;
     let previousDateFromRange;
     if (!state.animation.isPlaying) {
-
       // need to get previous available date to prevent unecessary requests
       let dateRange;
       // let previousDateFromRange;

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -140,29 +140,50 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param  {object} options Layer options
    * @return {object}         Closest date
    */
+
+
+  // self.closestDate = function(def, options) {
+  //   const state = store.getState();
+  //   const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
+  //   let date = options.date || new Date(state.date[activeDateStr]);
+
+  //   if (def.period === 'subdaily') {
+  //     date = nearestInterval(def, date);
+  //   } else {
+  //     date = options.date
+  //       ? util.clearTimeUTC(new Date(date.getTime()))
+  //       : util.clearTimeUTC(date);
+  //   }
+
+  //   return date;
+  // };
+
   self.closestDate = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     const stateCurrentDate = new Date(state.date[activeDateStr]);
     let date = options.date || stateCurrentDate;
-    if (state.animation.isPlaying) return date;
-    // need to get previous available date to prevent unecessary requests
-    let dateRange;
     let previousDateFromRange;
-    if (def.previousDate && def.nextDate) {
-      const dateTime = date.getTime();
-      const previousDateTime = def.previousDate.getTime();
-      const nextDateTime = def.nextDate.getTime();
-      // if current date is outside previous and next dates avaiable, recheck range
-      if (dateTime <= previousDateTime || dateTime >= nextDateTime) {
+    if (!state.animation.isPlaying) {
+
+      // need to get previous available date to prevent unecessary requests
+      let dateRange;
+      // let previousDateFromRange;
+      if (def.previousDate && def.nextDate) {
+        const dateTime = date.getTime();
+        const previousDateTime = def.previousDate.getTime();
+        const nextDateTime = def.nextDate.getTime();
+        // if current date is outside previous and next dates avaiable, recheck range
+        if (dateTime <= previousDateTime || dateTime >= nextDateTime) {
+          dateRange = datesinDateRanges(def, date);
+          previousDateFromRange = prevDateInDateRange(def, date, dateRange);
+        } else {
+          previousDateFromRange = def.previousDate;
+        }
+      } else {
         dateRange = datesinDateRanges(def, date);
         previousDateFromRange = prevDateInDateRange(def, date, dateRange);
-      } else {
-        previousDateFromRange = def.previousDate;
       }
-    } else {
-      dateRange = datesinDateRanges(def, date);
-      previousDateFromRange = prevDateInDateRange(def, date, dateRange);
     }
 
     if (def.period === 'subdaily') {


### PR DESCRIPTION
## Description

Fixes #2461  .

- [x] Conditionally use default date for animations rather then time snapping

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
