### PR TITLE
Prevent earlier dates from being added after later dates in layer dateArray building

### DIFF
--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -150,6 +150,12 @@ export function datesinDateRanges(def, date) {
       for (i = 0; i <= (dayDifference + 1); i++) {
         let day = new Date(minYear, minMonth, minDay + i * dateInterval);
         day = new Date(day.getTime() - (day.getTimezoneOffset() * 60000));
+        if (dateArray.length > 0) {
+          // prevent earlier dates from being added after later dates while building dateArray
+          if (day < dateArray[dateArray.length - 1]) {
+            continue;
+          }
+        }
         dateArray.push(day);
       }
       // Subdaily layers


### PR DESCRIPTION
## Description

Fixes #2540  .


- [x] Prevent earlier dates from being added after later dates in layer dateArray building

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
