### PR TITLE
2692 scrollbar overlap

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -216,8 +216,6 @@
   padding: 0 4px 4px;
 }
 
-
-
 /* .tour-in-progress */
 .tour-in-progress .modal {
   left: auto;

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -1,7 +1,7 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import SimpleBarReact from 'simplebar-react';
-
+import { debounce } from 'lodash';
 /**
  * Wrapper component for SimpleBar
  */
@@ -9,28 +9,26 @@ export default function Scrollbars(props) {
   const ref = useRef();
   const [scrollTop, updateScrollTop] = useState(0);
 
-  useEffect(() => {
+  /**
+   * Add/remove 'scrollbar-visible' class based on content size
+   */
+  useLayoutEffect(() => {
     if (!ref || !ref.current) {
       return;
     }
+    const { contentEl, contentWrapperEl } = ref.current;
     function toggleVisibleClass() {
-      const { contentEl, contentWrapperEl } = ref.current;
       if (contentEl.offsetHeight > contentWrapperEl.offsetHeight) {
         contentEl.classList.add('scrollbar-visible');
       } else {
         contentEl.classList.remove('scrollbar-visible');
       }
     };
-    setTimeout(toggleVisibleClass, 200);
-    // If scroll content is being loaded asynchronously,
-    // we don't have a reliable way to know when to re-check.
-    // So, this is a clumsy safeguard.
-    setTimeout(toggleVisibleClass, 600);
+    debounce(toggleVisibleClass, 100)();
   });
 
   /**
-   *  - Set scroll top when prop changes
-   *  - Add/remove 'scrollbar-visible' class based on content size
+   *  Set scroll top when prop changes
    */
   useEffect(() => {
     if (!ref || !ref.current) {
@@ -86,5 +84,5 @@ Scrollbars.propTypes = {
 };
 
 Scrollbars.defaultProps = {
-  scrollBarVerticalTop: 0
 };
+scrollBarVerticalTop: 0;

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -9,6 +9,25 @@ export default function Scrollbars(props) {
   const ref = useRef();
   const [scrollTop, updateScrollTop] = useState(0);
 
+  useEffect(() => {
+    if (!ref || !ref.current) {
+      return;
+    }
+    function toggleVisibleClass() {
+      const { contentEl, contentWrapperEl } = ref.current;
+      if (contentEl.offsetHeight > contentWrapperEl.offsetHeight) {
+        contentEl.classList.add('scrollbar-visible');
+      } else {
+        contentEl.classList.remove('scrollbar-visible');
+      }
+    };
+    setTimeout(toggleVisibleClass, 200);
+    // If scroll content is being loaded asynchronously,
+    // we don't have a reliable way to know when to re-check.
+    // So, this is a clumsy safeguard.
+    setTimeout(toggleVisibleClass, 600);
+  });
+
   /**
    *  - Set scroll top when prop changes
    *  - Add/remove 'scrollbar-visible' class based on content size
@@ -25,16 +44,7 @@ export default function Scrollbars(props) {
         contentWrapperEl.scrollTop = scrollBarVerticalTop;
       }
     };
-    function toggleVisibleClass() {
-      const { contentEl, contentWrapperEl } = ref.current;
-      if (contentEl.offsetHeight > contentWrapperEl.offsetHeight) {
-        contentEl.classList.add('scrollbar-visible');
-      } else {
-        contentEl.classList.remove('scrollbar-visible');
-      }
-    };
     setTimeout(setScrollTop, 100);
-    setTimeout(toggleVisibleClass, 100);
   }, [props.scrollBarVerticalTop]);
 
   /**

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import SimpleBarReact from 'simplebar-react';
 import { debounce } from 'lodash';
@@ -13,7 +13,7 @@ export default function Scrollbars(props) {
   /**
    * Add/remove 'scrollbar-visible' class based on content size
    */
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!ref || !ref.current) {
       return;
     }
@@ -25,7 +25,15 @@ export default function Scrollbars(props) {
         contentEl.classList.remove('scrollbar-visible');
       }
     };
-    debounce(toggleVisibleClass, 100)();
+    debounce(() => {
+      toggleVisibleClass();
+      // If scrollbar contents are loaded asynchronously, we need to delay
+      // comparing content/wrapper offsetHeights until the content has loaded.
+      // It would be better to call this after some event or callback rather
+      // than just guessing 800ms is long enough for content to load but this
+      // seems to work pretty well enough for now.
+      setTimeout(toggleVisibleClass, 800);
+    }, 50, { leading: true, trailing: true })();
   });
 
   /**

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -2,6 +2,7 @@ import React, { useRef, useState, useEffect, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import SimpleBarReact from 'simplebar-react';
 import { debounce } from 'lodash';
+
 /**
  * Wrapper component for SimpleBar
  */
@@ -84,5 +85,5 @@ Scrollbars.propTypes = {
 };
 
 Scrollbars.defaultProps = {
+  scrollBarVerticalTop: 0
 };
-scrollBarVerticalTop: 0;


### PR DESCRIPTION
## Description

Fixes #2692 

* move scrollbar visible class check to a `useLayoutEffect` hook on it's own that doesn't depend on `props.scrollBarVerticalTop` to change in order to run
* debounce the call to `toggleVisibileClass` since it will be called on each render

