### PR TITLE
Added padding modification to slightly tweak white space of GIF modal…

### DIFF
--- a/web/css/anim.widget.css
+++ b/web/css/anim.widget.css
@@ -280,6 +280,10 @@ a .wv-animation-widget-icon {
   font-weight: 400;
 }
 
+#download-gif-button {
+  margin: 10px;
+}
+
 .gif-download-grid .grid-child {
   width: 190px;
   font-size: 12px;
@@ -318,6 +322,10 @@ a .wv-animation-widget-icon {
   line-height: 30px;
   color: #000;
   font-size: 15px;
+}
+
+.gif-results-dialog {
+  padding-bottom: 7px;
 }
 
 .wv-gif-progress {

--- a/web/js/components/animation-widget/gif-post-creation.js
+++ b/web/js/components/animation-widget/gif-post-creation.js
@@ -65,7 +65,7 @@ export class GifResults extends Component {
             <img src={blobURL} width={imgElWidth} height={imgElHeight} />
             <div
               className="gif-results-dialog"
-              style={{ height: imgElHeight, minHeight: 210 }}
+              style={{ minHeight: 210 }}
             >
               <div>
                 <div>


### PR DESCRIPTION
## Description

Fixes #2288. Also added small margin adjustment to the download button as well. There was no spacing when the height of the GIF pushes the button off to right side of the window.

![image](https://user-images.githubusercontent.com/583793/73685415-1e8eca80-4694-11ea-94a3-6139e46b9620.png)

