### PR TITLE
Update upload script to set permissions on images/config directories

### DIFF
--- a/tasks/upload.js
+++ b/tasks/upload.js
@@ -122,6 +122,10 @@ async function upload() {
       cd ${root}/${name} &&
       tar xf ${worldview} --warning=no-unknown-keyword --strip-components=1 --touch`;
     result = await ssh.execCommand(cmd);
+    // Set permissions for Grou and Other for Read and Execute for images, config metadata, and brand
+    cmd = `chmod -R go+xr ${root}/${name}/config
+        && chmod -R go+xr ${root}/${name}/images
+        && chmod -R go+xr ${root}/${name}/brand`;
     process.stdout.write(result.stdout);
     process.stderr.write(result.stderr);
     ssh.dispose();


### PR DESCRIPTION
## Description

Using the upload script to deploy test instances works great but, there is an issue with image and metadata folder permissions which causes these assets to not load (a 403 status is returned).

Setting the permissions for Group and Other to XR (execute & read) appears to fix this issue.
