### PR TITLE
allow chrome e2e to fail 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   allow_failures:
     - os: windows
     - node_js: lts/*
+    - name: 'Node.js 10.16.3 - Chrome E2E'
 
   include:
     - os: osx


### PR DESCRIPTION
## Description

Fixes #2656

Chrome e2e tests fail to often when being run on Travis

- [x] allow chrome e2e tests to fail ✅ 

## Further comments

@jasontk19 I noticed that tests started to fail again as I was reviewing dependabot PRs

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
