### PR TITLE
Wrap vector layers at dateline

### DIFF
--- a/config/default/common/config/wv.json/layers/sedac/GRanD_Dams.json
+++ b/config/default/common/config/wv.json/layers/sedac/GRanD_Dams.json
@@ -15,6 +15,7 @@
             "vectorStyle": {
                 "id": "GRanD_Dams"
             },
+            "wrapX": true,
             "palette": {
                 "id": "GRanD_Dams",
                 "immutable": true,

--- a/config/default/common/config/wv.json/layers/sedac/GRanD_Reservoirs.json
+++ b/config/default/common/config/wv.json/layers/sedac/GRanD_Reservoirs.json
@@ -18,7 +18,8 @@
             "palette": {
                 "id": "GRanD_Reservoirs",
                 "immutable": true
-            }
+            },
+            "wrapX": true
         }
     }
 }

--- a/config/default/common/config/wv.json/layers/sedac/Nuclear_Power_Plant_Locations.json
+++ b/config/default/common/config/wv.json/layers/sedac/Nuclear_Power_Plant_Locations.json
@@ -18,7 +18,8 @@
             },
             "vectorStyle": {
                 "id": "Nuclear_Power_Plant_Locations"
-            }
+            },
+            "wrapX": true
         }
     }
 }

--- a/web/js/containers/map-interactions.js
+++ b/web/js/containers/map-interactions.js
@@ -57,7 +57,7 @@ export class MapInteractions extends React.Component {
     const hasFeatures = map.hasFeatureAtPixel(pixels);
     if (hasFeatures && !isShowingClick && !measureIsActive) {
       let isActiveLayer = false;
-      map.forEachFeatureAtPixel(pixels, function (feature, layer) {
+      map.forEachFeatureAtPixel(pixels, function(feature, layer) {
         if (!layer) {
           return;
         }

--- a/web/js/containers/map-interactions.js
+++ b/web/js/containers/map-interactions.js
@@ -51,13 +51,13 @@ export class MapInteractions extends React.Component {
     const coord = map.getCoordinateFromPixel(pixels);
     const { isShowingClick, changeCursor, measureIsActive, compareState, swipeOffset } = this.props;
     const [lon, lat] = coord;
-    if (lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+    if (lon < -250 || lon > 250 || lat < -90 || lat > 90) {
       return;
     }
     const hasFeatures = map.hasFeatureAtPixel(pixels);
     if (hasFeatures && !isShowingClick && !measureIsActive) {
       let isActiveLayer = false;
-      map.forEachFeatureAtPixel(pixels, function(feature, layer) {
+      map.forEachFeatureAtPixel(pixels, function (feature, layer) {
         if (!layer) {
           return;
         }

--- a/web/js/containers/map-interactions.js
+++ b/web/js/containers/map-interactions.js
@@ -6,7 +6,7 @@ import vectorDialog from './vector-dialog';
 import { onMapClickGetVectorFeatures } from '../modules/vector-styles/util';
 import { openCustomContent, onClose } from '../modules/modal/actions';
 import { selectVectorFeatures } from '../modules/vector-styles/actions';
-import { groupBy as lodashGroupBy, debounce as lodashDebounce } from 'lodash';
+import { groupBy as lodashGroupBy, debounce as lodashDebounce, get as lodashGet } from 'lodash';
 import { changeCursor } from '../modules/map/actions';
 import { isFromActiveCompareRegion } from '../modules/compare/util';
 
@@ -49,7 +49,7 @@ export class MapInteractions extends React.Component {
   mouseMove(event, map, crs) {
     const pixels = map.getEventPixel(event);
     const coord = map.getCoordinateFromPixel(pixels);
-    const { isShowingClick, changeCursor, measureIsActive, compareState, swipeOffset } = this.props;
+    const { isShowingClick, changeCursor, measureIsActive, compareState, swipeOffset, proj } = this.props;
     const [lon, lat] = coord;
     if (lon < -250 || lon > 250 || lat < -90 || lat > 90) {
       return;
@@ -58,10 +58,11 @@ export class MapInteractions extends React.Component {
     if (hasFeatures && !isShowingClick && !measureIsActive) {
       let isActiveLayer = false;
       map.forEachFeatureAtPixel(pixels, function(feature, layer) {
-        if (!layer) {
-          return;
-        }
-        if (isFromActiveCompareRegion(map, pixels, layer.wv, compareState, swipeOffset)) {
+        const def = lodashGet(layer, 'wv.def');
+        if (!def) return;
+        const isWrapped = proj.id === 'geographic' && (def.wrapadjacentdays || def.wrapX);
+        const isRenderedFeature = isWrapped ? (lon > -250 || lon < 250 || lat > -90 || lat < 90) : true;
+        if (isRenderedFeature && isFromActiveCompareRegion(map, pixels, layer.wv, compareState, swipeOffset)) {
           isActiveLayer = true;
         }
       });
@@ -126,7 +127,7 @@ const mapDispatchToProps = dispatch => ({
   }
 });
 function mapStateToProps(state) {
-  const { modal, map, measure, vectorStyles, browser, compare } = state;
+  const { modal, map, measure, vectorStyles, browser, compare, proj } = state;
   let swipeOffset;
   if (compare.active && compare.mode === 'swipe') {
     const percentOffset = state.compare.value || 50;
@@ -140,7 +141,8 @@ function mapStateToProps(state) {
     measureIsActive: measure.isActive,
     isMobile: browser.lessThan.medium,
     compareState: compare,
-    swipeOffset
+    swipeOffset,
+    proj
   };
 }
 MapInteractions.propTypes = {
@@ -156,6 +158,7 @@ MapInteractions.propTypes = {
   compareState: PropTypes.object,
   isMobile: PropTypes.bool,
   lastSelected: PropTypes.object,
+  proj: PropTypes.object,
   swipeOffset: PropTypes.number
 };
 export default connect(

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -31,7 +31,7 @@ import {
 export function mapLayerBuilder(models, config, cache, ui, store) {
   const self = {};
 
-  self.init = function () {
+  self.init = function() {
     self.extentLayers = [];
   };
 
@@ -83,7 +83,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param {object} options - Layer options
    * @returns {object} OpenLayers layer
    */
-  self.createLayer = function (def, options) {
+  self.createLayer = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     options = options || {};
@@ -143,7 +143,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param  {object} options Layer options
    * @return {object}         Closest date
    */
-  self.getRequestDates = function (def, options) {
+  self.getRequestDates = function(def, options) {
     const state = store.getState();
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     const stateCurrentDate = new Date(state.date[activeDateStr]);
@@ -203,7 +203,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param {boolean} precache
    * @returns {object} layer key Object
    */
-  self.layerKey = function (def, options, state) {
+  self.layerKey = function(def, options, state) {
     const { compare } = state;
     var date;
     var layerId = def.id;
@@ -291,7 +291,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param {object} options - Layer options
    * @returns {object} OpenLayers WMTS layer
    */
-  const createLayerWMTS = function (def, options, day, state) {
+  const createLayerWMTS = function(def, options, day, state) {
     const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
     const proj = state.proj.selected;
     const source = config.sources[def.source];
@@ -354,9 +354,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param {object} options - Layer options
    * @returns {object} OpenLayers Vector layer
    */
-  const createLayerVector = function (def, options, day, state) {
+  const createLayerVector = function(def, options, day, state) {
     const { proj, compare } = state;
-    let date, urlParameters, gridExtent, source, matrixSet, matrixIds, start, layerExtent;
+    var date, urlParameters, gridExtent, source, matrixSet, matrixIds, start, layerExtent;
     const selectedProj = proj.selected;
     const activeDateStr = compare.isCompareA ? 'selected' : 'selectedB';
     const activeGroupStr = options.group ? options.group : compare.activeString;
@@ -375,7 +375,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     }
     if (typeof def.matrixIds === 'undefined') {
       matrixIds = [];
-      lodashEach(matrixSet.resolutions, function (resolution, index) {
+      lodashEach(matrixSet.resolutions, function(resolution, index) {
         matrixIds.push(index);
       });
     } else {
@@ -465,7 +465,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
    * @param {object} options - Layer options
    * @returns {object} OpenLayers WMS layer
    */
-  const createLayerWMS = function (def, options, day, state) {
+  const createLayerWMS = function(def, options, day, state) {
     const { proj, compare } = state;
     const activeDateStr = compare.isCompareA ? 'selected' : 'selectedB';
     const selectedProj = proj.selected;

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -450,8 +450,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
           }
         });
       }
-      setStyleFunction(def, vectorStyleId, vectorStyles, layer, state, day);
-      if (day) { }
+      setStyleFunction(def, vectorStyleId, vectorStyles, layer, state);
     }
 
     return layer;

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -53,7 +53,6 @@ export function MapRunningData(models, compareUi, store) {
       const def = lodashGet(layer, 'wv.def');
       if (!def) return;
       const isWrapped = proj.id === 'geographic' && (def.wrapadjacentdays || def.wrapX);
-      console.log(isWrapped);
       const isRenderedFeature = isWrapped ? (lon > -250 || lon < 250 || lat > -90 || lat < 90) : true;
       if (!isRenderedFeature || !isFromActiveCompareRegion(map, pixels, layer.wv, state.compare, swipeOffset)) return;
       let color;

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -41,6 +41,7 @@ export function MapRunningData(models, compareUi, store) {
    */
   self.newPoint = function(pixels, map) {
     const state = store.getState();
+    const proj = state.proj;
     const activeLayerObj = {};
     const [lon, lat] = map.getCoordinateFromPixel(pixels);
     let swipeOffset;
@@ -48,33 +49,36 @@ export function MapRunningData(models, compareUi, store) {
       swipeOffset = Math.floor(compareUi.getOffset());
     }
 
-    if (!(lon < -180 || lon > 180 || lat < -90 || lat > 90)) {
-      map.forEachFeatureAtPixel(pixels, (feature, layer) => {
-        const def = lodashGet(layer, 'wv.def');
-        if (!def || !isFromActiveCompareRegion(map, pixels, layer.wv, state.compare, swipeOffset)) return;
-        let color;
-        const identifier = def.palette.styleProperty;
-        const layerId = def.id;
-        const paletteLegends = getPalette(layerId, undefined, undefined, state);
-        const legend = paletteLegends.legend;
+    map.forEachFeatureAtPixel(pixels, (feature, layer) => {
+      const def = lodashGet(layer, 'wv.def');
+      if (!def) return;
+      const isWrapped = proj.id === 'geographic' && (def.wrapadjacentdays || def.wrapX);
+      console.log(isWrapped);
+      const isRenderedFeature = isWrapped ? (lon > -250 || lon < 250 || lat > -90 || lat < 90) : true;
+      if (!isRenderedFeature || !isFromActiveCompareRegion(map, pixels, layer.wv, state.compare, swipeOffset)) return;
+      let color;
+      const identifier = def.palette.styleProperty;
+      const layerId = def.id;
+      const paletteLegends = getPalette(layerId, undefined, undefined, state);
+      const legend = paletteLegends.legend;
 
-        if (!identifier && legend.colors.length > 1) return;
-        if (identifier) {
-          const properties = feature.getProperties();
-          const value = properties[identifier] || def.palette.unclassified;
-          if (!value) return;
-          const tooltips = legend.tooltips.map(c => c.toLowerCase().replace(/\s/g, ''));
-          const colorIndex = tooltips.indexOf(value.toLowerCase().replace(/\s/g, ''));
-          color = legend.colors[colorIndex];
-        } else if (legend.colors.length === 1) {
-          color = legend.colors[0];
-        }
-        activeLayerObj[layerId] = {
-          paletteLegends,
-          paletteHex: color
-        };
-      });
-    }
+      if (!identifier && legend.colors.length > 1) return;
+      if (identifier) {
+        const properties = feature.getProperties();
+        const value = properties[identifier] || def.palette.unclassified;
+        if (!value) return;
+        const tooltips = legend.tooltips.map(c => c.toLowerCase().replace(/\s/g, ''));
+        const colorIndex = tooltips.indexOf(value.toLowerCase().replace(/\s/g, ''));
+        color = legend.colors[colorIndex];
+      } else if (legend.colors.length === 1) {
+        color = legend.colors[0];
+      }
+      activeLayerObj[layerId] = {
+        paletteLegends,
+        paletteHex: color
+      };
+    });
+
     map.forEachLayerAtPixel(pixels, function(layer, data) {
       if (!layer.wv) return;
       const { def } = layer.wv;

--- a/web/js/modules/vector-styles/selectors.js
+++ b/web/js/modules/vector-styles/selectors.js
@@ -54,7 +54,7 @@ export function findIndex(layerId, type, value, index, groupStr, state) {
   index = index || 0;
   var values = getVectorStyle(layerId, index, groupStr, state).entries.values;
   var result;
-  lodashEach(values, function (check, index) {
+  lodashEach(values, function(check, index) {
     var min = getMinValue(check);
     var max = getMaxValue(check);
     if (type === 'min' && value === min) {
@@ -101,7 +101,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
               : null;
       }
     }
-    lodashEach(activeLayers, function (def) {
+    lodashEach(activeLayers, function(def) {
       if (state.compare && state.compare.active) {
         if (layerGroup && layerGroup.getLayers().getArray().length) {
           lodashEach(layerGroup.getLayers().getArray(), subLayer => {
@@ -119,7 +119,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
       }
     });
   }
-  let layerArray = layer.getLayers ? layer.getLayers().getArray() : [layer]
+  const layerArray = layer.getLayers ? layer.getLayers().getArray() : [layer];
   lodashEach(layerArray, layerInLayerGroup => {
     // Apply mapbox-gl styles
     const extentStartX = layerInLayerGroup.getExtent()[0];
@@ -129,14 +129,14 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
     // Filter Orbit Tracks
     if (glStyle.name === 'Orbit Tracks') {
       // Filter time by 5 mins
-      layerInLayerGroup.setStyle(function (feature, resolution) {
+      layerInLayerGroup.setStyle(function(feature, resolution) {
         var minute;
         var minutes = feature.get('label');
         if (minutes) {
           minute = minutes.split(':');
         }
-        if (((minute && minute[1] % 5 === 0) || feature.getType() === 'LineString')
-          && shouldRenderFeature(feature, acceptableExtent)) {
+        if (((minute && minute[1] % 5 === 0) || feature.getType() === 'LineString') &&
+          shouldRenderFeature(feature, acceptableExtent)) {
           return styleFunction(feature, resolution);
         }
       });
@@ -144,7 +144,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
       ((selected[layerId] && selected[layerId].length))) {
       const selectedFeatures = selected[layerId];
 
-      layerInLayerGroup.setStyle(function (feature, resolution) {
+      layerInLayerGroup.setStyle(function(feature, resolution) {
         const data = state.config.vectorData[def.vectorData.id];
         const properties = data.mvt_properties;
         const features = feature.getProperties();
@@ -159,7 +159,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
         }
       });
     } else if (acceptableExtent) {
-      layerInLayerGroup.setStyle(function (feature, resolution) {
+      layerInLayerGroup.setStyle(function(feature, resolution) {
         if (shouldRenderFeature(feature, acceptableExtent)) {
           return styleFunction(feature, resolution);
         }
@@ -173,8 +173,7 @@ const shouldRenderFeature = (feature, acceptableExtent) => {
   const midpoint = feature.getFlatCoordinates();
   if (containsCoordinate(acceptableExtent, midpoint)) return true;
   return false;
-
-}
+};
 export function getKey(layerId, groupStr, state) {
   groupStr = groupStr || state.compare.activeString;
   if (!isActive(layerId, groupStr, state)) {
@@ -215,7 +214,7 @@ export function clearStyleFunction(def, vectorStyleId, vectorStyles, layer, stat
   styleFunction = stylefunction(layer, glStyle, vectorStyleId);
   if (glStyle.name === 'Orbit Tracks') {
     // Filter time by 5 mins
-    layer.setStyle(function (feature, resolution) {
+    layer.setStyle(function(feature, resolution) {
       var minute;
       var minutes = feature.get('label');
       if (minutes) {


### PR DESCRIPTION
## Description

Fixes #2511

- [x] Add vector wrapping capability
- [x] Apply `wrapX:true` to vector layers

## Further comments ✅ 
It was necessary to override the style function of wrapped layers to ensure that features outside of the bounds are not rendered. This override was necessary because as long as part of a vector tile is requested the entire tile will be retrieved and styled/rendered. (this was only really a problem in outer zoom levels)


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
