### PR TITLE
Fix add layer order based on overlay length and projection from action 

### DIFF
--- a/web/js/modules/layers/actions.js
+++ b/web/js/modules/layers/actions.js
@@ -53,7 +53,7 @@ export function addLayer(id, spec) {
   spec = spec || {};
   return (dispatch, getState) => {
     const state = getState();
-    const { layers, compare } = state;
+    const { layers, compare, proj } = state;
 
     const activeString = compare.activeString;
     const layerObj = getLayersSelector(
@@ -66,7 +66,8 @@ export function addLayer(id, spec) {
       spec,
       layers[activeString],
       layers.layerConfig,
-      layerObj.overlays.length || 0
+      layerObj.overlays.length || 0,
+      proj.id
     );
 
     dispatch({

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -103,8 +103,11 @@ export function hasSubDaily(layers) {
   return false;
 }
 
-export function addLayer(id, spec, layers, layerConfig, overlayLength) {
+export function addLayer(id, spec, layers, layerConfig, overlayLength, projection) {
   layers = lodashCloneDeep(layers);
+  if (projection) {
+    layers = layers.filter(layer => layer.projections[projection]);
+  }
   if (
     lodashFind(layers, {
       id: id

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -133,7 +133,8 @@ export function addLayer(id, spec, layers, layerConfig, overlayLength) {
   if (def.group === 'overlays') {
     layers.unshift(def);
   } else {
-    layers.splice(overlayLength, 0, def);
+    const overlaysLength = overlayLength || layers.filter(layer => layer.group === 'overlays').length;
+    layers.splice(overlaysLength, 0, def);
   }
   return layers;
 }


### PR DESCRIPTION
## Description

Fixes #2660  .

- [x] Filter by projection if provided (passed from `actions.js` `addLayer` func)
- [x] Get overlay layer length if not provided (used for adding baselayers only)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
