### PR TITLE
Removed wrap on AIRS L2 CO and Methane

### DIFF
--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.json
@@ -8,7 +8,6 @@
             "tags":     "CO",
             "group":    "overlays",
             "product":  "AIRS2RET",
-            "wrapadjacentdays": true,
             "layergroup": [
               "airs"
             ],

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night.json
@@ -8,8 +8,6 @@
             "tags":     "CO",
             "group":    "overlays",
             "product":  "AIRS2RET",
-            "wrapadjacentdays": true,
-
             "layergroup": [
               "airs"
             ],

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.json
@@ -8,8 +8,6 @@
             "tags":     "CH4",
             "group":    "overlays",
             "product":  "AIRS2RET",
-            "wrapadjacentdays": true,
-
             "layergroup": [
               "airs"
             ],

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Night.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Night.json
@@ -8,8 +8,6 @@
             "tags":     "CH4",
             "group":    "overlays",
             "product":  "AIRS2RET",
-            "wrapadjacentdays": true,
-
             "layergroup": [
               "airs"
             ],


### PR DESCRIPTION
## Description

Fixes #2552 .

Removed wrap for AIRS Level 2 Carbon Monoxide and Methane. 

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
