### PR TITLE
updated icesat-2 orbit designations

### DIFF
--- a/config/default/common/config/metadata/layers/reference/orbits/ICESAT-2.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/ICESAT-2.md
@@ -1,7 +1,7 @@
-### ICESAT-2 - Orbit Track & Time (Ascending/Day)
-The ICESAT-2 - Orbit Track & Time (Ascending/Day) layer is the path of the Ice, Cloud and land Elevation Satellite - 2 on its ascending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
+### ICESAT-2 - Orbit Track & Time (Ascending)
+The ICESAT-2 - Orbit Track & Time (Ascending) layer is the path of the Ice, Cloud and land Elevation Satellite - 2 on its ascending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
 
-### ICESAT-2 - Orbit Track & Time (Descending/Night)
-The ICESAT-2 - Orbit Track & Time (Descending/Night) layer is the path of the Ice, Cloud and land Elevation Satellite - 2  on its descending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
+### ICESAT-2 - Orbit Track & Time (Descending)
+The ICESAT-2 - Orbit Track & Time (Descending) layer is the path of the Ice, Cloud and land Elevation Satellite - 2  on its descending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.md
@@ -1,3 +1,3 @@
-The ICESAT-2 - Orbit Track & Time (Ascending/Day) layer is the path of the Ice, Cloud and land Elevation Satellite - 2 on its ascending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
+The ICESAT-2 - Orbit Track & Time (Ascending) layer is the path of the Ice, Cloud and land Elevation Satellite - 2 on its ascending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.md
@@ -1,3 +1,3 @@
-The ICESAT-2 - Orbit Track & Time (Descending/Night) layer is the path of the Ice, Cloud and land Elevation Satellite - 2  on its descending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
+The ICESAT-2 - Orbit Track & Time (Descending) layer is the path of the Ice, Cloud and land Elevation Satellite - 2  on its descending orbit. Overpass times are shown in Coordinated Universal Time (UTC).
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
@@ -5,7 +5,7 @@
       "title": "ICESAT-2 - Orbit Track & Time",
       "subtitle": "ICESAT-2 / Space-Track.org",
       "description": "reference/orbits/OrbitTracks_ICESAT-2_Ascending",
-      "tags": "tracks day",
+      "tags": "tracks",
       "group": "overlays",
       "format": "image/png",
       "type": "wms",
@@ -18,7 +18,7 @@
         "reference",
         "reference_orbits"
       ],
-      "daynight": "day",
+      "daynight": "",
       "track": "ascending",
       "startDate": "2018-09-15",
       "projections": {

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
@@ -5,7 +5,7 @@
       "title": "ICESAT-2 - Orbit Track & Time",
       "subtitle": "ICESAT-2 / Space-Track.org",
       "description": "reference/orbits/OrbitTracks_ICESAT-2_Descending",
-      "tags": "tracks night",
+      "tags": "tracks",
       "group": "overlays",
       "format": "image/png",
       "type": "wms",
@@ -18,7 +18,7 @@
         "reference",
         "reference_orbits"
       ],
-      "daynight": "night",
+      "daynight": "",
       "track": "descending",
       "startDate": "2018-09-15",
       "projections": {


### PR DESCRIPTION
## Description

Fixes #2808 .

Removed day and night distinction for IceSat-2 orbit tracks. Metop-A is sun-synchronous so it does not need to be changed. 

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
