### PR TITLE
Remove time zeroing from layer building date request

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -183,11 +183,7 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     if (def.period === 'subdaily') {
       date = nearestInterval(def, date);
     } else if (previousDateFromRange) {
-      date = util.clearTimeUTC(previousDateFromRange);
-    } else {
-      date = options.date
-        ? util.clearTimeUTC(new Date(date.getTime()))
-        : util.clearTimeUTC(date);
+      date = previousDateFromRange;
     }
 
     return { closestDate: date, previousDate: previousLayerDate, nextDate: nextLayerDate };

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -183,7 +183,9 @@ export function mapLayerBuilder(models, config, cache, ui, store) {
     if (def.period === 'subdaily') {
       date = nearestInterval(def, date);
     } else if (previousDateFromRange) {
-      date = previousDateFromRange;
+      date = util.clearTimeUTC(previousDateFromRange);
+    } else {
+      date = util.clearTimeUTC(date);
     }
 
     return { closestDate: date, previousDate: previousLayerDate, nextDate: nextLayerDate };

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -430,17 +430,18 @@ export default (function(self) {
     return str.replace(/\W/g, '_');
   };
   /**
-   * Sets a date to UTC midnight.
+   * Returns a new date from input date set to UTC midnight.
    *
    * @method clearTimeUTC
    * @static
    * @param date {Date} date to set the UTC hours, minutes, and seconds
    * to zero.
-   * @return {Date} the date object
+   * @return {Date} new date object
    */
   self.clearTimeUTC = function(date) {
-    date.setUTCHours(0, 0, 0, 0);
-    return date;
+    const newDate = new Date(date);
+    newDate.setUTCHours(0, 0, 0, 0);
+    return newDate;
   };
 
   self.dateAdd = function(date, interval, amount) {

--- a/web/js/util/util.test.js
+++ b/web/js/util/util.test.js
@@ -108,13 +108,13 @@ describe('fromCompactTimestamp', () => {
 
 test('clearTimeUTC', () => {
   const d = new Date(2013, 2, 15, 12, 34, 56, 789);
-  util.clearTimeUTC(d);
-  expect(2013).toBe(d.getUTCFullYear());
-  expect(2).toBe(d.getUTCMonth());
-  expect(15).toBe(d.getUTCDate());
-  expect(0).toBe(d.getUTCHours());
-  expect(0).toBe(d.getUTCMinutes());
-  expect(0).toBe(d.getUTCSeconds());
+  const dCleared = util.clearTimeUTC(d);
+  expect(2013).toBe(dCleared.getUTCFullYear());
+  expect(2).toBe(dCleared.getUTCMonth());
+  expect(15).toBe(dCleared.getUTCDate());
+  expect(0).toBe(dCleared.getUTCHours());
+  expect(0).toBe(dCleared.getUTCMinutes());
+  expect(0).toBe(dCleared.getUTCSeconds());
 });
 
 describe('dateAdd', () => {


### PR DESCRIPTION
## Description

Fixes #2768  .

- [x] Remove time zeroing from layer building date request as the date is already valid for the layer form the `datesinDateRanges` resultant `dateRange`.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
