### PR TITLE
v3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
## Technical Updates / Bugs:

- Clicking out of unacceptable date does not revert to previously selected date \[date.input.6\] [\#2580](https://github.com/nasa-gibs/worldview/issues/2580)

## [v3.4.0-rc.2](https://github.com/nasa-gibs/worldview/tree/v3.4.0-rc.2) (2020-01-14)

**Merged pull requests:**

- Remove AIRS CO Total Column [\#2566](https://github.com/nasa-gibs/worldview/pull/2566)
- Updated copyright year and add geostationary information [\#2560](https://github.com/nasa-gibs/worldview/pull/2560)
- Australia fire tour [\#2559](https://github.com/nasa-gibs/worldview/pull/2559)
- Add orbit daynight tags [\#2555](https://github.com/nasa-gibs/worldview/pull/2555)
- Removed wrap on AIRS L2 CO and Methane [\#2553](https://github.com/nasa-gibs/worldview/pull/2553)

## [v3.4.0-rc.1](https://github.com/nasa-gibs/worldview/tree/v3.4.0-rc.1) (2020-01-07)

**Implemented enhancements:**

- Refractoring  mapLocationToState [\#2529](https://github.com/nasa-gibs/worldview/issues/2529)
- Add snapshots wms matching support for vector layers [\#2360](https://github.com/nasa-gibs/worldview/issues/2360)
- Remove seconds from GIF labels [\#2534](https://github.com/nasa-gibs/worldview/pull/2534)
- Replace forked redux-location-state with up to date npm version [\#2505](https://github.com/nasa-gibs/worldview/pull/2505)
- Prevent custom interval selector from colliding with sidebar  [\#2500](https://github.com/nasa-gibs/worldview/pull/2500)
- Have coordinates show across dateline [\#2499](https://github.com/nasa-gibs/worldview/pull/2499)

## Technical Updates / Bugs:

- npm build error [\#2528](https://github.com/nasa-gibs/worldview/issues/2528)
- Can not drag image selection area corners freely [\#2446](https://github.com/nasa-gibs/worldview/issues/2446)
- Dragging animation interval interval can "stick" [\#2390](https://github.com/nasa-gibs/worldview/issues/2390)
- Map crashes when selecting Hurricane Dorian tour story from arctic projection [\#2356](https://github.com/nasa-gibs/worldview/issues/2356)
- Style sidebar event item to allow for longer titles and prevent wrapping below icon [\#2299](https://github.com/nasa-gibs/worldview/issues/2299)
- Projection button does not appear in IE 11 [\#2200](https://github.com/nasa-gibs/worldview/issues/2200)
- Unable to click and use the scroll bar in Layers list \(windows/edge\) [\#2170](https://github.com/nasa-gibs/worldview/issues/2170)
- When overzoomed, Last of the Wild legend is squished [\#1684](https://github.com/nasa-gibs/worldview/issues/1684)
- Change width of palette canvas when zot is active  [\#2516](https://github.com/nasa-gibs/worldview/pull/2516)
- Don't apply margin directly to palette canvas  [\#2504](https://github.com/nasa-gibs/worldview/pull/2504)

## External Dependency Updates:

- Bump react-dom from 16.11.0 to 16.12.0 [\#2417](https://github.com/nasa-gibs/worldview/pull/2417)

**Closed issues:**

- \[Question\]What server use as middle ware [\#2536](https://github.com/nasa-gibs/worldview/issues/2536)

**Merged pull requests:**

- Add scroll bar to layer info temporal scroll [\#2546](https://github.com/nasa-gibs/worldview/pull/2546)
- Vector bug fixes [\#2541](https://github.com/nasa-gibs/worldview/pull/2541)
- Update contribute docs [\#2531](https://github.com/nasa-gibs/worldview/pull/2531)
- Update mockCMR docs, ECHO api links [\#2524](https://github.com/nasa-gibs/worldview/pull/2524)
- Wrap vector layers at dateline [\#2523](https://github.com/nasa-gibs/worldview/pull/2523)
- Make Travis happy [\#2522](https://github.com/nasa-gibs/worldview/pull/2522)
- Image Download: Disable Worldfile when KMZ file type is selected [\#2517](https://github.com/nasa-gibs/worldview/pull/2517)
- Anti-meridian crossing measurements fix [\#2513](https://github.com/nasa-gibs/worldview/pull/2513)
- Allow date arrows to squash final left/right click if time difference is less than selected increment [\#2512](https://github.com/nasa-gibs/worldview/pull/2512)
- Loosen date selector input validation to allow temporary invalid values and mouse click changes [\#2510](https://github.com/nasa-gibs/worldview/pull/2510)
- Windows concurrency fix [\#2509](https://github.com/nasa-gibs/worldview/pull/2509)
- fix flaky e2e test [\#2503](https://github.com/nasa-gibs/worldview/pull/2503)
- Use concurrency in build for colormaps [\#2502](https://github.com/nasa-gibs/worldview/pull/2502)
- Add GC dir to clean script [\#2497](https://github.com/nasa-gibs/worldview/pull/2497)
- Added WELD Layer descriptions, added Vectors to Featured [\#2492](https://github.com/nasa-gibs/worldview/pull/2492)
- Create gitleaks secret check action [\#2476](https://github.com/nasa-gibs/worldview/pull/2476)