### PR TITLE
Prevent vector click/hover on non-active vector features in compare mode

### DIFF
--- a/web/js/modules/compare/util.js
+++ b/web/js/modules/compare/util.js
@@ -21,3 +21,28 @@ export function mapLocationToCompareState(parameters, stateFromLocation) {
   }
   return stateFromLocation;
 }
+/**
+ * Is layer on active side of Map while in swipe mode -
+ * No other modes will allow for running-data or vector interactions
+ * @param {Object} map | OL map object
+ * @param {Array} coords | Coordinates of hover point
+ * @param {Object} layerAttributes | Layer Properties
+ */
+export function isFromActiveCompareRegion(map, coords, layerAttributes, compareModel, swipeOffset) {
+  if (compareModel && compareModel.active) {
+    if (compareModel.mode !== 'swipe') {
+      return false;
+    } else {
+      if (compareModel.isCompareA) {
+        if (coords[0] > swipeOffset || layerAttributes.group !== 'active') {
+          return false;
+        }
+      } else {
+        if (coords[0] < swipeOffset || layerAttributes.group !== 'activeB') {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+};

--- a/web/js/modules/vector-styles/util.js
+++ b/web/js/modules/vector-styles/util.js
@@ -5,7 +5,7 @@ import {
 } from 'lodash';
 import { Stroke, Style, Fill, Circle } from 'ol/style';
 import { setStyleFunction } from './selectors';
-
+import { isFromActiveCompareRegion } from '../compare/util';
 export function getVectorStyleAttributeArray(layer) {
   var isCustomActive = false;
   var isMinActive = false;
@@ -138,7 +138,7 @@ export function getPaletteForStyle(layer, layerstyleLayerObject) {
     id: layer.id + '0_legend'
   }];
 }
-export function onMapClickGetVectorFeatures(pixels, map, state) {
+export function onMapClickGetVectorFeatures(pixels, map, state, swipeOffset) {
   const metaArray = [];
   const selected = {};
   const config = state.config;
@@ -167,6 +167,7 @@ export function onMapClickGetVectorFeatures(pixels, map, state) {
   map.forEachFeatureAtPixel(pixels, function(feature, layer) {
     const def = lodashGet(layer, 'wv.def');
     if (!def) return;
+    if (!isFromActiveCompareRegion(map, pixels, layer.wv, state.compare, swipeOffset)) return;
     if (def.vectorData && def.vectorData.id && def.title) {
       const layerId = def.id;
       if (!selected[layerId]) selected[layerId] = [];


### PR DESCRIPTION
## Description

Fixes #2465

Prevent vector click/hover on non-active vector features in compare mode
- [x] Can only click vector points in the swipe compare mode
- [x] can only click active side of map

## Further comments

Might make sense to make opacity mode clickable at certain  percents opacity (over 50%) in future?

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
