### PR TITLE
v3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## New Features
- Vector layers in Worldview! (SEDAC Reservoirs, SEDAC Dams and SEDAC Nuclear power plants layers) #2420
- Orbit tracks can now be added through the layer settings panel! #2428 

## New Tour Stories
- Dust storm story #2163, #2427

## Layer Updates
- Added SEDAC Vector layers #2420
- Added 4 WELD layers #2426
- Remove WELD v15 Alaska/CONUS layers #2457
- Changed OMPS AI product #2458
- Removed WELD Tree cover #2473

## Technical Updates / Bug Fixes
- Updated CSS to prevent event title wrapping #2315 
- Made animation panel draggable, collapsable #2322
- Updated chromedriver #2323
- Upgraded simplebar #2333
- Removed unused dependencies #2334
- Upgraded Core JS #2349
- Supercluster updated from 3.0.2 to 6.0.2 #2351
- Fixed imagery not loading after build date #2361
- Fixed production build #2375
- Fixed product picker scrolling to top on row expand #2384
- Fixed data-download endless loop on data tab click #2391
- Fixed animation dragger range selection to allow subdaily time units #2393
- Fixed anim playback hangs #2413
- Fixed threshold #2422
- Default to geographic selected projection if not specified for location pop action #2424
- Snap layer times to previous available dates to prevent unnecessary network requests #2432
- Fix drag/drop layers #2436
- Only try to show running data values for active compare mode #2440
- Fix running data tooltip in compare mode #2443
- Remove min height and width to allow looser image selection area, remove adjacent unused code #2448
- Preload sub-daily layers for animation #2450
- Make vector dialog more responsive #2451
- Added VIIRS Clear Sky Night  #2455
- Fix e2e tests sit #2456
- Conditionally use default date for animations rather then time snapping #2462
- Don't update permalink before user interacts with page bug #2467 
- Increase available zoom levels for arctic projection #2470 
- Prevent vector click/hover on non-active vector features in compare mode #2471 
- Only draw event markers and update track during deselectEvent if events tab is active #2474
- Apply vector selected style to swipe compare features #2475
- Fix vector dialog  bug #2478 
- Don't render sidebar contents when sidebar is collapsed #2481
- Don't show tooltips when target is not visible in sidebar scroll container #2482 

## Update Dependencies
- Bump stylelint from 10.1.0 to 11.1.1 #2326
- Bump postcss-loader from 2.1.6 to 3.0.0 #2327
- Bump react-redux from 6.0.1 to 7.1.1 #2329
- Bump react-draggable from 4.0.3 to 4.1.0 #2337
- Bump eslint from 6.5.1 to 6.6.0 #2338
- Bump fetch-mock from 7.5.1 to 7.7.0 #2342
- Bump yargs from 11.1.1 to 14.2.0 #2344
- Bump proj4 from 2.3.3 to 2.5.0 #2345
- Bump react from 16.9.0 to 16.11.0 #2346
- Bump eslint-plugin-jest from 22.20.0 to 23.0.2 #2350
- Bump uglify-js from 3.6.4 to 3.6.5 #2352
- Bump node-sass from 4.12.0 to 4.13.0 #2353
- Bump mini-css-extract-plugin from 0.4.5 to 0.8.0 #2354
- Bump webpack-cli from 3.3.9 to 3.3.10 #2362
- Bump core-js from 3.3.4 to 3.3.6 #2366
- Bump postcss-url from 7.3.2 to 8.0.0 #2367
- Bump chromedriver from 77.0.0 to 78.0.1 #2368
- Bump geckodriver from 1.19.0 to 1.19.1 #2369
- Bump file-saver from 1.3.8 to 2.0.2 #2370
- Bump react-beautiful-dnd from 11.0.5 to 12.0.0 #2372
- Bump @babel/preset-react from 7.6.3 to 7.7.0 #2380
- Bump showdown from 1.9.0 to 1.9.1 #2382
- Bump fetch-mock from 7.7.0 to 7.7.3 #2387
- Bump @babel/core from 7.6.4 to 7.7.2 #2394
- Bump simplebar-react from 2.0.4 to 2.0.8 #2397
- Bump web-streams-polyfill from 1.3.2 to 2.0.6 #2398
- Bump @babel/plugin-proposal-class-properties from 7.5.5 to 7.7.0 #2401
- Bump glob from 7.1.5 to 7.1.6 #2402
- Bump react-redux from 7.1.1 to 7.1.3 #2403
- Bump uglify-js from 3.6.5 to 3.6.9 #2410
