### PR TITLE
Don't update permalink before user interacts with page

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -88,7 +88,8 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     options = options || {};
     const group = options.group || null;
-    let date = self.closestDate(def, options);
+    const { closestDate, nextDate, previousDate } = self.getRequestDates(def, options);
+    let date = closestDate;
     if (date) {
       options.date = date;
     }
@@ -106,7 +107,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
         date,
         proj: proj.id,
         def,
-        group
+        group,
+        nextDate,
+        previousDate
       };
       def = lodashCloneDeep(def);
       lodashMerge(def, def.projections[proj.id]);
@@ -140,30 +143,39 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param  {object} options Layer options
    * @return {object}         Closest date
    */
-  self.closestDate = function(def, options) {
+  self.getRequestDates = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     const stateCurrentDate = new Date(state.date[activeDateStr]);
+    const previousLayer = options.previousLayer || {};
     let date = options.date || stateCurrentDate;
     let previousDateFromRange;
+    let previousLayerDate = previousLayer.previousDate;
+    let nextLayerDate = previousLayer.nextDate;
     if (!state.animation.isPlaying) {
       // need to get previous available date to prevent unecessary requests
       let dateRange;
       // let previousDateFromRange;
-      if (def.previousDate && def.nextDate) {
+      if (previousLayer.previousDate && previousLayer.nextDate) {
         const dateTime = date.getTime();
-        const previousDateTime = def.previousDate.getTime();
-        const nextDateTime = def.nextDate.getTime();
+        const previousDateTime = previousLayer.previousDate.getTime();
+        const nextDateTime = previousLayer.nextDate.getTime();
         // if current date is outside previous and next dates avaiable, recheck range
         if (dateTime <= previousDateTime || dateTime >= nextDateTime) {
           dateRange = datesinDateRanges(def, date);
-          previousDateFromRange = prevDateInDateRange(def, date, dateRange);
+          const { next, previous } = prevDateInDateRange(def, date, dateRange);
+          previousDateFromRange = previous;
+          previousLayerDate = previous;
+          nextLayerDate = next;
         } else {
           previousDateFromRange = def.previousDate;
         }
       } else {
         dateRange = datesinDateRanges(def, date);
-        previousDateFromRange = prevDateInDateRange(def, date, dateRange);
+        const { next, previous } = prevDateInDateRange(def, date, dateRange);
+        previousDateFromRange = previous;
+        previousLayerDate = previous;
+        nextLayerDate = next;
       }
     }
 
@@ -179,7 +191,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
       }
     }
 
-    return date;
+    return { closestDate: date, previousDate: previousLayerDate, nextDate: nextLayerDate };
   };
 
   /**
@@ -204,7 +216,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     // every date.
     if (def.period) {
       date = util.toISOStringSeconds(
-        util.roundTimeOneMinute(self.closestDate(def, options))
+        util.roundTimeOneMinute(self.getRequestDates(def, options).closestDate)
       );
     }
     if (isPaletteActive(def.id, activeGroupStr, state)) {
@@ -293,7 +305,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     }
     let date = options.date || state.date[activeDateStr];
     if (def.period === 'subdaily') {
-      date = self.closestDate(def, options);
+      date = self.getRequestDates(def, options).closestDate;
       date = new Date(date.getTime());
     }
     if (day && def.period !== 'subdaily') {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -167,7 +167,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
           previousLayerDate = previous;
           nextLayerDate = next;
         } else {
-          previousDateFromRange = def.previousDate;
+          previousDateFromRange = previousLayer.previousDate;
         }
       } else {
         dateRange = datesinDateRanges(def, date);

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -155,7 +155,6 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     if (!state.animation.isPlaying) {
       // need to get previous available date to prevent unecessary requests
       let dateRange;
-      // let previousDateFromRange;
       if (previousLayer.previousDate && previousLayer.nextDate) {
         const dateTime = date.getTime();
         const previousDateTime = previousLayer.previousDate.getTime();

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -98,7 +98,7 @@ export function mapui(models, config, store, ui) {
   const subscribeToStore = function(action) {
     switch (action.type) {
       case layerConstants.ADD_LAYER: {
-        const def = lodashCloneDeep(lodashFind(action.layers, { id: action.id }));
+        const def = lodashFind(action.layers, { id: action.id });
         return addLayer(def);
       }
       case CLEAR_ROTATE:

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -67,8 +67,8 @@ export function prevDateInDateRange(def, date, dateArray) {
   const currentDateOffsetCheck = new Date(currentDate.getTime() + (currentDate.getTimezoneOffset() * 60000));
 
   if (!dateArray ||
-      (def.period === 'monthly' && isFirstDayOfMonth(currentDateOffsetCheck)) ||
-      (def.period === 'yearly' && (currentDateOffsetCheck.getDate() === 1 && currentDateOffsetCheck.getMonth() === 0))) {
+    (def.period === 'monthly' && isFirstDayOfMonth(currentDateOffsetCheck)) ||
+    (def.period === 'yearly' && (currentDateOffsetCheck.getDate() === 1 && currentDateOffsetCheck.getMonth() === 0))) {
     return date;
   }
 
@@ -81,13 +81,10 @@ export function prevDateInDateRange(def, date, dateArray) {
   // use closest date index to find closest date in filtered closestAvailableDates
   const closestDateIndex = closestIndexTo(currentDate, closestAvailableDates);
   const closestDate = closestAvailableDates[closestDateIndex];
-  def.previousDate = closestDate || null;
 
   // check for potential next date in function passed dateArray
   const nextClosestDate = dateArray[closestDateIndex + 1];
-  def.nextDate = nextClosestDate || null;
-
-  return closestDate ? new Date(closestDate.getTime()) : date;
+  return { previous: closestDate ? new Date(closestDate.getTime()) : date, next: nextClosestDate || null };
 };
 
 /**
@@ -131,7 +128,7 @@ export function datesinDateRanges(def, date) {
         year = new Date(year.getTime() - (year.getTimezoneOffset() * 60000));
         dateArray.push(year);
       }
-    // Monthly layers
+      // Monthly layers
     } else if (def.period === 'monthly') {
       const maxMonthDate = new Date(maxYear, maxMonth + dateInterval, maxDay);
       if (currentDate >= minDate && currentDate <= maxMonthDate) {
@@ -142,7 +139,7 @@ export function datesinDateRanges(def, date) {
         month = new Date(month.getTime() - (month.getTimezoneOffset() * 60000));
         dateArray.push(month);
       }
-    // Daily layers
+      // Daily layers
     } else if (def.period === 'daily') {
       const maxDayDate = new Date(maxYear, maxMonth, maxDay + dateInterval);
       if (currentDate >= minDate && currentDate <= maxDayDate) {
@@ -155,7 +152,7 @@ export function datesinDateRanges(def, date) {
         day = new Date(day.getTime() - (day.getTimezoneOffset() * 60000));
         dateArray.push(day);
       }
-    // Subdaily layers
+      // Subdaily layers
     } else if (def.period === 'subdaily') {
       const maxHours = maxDate.getUTCHours();
       const maxMinutes = maxDate.getUTCMinutes();
@@ -300,7 +297,7 @@ export function dateOverlap(period, dateRanges) {
         previousEnd = new Date(
           previousEnd.setTime(
             previousEnd.getTime() +
-              (previous.dateInterval * 86400000 - 86400000)
+            (previous.dateInterval * 86400000 - 86400000)
           )
         );
       }


### PR DESCRIPTION
## Description
Depends on #2462
Fixes #1314

Don't update permalink before user does anything
- [x] Prevent layer state mutations

## Further comments
The `def.previousDate = someDate && def.nextDate = someDate` Code was mutating the redux state in the layer builder, causing the layer flag (`l`) in the permalink to update when a non-related action was fired. This PR attaches the previous and next date Info to the OL tileLayer object instead of our layers state object.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
