### PR TITLE
Remove seconds from GIF labels

### DIFF
--- a/web/js/modules/animation/selectors.js
+++ b/web/js/modules/animation/selectors.js
@@ -4,7 +4,7 @@ import {
   imageUtilGetCoordsFromPixelValues,
   getDownloadUrl
 } from '../image-download/util';
-import { getLayers } from '../layers/selectors';
+import { getLayers, hasSubDaily } from '../layers/selectors';
 import { timeScaleFromNumberKey } from '../date/constants';
 /*
  * loops through dates and created image
@@ -31,21 +31,21 @@ export function getImageArray(
   const a = [];
   const fromDate = new Date(startDate);
   const toDate = new Date(endDate);
+  const isSubDaily = hasSubDaily(layers[activeString]);
   let current = fromDate;
   let j = 0;
   let src;
   let strDate;
   let products;
   const useDelta = customSelected && customDelta ? customDelta : delta;
-  const useInterval = customSelected ? customInterval : interval;
   const increment = customSelected
     ? timeScaleFromNumberKey[customInterval]
     : timeScaleFromNumberKey[interval];
 
   while (current <= toDate) {
     j++;
-    if (useInterval > 3) {
-      strDate = util.toISOStringSeconds(current);
+    if (isSubDaily) {
+      strDate = util.toISOStringMinutes(current);
     } else {
       strDate = util.toISOStringDate(current);
     }


### PR DESCRIPTION
## Description

Fixes #2287

Remove seconds from GIF labels
- [x] Remove seconds from GIF labels
- [x] show down to minute whenever there is a subdaily layer present

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
