### PR TITLE
Fix strange rendering of dam layer in outermost zooms

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -415,14 +415,14 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
       '&Version=1.0.0' +
       '&FORMAT=application%2Fvnd.mapbox-vector-tile' +
       '&TileMatrix={z}&TileCol={x}&TileRow={y}';
-
+    const wrapX = !!(day === 1 || day === -1);
     var sourceOptions = new SourceVectorTile({
       url: source.url + urlParameters,
       layer: layerName,
       day: day,
-      format: new MVT({}),
+      format: new MVT(),
       matrixSet: tms,
-      wrapX: !!(day === 1 || day === -1),
+      wrapX: wrapX,
       tileGrid: new OlTileGridTileGrid({
         extent: gridExtent,
         resolutions: matrixSet.resolutions,
@@ -434,7 +434,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     var layer = new LayerVectorTile({
       extent: layerExtent,
       source: sourceOptions,
-      renderMode: 'image'
+      renderMode: wrapX ? 'image' : 'hybrid' // Todo: revert to just 'image' when styles are updated
     });
 
     if (config.vectorStyles && def.vectorStyle && def.vectorStyle.id) {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -420,9 +420,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
       url: source.url + urlParameters,
       layer: layerName,
       day: day,
-      format: new MVT(),
+      format: new MVT({}),
       matrixSet: tms,
-      wrapX: true,
+      wrapX: !!(day === 1 || day === -1),
       tileGrid: new OlTileGridTileGrid({
         extent: gridExtent,
         resolutions: matrixSet.resolutions,
@@ -433,8 +433,8 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
 
     var layer = new LayerVectorTile({
       extent: layerExtent,
-      source: sourceOptions
-
+      source: sourceOptions,
+      renderMode: 'image'
     });
 
     if (config.vectorStyles && def.vectorStyle && def.vectorStyle.id) {
@@ -452,7 +452,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
       }
       setStyleFunction(def, vectorStyleId, vectorStyles, layer, state);
     }
-
+    layer.wrap = day;
     return layer;
   };
 

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -1111,6 +1111,7 @@ export function mapui(models, config, store, ui) {
       var coords;
       var pixels;
       const state = store.getState();
+      if (self.mapIsbeingZoomed) return;
       if (compareMapUi && compareMapUi.dragging) return;
       // if mobile return
       if (util.browser.small) return;
@@ -1127,14 +1128,6 @@ export function mapui(models, config, store, ui) {
       coords = map.getCoordinateFromPixel(pixels);
       if (!coords) return;
 
-      if (Math.abs(coords[0]) > 180) {
-        if (coords[0] > 0) {
-          coords[0] = coords[0] - 360;
-        } else {
-          coords[0] = coords[0] + 360;
-        }
-      }
-
       // setting a limit on running-data retrievel
       if (self.mapIsbeingDragged || util.browser.small) {
         return;
@@ -1147,7 +1140,7 @@ export function mapui(models, config, store, ui) {
       var isMapAnimating = state.animation.isPlaying;
       if (isEventsTabActive || isDataTabActive || isMapAnimating) return;
 
-      if (!self.mapIsbeingDragged && !self.mapIsbeingZoomed) dataRunner.newPoint(pixels, map);
+      dataRunner.newPoint(pixels, map);
     }
     $(map.getViewport())
       .mouseout(function(e) {


### PR DESCRIPTION
## Description

Fixes #2581

- [x] Fix strange rendering of dam layer in outermost zooms
- [x] Add zoom performance enhancements 
- [x] Add orbit track vector styling functions (for future use)

## Further comments
Cherry-picked updates from the `fix-vector-labels-2279` branch. This is why there are irrelevant orbit-track fixes (they will be relevant when vector orbit tracks are released)


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
