### PR TITLE
Fix vector dialog

### DIFF
--- a/web/js/containers/map-interactions.js
+++ b/web/js/containers/map-interactions.js
@@ -93,6 +93,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(onClose());
   },
   openVectorDiaglog: (dialogId, metaArray, offsetLeft, offsetTop, isMobile) => {
+    const dialogKey = new Date().getUTCMilliseconds();
     dispatch(openCustomContent(dialogId,
       {
         backdrop: false,
@@ -104,7 +105,8 @@ const mapDispatchToProps = dispatch => ({
         CompletelyCustomModal: vectorDialog,
         isResizable: true,
         dragHandle: '.modal-header',
-        dialogKey: new Date().getUTCMilliseconds(),
+        dialogKey,
+        key: dialogKey,
         vectorMetaObject: lodashGroupBy(metaArray, 'id'),
         width: isMobile ? 250 : 445,
         height: 300,
@@ -150,7 +152,8 @@ MapInteractions.propTypes = {
   selectVectorFeatures: PropTypes.func.isRequired,
   compareState: PropTypes.object,
   isMobile: PropTypes.bool,
-  lastSelected: PropTypes.object
+  lastSelected: PropTypes.object,
+  swipeOffset: PropTypes.number
 };
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
## Description

Fixes #2477
When you click from a two tab dialog with the second tab selected to a one tab dialog, the app breaks

- [x] rerender vector-dialog container component on every change to dialog

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
