### PR TITLE
Add Timeline Data Availability Panel

### DIFF
--- a/e2e/features/timeline/data-coverage.js
+++ b/e2e/features/timeline/data-coverage.js
@@ -1,0 +1,55 @@
+const reuseables = require('../../reuseables/skip-tour.js');
+const localQuerystrings = require('../../reuseables/querystrings.js');
+
+const timelineDataAvailabilityContainer = '.timeline-data-panel-container';
+const timelineDataAvailabilityHandle = '#timeline-data-availability-panel-handle';
+const timelineDataAvailabilityAxisLine = '.axis-data-coverage-line';
+const TIME_LIMIT = 20000;
+
+module.exports = {
+  beforeEach: (client) => {
+    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  },
+
+  // verify default data coverage is visible on the timeline axis
+  'Data coverage is shown by default': (client) => {
+    client.waitForElementVisible(timelineDataAvailabilityAxisLine, TIME_LIMIT);
+  },
+
+  // verify no data coverage is visible on the timeline axis with just reference layers loaded
+  'No data coverage is shown by default': (client) => {
+    client.url(client.globals.url + localQuerystrings.referenceLayersOnly);
+    client.waitForElementVisible(timelineDataAvailabilityHandle, TIME_LIMIT);
+    client.expect.element(timelineDataAvailabilityAxisLine).to.not.be.present;
+  },
+
+  // verify panel is hidden and handle is visible on page load
+  'Panel is hidden on page load': (client) => {
+    client.waitForElementVisible(timelineDataAvailabilityHandle, TIME_LIMIT);
+  },
+
+  // verify panel opens on handle click
+  'Panel opens on handle click': (client) => {
+    client.waitForElementVisible(timelineDataAvailabilityHandle, TIME_LIMIT);
+    client
+      .click(timelineDataAvailabilityHandle)
+      .pause(1000);
+    client.expect.element(timelineDataAvailabilityContainer).to.be.visible;
+  },
+
+  // verify no hidden layers are visible by default on page load
+  'No hidden layers are visible in data panel by default': (client) => {
+    client.waitForElementVisible(timelineDataAvailabilityHandle, TIME_LIMIT);
+    client
+      .click(timelineDataAvailabilityHandle)
+      .pause(1000);
+    client.expect.element(timelineDataAvailabilityContainer).to.be.visible;
+    client.elements('css selector', '.data-panel-layer-list > div', (result) => {
+      client.assert.equal(result.value.length, 1);
+    });
+  },
+
+  after: (client) => {
+    client.end();
+  },
+};

--- a/e2e/reuseables/querystrings.js
+++ b/e2e/reuseables/querystrings.js
@@ -29,4 +29,5 @@ module.exports = {
   // layers
   multipleDataLayers: '?p=geographic&l=MODIS_Terra_Aerosol,MODIS_Terra_Brightness_Temp_Band31_Day&t=2017-03-22&z=3&v=136.07019188386334,14.722152527011556,155.59817576644127,24.312819167567586',
   continuousDataLayers: '?p=geographic&l=MODIS_Terra_Brightness_Temp_Band31_Day&t=2015-05-25&z=2&v=-42.148380855752734,42.13121723408824,22.122734950093943,85.16225953076464',
+  referenceLayersOnly: '?l=Reference_Labels(hidden),Reference_Features(hidden),Coastlines',
 };

--- a/web/css/map.css
+++ b/web/css/map.css
@@ -107,12 +107,12 @@
   border-right: 2px solid #fff;
 }
 .wv-map-scale-imperial {
-  bottom: 130px;
+  bottom: 150px;
   border-top: 2px solid #fff;
 }
 
 .wv-map-scale-metric {
-  bottom: 149px;
+  bottom: 169px;
   border-bottom: 2px solid #fff;
 }
 
@@ -124,7 +124,7 @@
   position: absolute;
   top: auto;
   right: 10px;
-  bottom: 85px;
+  bottom: 103px;
   white-space: pre;
   outline: none;
   color: #fff;

--- a/web/css/measure.css
+++ b/web/css/measure.css
@@ -1,6 +1,6 @@
 .wv-measure-button {
   position: absolute;
-  bottom: 128px;
+  bottom: 148px;
   right: 10px;
   padding: 6px 10px;
 }
@@ -8,7 +8,7 @@
 .modal-dialog.measure-tool-modal {
   position: absolute;
   right: 10px;
-  bottom: 151px;
+  bottom: 171px;
 
   & .modal-body {
     padding: 8px 0 0;

--- a/web/css/switch.css
+++ b/web/css/switch.css
@@ -55,3 +55,9 @@
 .react-switch-label:active .react-switch-button {
   width: 20px;
 }
+
+.switch-thin-border .react-switch-label {
+  border: thin solid rgb(97, 97, 97);
+  height: 17px;
+  width: 32px;
+}

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -795,7 +795,7 @@ button:focus {
 }
 
 #wv-toggle-data-matching-main .react-switch-case {
-  width: 30px;
+  width: 45px;
 }
 
 #wv-toggle-data-matching-main .react-switch-label {

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -860,13 +860,6 @@ button:focus {
   height: 12px;
 }
 
-.data-panel-coverage-line-overlay {
-  position: absolute;
-  pointer-events: none;
-  height: 12px;
-  z-index: 5;
-}
-
 .data-panel-layer-empty {
   height: 41px;
   padding: 6px;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -787,22 +787,18 @@ button:focus {
   color: #999;
 }
 
-#wv-toggle-data-matching-main {
+.wv-toggle-data-matching-main {
   align-items: center;
   margin: 0;
   white-space: nowrap;
   flex-grow: 1;
 }
 
-#wv-toggle-data-matching-main .react-switch-case {
+.wv-toggle-data-matching-main .react-switch-case {
   width: 45px;
 }
 
-#wv-toggle-data-matching-main .react-switch-label {
-  border: thin solid rgb(97, 97, 97);
-}
-
-#wv-toggle-data-matching-main > div.react-switch-label-case.switch-col {
+.wv-toggle-data-matching-main > div.react-switch-label-case.switch-col {
   padding-left: 5px;
 }
 

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -810,7 +810,8 @@ button:focus {
   position: relative;
   background-color: #212121;
   color: #fff;
-  border: thin solid #595959;
+  box-sizing: border-box;
+  border: thin solid #333;
   border-top-right-radius: 5px;
   border-top-left-radius: 5px;
 }
@@ -850,4 +851,14 @@ button:focus {
 .data-panel-coverage-line {
   position: relative;
   height: 12px;
+}
+
+.data-panel-layer-empty {
+  height: 41px;
+  padding: 6px;
+}
+
+.data-item-empty {
+  display: flex;
+  flex-direction: row;
 }

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -9,7 +9,7 @@ button:focus {
 
 .timeline-inner {
   position: absolute;
-  border: 1px solid #333;
+  border: thin solid #333;
   background: rgba(40, 40, 40, 0.85);
   border-radius: 5px;
   display: flex;
@@ -42,7 +42,7 @@ button:focus {
 
   & .input-wrapper {
     background: transparent;
-    border: 1px solid transparent;
+    border: thin solid transparent;
     vertical-align: top;
     box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -255,8 +255,8 @@ button:focus {
 }
 
 #timeline-footer {
-  border-left: 1px solid #666;
-  border-right: 1px solid #666;
+  border-left: thin solid #666;
+  border-right: thin solid #666;
 }
 
 #wv-timeline-range-selector {
@@ -539,19 +539,19 @@ button:focus {
   height: 64px;
   width: 20px;
   cursor: pointer;
-  border-left: 1px solid #1a1a1a;
+  border-left: thin solid #1a1a1a;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;
 }
 
-#timeline-hide:hover {
+#timeline-hide:hover,
+#timeline-data-availability-panel-handle:hover {
   background-color: #fff;
+  border-color: #000;
 }
 
-#timeline-hide:hover .wv-timeline-hide-double-chevron-left,
-#timeline-hide:hover .wv-timeline-hide-double-chevron-right,
-.wv-timeline-hide-double-chevron-left:hover,
-.wv-timeline-hide-double-chevron-right:hover {
+#timeline-hide:hover .wv-timeline-hide,
+#timeline-data-availability-panel-handle:hover .wv-timeline-data-availability-handle-chevron {
   background-position: -206px -63px;
 }
 
@@ -561,31 +561,58 @@ button:focus {
   right: -5px;
   color: #fff;
   cursor: pointer;
-  border-top-right-radius: 5px;
-  border-bottom-right-radius: 5px;
   user-select: none;
   height: 30px;
   width: 30px;
-}
-
-.wv-timeline-hide-double-chevron-left {
   position: absolute;
   background: url('../images/icon-sprite.svg') -206px -3px no-repeat;
   border-radius: 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   border-right: 0;
+}
+
+.wv-timeline-hide-double-chevron-left {
   transform: rotate(90deg);
 }
 
 .wv-timeline-hide-double-chevron-right {
+  transform: rotate(270deg);
+}
+
+#timeline-data-availability-panel-handle {
+  position: absolute;
+  height: 19px;
+  width: 57px;
+  top: -20px;
+  cursor: pointer;
+  border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+  background-color: rgba(40, 40, 40, 0.65);
+  border: thin solid #fff;
+  border-bottom: none;
+  overflow: hidden;
+}
+
+.wv-timeline-data-availability-handle-chevron {
   position: absolute;
   background: url('../images/icon-sprite.svg') -206px -3px no-repeat;
-  border-radius: 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
-  border-right: 0;
-  transform: rotate(270deg);
+  left: 50%;
+  width: 57px;
+  height: 20px;
+}
+
+.wv-timeline-data-availability-handle-chevron-open {
+  top: 2.5px;
+  margin-left: -43px;
+  transform: rotate(180deg);
+}
+
+.wv-timeline-data-availability-handle-chevron-closed {
+  top: -4px;
+  margin-left: -14px;
 }
 
 .dragger-container {
@@ -707,4 +734,120 @@ button:focus {
 
 .datepicker.android-dark .datepicker-scroll li.disabled {
   color: rgb(88, 88, 88) !important;
+}
+
+.datepicker-navbar-btn:hover {
+  background: #fff;
+}
+
+/* TIMELINE DATA PANEL */
+
+.timeline-data-panel-container {
+  position: absolute;
+  background: rgba(40, 40, 40, 1);
+  border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+}
+
+.animate-timeline-data-panel-slide-up {
+  z-index: 5;
+  bottom: 66px;
+  opacity: 1;
+}
+
+.animate-timeline-data-panel-slide-down {
+  z-index: -5;
+  bottom: -12px;
+  opacity: 0;
+}
+
+.timeline-data-panel i.wv-close:hover {
+  color: #999;
+  cursor: pointer;
+}
+
+.timeline-data-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: thin solid #808080;
+  padding: 5px;
+}
+
+.timeline-data-panel-header-title {
+  width: 150px;
+  padding: 5px;
+}
+
+.label-layer-active {
+  color: #000;
+}
+
+.label-layer-inactive {
+  color: #999;
+}
+
+#wv-toggle-data-matching-main {
+  align-items: center;
+  margin: 0;
+  white-space: nowrap;
+  flex-grow: 1;
+}
+
+#wv-toggle-data-matching-main .react-switch-case {
+  width: 30px;
+}
+
+#wv-toggle-data-matching-main .react-switch-label {
+  border: thin solid rgb(97, 97, 97);
+}
+
+#wv-toggle-data-matching-main > div.react-switch-label-case.switch-col {
+  padding-left: 5px;
+}
+
+.timeline-data-panel {
+  position: relative;
+  background-color: #212121;
+  color: #fff;
+  border: thin solid #595959;
+  border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+}
+
+.data-panel-layer-item {
+  border-bottom: thin solid #3c3c3c;
+  padding-bottom: 5px;
+}
+
+.data-panel-layer-item-header {
+  display: flex;
+  align-items: center;
+  padding: 5px 3px;
+  font-size: 11.7px;
+}
+
+.data-panel-layer-item-subtitle {
+  font-style: italic;
+  font-size: 10.4px;
+  padding-left: 3px;
+}
+
+.data-panel-layer-item-date-range {
+  position: absolute;
+  right: 15px;
+}
+
+.data-panel-layer-list {
+  overflow: hidden;
+}
+
+.data-panel-layer-coverage-line-container {
+  overflow: hidden;
+  height: 12px;
+}
+
+.data-panel-coverage-line {
+  position: relative;
+  height: 12px;
 }

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -829,6 +829,7 @@ button:focus {
 }
 
 .data-panel-layer-item-title {
+  white-space: nowrap;
   font-size: 1em;
 }
 
@@ -841,7 +842,8 @@ button:focus {
 .data-panel-layer-item-date-range {
   position: absolute;
   font-size: 0.9em;
-  right: 15px;
+  right: 0;
+  padding: 4px 10px;
 }
 
 .data-panel-layer-list {

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -826,17 +826,21 @@ button:focus {
   display: flex;
   align-items: center;
   padding: 5px 3px;
-  font-size: 11.7px;
+}
+
+.data-panel-layer-item-title {
+  font-size: 1em;
 }
 
 .data-panel-layer-item-subtitle {
   font-style: italic;
-  font-size: 10.4px;
+  font-size: 0.9em;
   padding-left: 3px;
 }
 
 .data-panel-layer-item-date-range {
   position: absolute;
+  font-size: 0.9em;
   right: 15px;
 }
 
@@ -849,9 +853,20 @@ button:focus {
   height: 12px;
 }
 
+.data-panel-coverage-line-container {
+  position: absolute;
+}
+
 .data-panel-coverage-line {
-  position: relative;
+  position: absolute;
   height: 12px;
+}
+
+.data-panel-coverage-line-overlay {
+  position: absolute;
+  pointer-events: none;
+  height: 12px;
+  z-index: 5;
 }
 
 .data-panel-layer-empty {

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -812,6 +812,7 @@ button:focus {
   color: #fff;
   box-sizing: border-box;
   border: thin solid #333;
+  border-bottom: 0;
   border-top-right-radius: 5px;
   border-top-left-radius: 5px;
 }

--- a/web/js/components/date-selector/date-selector.js
+++ b/web/js/components/date-selector/date-selector.js
@@ -305,7 +305,7 @@ class DateSelector extends Component {
     });
   }
 
-  shouldComponentUpdate(prevProps, prevState) {
+  shouldComponentUpdate(nextProps, nextState) {
     const {
       date,
       subDailyMode,
@@ -326,21 +326,21 @@ class DateSelector extends Component {
       tab,
     } = this.state;
 
-    const updateCheck = year === prevState.year
-      && month === prevState.month
-      && day === prevState.day
-      && hour === prevState.hour
-      && minute === prevState.minute
-      && yearValid === prevState.yearValid
-      && monthValid === prevState.monthValid
-      && dayValid === prevState.dayValid
-      && hourValid === prevState.hourValid
-      && minuteValid === prevState.minuteValid
-      && tab === prevState.tab
-      && date.getTime() === prevProps.date.getTime()
-      && subDailyMode === prevProps.subDailyMode
-      && maxDate.getTime() === prevProps.maxDate.getTime()
-      && minDate.getTime() === prevProps.minDate.getTime();
+    const updateCheck = year === nextState.year
+      && month === nextState.month
+      && day === nextState.day
+      && hour === nextState.hour
+      && minute === nextState.minute
+      && yearValid === nextState.yearValid
+      && monthValid === nextState.monthValid
+      && dayValid === nextState.dayValid
+      && hourValid === nextState.hourValid
+      && minuteValid === nextState.minuteValid
+      && tab === nextState.tab
+      && date.getTime() === nextProps.date.getTime()
+      && subDailyMode === nextProps.subDailyMode
+      && maxDate.getTime() === nextProps.maxDate.getTime()
+      && minDate.getTime() === nextProps.minDate.getTime();
     return !updateCheck;
   }
 

--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -38,10 +38,12 @@ class AxisHoverLine extends PureComponent {
       ? layer.startDate
       : layer.startDate && layer.visible));
 
+    // min 1 layer for error message display
+    const layerLengthCoef = Math.max(layers.length, 1);
     // handle active layer count dependent tooltip height
     if (isDataCoveragePanelOpen) {
       lineHeight = 111;
-      const addHeight = Math.min(layers.length, 5) * 40;
+      const addHeight = Math.min(layerLengthCoef, 5) * 40;
       lineHeight += addHeight;
       lineHeightInner = lineHeight;
     }
@@ -53,7 +55,7 @@ class AxisHoverLine extends PureComponent {
         : draggerPositionB;
       linePosition = selectedDraggerPosition + 47;
       // lineheight for dragger
-      const minusY1Height = Math.min(layers.length, 5) * 40.5;
+      const minusY1Height = Math.min(layerLengthCoef, 5) * 40.5;
       lineHeightInner = 40.5 + minusY1Height;
     }
 

--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -10,40 +10,89 @@ import PropTypes from 'prop-types';
 class AxisHoverLine extends PureComponent {
   render() {
     const {
+      activeLayers,
       axisWidth,
+      draggerSelected,
+      draggerPosition,
+      draggerPositionB,
+      isDataCoveragePanelOpen,
+      isDraggerDragging,
       isTimelineDragging,
       isAnimationDraggerDragging,
       showHoverLine,
+      shouldIncludeHiddenLayers,
       hoverLinePosition,
     } = this.props;
     // check for timeline/animation dragging and showhover handled by parent
-    const showHover = !isTimelineDragging && !isAnimationDraggerDragging && showHoverLine;
+    const isNoBlockingDragging = !isTimelineDragging && !isAnimationDraggerDragging;
+    const showHover = isNoBlockingDragging && showHoverLine;
+    const panelDraggerHoverLine = isDataCoveragePanelOpen && isNoBlockingDragging && isDraggerDragging;
+    const shouldDisplayHoverLine = showHover || panelDraggerHoverLine;
+
+    // init normal (no data coverage panel) line heights (svg container, inner line)
+    let lineHeight = 63;
+    let lineHeightInner = 63;
+    let linePosition = hoverLinePosition;
+
+    const layers = activeLayers.filter((layer) => (shouldIncludeHiddenLayers
+      ? layer.startDate
+      : layer.startDate && layer.visible));
+
+    // handle active layer count dependent tooltip height
+    if (isDataCoveragePanelOpen) {
+      lineHeight = 111;
+      const addHeight = Math.min(layers.length, 5) * 40;
+      lineHeight += addHeight;
+      lineHeightInner = lineHeight;
+    }
+
+    // hoverline positioning based on dragger position
+    if (panelDraggerHoverLine) {
+      const selectedDraggerPosition = draggerSelected === 'selected'
+        ? draggerPosition
+        : draggerPositionB;
+      linePosition = selectedDraggerPosition + 47;
+      // lineheight for dragger
+      const minusY1Height = Math.min(layers.length, 5) * 40.5;
+      lineHeightInner = 40.5 + minusY1Height;
+    }
+
     return (
-      showHover
-        ? (
-          <svg className="axis-hover-line-container" width={axisWidth} height={63}>
-            <line
-              className="axis-hover-line"
-              stroke="#0f51c0"
-              strokeWidth="2"
-              x1="0"
-              x2="0"
-              y1="0"
-              y2="63"
-              transform={`translate(${hoverLinePosition + 1}, 0)`}
-            />
-          </svg>
-        )
-        : null
+      shouldDisplayHoverLine && (
+        <svg
+          className="axis-hover-line-container"
+          width={axisWidth}
+          height={lineHeight}
+          style={{ zIndex: 6 }}
+        >
+          <line
+            className="axis-hover-line"
+            stroke="#0f51c0"
+            strokeWidth="2"
+            x1="0"
+            x2="0"
+            y1="0"
+            y2={lineHeightInner}
+            transform={`translate(${linePosition + 1}, 0)`}
+          />
+        </svg>
+      )
     );
   }
 }
 
 AxisHoverLine.propTypes = {
+  activeLayers: PropTypes.array,
   axisWidth: PropTypes.number,
+  draggerPosition: PropTypes.number,
+  draggerPositionB: PropTypes.number,
+  draggerSelected: PropTypes.string,
   hoverLinePosition: PropTypes.number,
   isAnimationDraggerDragging: PropTypes.bool,
+  isDataCoveragePanelOpen: PropTypes.bool,
+  isDraggerDragging: PropTypes.bool,
   isTimelineDragging: PropTypes.bool,
+  shouldIncludeHiddenLayers: PropTypes.bool,
   showHoverLine: PropTypes.bool,
 };
 

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -95,7 +95,9 @@ class DateToolTip extends PureComponent {
       const layers = activeLayers.filter((layer) => (shouldIncludeHiddenLayers
         ? layer.startDate
         : layer.startDate && layer.visible));
-      const addHeight = Math.min(layers.length, 5) * 40;
+      // min 1 layer for error message display
+      const layerLengthCoef = Math.max(layers.length, 1);
+      const addHeight = Math.min(layerLengthCoef, 5) * 40;
       toolTipHeightOffset -= addHeight;
       toolTipHeightOffset = Math.max(toolTipHeightOffset, -357);
     }

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -34,6 +34,7 @@ const getToolTipTime = (time, hasSubdailyLayers) => {
 class DateToolTip extends PureComponent {
   render() {
     const {
+      activeLayers,
       draggerSelected,
       draggerPosition,
       draggerPositionB,
@@ -43,17 +44,21 @@ class DateToolTip extends PureComponent {
       draggerTimeState,
       draggerTimeStateB,
       hoverTime,
+      isDataCoveragePanelOpen,
       showHoverLine,
+      shouldIncludeHiddenLayers,
       axisWidth,
     } = this.props;
     // checks for dragger and hover handled by parent
     const showDraggerToolTip = !!(showDraggerTime && draggerTimeState);
     const showHoverToolTip = !!(showHoverLine && hoverTime);
+    const shouldDisplayDraggerToolTip = showDraggerToolTip || showHoverToolTip;
 
-    let toolTipLeftOffest;
+    let toolTipLeftOffset;
     let toolTipDate;
     let toolTipDayOfYear;
     let toolTipDisplay;
+    let toolTipHeightOffset;
 
     if (showDraggerToolTip) {
       // handle dragger tooltip
@@ -67,31 +72,41 @@ class DateToolTip extends PureComponent {
         draggerTime = draggerTimeStateB;
         position = draggerPositionB;
       }
-      toolTipLeftOffest = position - (hasSubdailyLayers ? 68 : 35);
+      toolTipLeftOffset = position - (hasSubdailyLayers ? 68 : 35);
       toolTipDate = getToolTipTime(draggerTime, hasSubdailyLayers);
       toolTipDayOfYear = getDaysInYear(draggerTime);
-      toolTipDisplay = position > -49 && position < axisWidth - 49 ? 'block' : 'none';
+      toolTipDisplay = position > -49 && position < axisWidth - 49
+        ? 'block'
+        : 'none';
     } else if (showHoverToolTip) {
       // handle hover tooltip
-      toolTipLeftOffest = hasSubdailyLayers ? leftOffset - 117 : leftOffset - 84;
+      toolTipLeftOffset = hasSubdailyLayers
+        ? leftOffset - 117
+        : leftOffset - 84;
       toolTipDate = getToolTipTime(hoverTime, hasSubdailyLayers);
       toolTipDayOfYear = getDaysInYear(hoverTime);
       toolTipDisplay = 'block';
     }
+
+    // handle active layer count dependent tooltip height
+    toolTipHeightOffset = -100;
+    if (isDataCoveragePanelOpen) {
+      toolTipHeightOffset = -136;
+      const layers = activeLayers.filter((layer) => (shouldIncludeHiddenLayers
+        ? layer.startDate
+        : layer.startDate && layer.visible));
+      const addHeight = Math.min(layers.length, 5) * 40;
+      toolTipHeightOffset -= addHeight;
+      toolTipHeightOffset = Math.max(toolTipHeightOffset, -357);
+    }
     return (
-      <>
-        { (showDraggerToolTip || showHoverToolTip)
-        && (
+      shouldDisplayDraggerToolTip && (
         <div
           className="date-tooltip"
           style={{
-            transform: `translate(${toolTipLeftOffest}px, -100px)`,
+            transform: `translate(${toolTipLeftOffset}px, ${toolTipHeightOffset}px)`,
             display: toolTipDisplay,
-            width: hasSubdailyLayers
-              ? toolTipDayOfYear >= 100
-                ? '239px'
-                : '232px'
-              : '165px',
+            width: hasSubdailyLayers ? '232px' : '165px',
           }}
         >
           { toolTipDate }
@@ -102,13 +117,13 @@ class DateToolTip extends PureComponent {
             )
           </span>
         </div>
-        )}
-      </>
+      )
     );
   }
 }
 
 DateToolTip.propTypes = {
+  activeLayers: PropTypes.array,
   axisWidth: PropTypes.number,
   draggerPosition: PropTypes.number,
   draggerPositionB: PropTypes.number,
@@ -117,7 +132,9 @@ DateToolTip.propTypes = {
   draggerTimeStateB: PropTypes.string,
   hasSubdailyLayers: PropTypes.bool,
   hoverTime: PropTypes.string,
+  isDataCoveragePanelOpen: PropTypes.bool,
   leftOffset: PropTypes.number,
+  shouldIncludeHiddenLayers: PropTypes.bool,
   showDraggerTime: PropTypes.bool,
   showHoverLine: PropTypes.bool,
 };

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
@@ -10,7 +10,6 @@ import React from 'react';
 const axisScaleTextElementWrapper = (item, index, gridWidth) => {
   let dateText;
   let dateTextYear;
-  // TODO: may need to expand for subdaily to differentiate time units
   if (item.timeScale === 'day') {
     const dateSplit = item.date.split(' ');
     [dateText, dateTextYear] = dateSplit;

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1,3 +1,4 @@
+/* eslint no-nested-ternary: 0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';
@@ -75,7 +76,6 @@ class TimelineAxis extends Component {
     const options = timeScaleOptions[timeScale].timeAxis;
     const { gridWidth } = options;
     const timelineAxisWidth = axisWidth;
-    // eslint-disable-next-line no-nested-ternary
     const hoverLeftOffset = leftOffsetFixedCoeff
       ? timelineAxisWidth * leftOffsetFixedCoeff
       : leftOffset === 0
@@ -132,7 +132,6 @@ class TimelineAxis extends Component {
     let draggerTime;
     let draggerTimeB;
     if (draggerSelected === 'selected') {
-    // eslint-disable-next-line no-nested-ternary
       draggerTime = hoverChange
         ? draggerTimeState
         : isCompareModeActive
@@ -141,7 +140,6 @@ class TimelineAxis extends Component {
       draggerTimeB = isCompareModeActive ? dateB : draggerTimeStateB;
     } else {
       draggerTime = isCompareModeActive ? dateA : draggerTimeState;
-      // eslint-disable-next-line no-nested-ternary
       draggerTimeB = hoverChange
         ? draggerTimeStateB
         : isCompareModeActive
@@ -678,10 +676,8 @@ class TimelineAxis extends Component {
   * @returns {void}
   */
   updateScaleWithOffset = (date, timeScale, draggerCheck) => {
-    // eslint-disable-next-line no-nested-ternary
     const leftOffsetFixedCoeff = draggerCheck.newDraggerDiff > 5
       ? 0.5
-      // eslint-disable-next-line no-nested-ternary
       : draggerCheck.newDateInThePast
         ? !draggerCheck.withinRange
           ? 0.5
@@ -1253,7 +1249,6 @@ class TimelineAxis extends Component {
     const timelineEndDateLimitDateObj = new Date(timelineEndDateLimit);
     const hoverTimeDateObj = new Date(hoverTimeDate);
 
-    // eslint-disable-next-line no-nested-ternary
     hoverTimeDate = hoverTimeDateObj > timelineEndDateLimitDateObj
       ? timelineEndDateLimit
       : hoverTimeDateObj < timelineStartDateLimitDateObj

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -175,7 +175,7 @@ class LayerDataItems extends Component {
       >
         <Tooltip
           placement={toolTipPlacement}
-          boundariesElement="data-panel-coverage-line"
+          boundariesElement={`data-coverage-line-${dateRangeStartEnd}`}
           offset={toolTipOffset}
           container={`.data-item-${id}`}
           isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -155,9 +155,15 @@ class LayerDataItems extends Component {
       toolTipText,
     } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
     const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
+
+    // handle tooltip positioning
     const toolTipOffset = -options.leftOffset - (width < axisWidth ? options.leftOffset : axisWidth / 2);
     const toolTipPlacement = 'auto';
 
+    // candy stripe alt color
+    const altLineColor = color === 'rgb(0, 69, 123)'
+      ? '#164e7a'
+      : '#797979';
     return (
       <div
         id={`data-coverage-line-${dateRangeStartEnd}`}
@@ -167,10 +173,14 @@ class LayerDataItems extends Component {
         onMouseLeave={() => hoverOffToolTip()}
         style={{
           position,
-          left: options.leftOffset,
+          transform: `translate(${options.leftOffset}px, 0)`,
           width: `${width}px`,
-          backgroundColor: color,
           borderRadius: options.borderRadius,
+          background: `repeating-linear-gradient(45deg,
+            ${color},
+            ${color} 20px,
+            ${altLineColor} 20px,
+            ${altLineColor} 40px)`,
         }}
       >
         <Tooltip
@@ -192,11 +202,10 @@ class LayerDataItems extends Component {
   * @param {Object} range date object
   * @param {String} time unit period
   * @param {Number} itemRangeInterval
-  * @param {Object} endDateLimit data object
   * @param {Object} nextDate range object with date
   * @returns {Object} rangeDateEnd date object
   */
-  getRangeDateEndWithAddedInterval = (rangeDate, layerPeriod, itemRangeInterval, endDateLimit, nextDate) => {
+  getRangeDateEndWithAddedInterval = (rangeDate, layerPeriod, itemRangeInterval, nextDate) => {
     const { appNow } = this.props;
     const minYear = rangeDate.getUTCFullYear();
     const minMonth = rangeDate.getUTCMonth();
@@ -513,7 +522,7 @@ class LayerDataItems extends Component {
                               // const rangeDate = itemRange.date;
                               // const itemRangeInterval = itemRange.interval;
                               const nextDate = multiDateToDisplay[multiIndex + 1];
-                              const rangeDateEnd = this.getRangeDateEndWithAddedInterval(date, layerPeriod, interval, endDateLimit, nextDate);
+                              const rangeDateEnd = this.getRangeDateEndWithAddedInterval(date, layerPeriod, interval, nextDate);
                               // get range line dimensions
                               const multiLineRangeOptions = getMatchingCoverageLineDimensions(layer, date, rangeDateEnd);
                               // create DOM line element

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -1,0 +1,446 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { Tooltip } from 'reactstrap';
+import { datesinDateRanges } from '../../../modules/layers/util';
+import util from '../../../util/util';
+
+import {
+  timeScaleToNumberKey,
+} from '../../../modules/date/constants';
+
+// ignore multiple date ranges due to WV config not building to
+// handle varying periods in same layer (example: M and D)
+const ignoredLayer = {
+  GRACE_Tellus_Liquid_Water_Equivalent_Thickness_Mascon_CRI: true,
+};
+
+/*
+ * Layer Data Container for layer coverage.
+ *
+ * @class LayerDataItems
+ */
+
+class LayerDataItems extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  /**
+  * @desc get layer header with title, subtitle, and full date range
+  * @param {Object} layer
+  * @param {Boolean} visible
+  * @param {String} dateRange
+  * @param {String} background color
+  * @returns {DOM Element} header
+  */
+  getHeader = (layer, visible, dateRange, layerItemBackground) => {
+    const titleColor = visible ? '#000' : '#999';
+    const textColor = visible ? '#222' : '#999';
+    return (
+      <>
+        <div className="data-panel-layer-item-header">
+          <div
+            className="data-panel-layer-item-title"
+            style={{
+              color: titleColor,
+              fontSize: '1em',
+            }}
+          >
+            {layer.title}
+            {' '}
+            <span
+              className="data-panel-layer-item-subtitle"
+              style={{
+                color: textColor,
+                fontSize: '0.9em',
+              }}
+            >
+              {layer.subtitle}
+            </span>
+          </div>
+          <div
+            className="data-panel-layer-item-date-range"
+            style={{
+              background: layerItemBackground,
+              color: textColor,
+              fontSize: '0.9em',
+            }}
+          >
+            {dateRange}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  /**
+  * @desc get line DOM element from full/partial (interval) date range
+  * @param {String} id
+  * @param {Object} options
+  * @param {String} dateRangeStart
+  * @param {String} dateRangeEnd
+  * @param {String} color
+  * @param {String} position
+  * @param {String} toolTipText
+  * @param {Number/String} index
+  * @returns {DOM Element} line
+  */
+  createMatchingCoverageLineDOMEl = (id, options, dateRangeStart, dateRangeEnd, color, position, toolTipText, index) => {
+    const { hoverOnToolTip, hoverOffToolTip, hoveredTooltip } = this.props;
+    const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
+    const width = Math.max(options.width, 0);
+
+    return (
+      <div
+        id={`data-coverage-line-${dateRangeStartEnd}`}
+        className="data-panel-coverage-line"
+        key={index}
+        onMouseEnter={() => hoverOnToolTip(`${dateRangeStartEnd}`)}
+        onMouseLeave={() => hoverOffToolTip()}
+        style={{
+          position,
+          left: options.leftOffset,
+          width: `${width}px`,
+          backgroundColor: color,
+          borderRadius: options.borderRadius,
+        }}
+      >
+        <Tooltip
+          placement={options.toolTipPlacement}
+          container={`.data-item-${id}`}
+          isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
+          target={`data-coverage-line-${dateRangeStartEnd}`}
+        >
+          {toolTipText}
+        </Tooltip>
+      </div>
+    );
+  }
+
+  /**
+  * @desc get range date end with added interval based on period
+  * @param {Object} range date object
+  * @param {String} time unit period
+  * @param {Number} itemRangeInterval
+  * @returns {Object} rangeDateEnd date object
+  */
+  getRangeDateEndWithAddedInterval = (rangeDate, layerPeriod, itemRangeInterval) => {
+    const minYear = rangeDate.getUTCFullYear();
+    const minMonth = rangeDate.getUTCMonth();
+    const minDay = rangeDate.getUTCDate();
+    const minHour = rangeDate.getUTCHours();
+    const minMinute = rangeDate.getUTCMinutes();
+    const yearAdd = layerPeriod === 'years' ? itemRangeInterval : 0;
+    const monthAdd = layerPeriod === 'months' ? itemRangeInterval : 0;
+    const dayAdd = layerPeriod === 'days' ? itemRangeInterval : 0;
+    const hourAdd = layerPeriod === 'hours' ? itemRangeInterval : 0;
+    const minuteAdd = layerPeriod === 'minutes' ? itemRangeInterval : 0;
+    const rangeDateEndLocal = new Date(
+      minYear + yearAdd,
+      minMonth + monthAdd,
+      minDay + dayAdd,
+      minHour + hourAdd,
+      minMinute + minuteAdd,
+    );
+
+    const rangeDateEnd = new Date(rangeDateEndLocal.getTime() - (rangeDateEndLocal.getTimezoneOffset() * 60000));
+    return rangeDateEnd;
+  }
+
+  /**
+  * @desc get formatted, readable date range for header
+  * @param {Object} layer
+  * @returns {String} dateRangeText
+  */
+  getFormattedDateRange = (layer) => {
+    // get start date -or- 'start'
+    let dateRangeStart;
+    if (layer.startDate) {
+      const yearMonthDaySplit = layer.startDate.split('T')[0].split('-');
+      const year = yearMonthDaySplit[0];
+      const month = yearMonthDaySplit[1];
+      const day = yearMonthDaySplit[2];
+
+      const monthAbbrev = util.monthStringArray[Number(month) - 1];
+
+      dateRangeStart = `${year} ${monthAbbrev} ${day}`;
+    } else {
+      dateRangeStart = 'Start';
+    }
+
+    // get end date -or- 'present'
+    let dateRangeEnd;
+    if (layer.endDate) {
+      const yearMonthDaySplit = layer.endDate.split('T')[0].split('-');
+      const year = yearMonthDaySplit[0];
+      const month = yearMonthDaySplit[1];
+      const day = yearMonthDaySplit[2];
+
+      const monthAbbrev = util.monthStringArray[Number(month) - 1];
+
+      dateRangeEnd = `${year} ${monthAbbrev} ${day}`;
+    } else {
+      dateRangeEnd = 'Present';
+    }
+
+    const dateRangeText = `${dateRangeStart} to ${dateRangeEnd}`;
+    return dateRangeText;
+  }
+
+  render() {
+    const {
+      activeLayers,
+      appNow,
+      axisWidth,
+      backDate,
+      frontDate,
+      getMatchingCoverageLineDimensions,
+      hoveredLayer,
+      timeScale,
+    } = this.props;
+
+    const baseLineColor = '#00457B';
+    return (
+      <div className="data-panel-layer-list">
+        {activeLayers.map((layer, index) => {
+          const {
+            dateRanges,
+            endDate,
+            id,
+            inactive,
+            period,
+            startDate,
+            visible,
+          } = layer;
+          if (!dateRanges) {
+            return null;
+          }
+          // check for multiple date ranges
+          let multipleCoverageRanges = false;
+          if (dateRanges && !ignoredLayer[id]) {
+            multipleCoverageRanges = dateRanges.length > 1;
+          }
+          // eslint-disable-next-line no-nested-ternary
+          let layerPeriod = period === 'daily'
+            ? 'day'
+            // eslint-disable-next-line no-nested-ternary
+            : period === 'monthly'
+              ? 'month'
+              : period === 'yearly'
+                ? 'year'
+                : 'minute';
+
+          // get layer scale number to determine relation to current axis zoom level
+          const timeScaleNumber = timeScaleToNumberKey[timeScale];
+          const layerScaleNumber = timeScaleToNumberKey[layerPeriod];
+          const isLayerGreaterIncrementThanZoom = layerScaleNumber < timeScaleNumber;
+          const isLayerEqualIncrementThanZoom = layerScaleNumber === timeScaleNumber;
+
+          // concat (ex: day to days) for moment manipulation below
+          layerPeriod += 's';
+
+          // get line dimensions and handle condtional styling
+          const containerLineDimensions = getMatchingCoverageLineDimensions(layer);
+          const containerBackgroundColor = visible ? '#ccc' : 'rgb(79, 79, 79)';
+          // lighten data panel layer container on sidebar hover
+          const containerHoveredBackgroundColor = visible ? '#e6e6e6' : 'rgb(101, 101, 101)';
+          const backgroundColor = visible ? baseLineColor : 'rgb(116, 116, 116)';
+          const isLayerHoveredInSidebar = id === hoveredLayer;
+
+          // get date range to display
+          const dateRangeStart = (startDate && startDate.split('T')[0]) || 'start';
+          const dateRangeEnd = (endDate && endDate.split('T')[0]) || 'present';
+          const dateRange = this.getFormattedDateRange(layer);
+          const dateRangeIntervalZeroIndex = dateRanges
+            ? Number(dateRanges[0].dateInterval)
+            : 1;
+
+          const multipleCoverageRangesDateIntervals = {};
+          const layerItemBackground = isLayerHoveredInSidebar ? containerHoveredBackgroundColor : containerBackgroundColor;
+          const key = index;
+          return (
+            <div
+              key={key}
+              className={`data-panel-layer-item data-item-${id}`}
+              style={{
+                background: layerItemBackground,
+                outline: isLayerHoveredInSidebar ? '1px solid #222' : '',
+              }}
+            >
+              {/* Layer Header */
+                this.getHeader(layer, visible, dateRange, layerItemBackground)
+              }
+              <div
+                className={`data-panel-layer-coverage-line-container data-line-${id}`}
+                style={{
+                  maxWidth: `${axisWidth}px`,
+                }}
+              >
+                {(isLayerGreaterIncrementThanZoom && (multipleCoverageRanges || dateRangeIntervalZeroIndex))
+                || (isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex && dateRangeIntervalZeroIndex !== 1)
+                // multiple coverage ranges
+                  ? (
+                    <div
+                      className="data-panel-coverage-line"
+                      style={{
+                        width: `${containerLineDimensions.width}px`,
+                      }}
+                    >
+                      {dateRanges.map((range, innerIndex) => {
+                        const rangeInterval = Number(range.dateInterval);
+                        const rangeStart = range.startDate;
+                        let rangeEnd = range.endDate;
+                        // multi time unit range - no year time unit
+                        if (isLayerGreaterIncrementThanZoom || (rangeInterval !== 1 && timeScale !== 'year')) {
+                          let startDateLimit = new Date(frontDate);
+                          // get leading start date minus rangeInterval and add to end date
+                          startDateLimit = moment.utc(startDateLimit).subtract(rangeInterval, layerPeriod);
+                          startDateLimit = moment(startDateLimit).toDate();
+                          rangeEnd = moment.utc(rangeEnd).add(rangeInterval, layerPeriod);
+                          rangeEnd = moment(rangeEnd).toDate();
+                          // get max end date based on dates visible on axis and appNow date
+                          let endDateLimit = new Date(backDate);
+                          const appNowDate = new Date(appNow);
+                          if (appNowDate < endDateLimit) {
+                            endDateLimit = appNowDate;
+                          }
+                          // if last date of multiple ranges check for endDate over appNow date
+                          if (!inactive && innerIndex === dateRanges.length - 1) {
+                            if (endDateLimit > appNowDate) {
+                              endDateLimit = appNowDate;
+                            }
+                            rangeEnd = appNowDate;
+                          }
+
+                          // get dates within given date range
+                          let dateIntervalStartDates = [];
+                          const startLessThanOrEqualToEndDateLimit = new Date(rangeStart).getTime() <= endDateLimit.getTime();
+                          const endGreaterThanOrEqualToStartDateLimit = new Date(rangeEnd).getTime() >= startDateLimit.getTime();
+                          if (startLessThanOrEqualToEndDateLimit && endGreaterThanOrEqualToStartDateLimit) {
+                            const inputStartDate = new Date(startDateLimit);
+                            const inputEndDate = new Date(endDateLimit);
+                            dateIntervalStartDates = datesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate);
+                          }
+                          // add date intervals to multipleCoverageRangesDateIntervals object to catch repeats
+                          dateIntervalStartDates.forEach((dateInt) => {
+                            const dateIntFormatted = dateInt.toISOString();
+                            multipleCoverageRangesDateIntervals[dateIntFormatted] = { date: dateInt, interval: rangeInterval };
+                          });
+
+                          // if at the end of dateRanges array, display results from multipleCoverageRangesDateIntervals
+                          if (innerIndex === dateRanges.length - 1) {
+                            const multiDateToDisplay = Object.values(multipleCoverageRangesDateIntervals);
+                            return multiDateToDisplay.map((itemRange, multiIndex) => {
+                              const rangeDate = itemRange.date;
+                              const itemRangeInterval = itemRange.interval;
+                              let rangeDateEnd = this.getRangeDateEndWithAddedInterval(rangeDate, layerPeriod, itemRangeInterval);
+                              // check if next date cuts off this range
+                              // (e.g., 8 day interval with: currentDate = 12-27-1999, and nextDate = 1-1-2000)
+                              if (multiDateToDisplay[multiIndex + 1]) {
+                                const nextDateObject = multiDateToDisplay[multiIndex + 1];
+                                const rangeDateEndTime = rangeDateEnd.getTime();
+                                const nextDate = nextDateObject.date;
+                                const nextDateTime = nextDate.getTime();
+                                if (nextDateTime <= rangeDateEndTime) {
+                                  rangeDateEnd = nextDate;
+                                }
+                              }
+                              if (endDateLimit < rangeDateEnd) {
+                                rangeDateEnd = endDateLimit;
+                              }
+
+                              // get range line dimensions
+                              const multiLineRangeOptions = getMatchingCoverageLineDimensions(layer, rangeDate, rangeDateEnd);
+
+                              // get formatted dates for tooltip display
+                              const cleanRangeStart = rangeDate.toISOString().replace(/[.:]/g, '_');
+                              const cleanRangeEnd = rangeDateEnd.toISOString().replace(/[.:]/g, '_');
+                              let displayText = `${cleanRangeStart.split('T')[0]} to ${cleanRangeEnd.split('T')[0]}`;
+
+                              // handle minutes range display text (ex: '14:50 to 15:00')
+                              if (layerPeriod === 'minutes') {
+                                const minutesRangeDateStart = rangeDate.toISOString().split('T')[1];
+                                const minutesRangeDateEnd = rangeDateEnd.toISOString().split('T')[1];
+                                displayText = `${minutesRangeDateStart.split(':', 2).join(':')} to ${minutesRangeDateEnd.split(':', 2).join(':')}`;
+                              }
+                              return multiLineRangeOptions.visible
+                                && this.createMatchingCoverageLineDOMEl(
+                                  id,
+                                  multiLineRangeOptions,
+                                  cleanRangeStart,
+                                  cleanRangeEnd,
+                                  backgroundColor,
+                                  'absolute',
+                                  displayText,
+                                  multiIndex,
+                                );
+                            });
+                          }
+                          return null;
+                        }
+                        // handle single coverage
+                        if (range.startDate === range.endDate) {
+                          rangeEnd = moment.utc(range.startDate).add(rangeInterval + 1, layerPeriod).format();
+                        } else {
+                          rangeEnd = moment.utc(rangeEnd).endOf(layerPeriod).format();
+                        }
+
+                        // get range line dimensions
+                        const singleLineOptions = getMatchingCoverageLineDimensions(layer, rangeStart, rangeEnd);
+
+                        // get formatted dates for tooltip display
+                        const cleanRangeStart = rangeStart.replace(/:/g, '_');
+                        const cleanRangeEnd = rangeEnd.replace(/:/g, '_');
+                        return singleLineOptions.visible
+                          && this.createMatchingCoverageLineDOMEl(
+                            id,
+                            singleLineOptions,
+                            cleanRangeStart,
+                            cleanRangeEnd,
+                            backgroundColor,
+                            'absolute',
+                            `${cleanRangeStart.split('T')[0]} to ${cleanRangeEnd.split('T')[0]}`,
+                            index,
+                          );
+                      })}
+                    </div>
+                  )
+                  // single start -> end date range coverage
+                  : containerLineDimensions.visible
+                  && this.createMatchingCoverageLineDOMEl(
+                    id,
+                    containerLineDimensions,
+                    dateRangeStart,
+                    dateRangeEnd,
+                    backgroundColor,
+                    'relative',
+                    `${dateRangeStart} to ${dateRangeEnd}`,
+                    `${id}-0`,
+                  )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+LayerDataItems.propTypes = {
+  activeLayers: PropTypes.array,
+  appNow: PropTypes.object,
+  axisWidth: PropTypes.number,
+  backDate: PropTypes.string,
+  frontDate: PropTypes.string,
+  getMatchingCoverageLineDimensions: PropTypes.func,
+  hoveredLayer: PropTypes.string,
+  hoveredTooltip: PropTypes.object,
+  hoverOffToolTip: PropTypes.func,
+  hoverOnToolTip: PropTypes.func,
+  timeScale: PropTypes.string,
+};
+
+export default LayerDataItems;

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -27,19 +27,7 @@ class LayerDataItems extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      initPosition: '',
     };
-  }
-
-  /**
-  * @desc setPropPosition set init position related to timeline axis
-  * @returns {void}
-  */
-  setPropPosition = () => {
-    const { position } = this.props;
-    this.setState({
-      initPosition: position,
-    });
   }
 
   /**
@@ -160,9 +148,6 @@ class LayerDataItems extends Component {
       position,
       transformX,
     } = this.props;
-    const {
-      initPosition,
-    } = this.state;
     const width = Math.max(options.width, 0);
     // get formatted dates based on line type
     const {
@@ -175,11 +160,6 @@ class LayerDataItems extends Component {
     const toolTipOffset = -options.leftOffset - (width < axisWidth ? options.leftOffset : axisWidth / 2);
     const toolTipPlacement = 'auto';
 
-    // handle line overlay for wide lines
-    const needsLineOverlay = options.leftOffset === 0 && options.width >= axisWidth * 2;
-    const overlayWidth = width * 10;
-    const overlayTransform = -overlayWidth / 2 + initPosition + position + transformX;
-
     // candy stripe color
     const altLineColor = color === 'rgb(0, 69, 123)'
       ? '#164e7a'
@@ -189,23 +169,13 @@ class LayerDataItems extends Component {
       ${color} 20px,
       ${altLineColor} 20px,
       ${altLineColor} 40px)`;
+    const bgPosition = `${options.leftOffset + width + position + transformX}px 0`;
 
     return (
       <div
         key={index}
         className="data-panel-coverage-line-container"
       >
-        { needsLineOverlay
-        && (
-        <div
-          className="data-panel-coverage-line-overlay"
-          style={{
-            width: `${width * 10}px`,
-            transform: `translate(${overlayTransform}px, 0)`,
-            background: stripeBackground,
-          }}
-        />
-        )}
         <div
           id={`data-coverage-line-${dateRangeStartEnd}`}
           className="data-panel-coverage-line"
@@ -216,6 +186,7 @@ class LayerDataItems extends Component {
             width: `${width}px`,
             borderRadius: options.borderRadius,
             background: stripeBackground,
+            backgroundPosition: width < axisWidth ? 0 : bgPosition,
           }}
         >
           <Tooltip
@@ -429,10 +400,6 @@ class LayerDataItems extends Component {
       layerItemBackground,
       layerItemOutline,
     };
-  }
-
-  componentDidMount() {
-    this.setPropPosition();
   }
 
   render() {

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -31,10 +31,10 @@ class LayerDataItems extends Component {
     };
   }
 
-  componentDidMount() {
-    this.setPropPosition();
-  }
-
+  /**
+  * @desc setPropPosition set init position related to timeline axis
+  * @returns {void}
+  */
   setPropPosition = () => {
     const { position } = this.props;
     this.setState({
@@ -176,7 +176,7 @@ class LayerDataItems extends Component {
     const toolTipPlacement = 'auto';
 
     // handle line overlay for wide lines
-    const needsLineOverlay = options.leftOffset === 0 && options.width > axisWidth;
+    const needsLineOverlay = options.leftOffset === 0 && options.width >= axisWidth * 2;
     const overlayWidth = width * 10;
     const overlayTransform = -overlayWidth / 2 + initPosition + position + transformX;
 
@@ -431,6 +431,9 @@ class LayerDataItems extends Component {
     };
   }
 
+  componentDidMount() {
+    this.setPropPosition();
+  }
 
   render() {
     const {

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -101,8 +101,8 @@ class TimelineData extends Component {
     const { gridWidth } = timeScaleOptions[timeScale].timeAxis;
     const axisFrontDate = new Date(frontDate).getTime();
     const axisBackDate = new Date(backDate).getTime();
-    let layerStart; let
-      layerEnd;
+    let layerStart;
+    let layerEnd;
 
     if (rangeStart || layer.startDate) {
       layerStart = new Date(rangeStart || layer.startDate).getTime();
@@ -125,7 +125,6 @@ class TimelineData extends Component {
     let borderRadiusRight = '0';
 
     let width = axisWidth * 2;
-    // let width = axisWidth;
     if (visible) {
       if (layerStart <= axisFrontDate) {
         leftOffset = 0;

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -1,0 +1,390 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import moment from 'moment';
+import {
+  isEqual as lodashIsEqual,
+} from 'lodash';
+import {
+  timeScaleOptions,
+} from '../../../modules/date/constants';
+import Scrollbars from '../../util/scrollbar';
+import Switch from '../../util/switch';
+import LayerDataItems from './layer-data-items';
+
+/*
+ * Timeline Data Panel for layer coverage.
+ *
+ * @class TimelineData
+ */
+
+class TimelineData extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeLayers: [],
+      shouldIncludeHiddenLayers: false,
+      hoveredTooltip: {},
+    };
+  }
+
+  componentDidMount() {
+    const { activeLayers } = this.props;
+    const { shouldIncludeHiddenLayers } = this.state;
+
+    const layers = this.getActiveLayers(activeLayers);
+    this.setActiveLayers(layers);
+    // prevent bubbling to parent which the wheel event is blocked for timeline zoom in/out wheel event
+    document.querySelector('.timeline-data-panel-container').addEventListener('wheel', (e) => e.stopPropagation(), { passive: false });
+    // init populate of activeLayers
+    this.addMatchingCoverageToTimeline(shouldIncludeHiddenLayers, layers);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { activeLayers } = this.props;
+    const { shouldIncludeHiddenLayers } = this.state;
+
+    const toggleHiddenChange = prevState.shouldIncludeHiddenLayers !== shouldIncludeHiddenLayers;
+    // need to update layer toggles for show/hide/remove
+    if (!lodashIsEqual(prevProps.activeLayers, activeLayers) || toggleHiddenChange) {
+      // update coverage including layer added/removed and option changes (active/inactive)
+      const layers = this.getActiveLayers(activeLayers);
+      this.setActiveLayers(layers);
+      this.addMatchingCoverageToTimeline(shouldIncludeHiddenLayers, layers);
+    }
+  }
+
+  /**
+  * @desc set active layers
+  * @param {Array} layers
+  * @returns {void}
+  */
+  setActiveLayers = (layers) => {
+    this.setState({
+      activeLayers: layers,
+    });
+  }
+
+  /**
+  * @desc get active layers
+  * @param {Array} layerCollection
+  * @returns {Array}
+  */
+  getActiveLayers = (layerCollection) => {
+    const { shouldIncludeHiddenLayers } = this.state;
+    const layers = layerCollection.filter((layer) => (shouldIncludeHiddenLayers
+      ? layer.startDate
+      : layer.startDate && layer.visible));
+    return layers;
+  }
+
+  /**
+  * @desc get line dimensions for given date range
+  * @param {Object} layer
+  * @param {String} rangeStart
+  * @param {String} rangeEnd
+  * @returns {Object} visible, leftOffset, width, borderRadius, toolTipPlacement
+  */
+  getMatchingCoverageLineDimensions = (layer, rangeStart, rangeEnd) => {
+    const {
+      appNow,
+      axisWidth,
+      backDate,
+      frontDate,
+      position,
+      timeScale,
+      timelineStartDateLimit,
+      transformX,
+    } = this.props;
+
+    const postionTransformX = position + transformX;
+    const { gridWidth } = timeScaleOptions[timeScale].timeAxis;
+    const axisFrontDate = new Date(frontDate).getTime();
+    const axisBackDate = new Date(backDate).getTime();
+    let layerStart; let
+      layerEnd;
+
+    if (rangeStart || layer.startDate) {
+      layerStart = new Date(rangeStart || layer.startDate).getTime();
+    } else {
+      layerStart = new Date(timelineStartDateLimit).getTime();
+    }
+    if (rangeEnd || layer.inactive === true) {
+      layerEnd = new Date(rangeEnd || layer.endDate).getTime();
+    } else {
+      layerEnd = new Date(appNow).getTime();
+    }
+
+    let visible = true;
+    if (layerStart >= axisBackDate || layerEnd <= axisFrontDate) {
+      visible = false;
+    }
+
+    let leftOffset = 0;
+    let borderRadiusLeft = '0';
+    let borderRadiusRight = '0';
+
+    let width = axisWidth * 2;
+    if (visible) {
+      if (layerStart <= axisFrontDate) {
+        leftOffset = 0;
+      } else {
+        // positive diff means layerStart more recent than axisFrontDate
+        const diff = moment.utc(layerStart).diff(axisFrontDate, timeScale, true);
+        const gridDiff = gridWidth * diff;
+        leftOffset = gridDiff + postionTransformX;
+        borderRadiusLeft = '3px';
+      }
+
+      if (layerEnd <= axisBackDate) {
+        // positive diff means layerEnd earlier than back date
+        const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
+        const gridDiff = gridWidth * diff;
+        width = gridDiff + postionTransformX - leftOffset;
+        borderRadiusRight = '3px';
+      }
+    }
+
+    const borderRadius = `${borderRadiusLeft} ${borderRadiusRight} ${borderRadiusRight} ${borderRadiusLeft}`;
+    const toolTipPlacement = 'auto';
+
+    return {
+      visible,
+      leftOffset,
+      width,
+      borderRadius,
+      toolTipPlacement,
+    };
+  }
+
+  /**
+  * @desc handle hovering on line and adding active tooltip
+  * @param {String} input
+  * @returns {void}
+  */
+  hoverOnToolTip = (input) => {
+    this.setState({
+      hoveredTooltip: { [input]: true },
+    });
+  }
+
+  /**
+  * @desc handle hovering off line and removing active tooltip
+  * @returns {void}
+  */
+  hoverOffToolTip = () => {
+    this.setState({
+      hoveredTooltip: {},
+    });
+  }
+
+  /**
+  * @desc handle open/close modal from clicking handle
+  * @returns {void}
+  */
+  togglePanelOpenClose = () => {
+    const {
+      isDataCoveragePanelOpen,
+      toggleDataCoveragePanel,
+    } = this.props;
+    toggleDataCoveragePanel(!isDataCoveragePanelOpen);
+  }
+
+  /**
+  * @desc get startDate and endDate based on layers currently selected for matching coverage
+  * @param {Array} layers
+  * @returns {Object} startDate, endDate
+  */
+  addMatchingCoverageToTimeline = (isChecked, layerCollection = this.state.activeLayers) => {
+    const { setMatchingTimelineCoverage } = this.props;
+    const layers = this.getActiveLayers(layerCollection);
+    const dateRange = this.getNewMatchingDatesRange(layers);
+    setMatchingTimelineCoverage(dateRange, isChecked);
+    this.setState({
+      activeLayers: layers,
+      shouldIncludeHiddenLayers: isChecked,
+    });
+  }
+
+  /**
+  * @desc get startDate and endDate based on layers currently selected for matching coverage
+  * @param {Array} layers
+  * @returns {Object} startDate, endDate
+  */
+  getNewMatchingDatesRange = (layers) => {
+    const { appNow } = this.props;
+    let startDate;
+    let endDate = new Date(appNow);
+    if (layers.length > 0) {
+      // for each start date, find latest that is still below end date
+      const startDates = layers.reduce((acc, x) => (x.startDate ? acc.concat(x.startDate) : acc), []);
+      for (let i = 0; i < startDates.length; i += 1) {
+        const date = new Date(startDates[i]);
+        if (i === 0) {
+          startDate = date;
+        }
+        if (date.getTime() > startDate.getTime()) {
+          startDate = date;
+        }
+      }
+      // for each end date, find earlier that is still after start date
+      const endDates = layers.reduce((acc, x) => (x.endDate ? acc.concat(x.endDate) : acc), []);
+      for (let i = 0; i < endDates.length; i += 1) {
+        const date = new Date(endDates[i]);
+        if (i === 0) {
+          endDate = date;
+        }
+        if (date.getTime() < endDate.getTime()) {
+          endDate = date;
+        }
+      }
+
+      return {
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+      };
+    }
+  }
+
+  render() {
+    const {
+      appNow,
+      axisWidth,
+      backDate,
+      frontDate,
+      hoveredLayer,
+      isDataCoveragePanelOpen,
+      parentOffset,
+      timeScale,
+    } = this.props;
+    const {
+      activeLayers,
+      hoveredTooltip,
+      shouldIncludeHiddenLayers,
+    } = this.state;
+    // filter current active layers
+    const layers = activeLayers.filter((layer) => (shouldIncludeHiddenLayers
+      ? layer.startDate
+      : layer.startDate && layer.visible));
+
+    // handle conditional styling
+    const maxHeightScrollBar = '203px';
+    const layerListItemHeigthConstant = layers.length * 41;
+
+    const dataAvailabilityHandleTopOffset = `${Math.max(-54 - layerListItemHeigthConstant, -259)}px`;
+
+    const mainContainerWidth = `${axisWidth + 78}px`;
+    const mainContainerHeight = `${Math.min(35 + layerListItemHeigthConstant, 240)}px`;
+    const mainContainerLeftOffset = `${parentOffset - 10}px`;
+
+    const animateBottomClassName = `animate-timeline-data-panel-slide-${isDataCoveragePanelOpen ? 'up' : 'down'}`;
+    const panelChevronClassName = `wv-timeline-data-availability-handle-chevron-${isDataCoveragePanelOpen ? 'open' : 'closed'}`;
+
+    return (
+      <>
+        {/* Data Coverage Panel open/close handle */}
+        <div
+          id="timeline-data-availability-panel-handle"
+          onClick={this.togglePanelOpenClose}
+          style={{
+            right: Math.floor((axisWidth + 75) / 2),
+            top: isDataCoveragePanelOpen ? dataAvailabilityHandleTopOffset : '-19px',
+          }}
+        >
+          <div className={`wv-timeline-data-availability-handle-chevron ${panelChevronClassName}`} />
+        </div>
+        <div
+          className={`timeline-data-panel-container ${animateBottomClassName}`}
+          style={{
+            width: mainContainerWidth,
+            height: mainContainerHeight,
+            left: mainContainerLeftOffset,
+          }}
+        >
+          {/* Data Coverage Panel */}
+          {isDataCoveragePanelOpen
+          && (
+          <div
+            className="timeline-data-panel"
+            style={{
+              width: mainContainerWidth,
+            }}
+          >
+            <header className="timeline-data-panel-header">
+              <h3 className="timeline-data-panel-header-title">LAYER COVERAGE</h3>
+              <Switch
+                active={shouldIncludeHiddenLayers}
+                color="00457b"
+                id="wv-toggle-data-matching-toggle"
+                containerId="wv-toggle-data-matching-main"
+                label="Include Hidden Layers"
+                toggle={() => this.addMatchingCoverageToTimeline(!shouldIncludeHiddenLayers)}
+              />
+            </header>
+            <Scrollbars style={{ maxHeight: maxHeightScrollBar }}>
+              <LayerDataItems
+                activeLayers={activeLayers}
+                appNow={appNow}
+                axisWidth={axisWidth}
+                backDate={backDate}
+                frontDate={frontDate}
+                getMatchingCoverageLineDimensions={this.getMatchingCoverageLineDimensions}
+                hoveredLayer={hoveredLayer}
+                hoveredTooltip={hoveredTooltip}
+                hoverOffToolTip={this.hoverOffToolTip}
+                hoverOnToolTip={this.hoverOnToolTip}
+                timeScale={timeScale}
+              />
+            </Scrollbars>
+          </div>
+          )}
+        </div>
+      </>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  const {
+    compare,
+    layers,
+    date,
+  } = state;
+  const {
+    appNow,
+  } = date;
+
+  const activeLayers = layers[compare.activeString].filter((activeLayer) => activeLayer.startDate);
+  const { hoveredLayer } = layers;
+
+  return {
+    activeLayers,
+    hoveredLayer,
+    appNow,
+  };
+}
+
+const mapDispatchToProps = (dispatch) => ({
+});
+
+TimelineData.propTypes = {
+  activeLayers: PropTypes.array,
+  appNow: PropTypes.object,
+  axisWidth: PropTypes.number,
+  backDate: PropTypes.string,
+  frontDate: PropTypes.string,
+  hoveredLayer: PropTypes.string,
+  isDataCoveragePanelOpen: PropTypes.bool,
+  parentOffset: PropTypes.number,
+  position: PropTypes.number,
+  setMatchingTimelineCoverage: PropTypes.func,
+  timelineStartDateLimit: PropTypes.string,
+  timeScale: PropTypes.string,
+  toggleDataCoveragePanel: PropTypes.func,
+  transformX: PropTypes.number,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TimelineData);

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -324,9 +324,10 @@ class TimelineData extends Component {
               <h3 className="timeline-data-panel-header-title">LAYER COVERAGE</h3>
               <Switch
                 active={shouldIncludeHiddenLayers}
+                border
                 color="00457b"
                 id="wv-toggle-data-matching-toggle"
-                containerId="wv-toggle-data-matching-main"
+                containerClassAddition="wv-toggle-data-matching-main"
                 label="Include Hidden Layers"
                 toggle={() => this.addMatchingCoverageToTimeline(!shouldIncludeHiddenLayers)}
               />

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -54,6 +54,43 @@ class TimelineData extends Component {
     }
   }
 
+  // shouldComponentUpdate(nextProps, nextState) {
+  //   const {
+  //     activeLayers,
+  //     appNow,
+  //     axisWidth,
+  //     backDate,
+  //     frontDate,
+  //     parentOffset,
+  //     isDataCoveragePanelOpen,
+  //     position,
+  //     timeScale,
+  //     timelineStartDateLimit,
+  //     transformX,
+  //   } = this.props;
+
+  //   const checkForPropsUpdates = nextProps.appNow === appNow
+  //     && nextProps.axisWidth === axisWidth
+  //     && nextProps.backDate === backDate
+  //     && nextProps.frontDate === frontDate
+  //     && nextProps.position === position
+  //     && nextProps.isDataCoveragePanelOpen === isDataCoveragePanelOpen
+  //     && nextProps.parentOffset === parentOffset
+  //     && nextProps.timeScale === timeScale
+  //     && nextProps.timelineStartDateLimit === timelineStartDateLimit
+  //     && nextProps.transformX === transformX
+  //     && lodashIsEqual(nextProps.activeLayers, activeLayers);
+
+
+  //   const { shouldIncludeHiddenLayers } = this.state;
+  //   const checkForStateUpdates = shouldIncludeHiddenLayers === nextState.shouldIncludeHiddenLayers;
+  //   if (checkForPropsUpdates && checkForStateUpdates) {
+  //     return false;
+  //   }
+
+  //   return true;
+  // }
+
   /**
   * @desc set active layers
   * @param {Array} layers
@@ -124,7 +161,8 @@ class TimelineData extends Component {
     let borderRadiusLeft = '0';
     let borderRadiusRight = '0';
 
-    let width = axisWidth * 2;
+    // let width = axisWidth * 2;
+    let width = axisWidth;
     if (visible) {
       if (layerStart <= axisFrontDate) {
         leftOffset = 0;
@@ -209,10 +247,14 @@ class TimelineData extends Component {
   /**
   * @desc get startDate and endDate based on layers currently selected for matching coverage
   * @param {Array} layers
-  * @returns {Object} startDate, endDate
+  * @returns {Object}
+    * @param {String} startDate
+    * @param {String} endDate
   */
   getNewMatchingDatesRange = (layers) => {
-    const { appNow } = this.props;
+    const {
+      appNow,
+    } = this.props;
     let startDate;
     let endDate = new Date(appNow);
     if (layers.length > 0) {
@@ -227,7 +269,7 @@ class TimelineData extends Component {
           startDate = date;
         }
       }
-      // for each end date, find earlier that is still after start date
+      // for each end date, find earliest that is still after start date
       const endDates = layers.reduce((acc, x) => (x.endDate ? acc.concat(x.endDate) : acc), []);
       for (let i = 0; i < endDates.length; i += 1) {
         const date = new Date(endDates[i]);
@@ -267,9 +309,11 @@ class TimelineData extends Component {
       ? layer.startDate
       : layer.startDate && layer.visible));
 
+    const emptyLayers = activeLayers.length === 0;
+
     // handle conditional styling
     const maxHeightScrollBar = '203px';
-    const layerListItemHeigthConstant = layers.length * 41;
+    const layerListItemHeigthConstant = emptyLayers ? 41 : layers.length * 41;
 
     const dataAvailabilityHandleTopOffset = `${Math.max(-54 - layerListItemHeigthConstant, -259)}px`;
 

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -83,7 +83,7 @@ class TimelineData extends Component {
   * @param {Object} layer
   * @param {String} rangeStart
   * @param {String} rangeEnd
-  * @returns {Object} visible, leftOffset, width, borderRadius, toolTipPlacement
+  * @returns {Object} visible, leftOffset, width, borderRadius
   */
   getMatchingCoverageLineDimensions = (layer, rangeStart, rangeEnd) => {
     const {
@@ -146,14 +146,12 @@ class TimelineData extends Component {
     }
 
     const borderRadius = `${borderRadiusLeft} ${borderRadiusRight} ${borderRadiusRight} ${borderRadiusLeft}`;
-    const toolTipPlacement = 'auto';
 
     return {
       visible,
       leftOffset,
       width,
       borderRadius,
-      toolTipPlacement,
     };
   }
 
@@ -259,7 +257,9 @@ class TimelineData extends Component {
       hoveredLayer,
       isDataCoveragePanelOpen,
       parentOffset,
+      position,
       timeScale,
+      transformX,
     } = this.props;
     const {
       activeLayers,
@@ -340,6 +340,8 @@ class TimelineData extends Component {
                 hoverOffToolTip={this.hoverOffToolTip}
                 hoverOnToolTip={this.hoverOnToolTip}
                 timeScale={timeScale}
+                position={position}
+                transformX={transformX}
               />
             </Scrollbars>
           </div>

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -41,8 +41,13 @@ class TimelineData extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { activeLayers } = this.props;
+    const { activeLayers, isProductPickerOpen, isDataCoveragePanelOpen } = this.props;
     const { shouldIncludeHiddenLayers } = this.state;
+
+    if (!prevProps.isProductPickerOpen && isProductPickerOpen && isDataCoveragePanelOpen) {
+      this.togglePanelOpenClose();
+      return;
+    }
 
     const toggleHiddenChange = prevState.shouldIncludeHiddenLayers !== shouldIncludeHiddenLayers;
     // need to update layer toggles for show/hide/remove
@@ -285,7 +290,6 @@ class TimelineData extends Component {
 
     const animateBottomClassName = `animate-timeline-data-panel-slide-${isDataCoveragePanelOpen ? 'up' : 'down'}`;
     const panelChevronClassName = `wv-timeline-data-availability-handle-chevron-${isDataCoveragePanelOpen ? 'open' : 'closed'}`;
-
     return (
       <>
         {/* Data Coverage Panel open/close handle */}
@@ -355,8 +359,9 @@ class TimelineData extends Component {
 function mapStateToProps(state) {
   const {
     compare,
-    layers,
     date,
+    layers,
+    modal,
   } = state;
   const {
     appNow,
@@ -364,11 +369,13 @@ function mapStateToProps(state) {
 
   const activeLayers = layers[compare.activeString].filter((activeLayer) => activeLayer.startDate);
   const { hoveredLayer } = layers;
+  const isProductPickerOpen = modal.isOpen && modal.id === 'LAYER_PICKER_COMPONENT';
 
   return {
     activeLayers,
     hoveredLayer,
     appNow,
+    isProductPickerOpen,
   };
 }
 
@@ -383,6 +390,7 @@ TimelineData.propTypes = {
   frontDate: PropTypes.string,
   hoveredLayer: PropTypes.string,
   isDataCoveragePanelOpen: PropTypes.bool,
+  isProductPickerOpen: PropTypes.bool,
   parentOffset: PropTypes.number,
   position: PropTypes.number,
   setMatchingTimelineCoverage: PropTypes.func,

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -279,7 +279,7 @@ class TimelineData extends Component {
 
     const dataAvailabilityHandleTopOffset = `${Math.max(-54 - layerListItemHeigthConstant, -259)}px`;
 
-    const mainContainerWidth = `${axisWidth + 78}px`;
+    const mainContainerWidth = `${axisWidth + 1}px`;
     const mainContainerHeight = `${Math.min(35 + layerListItemHeigthConstant, 240)}px`;
     const mainContainerLeftOffset = `${parentOffset - 10}px`;
 

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -54,43 +54,6 @@ class TimelineData extends Component {
     }
   }
 
-  // shouldComponentUpdate(nextProps, nextState) {
-  //   const {
-  //     activeLayers,
-  //     appNow,
-  //     axisWidth,
-  //     backDate,
-  //     frontDate,
-  //     parentOffset,
-  //     isDataCoveragePanelOpen,
-  //     position,
-  //     timeScale,
-  //     timelineStartDateLimit,
-  //     transformX,
-  //   } = this.props;
-
-  //   const checkForPropsUpdates = nextProps.appNow === appNow
-  //     && nextProps.axisWidth === axisWidth
-  //     && nextProps.backDate === backDate
-  //     && nextProps.frontDate === frontDate
-  //     && nextProps.position === position
-  //     && nextProps.isDataCoveragePanelOpen === isDataCoveragePanelOpen
-  //     && nextProps.parentOffset === parentOffset
-  //     && nextProps.timeScale === timeScale
-  //     && nextProps.timelineStartDateLimit === timelineStartDateLimit
-  //     && nextProps.transformX === transformX
-  //     && lodashIsEqual(nextProps.activeLayers, activeLayers);
-
-
-  //   const { shouldIncludeHiddenLayers } = this.state;
-  //   const checkForStateUpdates = shouldIncludeHiddenLayers === nextState.shouldIncludeHiddenLayers;
-  //   if (checkForPropsUpdates && checkForStateUpdates) {
-  //     return false;
-  //   }
-
-  //   return true;
-  // }
-
   /**
   * @desc set active layers
   * @param {Array} layers

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -124,8 +124,8 @@ class TimelineData extends Component {
     let borderRadiusLeft = '0';
     let borderRadiusRight = '0';
 
-    // let width = axisWidth * 2;
-    let width = axisWidth;
+    let width = axisWidth * 2;
+    // let width = axisWidth;
     if (visible) {
       if (layerStart <= axisFrontDate) {
         leftOffset = 0;
@@ -134,7 +134,7 @@ class TimelineData extends Component {
         const diff = moment.utc(layerStart).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         leftOffset = gridDiff + postionTransformX;
-        borderRadiusLeft = '3px';
+        borderRadiusLeft = '6px';
       }
 
       if (layerEnd <= axisBackDate) {
@@ -142,7 +142,7 @@ class TimelineData extends Component {
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         width = gridDiff + postionTransformX - leftOffset;
-        borderRadiusRight = '3px';
+        borderRadiusRight = '6px';
       }
     }
 

--- a/web/js/components/util/switch.js
+++ b/web/js/components/util/switch.js
@@ -8,9 +8,10 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 // https://upmostly.com/tutorials/build-a-react-switch-toggle-component
 const Switch = (props) => {
   const {
+    border,
     id,
     color,
-    containerId,
+    containerClassAddition,
     active,
     toggle,
     label,
@@ -20,13 +21,14 @@ const Switch = (props) => {
   const [tooltipOpen, toggleTooltip] = useState(false);
   const activeColor = color || '007BFF';
   const style = isActive ? { backgroundColor: `#${activeColor}` } : {};
+  const containerClass = `react-switch ${containerClassAddition || ''} ${border ? 'switch-thin-border' : ''}`;
 
   useEffect(() => {
     toggleActive(active);
   }, [active]);
 
   return (
-    <div id={containerId} className="react-switch">
+    <div className={containerClass}>
       <div className="react-switch-case switch-col">
         <input
           className="react-switch-checkbox"
@@ -68,12 +70,14 @@ const Switch = (props) => {
   );
 };
 Switch.defaultProps = {
-  containerId: '',
+  containerClassAddition: '',
+  border: false,
 };
 Switch.propTypes = {
   active: PropTypes.bool,
+  border: PropTypes.bool,
   color: PropTypes.string,
-  containerId: PropTypes.string,
+  containerClassAddition: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
   toggle: PropTypes.func,

--- a/web/js/components/util/switch.js
+++ b/web/js/components/util/switch.js
@@ -10,6 +10,7 @@ const Switch = (props) => {
   const {
     id,
     color,
+    containerId,
     active,
     toggle,
     label,
@@ -25,7 +26,7 @@ const Switch = (props) => {
   }, [active]);
 
   return (
-    <div className="react-switch">
+    <div id={containerId} className="react-switch">
       <div className="react-switch-case switch-col">
         <input
           className="react-switch-checkbox"
@@ -50,25 +51,29 @@ const Switch = (props) => {
         {label}
         {tooltip
           && (
-          <>
-            <FontAwesomeIcon icon={faInfoCircle} id="availability-filter" />
-            <Tooltip
-              placement="right"
-              isOpen={tooltipOpen}
-              target="availability-filter"
-              toggle={() => { toggleTooltip(!tooltipOpen); }}
-            >
-              {tooltip}
-            </Tooltip>
-          </>
+            <>
+              <FontAwesomeIcon icon={faInfoCircle} id="availability-filter" />
+              <Tooltip
+                placement="right"
+                isOpen={tooltipOpen}
+                target="availability-filter"
+                toggle={() => { toggleTooltip(!tooltipOpen); }}
+              >
+                {tooltip}
+              </Tooltip>
+            </>
           )}
       </div>
     </div>
   );
 };
+Switch.defaultProps = {
+  containerId: '',
+};
 Switch.propTypes = {
   active: PropTypes.bool,
   color: PropTypes.string,
+  containerId: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string,
   toggle: PropTypes.func,

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -113,7 +113,7 @@ class AnimationWidget extends React.Component {
       customIntervalModalOpen: false,
       widgetPosition: {
         x: (props.screenWidth / 2) - halfWidgetWidth,
-        y: 0,
+        y: -10,
       },
       collapsed: false,
       collapsedWidgetPosition: { x: 0, y: 0 },

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -182,7 +182,7 @@ class Sidebar extends React.Component {
             href="/"
             title="Click to Reset Worldview to Defaults"
             id="wv-logo"
-            onClick={resetWorldview}
+            onClick={(e) => resetWorldview(e, isDistractionFreeModeActive)}
             // eslint-disable-next-line no-return-assign
             ref={(iconElement) => (this.iconElement = iconElement)}
             onWheel={wheelCallBack}

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -113,7 +113,7 @@ class Timeline extends React.Component {
     } = this.props;
 
     // left/right arrows
-    const throttleSettings = throttleSettings;
+    const throttleSettings = { leading: true, trailing: false };
     this.debounceDateUpdate = lodashDebounce(changeDate, 8);
     this.throttleDecrementDate = lodashThrottle(
       this.handleArrowDateChange.bind(this, -1),

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -206,6 +206,10 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
       }
       for (i = 0; i <= (yearDifference + 1); i += 1) {
         let year = new Date(minYear + i * dateInterval, minMonth, minDay);
+        if (year.getTime() >= maxYearDate.getTime()) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
         year = new Date(year.getTime() - (year.getTimezoneOffset() * 60000));
         dateArray.push(year);
       }

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -167,6 +167,23 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
     let minDate = new Date(dateRange.startDate);
     let maxDate = new Date(dateRange.endDate);
 
+    // explicit min/max ranges provided
+    if (rangeLimitsProvided) {
+      // handle single date coverage
+      if (dateRange.startDate === dateRange.endDate) {
+        const dateTime = new Date(minDate.getTime());
+        dateArray.push(dateTime);
+        return;
+      }
+      const startDateLimitTime = startDateLimit.getTime();
+      const endDateLimitTime = endDateLimit.getTime();
+      const minDateTime = minDate.getTime();
+      const minDateWithinRangeLimits = minDateTime > startDateLimitTime && minDateTime < endDateLimitTime;
+      if (currentDate.getTime() < minDateTime && minDateWithinRangeLimits) {
+        currentDate = minDate;
+      }
+    }
+
     // set maxDate to current date if layer coverage is ongoing
     if (index === def.dateRanges.length - 1 && !inactiveLayer) {
       maxDate = new Date();
@@ -180,13 +197,6 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
     const minDay = minDate.getUTCDate();
 
     let i;
-
-    // handle single date coverage
-    if (dateRange.startDate === dateRange.endDate) {
-      const dateTime = new Date(minDate.getTime());
-      dateArray.push(dateTime);
-      return;
-    }
 
     // Yearly layers
     if (period === 'yearly') {

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -249,11 +249,11 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
       if (currentDate.getTime() < minDateTime && minDateWithinRangeLimits) {
         currentDate = minDate;
       }
-    }
 
-    // set maxDate to current date if layer coverage is ongoing
-    if (index === def.dateRanges.length - 1 && !inactiveLayer) {
-      maxDate = new Date();
+      // set maxDate to current date if layer coverage is ongoing
+      if (index === def.dateRanges.length - 1 && !inactiveLayer) {
+        maxDate = new Date();
+      }
     }
 
     const maxYear = maxDate.getUTCFullYear();
@@ -309,7 +309,7 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
         month = new Date(month.getTime() - (month.getTimezoneOffset() * 60000));
         const monthTime = month.getTime();
         if (monthTime < maxEndDate.getTime()) {
-          if (dateArray.length > 0) {
+          if (rangeLimitsProvided && dateArray.length > 0) {
             dateArray = getDateArrayLastDateInOrder(month, dateArray);
           }
 
@@ -353,7 +353,7 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
         day = new Date(day.getTime() - (day.getTimezoneOffset() * 60000));
         const dayTime = day.getTime();
         if (dayTime < maxEndDate.getTime()) {
-          if (dateArray.length > 0) {
+          if (rangeLimitsProvided && dateArray.length > 0) {
             dateArray = getDateArrayLastDateInOrder(day, dateArray);
           }
 


### PR DESCRIPTION
## Description

Fixes #1772 part of #1776  .

**Add Timeline Data Availability Panel**

- Add "matching coverage" line on the timeline axis for coinciding coverage of selected layers
- Panel shows individual layer coverage with full range listed and multiple time units (ex: 8-day layer) broken up into separate time lines in current and smaller time units (e.g., 8-day is shown as separate 8-day data lines in day, hour, and minute time scales; however, single day data lines would only show as separate data lines in hour and minute time scales).
- Ability to toggle layers that are hidden in the sidebar to:
  - Show up in the data availability panel
  - Be included in the "matching coverage" line on the timeline axis
- Add E2E tests, various lint fixes, logic cleanups

**PR Review Fixes:**

- [x] Break up large rendering `layer-data-items` component
- [x] Allow layers with `rangeStart` but no `rangeDates` (e.g., Blue Marble, Fires)
- [x] Hover action outline spacing issue for timescale change
- [x] Tooltip positioning to reduce overflow cutoffs
- [x] GRACE unique key
- [x] Add warning message to users if no layers available so no empty panel
- [x] Increase border radius for data lines to improve identifying where the coverage splits for adjacent data lines of the same layer
- [x] Fix missing `throttleSettings`


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
