### PR TITLE
Use concurrency in build for colormaps

### DIFF
--- a/tasks/buildOptions.sh
+++ b/tasks/buildOptions.sh
@@ -68,7 +68,7 @@ fi
 # Run extractConfigFromWMTS.py script with config.json
 if [ -e "$BUILD_DIR/config.json" ] ; then
     "$PYTHON_SCRIPTS_DIR/extractConfigFromWMTS.py" "$BUILD_DIR/config.json" "$BUILD_DIR/gc" \
-        "$BUILD_DIR/_wmts" "$BUILD_DIR/colormaps"
+        "$BUILD_DIR/_wmts"
 fi
 
 # # Run processVectorStyles.py and move vectorstyles where we want them

--- a/tasks/python3/extractConfigFromWMTS.py
+++ b/tasks/python3/extractConfigFromWMTS.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from datetime import datetime, date, timedelta
 import json
 from optparse import OptionParser
@@ -17,18 +18,17 @@ help_description = """\
 Extracts configuration information from a WMTS GetCapabilities file.
 """
 
-parser = OptionParser(usage="Usage: %s <config_file> <input_dir> <output_dir> <colormaps_dir>" % prog,
+parser = OptionParser(usage="Usage: %s <config_file> <input_dir> <output_dir>" % prog,
                       version="%s version %s" % (prog, version),
                       epilog=help_description)
 (options, args) = parser.parse_args()
 
-if len(args) != 4:
+if len(args) != 3:
     parser.error("Invalid number of arguments")
 
 config_file = args[0]
 input_dir = args[1]
 output_dir = args[2]
-colormaps_dir = args[3]
 
 with open(config_file) as fp:
     config = json.load(fp)
@@ -57,7 +57,7 @@ json_options["separators"] = (',', ': ')
 class SkipException(Exception):
     pass
 
-def process_layer(gc_layer, wv_layers, colormaps):
+def process_layer(gc_layer, wv_layers):
     ident = gc_layer["ows:Identifier"]
     if ident in skip:
         print("%s: skipping" % ident)
@@ -141,7 +141,7 @@ def process_layer(gc_layer, wv_layers, colormaps):
                         "id": vectorstyle_id
                     }
 
-def process_entry(entry, colormaps):
+def process_entry(entry):
     layer_count = 0
     warning_count = 0
     error_count = 0
@@ -184,7 +184,7 @@ def process_entry(entry, colormaps):
         ident = gc_layer["ows:Identifier"]
         try:
             layer_count += 1
-            process_layer(gc_layer, wv_layers, colormaps)
+            process_layer(gc_layer, wv_layers)
         except SkipException as se:
             warning_count += 1
             sys.stderr.write("%s: WARNING: [%s] Skipping\n" % (prog, ident))
@@ -197,7 +197,7 @@ def process_entry(entry, colormaps):
             ident = gc_layer["ows:Identifier"]
             try:
                 layer_count += 1
-                process_layer(gc_layer, wv_layers, colormaps)
+                process_layer(gc_layer, wv_layers)
             except SkipException as se:
                 warning_count += 1
                 sys.stderr.write("%s: WARNING: [%s] Skipping\n" % (prog, id))
@@ -250,15 +250,14 @@ def process_entry(entry, colormaps):
 
 
 # Main
-colormaps = {}
 for entry in entries:
-    error_count, warning_count, layer_count = process_entry(entry, colormaps)
+    error_count, warning_count, layer_count = process_entry(entry)
     total_error_count += error_count
     total_warning_count += warning_count
     total_layer_count += layer_count
 
 print("%s: %d error(s), %d warning(s), %d layers" % (prog, total_error_count,
-        total_warning_count, total_layer_count))
+    total_warning_count, total_layer_count))
 
 if total_error_count > 0:
     sys.exit(1)

--- a/tasks/python3/getCapabilities.py
+++ b/tasks/python3/getCapabilities.py
@@ -2,7 +2,6 @@
 
 from concurrent.futures import ThreadPoolExecutor
 from optparse import OptionParser
-from datetime import datetime
 from collections import OrderedDict
 import os
 import sys
@@ -136,7 +135,7 @@ def process_colormaps():
     sys.stdout.flush()
     if not os.path.exists(colormaps_dir):
         os.makedirs(colormaps_dir)
-    with ThreadPoolExecutor(max_workers=20) as executor:
+    with ThreadPoolExecutor() as executor:
         for link in colormaps.values():
             executor.submit(process_single_colormap, link)
 
@@ -182,7 +181,7 @@ def process_vectordata():
 
 tolerant = config.get("tolerant", False)
 if "wv-options-fetch" in config:
-    with ThreadPoolExecutor(max_workers=3) as executor:
+    with ThreadPoolExecutor() as executor:
         for entry in config["wv-options-fetch"]:
             try:
                 remote_count += 1

--- a/tasks/python3/getCapabilities.py
+++ b/tasks/python3/getCapabilities.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from concurrent.futures import as_completed, wait, ThreadPoolExecutor
-from requests_futures.sessions import FuturesSession
+from concurrent.futures import ThreadPoolExecutor
 from optparse import OptionParser
 from datetime import datetime
 from collections import OrderedDict
@@ -117,26 +116,29 @@ def process_remote(entry):
         print(('error: %s: %s' % (url, str(e))))
         print((str(traceback.format_exc())))
 
+# Fetch a single colormap and write to file
+def process_single_colormap(link):
+    try:
+        response = http.request("GET", link)
+        contents = response.data
+        output_file = os.path.join(colormaps_dir, os.path.basename(link))
+        with open(output_file, "w") as fp:
+            fp.write(contents.decode('utf-8'))
+    except Exception as e:
+        sys.stderr.write("%s:   WARN: Unable to fetch %s: %s\n" %
+            (prog, link, str(e)))
+        global warning_count
+        warning_count += 1
+
 # Fetch every colormap from the API and write response to file system
 def process_colormaps():
     print("%s: Fetching %d colormaps..." % (prog, len(colormaps)))
     sys.stdout.flush()
     if not os.path.exists(colormaps_dir):
         os.makedirs(colormaps_dir)
-    with FuturesSession(max_workers=100) as fs:
-        futures = { fs.get(link):link for link in colormaps.values() }
-        for future in as_completed(futures):
-            fileName = futures[future]
-            try:
-                data = future.result()
-                output_file = os.path.join(colormaps_dir, os.path.basename(fileName))
-                with open(output_file, "w") as fp:
-                    fp.write(data.text)
-            except Exception as e:
-                sys.stderr.write("%s:   WARN: Unable to fetch %s: %s\n" %
-                    (prog, link, str(e)))
-                global warning_count
-                warning_count += 1
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        for link in colormaps.values():
+            executor.submit(process_single_colormap, link)
 
 # Fetch every vectorstyle from the API and write response to file system
 def process_vectorstyles():
@@ -180,20 +182,18 @@ def process_vectordata():
 
 tolerant = config.get("tolerant", False)
 if "wv-options-fetch" in config:
-    executor = ThreadPoolExecutor(3)
-    gc_futures = []
-    for entry in config["wv-options-fetch"]:
-        try:
-            remote_count += 1
-            gc_futures.append(executor.submit(process_remote, entry))
-        except Exception as e:
-            if tolerant:
-                warning_count += 1
-                sys.stderr.write("%s:   WARN: %s\n" % (prog, str(e)))
-            else:
-                error_count += 1
-                sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
-    wait(gc_futures)
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        for entry in config["wv-options-fetch"]:
+            try:
+                remote_count += 1
+                executor.submit(process_remote, entry)
+            except Exception as e:
+                if tolerant:
+                    warning_count += 1
+                    sys.stderr.write("%s:   WARN: %s\n" % (prog, str(e)))
+                else:
+                    error_count += 1
+                    sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
     if colormaps:
         process_colormaps()
     if vectorstyles:

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from concurrent.futures import  ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from optparse import OptionParser
 import os
 import re
@@ -180,12 +180,12 @@ file_count = 0
 error_count = 0
 futures = []
 
-with ProcessPoolExecutor(max_workers=100) as readExecutor:
+with ProcessPoolExecutor() as readExecutor:
     for root, dirs, files in os.walk(input_dir):
         for file in files:
             input_file = os.path.join(root, file)
             futures.append(readExecutor.submit(read_file, input_file))
-with ProcessPoolExecutor(max_workers=100) as writeExecutor:
+with ProcessPoolExecutor() as writeExecutor:
     for future in futures:
         try:
             file_count += 1

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from concurrent.futures import  ProcessPoolExecutor
 from optparse import OptionParser
 import os
 import re
@@ -133,16 +134,16 @@ def process_entries(colormap):
 
     return result
 
-def process_file(file):
-    input_file = os.path.join(root, file)
-    id = os.path.splitext(os.path.basename(input_file))[0]
+def read_file(file):
+    id = os.path.splitext(os.path.basename(file))[0]
     if id in skips:
-        sys.stderr.write("%s:  WARN: [%s] %s\n" % (prog, input_file,
-                "Skipping"))
+        sys.stderr.write("%s:  WARN: [%s] %s\n" % (prog, file), "Skipping")
         return
-
-    with open(input_file) as fp:
+    with open(file) as fp:
         xml = fp.read()
+    return (id, xml)
+
+def process_file(id, xml):
     document = xmltodict.parse(xml)
     colormaps = to_list(document["ColorMaps"]["ColorMap"])
     maps = []
@@ -177,15 +178,22 @@ def process_file(file):
 # Main
 file_count = 0
 error_count = 0
+futures = []
 
-for root, dirs, files in os.walk(input_dir):
-    for file in files:
+with ProcessPoolExecutor(max_workers=100) as readExecutor:
+    for root, dirs, files in os.walk(input_dir):
+        for file in files:
+            input_file = os.path.join(root, file)
+            futures.append(readExecutor.submit(read_file, input_file))
+with ProcessPoolExecutor(max_workers=100) as writeExecutor:
+    for future in futures:
         try:
             file_count += 1
-            process_file(file)
+            (id, xml) = future.result()
+            writeExecutor.submit(process_file, id, xml)
         except Exception as e:
-            sys.stderr.write("%s: ERROR: [%s] %s\n" % (prog, file, str(e)))
-            error_count += 1
+                sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
+                error_count += 1
 
 print("%s: %d error(s), %d file(s)" % (prog, error_count, file_count))
 

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -192,7 +192,7 @@ with ProcessPoolExecutor() as writeExecutor:
             (id, xml) = future.result()
             writeExecutor.submit(process_file, id, xml)
         except Exception as e:
-            sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
+            sys.stderr.write("%s: ERROR: [%s] %s\n" % (prog, id, str(e)))
             error_count += 1
 
 print("%s: %d error(s), %d file(s)" % (prog, error_count, file_count))

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -172,6 +172,7 @@ def process_file(id, xml):
     json_options["separators"] = (',', ': ')
 
     output_file = os.path.join(output_dir, id + ".json")
+    # print('I YIELD M\'LORD!!!', id)
     with open(output_file, "w") as fp:
         json.dump(data, fp, **json_options)
 
@@ -192,8 +193,8 @@ with ProcessPoolExecutor() as writeExecutor:
             (id, xml) = future.result()
             writeExecutor.submit(process_file, id, xml)
         except Exception as e:
-                sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
-                error_count += 1
+            sys.stderr.write("%s: ERROR: %s\n" % (prog, str(e)))
+            error_count += 1
 
 print("%s: %d error(s), %d file(s)" % (prog, error_count, file_count))
 

--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -172,7 +172,6 @@ def process_file(id, xml):
     json_options["separators"] = (',', ': ')
 
     output_file = os.path.join(output_dir, id + ".json")
-    # print('I YIELD M\'LORD!!!', id)
     with open(output_file, "w") as fp:
         json.dump(data, fp, **json_options)
 


### PR DESCRIPTION
## Description
Fetches, reads and writes colormaps concurrently in order to speed up the build process.  Some rough testing shows build time reduced by ~30 sec.

Fixes #2498.