### PR TITLE
Add extra width to date tool tip

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -216,8 +216,6 @@
   padding: 0 4px 4px;
 }
 
-
-
 /* .tour-in-progress */
 .tour-in-progress .modal {
   left: auto;

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -81,22 +81,26 @@ class DateToolTip extends PureComponent {
     return (
       <React.Fragment>
         { (showDraggerToolTip || showHoverToolTip) &&
-          <div
-            className="date-tooltip"
-            style={{
-              transform: `translate(${toolTipLeftOffest}px, -100px)`,
-              display: toolTipDisplay,
-              width: hasSubdailyLayers ? '232px' : '165px'
-            }}
-          >
-            { toolTipDate } <span className="date-tooltip-day">({ toolTipDayOfYear })</span>
-          </div>
+        <div
+          className="date-tooltip"
+          style={{
+            transform: `translate(${toolTipLeftOffest}px, -100px)`,
+            display: toolTipDisplay,
+            width: hasSubdailyLayers
+              ? toolTipDayOfYear >= 100
+                ? '239px'
+                : '232px'
+              : '165px'
+          }}
+        >
+          { toolTipDate } <span className="date-tooltip-day">({ toolTipDayOfYear })</span>
+        </div>
         }
       </React.Fragment>
     );
   }
 }
-
+// 237px
 DateToolTip.propTypes = {
   axisWidth: PropTypes.number,
   draggerPosition: PropTypes.number,

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -100,7 +100,7 @@ class DateToolTip extends PureComponent {
     );
   }
 }
-// 237px
+
 DateToolTip.propTypes = {
   axisWidth: PropTypes.number,
   draggerPosition: PropTypes.number,


### PR DESCRIPTION
## Description

- [x] Add extra width to date tool tip for subdaily hover time on day num >= 100 

![image](https://user-images.githubusercontent.com/24417194/75182963-7b1f5b80-570f-11ea-9d70-e81a7510aa27.png)


## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
