### PR TITLE
Loaded lodash isEqual method to compare layer settings after prop cha…

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import util from '../../util/util';
 import { drawSidebarPaletteOnCanvas, drawTicksOnCanvas } from '../../modules/palettes/util';
 import lodashIsNumber from 'lodash/isNumber';
+import lodashIsEqual from 'lodash/isEqual';
 import { Tooltip } from 'reactstrap';
 import { getOrbitTrackTitle } from '../../modules/layers/util';
 import VisibilitySensor from 'react-visibility-sensor/visibility-sensor';
@@ -40,8 +41,11 @@ class PaletteLegend extends React.Component {
     });
   }
 
-  componentDidUpdate() {
-    this.updateCanvas();
+  componentDidUpdate(prevProps) {
+    // Only updates when layer options/settings have changed
+    if (!lodashIsEqual(this.props.layer, prevProps.layer)) {
+      this.updateCanvas();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #2123 .

[Description of the bug or feature]

`componentDidUpdate()` is being constantly triggered forcing `updateCanvas` to be called at a very high and unnecessary rate.

## Further comments

Used Lodash to compare prop of the layer to determine whether or not `updateCanvas` needed to be called.

@nasa-gibs/worldview
