### PR TITLE
Image Download: Disable Worldfile when KMZ file type is selected

### DIFF
--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -57,7 +57,7 @@ export default class ImageResSelection extends React.Component {
       { width, height },
       time,
       fileType,
-      isWorldfile
+      fileType === 'application/vnd.google-earth.kmz' ? false : isWorldfile
     );
 
     if (url) {
@@ -119,10 +119,9 @@ export default class ImageResSelection extends React.Component {
   _renderWorldfileSelect() {
     if (this.props.worldFileOptions) {
       const value = this.state.isWorldfile ? 1 : 0;
-
       return (
         <div className="wv-image-header">
-          {this.state.fileType === 'image/kmz' ? (
+          {this.state.fileType === 'application/vnd.google-earth.kmz' ? (
             <select disabled>
               <option value={0}>No</option>
             </select>


### PR DESCRIPTION
## Description

Fixes #1854

- [x] Disable Worldfile when KMZ file type is selected
- [x] Make sure worldfile is not part of requested when downloading KMZ


## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
