### PR TITLE
Only draw event markers and update track during deselectEvent if events tab is active

### DIFF
--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -309,8 +309,11 @@ export default function naturalEventsUI(ui, config, store, models) {
   self.deselectEvent = function() {
     self.selected = {};
     naturalEventMarkers.remove(self.markers);
-    self.markers = naturalEventMarkers.draw();
-    naturalEventsTrack.update(null);
+    const state = store.getState();
+    if (state.events.active) {
+      self.markers = naturalEventMarkers.draw();
+      naturalEventsTrack.update(null);
+    }
     store.dispatch(deselectEventAction);
     self.events.trigger('change');
   };


### PR DESCRIPTION
## Description

Fixes #2459  .

- [x] Only draw event markers and update track during `deselectEvent` if natural events tab is active

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
