### PR TITLE
Prevent keypress distraction free mode from invoking, close modals with ESC

### DIFF
--- a/web/js/modules/animation/reducers.js
+++ b/web/js/modules/animation/reducers.js
@@ -93,6 +93,13 @@ export function animationReducer(state = defaultState, action) {
           isPlaying: !state.isPlaying,
         });
       }
+      if (action.keyCode === 27) {
+        return lodashAssign({}, state, {
+          isActive: false,
+          gifActive: false,
+          isPlaying: false,
+        });
+      }
       return state;
 
     default:

--- a/web/js/modules/key-press/actions.js
+++ b/web/js/modules/key-press/actions.js
@@ -16,28 +16,34 @@ export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey) {
     const {
       modal, animation, tour, ui,
     } = getState();
-    const modalIsOpen = modal.isOpen;
+    const {
+      id,
+      isOpen,
+    } = modal;
     const { isDistractionFreeModeActive } = ui;
-    if (animation.isActive && !modalIsOpen) {
-      // can get more specific modal.key !== "LAYER_PICKER_COMPONENT"
-      dispatch({
-        type: ANIMATION_KEY_PRESS_ACTION,
-        keyCode,
-      });
-    }
+    const isProductPickerOpen = isOpen && id === 'LAYER_PICKER_COMPONENT';
     if (tour.active && keyCode === 27) {
       dispatch({
         type: TOUR_KEY_PRESS_CLOSE,
       });
-    }
-    if (!ctrlOrCmdKey && shiftKey && keyCode === 68) {
-      dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
-      if (!isDistractionFreeModeActive && modalIsOpen) {
-        dispatch({ type: CLOSE_MODAL });
+    } else if (!isProductPickerOpen) {
+      if (animation.isActive) {
+        dispatch({
+          type: ANIMATION_KEY_PRESS_ACTION,
+          keyCode,
+        });
+      } else if (!ctrlOrCmdKey && shiftKey && keyCode === 68) {
+        dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
+        if (!isDistractionFreeModeActive && isOpen) {
+          dispatch({ type: CLOSE_MODAL });
+        }
+      } else if (keyCode === 27) {
+        if (isDistractionFreeModeActive) {
+          dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
+        } else {
+          dispatch({ type: CLOSE_MODAL });
+        }
       }
-    }
-    if (isDistractionFreeModeActive && keyCode === 27) {
-      dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
     }
   };
 }


### PR DESCRIPTION
## Description

- [x] Prevent distraction mode firing when product picker is open. Fixes #2826
- [x] Close modals using `ESC` (e.g., image download, layer settings, share, etc.). Fixes #2828 
- [x] Close animation widget on ESC (slightly different behavior than other modals)

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
