### PR TITLE
Fix data download commonly flaky e2e test

### DIFF
--- a/e2e/features/data-download/data-download-test.js
+++ b/e2e/features/data-download/data-download-test.js
@@ -107,8 +107,9 @@ module.exports = {
 
     // Zoom out three times for a data point granule selection button to be visible and indicator disappears
     client.click(zoomOutButton);
+    client.pause(750);
     client.click(zoomOutButton);
-    client.click(zoomOutButton);
+    client.pause(750);
     client.click(zoomOutButton);
     client.expect
       .element('#indicator')
@@ -116,6 +117,9 @@ module.exports = {
 
     // Zoom in data point granule selection button is not visible and indicator reappears
     client.click(zoomInButton);
+    client.pause(750);
+    client.click(zoomInButton);
+    client.pause(750);
     client.click(zoomInButton);
     client.expect
       .element('#indicator')


### PR DESCRIPTION
## Description

Fixes #2355  .

- [x] Fix commonly flaky data-download e2e test - the issue was related to timing of the map zooming in and out that isn't consistent (primarily in Chrome) with the rapid e2e zoom in/out button presses. This fix adds an additional zoom in button press and pauses between button presses to cushion the timings.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
