### PR TITLE
2664 layer legend disappear fix

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -42,7 +42,7 @@ class PaletteLegend extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     // Only updates when layer options/settings have changed or if ZOT changes the width of the palette
     if (!lodashIsEqual(this.props.layer, prevProps.layer) || (prevProps.width !== this.props.width)) {
       this.updateCanvas();

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -16,6 +16,7 @@ class PaletteLegend extends React.Component {
       colorHex: props.colorHex,
       isHoveringCanvas: props.isHoveringCanvas,
       width: this.props.width,
+
       scrollContainerEl: null
     };
   }
@@ -41,9 +42,9 @@ class PaletteLegend extends React.Component {
     });
   }
 
-  componentDidUpdate(prevProps) {
-    // Only updates when layer options/settings have changed
-    if (!lodashIsEqual(this.props.layer, prevProps.layer)) {
+  componentDidUpdate(prevProps, prevState) {
+    // Only updates when layer options/settings have changed or if ZOT changes the width of the palette
+    if (!lodashIsEqual(this.props.layer, prevProps.layer) || (prevProps.width !== this.props.width)) {
       this.updateCanvas();
     }
   }


### PR DESCRIPTION
## Description

Fixes #2664 . 

When zooming in on a layer and triggering the ZOT, the palette legend would disappear. This resolves the issue.

## Further comments

The reason for this bug appearing was because the `componentDidUpdate()` was triggering the `updateCanvas()` extremely frequently. Thus, we wanted to only redraw when a layer's settings changed (i.e. threshold, squash, color scheme, etc.) I think there is a better way to resolve this by having the ZOT property embedded with the layer object. I wasn't particular sure how to go about it and maybe it was more work than what it is worth?

@nasa-gibs/worldview
