### PR TITLE
Fix issue #2642: Mobile datepicker should show forward/backward buttons

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -641,6 +641,18 @@ button:focus {
   cursor: pointer;
 }
 
+/* Mobile date change arrows */
+.mobile-date-change-arrows-btn {
+  position: absolute;
+  left: 120px;
+  bottom: 10px;
+  background: rgba(40, 40, 40, 0.85);
+  border: thin solid #333;
+  padding: 3px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
 .datepicker-header,
 .datepicker-navbar-btn {
   font-weight: 700;

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -905,13 +905,29 @@ class Timeline extends React.Component {
         {initialLoadComplete
           ? <ErrorBoundary>
             {isSmallScreen
-              ? <MobileDatePicker
-                date={selectedDate}
-                startDateLimit={timelineStartDateLimit}
-                endDateLimit={timelineEndDateLimit}
-                onDateChange={this.onDateChange}
-                hasSubdailyLayers={hasSubdailyLayers}
-              />
+              ? <div id="timeline-header">
+                <div id="date-selector-main">
+                  <MobileDatePicker
+                    date={selectedDate}
+                    startDateLimit={timelineStartDateLimit}
+                    endDateLimit={timelineEndDateLimit}
+                    onDateChange={this.onDateChange}
+                    hasSubdailyLayers={hasSubdailyLayers}
+                  />
+                </div>
+                <div className="mobile-date-change-arrows-btn">
+                  <div id="zoom-buttons-group">
+                    <DateChangeArrows
+                      leftArrowDown={this.throttleDecrementDate}
+                      leftArrowUp={this.stopLeftArrow}
+                      leftArrowDisabled={leftArrowDisabled}
+                      rightArrowDown={this.throttleIncrementDate}
+                      rightArrowUp={this.stopRightArrow}
+                      rightArrowDisabled={rightArrowDisabled}
+                    />
+                  </div>
+                </div>
+              </div>
               : <section id="timeline" className="timeline-inner clearfix">
                 <div id="timeline-header"
                   className={hasSubdailyLayers ? 'subdaily' : ''}


### PR DESCRIPTION
## Description
Add forward and backward buttons to the mobile datepicker for worldview.

Fixes issue #2642.

## Screenshot
![image](https://user-images.githubusercontent.com/33646954/74096117-7a0fec80-4ac8-11ea-8ddf-865f5e61dba1.png)

## Files modified:
`timeline.css`, `timeline.js`. re-used `DateChangeArrows` component.

## Further comments
I'm fairly new to front end development, as well as the reactjs library. I'm open to any feedback to my proposed design.
- I don't know if the design style I've put in (combination of `.css`, `id` and `className`) is how a front end developer usually does it. Please advise if there's a better/cleaner way.
- Right now the arrows look a little bigger than the mobile datepicker. I don't know if I should shrink the arrows or enlarge the mobile datepicker.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
