### PR TITLE
Don't render sidebar contents when sidebar is collapsed

### DIFF
--- a/e2e/features/compare/compare-test.js
+++ b/e2e/features/compare/compare-test.js
@@ -99,7 +99,7 @@ module.exports = {
       client.click(toggleButton);
       client.pause(100);
       client.expect.element(collapsedToggleButton).to.be.visible;
-      client.expect.element(toggleButton).to.not.be.visible;
+      client.waitForElementNotPresent(toggleButton, TIME_LIMIT);
       client.useCss().assert.containsText(collapsedToggleButton, 'Layers (6)');
       client.click(collapsedToggleButton);
       client.pause(100);

--- a/web/css/tooltip.css
+++ b/web/css/tooltip.css
@@ -1,3 +1,9 @@
+
+/* Bootstrap override */
+.tooltip {
+  z-index: 1040;
+}
+
 .wv-tooltip-case {
   display: inline-block;
   position: relative;

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -203,44 +203,48 @@ class Sidebar extends React.Component {
             }
             onWheel={wheelCallBack}
           >
-            <NavCase
-              activeTab={activeTab}
-              onTabClick={onTabClick}
-              tabTypes={tabTypes}
-              isMobile={isMobile}
-              toggleSidebar={this.toggleSidebar.bind(this)}
-              isCompareMode={isCompareMode}
-              isDataDisabled={isDataDisabled}
-            />
-            <TabContent activeTab={activeTab}>
-              <TabPane tabId="layers">
-                {this.getProductsToRender(activeTab, isCompareMode)}
-              </TabPane>
-              <TabPane tabId="events">
-                {naturalEventsFeatureActive
-                  ? <Events
-                    isActive={activeTab === 'events'}
-                    height={subComponentHeight}
-                  />
-                  : null
-                }
-              </TabPane>
-              <TabPane tabId="download">
-                {dataDownloadFeatureActive
-                  ? <Data
-                    isActive={activeTab === 'download'}
-                    height={subComponentHeight}
-                    tabTypes={tabTypes}
-                  />
-                  : null
-                }
-              </TabPane>
-              <footer
-                ref={footerElement => (this.footerElement = footerElement)}
-              >
-                <FooterContent tabTypes={tabTypes} activeTab={activeTab} />
-              </footer>
-            </TabContent>
+            {!isCollapsed && (
+              <>
+                <NavCase
+                  activeTab={activeTab}
+                  onTabClick={onTabClick}
+                  tabTypes={tabTypes}
+                  isMobile={isMobile}
+                  toggleSidebar={this.toggleSidebar.bind(this)}
+                  isCompareMode={isCompareMode}
+                  isDataDisabled={isDataDisabled}
+                />
+                <TabContent activeTab={activeTab}>
+                  <TabPane tabId="layers">
+                    {this.getProductsToRender(activeTab, isCompareMode)}
+                  </TabPane>
+                  <TabPane tabId="events">
+                    {naturalEventsFeatureActive
+                      ? <Events
+                        isActive={activeTab === 'events'}
+                        height={subComponentHeight}
+                      />
+                      : null
+                    }
+                  </TabPane>
+                  <TabPane tabId="download">
+                    {dataDownloadFeatureActive
+                      ? <Data
+                        isActive={activeTab === 'download'}
+                        height={subComponentHeight}
+                        tabTypes={tabTypes}
+                      />
+                      : null
+                    }
+                  </TabPane>
+                  <footer
+                    ref={footerElement => (this.footerElement = footerElement)}
+                  >
+                    <FooterContent tabTypes={tabTypes} activeTab={activeTab} />
+                  </footer>
+                </TabContent>
+              </>
+            )}
           </div>
         </section>
       </ErrorBoundary>


### PR DESCRIPTION
## Description

Fixes #2480.

* fixes an issue where tooltips show when the sidebar was collapsed by not rendering sidebar contents at all when the sidebar is collapsed.  
* also fixes issue where tooltip shows above vector dialogs


