### PR TITLE
Fix map scale remaining visible on hover when distraction free mode is activated

### DIFF
--- a/web/css/map.css
+++ b/web/css/map.css
@@ -202,7 +202,7 @@
 
 .distraction-free-active .wv-map-zoom-in,
 .distraction-free-active .wv-map-zoom-out,
-.distraction-free-active .wv-map-scale-imperial,
-.distraction-free-active .wv-map-scale-metric {
+.distraction-free-active .ol-overlaycontainer,
+.distraction-free-active .ol-overlaycontainer-stopevent {
   display: none;
 }

--- a/web/css/map.css
+++ b/web/css/map.css
@@ -200,8 +200,7 @@
   background-position: -14px;
 }
 
-.distraction-free-active .wv-map-zoom-in,
-.distraction-free-active .wv-map-zoom-out,
+.distraction-free-active .wv-map-zoom,
 .distraction-free-active .ol-overlaycontainer,
 .distraction-free-active .ol-overlaycontainer-stopevent {
   display: none;

--- a/web/js/components/timeline/timeline-controls/axis-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/axis-timescale-change.js
@@ -21,7 +21,12 @@ class AxisTimeScaleChange extends PureComponent {
 
   // TimeScale select tooltip on
   toolTipHoverOn = () => {
-    if (!this.props.isDraggerDragging) { // in event of dragging off axis, prevent tooltip display
+    const {
+      isDistractionFreeModeActive,
+      isDraggerDragging,
+    } = this.props;
+    // in event of dragging off axis, prevent tooltip displayD
+    if (!isDraggerDragging && !isDistractionFreeModeActive) {
       this.disableMapScales(true);
       this.setState({
         toolTipHovered: true,
@@ -60,18 +65,27 @@ class AxisTimeScaleChange extends PureComponent {
 
   // ex: month(2) to day(3)
   incrementTimeScale = () => {
-    const timeScaleNumber = timeScaleToNumberKey[this.props.timeScale];
-    const maxTimeScaleNumber = this.props.hasSubdailyLayers ? 5 : 3;
+    const {
+      changeTimeScale,
+      hasSubdailyLayers,
+      timeScale,
+    } = this.props;
+    const timeScaleNumber = timeScaleToNumberKey[timeScale];
+    const maxTimeScaleNumber = hasSubdailyLayers ? 5 : 3;
     if (timeScaleNumber < maxTimeScaleNumber) {
-      this.props.changeTimeScale(timeScaleNumber + 1);
+      changeTimeScale(timeScaleNumber + 1);
     }
   }
 
   // ex: day(3) to month(2)
   decrementTimeScale = () => {
-    const timeScaleNumber = timeScaleToNumberKey[this.props.timeScale];
+    const {
+      changeTimeScale,
+      timeScale,
+    } = this.props;
+    const timeScaleNumber = timeScaleToNumberKey[timeScale];
     if (timeScaleNumber > 1) {
-      this.props.changeTimeScale(timeScaleNumber - 1);
+      changeTimeScale(timeScaleNumber - 1);
     }
   }
 
@@ -114,6 +128,7 @@ class AxisTimeScaleChange extends PureComponent {
 AxisTimeScaleChange.propTypes = {
   changeTimeScale: PropTypes.func,
   hasSubdailyLayers: PropTypes.bool,
+  isDistractionFreeModeActive: PropTypes.bool,
   isDraggerDragging: PropTypes.bool,
   timelineHidden: PropTypes.bool,
   timeScale: PropTypes.string,

--- a/web/js/components/timeline/timeline-controls/axis-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/axis-timescale-change.js
@@ -25,7 +25,7 @@ class AxisTimeScaleChange extends PureComponent {
       isDistractionFreeModeActive,
       isDraggerDragging,
     } = this.props;
-    // in event of dragging off axis, prevent tooltip displayD
+    // in event of dragging off axis, prevent tooltip display
     if (!isDraggerDragging && !isDistractionFreeModeActive) {
       this.disableMapScales(true);
       this.setState({

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1247,6 +1247,7 @@ class Timeline extends React.Component {
                       timeScale={timeScale}
                       changeTimeScale={this.changeTimeScale}
                       isDraggerDragging={isDraggerDragging}
+                      isDistractionFreeModeActive={isDistractionFreeModeActive}
                       hasSubdailyLayers={hasSubdailyLayers}
                       timelineHidden={isTimelineHidden}
                     />


### PR DESCRIPTION
## Description

This fixes an issue that if you hover over the timescale axis unit list on the right of the timeline and move the cursor outside the list over the map scale then activating distraction free mode can still retain the map scale.

- [x] Fix map scale remaining visible on hover when distraction free mode is activated

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
