### PR TITLE
Change width of palette canvas when zot is active 

### DIFF
--- a/web/css/palettes.css
+++ b/web/css/palettes.css
@@ -169,7 +169,6 @@
 }
 
 .wv-palettes-colorbar {
-  width: 231px;
   height: 24px;
   margin-bottom: 13px;
   max-width: 231px;

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -266,6 +266,7 @@ class PaletteLegend extends React.Component {
             id={layer.id + '-' + legend.id + index + 'colorbar'}
             width={width}
             height={24}
+            style={{ width: width }}
             ref={this['canvas_' + index]}
             onMouseEnter={!isMobile ? this.onMouseEnter.bind(this) : null}
             onMouseLeave={!isMobile ? this.hideValue.bind(this) : null}
@@ -335,7 +336,7 @@ class PaletteLegend extends React.Component {
         containment={scrollContainerEl}
         partialVisibility={true}
       >
-        { ({ isVisible }) => (
+        {({ isVisible }) => (
           <div className={legendClass} key={legend.id + '_' + legendIndex}>
             {legend.colors.map((color, keyIndex) => {
               const isActiveKey = activeKeyObj && activeKeyObj.index === keyIndex;

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -53,7 +53,8 @@ class Layer extends React.Component {
       requestPalette,
       isCustomPalette,
       isLoading,
-      isMobile
+      isMobile,
+      zot
     } = this.props;
     if (!lodashIsEmpty(renderedPalette)) {
       const isRunningData = compare.active
@@ -66,6 +67,7 @@ class Layer extends React.Component {
           layerGroupName={layerGroupName}
           paletteId={palette.id}
           getPalette={getPalette}
+          width={zot ? 220 : 231}
           paletteLegends={paletteLegends}
           isCustomPalette={isCustomPalette}
           isRunningData={isRunningData}


### PR DESCRIPTION
## Description

Fixes #2321

Width of palette canvas overflows layer-list when `zot` is present
- [x] shorten width of palette canvas when zot is active   

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
