### PR TITLE
This resolves the view extent / zoom not being properly applied upon …

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -59,7 +59,13 @@ window.onload = () => {
 
   loadingIndicator.delayed(promise, 1000);
   promise
-    .done((config) => {
+    .done(config => {
+      // Perform check to see if app was in the midst of a tour
+      if (parameters.tr) {
+        // Gets the extent of the first step of specified tour and overrides current view params
+        const tourParams = util.fromQueryString(config.stories[parameters.tr].steps[0].stepLink);
+        parameters.v = tourParams.v;
+      }
       config.pageLoadTime = parameters.now
         ? util.parseDateUTC(parameters.now) || new Date()
         : new Date();

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -59,7 +59,7 @@ window.onload = () => {
 
   loadingIndicator.delayed(promise, 1000);
   promise
-    .done(config => {
+    .done((config) => {
       // Perform check to see if app was in the midst of a tour
       if (parameters.tr) {
         // Gets the extent of the first step of specified tour and overrides current view params


### PR DESCRIPTION
…reload of the page during a tour.

## Description

Fixes #2704

[Description of the bug or feature]

- During a tour, refreshing the page on any other step, other than first step, would result in loading the first step but with the wrong extent / zoom level. This fix now determines the correct extent for the tour's first step and applies it on reloading of the page.

@nasa-gibs/worldview
