### PR TITLE
Fix measure tooltip placement issue

### DIFF
--- a/web/js/map/measure/ui.js
+++ b/web/js/map/measure/ui.js
@@ -117,8 +117,8 @@ export function measure(map, mapUiEvents, store) {
     let tooltipCoord;
     mapUiEvents.trigger('disable-click-zoom');
     sketch = evt.feature;
-    drawChangeListener = sketch.getGeometry().on('change', (evt) => {
-      const geom = evt.target;
+    drawChangeListener = sketch.getGeometry().on('change', (e) => {
+      const geom = e.target;
       if (geom instanceof OlGeomPolygon) {
         tooltipCoord = geom.getInteriorPoint().getCoordinates();
       } else if (geom instanceof OlLineString) {


### PR DESCRIPTION
## Description

When drawing measurements with long segments that exceed 180 degrees, shift the entire drawing either east/west by 360 degrees to line up with the orientation of the active segment which is seeking the shortest distance between its two points

Tagging @minniewong for testing and @Benjaki2 for code review.

Fixes #2515

@nasa-gibs/worldview
