### PR TITLE
Various timeline data panel and dragger pan related UI fixes

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -814,6 +814,7 @@ button:focus {
 }
 
 .data-panel-layer-item {
+  position: relative;
   border-bottom: thin solid #3c3c3c;
   padding-bottom: 5px;
 }
@@ -839,6 +840,7 @@ button:focus {
   position: absolute;
   font-size: 0.9em;
   right: 0;
+  top: 0;
   padding: 4px 10px;
 }
 

--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -42,7 +42,7 @@ class AxisHoverLine extends PureComponent {
     const layerLengthCoef = Math.max(layers.length, 1);
     // handle active layer count dependent tooltip height
     if (isDataCoveragePanelOpen) {
-      lineHeight = 111;
+      lineHeight = 112;
       const addHeight = Math.min(layerLengthCoef, 5) * 40;
       lineHeight += addHeight;
       lineHeightInner = lineHeight;
@@ -56,7 +56,7 @@ class AxisHoverLine extends PureComponent {
       linePosition = selectedDraggerPosition + 47;
       // lineheight for dragger
       const minusY1Height = Math.min(layerLengthCoef, 5) * 40.5;
-      lineHeightInner = 40.5 + minusY1Height;
+      lineHeightInner = 47 + minusY1Height;
     }
 
     return (

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -101,6 +101,19 @@ class DateToolTip extends PureComponent {
       toolTipHeightOffset -= addHeight;
       toolTipHeightOffset = Math.max(toolTipHeightOffset, -357);
     }
+
+    // eslint-disable-next-line no-nested-ternary
+    const toolTipWidth = hasSubdailyLayers
+      ? toolTipDayOfYear >= 100
+        ? '239px'
+        : '232px'
+      : '165px';
+
+    // add leading zero for single digits
+    toolTipDayOfYear = toolTipDayOfYear < 10
+      ? `0${toolTipDayOfYear}`
+      : toolTipDayOfYear;
+
     return (
       shouldDisplayDraggerToolTip && (
         <div
@@ -108,7 +121,7 @@ class DateToolTip extends PureComponent {
           style={{
             transform: `translate(${toolTipLeftOffset}px, ${toolTipHeightOffset}px)`,
             display: toolTipDisplay,
-            width: hasSubdailyLayers ? '232px' : '165px',
+            width: toolTipWidth,
           }}
         >
           { toolTipDate }

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -148,7 +148,14 @@ class LayerDataItems extends Component {
       position,
       transformX,
     } = this.props;
-    const width = Math.max(options.width, 0);
+    const {
+      borderRadius,
+      leftOffset,
+      isWidthGreaterThanRendered,
+      width,
+    } = options;
+    const lineWidth = Math.max(width, 0);
+
     // get formatted dates based on line type
     const {
       dateRangeStart,
@@ -156,8 +163,9 @@ class LayerDataItems extends Component {
       toolTipText,
     } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
     const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
+
     // handle tooltip positioning
-    const toolTipOffset = -options.leftOffset - (width < axisWidth ? options.leftOffset : axisWidth / 2);
+    const toolTipOffset = -leftOffset - (lineWidth < axisWidth ? leftOffset : axisWidth / 2);
     const toolTipPlacement = 'auto';
 
     // candy stripe color
@@ -169,7 +177,11 @@ class LayerDataItems extends Component {
       ${color} 20px,
       ${altLineColor} 20px,
       ${altLineColor} 40px)`;
-    const bgPosition = `${options.leftOffset + width + position + transformX}px 0`;
+    const backgroundPositionCalculated = `${leftOffset + lineWidth + position + transformX}px 0`;
+    const backgroundPosition = !isWidthGreaterThanRendered
+      || (leftOffset !== 0 && isWidthGreaterThanRendered)
+      ? 0
+      : backgroundPositionCalculated;
 
     return (
       <div
@@ -182,11 +194,11 @@ class LayerDataItems extends Component {
           onMouseEnter={() => hoverOnToolTip(`${dateRangeStartEnd}`)}
           onMouseLeave={() => hoverOffToolTip()}
           style={{
-            transform: `translate(${options.leftOffset}px, 0)`,
-            width: `${width}px`,
-            borderRadius: options.borderRadius,
+            transform: `translate(${leftOffset}px, 0)`,
+            width: `${lineWidth}px`,
+            borderRadius,
             background: stripeBackground,
-            backgroundPosition: width < axisWidth ? 0 : bgPosition,
+            backgroundPosition,
           }}
         >
           <Tooltip

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -88,7 +88,7 @@ class TimelineData extends Component {
   * @param {Object} layer
   * @param {String} rangeStart
   * @param {String} rangeEnd
-  * @returns {Object} visible, leftOffset, width, borderRadius
+  * @returns {Object} visible, leftOffset, width, borderRadius, isWidthGreaterThanRendered
   */
   getMatchingCoverageLineDimensions = (layer, rangeStart, rangeEnd) => {
     const {
@@ -150,6 +150,7 @@ class TimelineData extends Component {
       }
     }
 
+    const isWidthGreaterThanRendered = layerStart < axisFrontDate || layerEnd > axisBackDate;
     const borderRadius = `${borderRadiusLeft} ${borderRadiusRight} ${borderRadiusRight} ${borderRadiusLeft}`;
 
     return {
@@ -157,6 +158,7 @@ class TimelineData extends Component {
       leftOffset,
       width,
       borderRadius,
+      isWidthGreaterThanRendered,
     };
   }
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1248,6 +1248,23 @@ class Timeline extends React.Component {
                         isDataCoveragePanelOpen={isDataCoveragePanelOpen}
                       />
 
+                      {/* Data Coverage Panel */}
+                      <TimelineData
+                        appNow={appNow}
+                        position={position}
+                        transformX={transformX}
+                        timeScale={timeScale}
+                        frontDate={frontDate}
+                        backDate={backDate}
+                        timelineStartDateLimit={timelineStartDateLimit}
+                        parentOffset={parentOffset}
+                        axisWidth={axisWidth}
+                        setMatchingTimelineCoverage={this.setMatchingTimelineCoverage}
+                        matchingTimelineCoverage={matchingTimelineCoverage}
+                        toggleDataCoveragePanel={this.toggleDataCoveragePanel}
+                        isDataCoveragePanelOpen={isDataCoveragePanelOpen}
+                      />
+
                       {isAnimationWidgetReady
                       && (
                       <TimelineRangeSelector
@@ -1314,23 +1331,6 @@ class Timeline extends React.Component {
                         isDataCoveragePanelOpen={isDataCoveragePanelOpen}
                       />
                       )}
-
-                      {/* Data Coverage Panel */}
-                      <TimelineData
-                        appNow={appNow}
-                        position={position}
-                        transformX={transformX}
-                        timeScale={timeScale}
-                        frontDate={frontDate}
-                        backDate={backDate}
-                        timelineStartDateLimit={timelineStartDateLimit}
-                        parentOffset={parentOffset}
-                        axisWidth={axisWidth}
-                        setMatchingTimelineCoverage={this.setMatchingTimelineCoverage}
-                        matchingTimelineCoverage={matchingTimelineCoverage}
-                        toggleDataCoveragePanel={this.toggleDataCoveragePanel}
-                        isDataCoveragePanelOpen={isDataCoveragePanelOpen}
-                      />
                     </div>
 
                     {/* Custom Interval Selector Widget */}


### PR DESCRIPTION
## Description

Various timeline data panel and dragger pan related UI fixes.

- [x] Modify dragger pan axis update and extend rendered grids/modify leftbound. Fixes #2811 
- [x] Add to y axis blue line height. Fixes #2815 
- [x] Add leading `0` for date tooltip day of year < 10
- [x] Change `.data-panel-layer-item-date-range` position for consistent IE11 styling
- [x] Simplify data line position with boolean to improve weird background stripe rendering issue
- [x] Reorder `TimlineData` component to render behind animation draggers when unopened. Fixes #2829 

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
