### PR TITLE
preview fetch script fixes, integrate into build

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -7,6 +7,7 @@
         "compare": true,
         "tour": true,
         "feedback": true,
+        "previewSnapshots": true,
         "googleTagManager": {
             "id": "GTM-WNP7MLF"
         },

--- a/doc/features.md
+++ b/doc/features.md
@@ -4,9 +4,13 @@ Some of these features require CGI scripts to execute on your server. In order f
 to function, make sure your server is configured to allow the execution of
 CGI files. Next, enable these features in your configuration file.
 
+## Layer Preview Images
+
+By default during the build process we try to fetch images of layers from our Snapshots application to show as previews in the layer picker component.  However, this will only work for layers that are present in NASA GIBS (Global Imagery Browse Service).  If you are serving your own layers, you will likely wish to disable this feature by setting `"previewSnapshots": false` in `config/default/common/features.json`.
+
 ## Natural Events
 
-This feature provides natural events queried by Earth Observatory Natural Event Tracker (EONET) by default. To enable, edit `options/common/features.json` and set:
+This feature provides natural events queried by Earth Observatory Natural Event Tracker (EONET) by default. To enable, edit `config/default/common/features.json` and set:
 
 ```
 "naturalEvents": {
@@ -20,14 +24,14 @@ to disable, set:
 ## Data Download
 
 This feature uses CGI scripts to query the CMR API on the server. To enable,
-edit `options/common/features.json` and set `"dataDownload": true`.
+edit `config/default/common/features.json` and set `"dataDownload": true`.
 
 ## URL Shortening
 
 This feature uses
 [bit.ly](http://bit.ly) to shorten links. Follow these steps to enable it:
 
-* Edit `options/common/features.json` and set `"urlShortening": true`.
+* Edit `config/default/common/features.json` and set `"urlShortening": true`.
 * Get a login and API key from [bit.ly](http://bit.ly).
 * Create `build/options/bitly.json` with the following contents (replacing `your_login` and `your_key` with the appropriate values);
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ isodate==0.6.0
 six==1.11.0
 xmltodict==0.11.0
 urllib3[secure]==1.24.3
+requests==2.20.0

--- a/tasks/buildOptions.sh
+++ b/tasks/buildOptions.sh
@@ -142,6 +142,9 @@ done
 cp -r "$BUILD_DIR/brand" "$DEST_DIR"
 cp "$BUILD_DIR/brand.json" "$DEST_DIR"
 
+"$PYTHON_SCRIPTS_DIR/fetchPreviewSnapshots.py"  "$DEST_DIR/config/wv.json" \
+    "$OPT_DIR/common/previewLayerOverrides.json"
+
 # Validate the options build
 "$PYTHON_SCRIPTS_DIR/validateOptions.py" "$BUILD_DIR/config.json" "$DEST_DIR/config"
 

--- a/web/js/components/layer/product-picker/layer-metadata-detail.js
+++ b/web/js/components/layer/product-picker/layer-metadata-detail.js
@@ -123,13 +123,14 @@ class LayerMetadataDetail extends React.Component {
         </div>
       );
     }
-    const { layer, selectedProjection, isActive } = this.props;
+    const { layer, selectedProjection, isActive, showPreviewImage } = this.props;
     const { title, subtitle, track, metadata } = layer;
     const layerTitle = !track ? title : `${title} (${getOrbitTrackTitle(layer)})`;
     const previewUrl = 'images/layers/previews/' + selectedProjection + '/' + layer.id + '.jpg';
     const buttonText = isActive ? 'Remove Layer' : 'Add Layer';
     const btnClass = isActive ? 'add-to-map-btn text-center is-active' : 'add-to-map-btn text-center';
     const btnIconClass = isActive ? 'fa fa-minus' : 'fa fa-plus';
+
     return (
       <div className="layers-all-layer">
         <div className="layers-all-header">
@@ -141,11 +142,13 @@ class LayerMetadataDetail extends React.Component {
             </Button>
           */}
         </div>
-        <div className="text-center">
-          <a href={previewUrl} rel="noopener noreferrer" target="_blank">
-            <img className="img-fluid layer-preview" src={previewUrl} />
-          </a>
-        </div>
+        {showPreviewImage &&
+          <div className="text-center">
+            <a href={previewUrl} rel="noopener noreferrer" target="_blank">
+              <img className="img-fluid layer-preview" src={previewUrl} />
+            </a>
+          </div>
+        }
         <div className="text-center">
           <Button className={btnClass} onClick={this.toggleLayer.bind(this)}>
             <i className={btnIconClass} aria-hidden="true"></i>
@@ -167,7 +170,8 @@ LayerMetadataDetail.propTypes = {
   layer: PropTypes.object,
   removeLayer: PropTypes.func,
   selectedProjection: PropTypes.string,
-  showMetadataForLayer: PropTypes.func
+  showMetadataForLayer: PropTypes.func,
+  showPreviewImage: PropTypes.bool
 };
 
 export default LayerMetadataDetail;

--- a/web/js/components/layer/product-picker/product-picker.js
+++ b/web/js/components/layer/product-picker/product-picker.js
@@ -395,7 +395,8 @@ class ProductPicker extends React.Component {
       selectedProjection,
       category,
       listType,
-      selectedLayer
+      selectedLayer,
+      showPreviewImage
     } = this.props;
     const isSearching = listType === 'search';
     const selectedLayerActive = selectedLayer &&
@@ -416,6 +417,7 @@ class ProductPicker extends React.Component {
               addLayer={addLayer}
               removeLayer={removeLayer}
               selectedProjection={selectedProjection}
+              showPreviewImage={showPreviewImage}
               showMetadataForLayer={this.showMetadataForLayer.bind(this)}>
             </LayerMetadataDetail>
           </Scrollbars>
@@ -579,6 +581,7 @@ ProductPicker.propTypes = {
   selectedMeasurementSource: PropTypes.object,
   selectedMeasurementSourceIndex: PropTypes.number,
   selectedProjection: PropTypes.string,
+  showPreviewImage: PropTypes.bool,
   update: PropTypes.func,
   updateScrollPosition: PropTypes.func,
   width: PropTypes.number
@@ -637,6 +640,7 @@ function mapStateToProps(state, ownProps) {
     allLayers,
     activeLayers,
     selectedProjection: proj.id,
+    showPreviewImage: config.features.previewSnapshots,
     filterProjections: layer => {
       return !layer.projections[proj.id];
     },


### PR DESCRIPTION
## Description

Fixes #2669.

* Integrates preview image fetching into build process.  From now on, when new layers are added (or old layers are renamed) layer preview images will be requested from snapshots automatically.  Terminal output will give feedback on whether the request was successful and whether or not we think the image only came back with base layer content.

* Allow flagging this feature on/off in `features.json` and update docs to explain how to turn this off for user running their own WV instance serving their own imagery.

Before building this branch, run the following to make sure you have all the necessary python dependencies: `pip3 install -r requirements.txt`


