### PR TITLE
Restore customs palette after closing gif or image-download 

### DIFF
--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   find as lodashFind,
-  get as lodashGet
+  get as lodashGet,
+  cloneDeep as lodashCloneDeep
 } from 'lodash';
 import googleTagManager from 'googleTagManager';
 import util from '../util/util';
@@ -208,6 +209,7 @@ class AnimationWidget extends React.Component {
     if (numberOfFrames >= maxFrames) {
       return;
     }
+    const paletteStore = lodashCloneDeep(activePalettes);
 
     this.getPromise(hasCustomPalettes, 'palette', clearCustoms, 'Notice').then(
       () => {
@@ -229,7 +231,7 @@ class AnimationWidget extends React.Component {
               event: 'GIF_create_animated_button'
             });
             this.onCloseGif = () => {
-              refreshStateAfterGif(hasCustomPalettes ? activePalettes : undefined, rotation, hasGraticule);
+              refreshStateAfterGif(hasCustomPalettes ? paletteStore : undefined, rotation, hasGraticule);
               toggleGif();
             };
             toggleGif();

--- a/web/js/containers/image-download.js
+++ b/web/js/containers/image-download.js
@@ -70,7 +70,7 @@ class ImageDownloadContainer extends Component {
       proj,
       map,
       url,
-      onClose,
+      closeModal,
       screenWidth,
       screenHeight,
       date,
@@ -125,7 +125,7 @@ class ImageDownloadContainer extends Component {
           maxHeight={screenHeight}
           maxWidth={screenWidth}
           onChange={this.onBoundaryChange}
-          onClose={onClose}
+          onClose={closeModal}
           bottomLeftStyle={{
             left: x,
             top: y2 + 5,
@@ -217,10 +217,10 @@ ImageDownloadContainer.defualtProps = {
   fileType: 'image/jpeg'
 };
 ImageDownloadContainer.propTypes = {
+  closeModal: PropTypes.func.isRequired,
   fileType: PropTypes.string.isRequired,
   map: PropTypes.object.isRequired,
   onBoundaryChange: PropTypes.func.isRequired,
-  onClose: PropTypes.func.isRequired,
   onPanelChange: PropTypes.func.isRequired,
   proj: PropTypes.object.isRequired,
   url: PropTypes.string.isRequired,

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -8,7 +8,7 @@ import Projection from './projection';
 import InfoList from './info';
 import ShareLinks from './share';
 import ErrorBoundary from './error-boundary';
-import { get as lodashGet, find as lodashFind } from 'lodash';
+import { get as lodashGet, find as lodashFind, cloneDeep as lodashCloneDeep } from 'lodash';
 import {
   requestNotifications,
   setNotifications
@@ -86,6 +86,8 @@ class toolbarContainer extends Component {
 
   openImageDownload() {
     const { openModal, hasCustomPalette, isRotated, hasGraticule, activePalettes, rotation, refreshStateAfterImageDownload } = this.props;
+
+    const paletteStore = lodashCloneDeep(activePalettes);
     this.getPromise(hasCustomPalette, 'palette', clearCustoms, 'Notice').then(
       () => {
         this.getPromise(
@@ -102,7 +104,14 @@ class toolbarContainer extends Component {
           ).then(() => {
             openModal(
               'TOOLBAR_SNAPSHOT',
-              Object.assign({}, CUSTOM_MODAL_PROPS.TOOLBAR_SNAPSHOT, { onClose: () => refreshStateAfterImageDownload(hasCustomPalette ? activePalettes : undefined, rotation, hasGraticule) })
+              Object.assign({}, CUSTOM_MODAL_PROPS.TOOLBAR_SNAPSHOT,
+                {
+                  onClose: () => {
+                    refreshStateAfterImageDownload(
+                      hasCustomPalette ? paletteStore : undefined, rotation, hasGraticule
+                    );
+                  }
+                })
             );
           });
         });


### PR DESCRIPTION
## Description

Fixes #2665
- [x] restore palette for GIF
- [x] restore palette for Image download
- [x] restore palette/rotation/graticule when clicking crop boundary to exit

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
