### PR TITLE
Optimize datesinDateRanges date coverage array building

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18840,9 +18840,9 @@
       }
     },
     "react-draggable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.1.0.tgz",
-      "integrity": "sha512-Or/qe70cfymshqoC8Lsp0ukTzijJObehb7Vfl7tb5JRxoV+b6PDkOGoqYaWBzZ59k9dH/bwraLGsnlW78/3vrA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.3.1.tgz",
+      "integrity": "sha512-m8QeV+eIi7LhD5mXoLqDzLbokc6Ncwa0T34fF6uJzWSs4vc4fdZI/XGqHYoEn91T8S6qO+BSXslONh7Jz9VPQQ==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"

--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -75,7 +75,7 @@ class AxisHoverLine extends PureComponent {
             x2="0"
             y1="0"
             y2={lineHeightInner}
-            transform={`translate(${linePosition + 1}, 0)`}
+            transform={`translate(${linePosition + 1})`}
           />
         </svg>
       )

--- a/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
@@ -48,7 +48,10 @@ class GridRange extends PureComponent {
     } = this.props;
     const tileTextCondition = tileTextConditionOptions[timeScale];
     return (
-      <g className="axis-grid-container" transform={`translate(${transformX}, 0)`}>
+      <g
+        className="axis-grid-container"
+        transform={`translate(${transformX}, 0)`}
+      >
         <>
           {timeRange.map((item, index) => (
             item.withinRange

--- a/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
@@ -50,7 +50,7 @@ class GridRange extends PureComponent {
     return (
       <g
         className="axis-grid-container"
-        transform={`translate(${transformX}, 0)`}
+        transform={`translate(${transformX})`}
       >
         <>
           {timeRange.map((item, index) => (

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
@@ -96,7 +96,7 @@ class TileRect extends PureComponent {
             width={gridWidth}
             height={65}
             x={indexGridWithCoeff}
-            fill={item.withinRange ? 'rgba(0,0,0,0)' : 'black'}
+            fill="transparent"
           />
           <line
             className="axis-grid-line"
@@ -113,7 +113,7 @@ class TileRect extends PureComponent {
             stroke="#555"
             strokeWidth={1}
             x1={indexGridWithCoeff + 1}
-            x2={gridWidth}
+            x2={indexGridWithCoeff + 1 + gridWidth}
             y1="46"
             y2="46"
           />

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
@@ -87,6 +87,7 @@ class TileRect extends PureComponent {
     const tileOptions = tileRectTimeScaleOptions[timeScale]();
     const lineLengthY = tileOptions.lineLengthY(item);
     const whiteLineStrokeWidth = lineLengthY !== 10 ? 2 : 1;
+    const indexGridWithCoeff = index * gridWidth;
     return (
       <>
         <g onMouseMove={this.showHover}>
@@ -94,7 +95,7 @@ class TileRect extends PureComponent {
             className="axis-grid-rect"
             width={gridWidth}
             height={65}
-            transform={`translate(${index * gridWidth}, 0)`}
+            x={indexGridWithCoeff}
             fill={item.withinRange ? 'rgba(0,0,0,0)' : 'black'}
           />
           <line
@@ -102,32 +103,29 @@ class TileRect extends PureComponent {
             stroke="black"
             strokeLinecap="round"
             strokeWidth="0.2"
-            x1="0"
-            x2="0"
+            x1={indexGridWithCoeff + 2.2}
+            x2={indexGridWithCoeff + 2.2}
             y1="0"
             y2={lineLengthY}
-            transform={`translate(${index * gridWidth + 2.2}, 0)`}
           />
           <line
             className="axis-grid-line"
             stroke="#555"
             strokeWidth={1}
-            x1="0"
+            x1={indexGridWithCoeff + 1}
             x2={gridWidth}
             y1="46"
             y2="46"
-            transform={`translate(${index * gridWidth + 1}, 0)`}
           />
           <line
             className="axis-grid-line"
             stroke="white"
             strokeLinecap="round"
             strokeWidth={whiteLineStrokeWidth}
-            x1="0"
-            x2="0"
+            x1={indexGridWithCoeff + 1}
+            x2={indexGridWithCoeff + 1}
             y1="0"
             y2={lineLengthY}
-            transform={`translate(${index * gridWidth + 1}, 0)`}
           />
         </g>
       </>

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
@@ -31,11 +31,13 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
   }
   return (
     <>
-      <g transform={`translate(${indexGridWithCoeff + xOffsetAdded}, 20)`}>
+      <g
+        transform={`translate(${indexGridWithCoeff + xOffsetAdded})`}
+      >
         <text
           className={`axis-grid-text axis-grid-text-${item.timeScale}`}
           x="0"
-          y="42"
+          y="62"
           fill="white"
           clipPath="url(#textDisplay)"
         >
@@ -45,10 +47,9 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
           ? (
             <text
               className="axis-grid-text axis-grid-text-year"
-              x="0"
-              y="42"
+              x="40"
+              y="62"
               fill="#cccccc"
-              transform="translate(40, 0)"
               clipPath="url(#textDisplay)"
             >
               {dateTextYear}

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
@@ -8,6 +8,7 @@ import React from 'react';
 * @returns {Object} svg text DOM object
 */
 const axisScaleTextElementWrapper = (item, index, gridWidth) => {
+  const indexGridWithCoeff = index * gridWidth;
   let dateText;
   let dateTextYear;
   if (item.timeScale === 'day') {
@@ -30,30 +31,32 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
   }
   return (
     <>
-      <text
-        className={`axis-grid-text axis-grid-text-${item.timeScale}`}
-        x="0"
-        y="42"
-        fill={item.withinRange ? 'white' : ''}
-        transform={`translate(${(index * gridWidth) + xOffsetAdded}, 20)`}
-        clipPath="url(#textDisplay)"
-      >
-        {dateText}
-      </text>
-      {item.timeScale === 'day'
-        ? (
-          <text
-            className="axis-grid-text axis-grid-text-year"
-            x="0"
-            y="42"
-            fill={item.withinRange ? '#cccccc' : ''}
-            transform={`translate(${(index * gridWidth) + xOffsetAdded + 40}, 20)`}
-            clipPath="url(#textDisplay)"
-          >
-            {dateTextYear}
-          </text>
-        )
-        : null}
+      <g>
+        <text
+          className={`axis-grid-text axis-grid-text-${item.timeScale}`}
+          x="0"
+          y="42"
+          fill={item.withinRange ? 'white' : ''}
+          transform={`translate(${indexGridWithCoeff + xOffsetAdded}, 20)`}
+          clipPath="url(#textDisplay)"
+        >
+          {dateText}
+        </text>
+        {item.timeScale === 'day'
+          ? (
+            <text
+              className="axis-grid-text axis-grid-text-year"
+              x="0"
+              y="42"
+              fill={item.withinRange ? '#cccccc' : ''}
+              transform={`translate(${indexGridWithCoeff + xOffsetAdded + 40}, 20)`}
+              clipPath="url(#textDisplay)"
+            >
+              {dateTextYear}
+            </text>
+          )
+          : null}
+      </g>
     </>
   );
 };

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
@@ -31,13 +31,12 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
   }
   return (
     <>
-      <g>
+      <g transform={`translate(${indexGridWithCoeff + xOffsetAdded}, 20)`}>
         <text
           className={`axis-grid-text axis-grid-text-${item.timeScale}`}
           x="0"
           y="42"
-          fill={item.withinRange ? 'white' : ''}
-          transform={`translate(${indexGridWithCoeff + xOffsetAdded}, 20)`}
+          fill="white"
           clipPath="url(#textDisplay)"
         >
           {dateText}
@@ -48,8 +47,8 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
               className="axis-grid-text axis-grid-text-year"
               x="0"
               y="42"
-              fill={item.withinRange ? '#cccccc' : ''}
-              transform={`translate(${indexGridWithCoeff + xOffsetAdded + 40}, 20)`}
+              fill="#cccccc"
+              transform="translate(40, 0)"
               clipPath="url(#textDisplay)"
             >
               {dateTextYear}

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -420,7 +420,6 @@ class TimelineAxis extends Component {
     draggerPosition = draggerPosition - pixelsToAdd + position - draggerWidth + boundsDiff;
     draggerPositionB = draggerPositionB - pixelsToAdd + position - draggerWidth + boundsDiff;
     const updatePositioningArguments = {
-      hasMoved: false,
       isTimelineDragging: false,
       position,
       transformX,
@@ -1014,12 +1013,11 @@ class TimelineAxis extends Component {
   */
   handleStartDrag = () => {
     const {
-      hasMoved,
       isTimelineDragging,
       updateTimelineMoveAndDrag,
     } = this.props;
     if (!isTimelineDragging) {
-      updateTimelineMoveAndDrag(hasMoved, true);
+      updateTimelineMoveAndDrag(true);
     }
   }
 
@@ -1067,7 +1065,6 @@ class TimelineAxis extends Component {
       const frontDate = currentTimeRange[0].rawDate;
       const backDate = currentTimeRange[currentTimeRange.length - 1].rawDate;
       const updatePositioningArguments = {
-        hasMoved: true,
         isTimelineDragging: true,
         position,
         transformX,
@@ -1113,7 +1110,6 @@ class TimelineAxis extends Component {
         const frontDate = newCurrentTimeRange[0].rawDate;
         const backDate = newCurrentTimeRange[newCurrentTimeRange.length - 1].rawDate;
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           transformX,
@@ -1138,7 +1134,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           draggerPosition,
@@ -1180,7 +1175,6 @@ class TimelineAxis extends Component {
         const frontDate = newCurrentTimeRange[0].rawDate;
         const backDate = newCurrentTimeRange[newCurrentTimeRange.length - 1].rawDate;
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           transformX,
@@ -1205,7 +1199,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           draggerPosition,
@@ -1264,7 +1257,6 @@ class TimelineAxis extends Component {
     rightBound += midPoint - d.x;
 
     const updatePositioningArguments = {
-      hasMoved,
       isTimelineDragging: false,
       position: midPoint,
       transformX: newTransformX,
@@ -1513,7 +1505,6 @@ TimelineAxis.propTypes = {
   draggerVisible: PropTypes.bool,
   draggerVisibleB: PropTypes.bool,
   frontDate: PropTypes.string,
-  hasMoved: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
   hoverTime: PropTypes.string,
   isAnimationDraggerDragging: PropTypes.bool,

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1415,12 +1415,13 @@ class TimelineAxis extends Component {
       lineCoverageOptions = this.getMatchingCoverageLineDimensions();
     }
     const shouldDisplayMatchingCoverageLine = matchingTimelineCoverage && lineCoverageOptions;
+    const axisWidthStr = `${axisWidth}px`;
 
     return (
       <>
         <div
           className="timeline-axis-container"
-          style={{ width: `${axisWidth}px` }}
+          style={{ width: axisWidthStr }}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.setLineTime}
           onWheel={this.handleWheelType}
@@ -1434,23 +1435,52 @@ class TimelineAxis extends Component {
               <svg
                 className="timeline-axis-svg"
                 id="timeline-footer-svg"
-                width={axisWidth}
-                height={64}
+                width={axisWidthStr}
+                height="64px"
                 viewBox={`0 0 ${axisWidth} 64`}
+                preserveAspectRatio="xMinYMin slice"
               >
                 <defs>
                   {/* clip axis grid text */}
                   <clipPath id="textDisplay">
-                    <rect width="84" height="64" />
+                    <rect width="84px" height="64px" />
                   </clipPath>
                   {/* clip matching coverage data line */}
                   <clipPath id="matchingCoverage">
-                    <rect x={transformX} y="0" width={axisWidth} height={64} />
+                    <rect x={transformX} y="0" width={axisWidthStr} height="64px" />
                   </clipPath>
                   {/* clip axis grid overflow */}
                   <clipPath id="timelineBoundary">
-                    <rect x={-position} y="0" width={axisWidth} height={64} />
+                    <rect x={-position} y="0" width={axisWidthStr} height="64px" />
                   </clipPath>
+                  {/* data line boundary and background patterns  */}
+                  <clipPath id="dataLineBoundary">
+                    <rect x="0" y="0" width={axisWidthStr} height="12" />
+                  </clipPath>
+                  <pattern
+                    id="data-line-pattern"
+                    x="0"
+                    y="0"
+                    width="30px"
+                    height="12px"
+                    patternUnits="userSpaceOnUse"
+                    patternTransform="rotate(45)"
+                  >
+                    <rect fill="rgb(0, 69, 123)" width="30px" height="12px" x="0" y="0" />
+                    <line stroke="#164e7a" strokeWidth="30px" y1="12" />
+                  </pattern>
+                  <pattern
+                    id="data-line-pattern-hidden"
+                    x="0"
+                    y="0"
+                    width="30px"
+                    height="12px"
+                    patternUnits="userSpaceOnUse"
+                    patternTransform="rotate(45)"
+                  >
+                    <rect fill="rgb(116, 116, 116)" width="30px" height="12px" x="0" y="0" />
+                    <line stroke="#797979" strokeWidth="30px" y1="12" />
+                  </pattern>
                 </defs>
                 {shouldDisplayMatchingCoverageLine
                   && this.createMatchingCoverageLineDOMEl(lineCoverageOptions, transformX) }

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1329,8 +1329,9 @@ class TimelineAxis extends Component {
     }
 
     let leftOffset = 0;
-    const layerStartBeforeAxisFront = layerStart <= axisFrontDate;
+    const layerStartBeforeAxisFront = layerStart < axisFrontDate;
     const layerEndBeforeAxisBack = layerEnd <= axisBackDate;
+
     // oversized width allows axis drag buffer
     let width = axisWidth * 2;
     if (visible) {

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1057,9 +1057,8 @@ class TimelineAxis extends Component {
     animationStartLocation += deltaX;
     animationEndLocation += deltaX;
     // update not necessary for year or month since all units are displayed
-    if (timeScale === 'year' || timeScale === 'month') {
+    if (timeScale === 'month' || timeScale === 'year') {
       const updateSimplePositioningArguments = {
-        isTimelineDragging: true,
         position,
         draggerPosition,
         draggerPositionB,
@@ -1121,7 +1120,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          isTimelineDragging: true,
           position,
           draggerPosition,
           draggerPositionB,
@@ -1186,7 +1184,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          isTimelineDragging: true,
           position,
           draggerPosition,
           draggerPositionB,
@@ -1369,6 +1366,7 @@ class TimelineAxis extends Component {
       <g
         className="axis-data-coverage-line"
         transform={`translate(${-transformX}, 0)`}
+        clipPath="url(#matchingCoverage)"
       >
         <rect
           style={{
@@ -1439,6 +1437,10 @@ class TimelineAxis extends Component {
                   {/* clip axis grid text */}
                   <clipPath id="textDisplay">
                     <rect width="64" height="44" />
+                  </clipPath>
+                  {/* clip matching coverage data line */}
+                  <clipPath id="matchingCoverage">
+                    <rect x={transformX} y="0" width={axisWidth} height={64} />
                   </clipPath>
                   {/* clip axis grid overflow */}
                   <clipPath id="timelineBoundary">

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1033,16 +1033,12 @@ class TimelineAxis extends Component {
       e.preventDefault();
     }
     const {
-      currentTimeRange,
       gridWidth,
       dragSentinelChangeNumber,
       dragSentinelCount,
     } = this.state;
     const {
-      draggerVisible,
-      draggerVisibleB,
       timeScale,
-      transformX,
       updatePositioning,
       updatePositioningOnSimpleDrag,
     } = this.props;
@@ -1062,25 +1058,16 @@ class TimelineAxis extends Component {
     animationEndLocation += deltaX;
     // update not necessary for year or month since all units are displayed
     if (timeScale === 'year' || timeScale === 'month') {
-      const frontDate = currentTimeRange[0].rawDate;
-      const backDate = currentTimeRange[currentTimeRange.length - 1].rawDate;
-      const updatePositioningArguments = {
+      const updateSimplePositioningArguments = {
         isTimelineDragging: true,
         position,
-        transformX,
-        frontDate,
-        backDate,
         draggerPosition,
         draggerPositionB,
-        draggerVisible,
-        draggerVisibleB,
         animationStartLocation,
         animationEndLocation,
       };
-      this.setState({
-        dragSentinelCount: dragSentinelCount + deltaX,
-      });
-      updatePositioning(updatePositioningArguments);
+
+      updatePositioningOnSimpleDrag(updateSimplePositioningArguments);
       // handle all timescale other than year and month to add new groups of tile item dates
     } else if (deltaX > 0) {
       // dragging right - exposing past dates
@@ -1376,28 +1363,31 @@ class TimelineAxis extends Component {
   * @param {Number} transformX
   * @returns {Object} DOM SVG object
   */
-  createMatchingCoverageLineDOMEl = (lineCoverageOptions, transformX) => (
-    <g
-      className="axis-data-coverage-line"
-      transform={`translate(${-transformX}, 0)`}
-    >
-      <rect
-        style={{
-          left: lineCoverageOptions.leftOffset,
-          visibility: lineCoverageOptions.visible ? 'visible' : 'hidden',
-          margin: '0 0 6px 0',
-        }}
-        rx={0}
-        ry={0}
-        width={lineCoverageOptions.width}
-        height={10}
-        transform={`translate(${transformX + lineCoverageOptions.leftOffset}, 0)`}
-        fill="rgba(0, 119, 212, 0.5)"
-        stroke="rgba(0, 69, 123, 0.8)"
-        strokeWidth={3}
-      />
-    </g>
-  )
+  createMatchingCoverageLineDOMEl = (lineCoverageOptions, transformX) => {
+    const { leftOffset, visible, width } = lineCoverageOptions;
+    return (
+      <g
+        className="axis-data-coverage-line"
+        transform={`translate(${-transformX}, 0)`}
+      >
+        <rect
+          style={{
+            left: leftOffset,
+            visibility: visible ? 'visible' : 'hidden',
+            margin: '0 0 6px 0',
+          }}
+          rx={0}
+          ry={0}
+          width={width}
+          height={10}
+          transform={`translate(${transformX + leftOffset}, 0)`}
+          fill="rgba(0, 119, 212, 0.5)"
+          stroke="rgba(0, 69, 123, 0.8)"
+          strokeWidth={3}
+        />
+      </g>
+    );
+  };
 
   render() {
     const {
@@ -1444,16 +1434,15 @@ class TimelineAxis extends Component {
                 width={axisWidth}
                 height={64}
                 viewBox={`0 0 ${axisWidth} 64`}
-                preserveAspectRatio="xMinYMin slice"
               >
                 <defs>
                   {/* clip axis grid text */}
                   <clipPath id="textDisplay">
-                    <rect width="200" height="64" />
+                    <rect width="64" height="44" />
                   </clipPath>
                   {/* clip axis grid overflow */}
                   <clipPath id="timelineBoundary">
-                    <rect width={axisWidth} height={64} />
+                    <rect x={-position} y="0" width={axisWidth} height={64} />
                   </clipPath>
                 </defs>
                 {shouldDisplayMatchingCoverageLine
@@ -1469,7 +1458,7 @@ class TimelineAxis extends Component {
                     left: leftBound, top: 0, bottom: 0, right: rightBound,
                   }}
                 >
-                  <g>
+                  <g clipPath="url(#timelineBoundary)">
                     <GridRange
                       showHover={showHover}
                       timeScale={timeScale}

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1329,9 +1329,12 @@ class TimelineAxis extends Component {
     }
 
     let leftOffset = 0;
+    const layerStartBeforeAxisFront = layerStart <= axisFrontDate;
+    const layerEndBeforeAxisBack = layerEnd <= axisBackDate;
+    // oversized width allows axis drag buffer
     let width = axisWidth * 2;
     if (visible) {
-      if (layerStart <= axisFrontDate) {
+      if (layerStartBeforeAxisFront) {
         leftOffset = 0;
       } else {
         // positive diff means layerStart more recent than axisFrontDate
@@ -1340,13 +1343,14 @@ class TimelineAxis extends Component {
         leftOffset = gridDiff + postionTransformX;
       }
 
-      if (layerEnd <= axisBackDate) {
+      if (layerEndBeforeAxisBack) {
         // positive diff means layerEnd earlier than back date
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         width = Math.max(gridDiff + postionTransformX - leftOffset, 0);
       }
     }
+
     return {
       visible,
       leftOffset,
@@ -1365,7 +1369,7 @@ class TimelineAxis extends Component {
     return (
       <g
         className="axis-data-coverage-line"
-        transform={`translate(${-transformX}, 0)`}
+        transform={`translate(${-transformX})`}
         clipPath="url(#matchingCoverage)"
       >
         <rect
@@ -1378,7 +1382,7 @@ class TimelineAxis extends Component {
           ry={0}
           width={width}
           height={10}
-          transform={`translate(${transformX + leftOffset}, 0)`}
+          transform={`translate(${transformX + leftOffset})`}
           fill="rgba(0, 119, 212, 0.5)"
           stroke="rgba(0, 69, 123, 0.8)"
           strokeWidth={3}
@@ -1436,7 +1440,7 @@ class TimelineAxis extends Component {
                 <defs>
                   {/* clip axis grid text */}
                   <clipPath id="textDisplay">
-                    <rect width="64" height="44" />
+                    <rect width="84" height="64" />
                   </clipPath>
                   {/* clip matching coverage data line */}
                   <clipPath id="matchingCoverage">

--- a/web/js/components/timeline/timeline-data/data-item-container.js
+++ b/web/js/components/timeline/timeline-data/data-item-container.js
@@ -102,8 +102,7 @@ class DataItemContainer extends Component {
       getRangeDateEndWithAddedInterval,
       layer,
       layerPeriod,
-      position,
-      transformX,
+      positionTransformX,
       needDateRangeBuilt,
     } = this.props;
     const {
@@ -134,34 +133,8 @@ class DataItemContainer extends Component {
         >
           <svg
             className="data-panel-coverage-line-svg"
-            width={axisWidth}
-            viewBox={`0 0 ${axisWidth} 64`}
+            width={`${axisWidth}px`}
           >
-            <defs>
-              <clipPath id="dataLineBoundary">
-                <rect x="0" y="0" width={axisWidth} height={12} />
-              </clipPath>
-              <pattern
-                id="pattern"
-                width="30"
-                height="12"
-                patternUnits="userSpaceOnUse"
-                patternTransform="rotate(135 50 50)"
-              >
-                <rect fill="rgb(0, 69, 123)" width="30" height="12" />
-                <line stroke="#164e7a" strokeWidth="30" y1="12" />
-              </pattern>
-              <pattern
-                id="pattern2"
-                width="30"
-                height="12"
-                patternUnits="userSpaceOnUse"
-                patternTransform="rotate(135 50 50)"
-              >
-                <rect fill="rgb(116, 116, 116)" width="30" height="12" />
-                <line stroke="#797979" strokeWidth="30" y1="12" />
-              </pattern>
-            </defs>
             {needDateRangeBuilt
               ? dataDateRanges.map((itemRange, multiIndex, array) => {
                 const { date, interval } = itemRange;
@@ -177,8 +150,7 @@ class DataItemContainer extends Component {
                     <React.Fragment key={key}>
                       <DataLine
                         axisWidth={axisWidth}
-                        position={position}
-                        transformX={transformX}
+                        positionTransformX={positionTransformX}
                         id={id}
                         options={multiLineRangeOptions}
                         lineType="MULTI"
@@ -194,11 +166,10 @@ class DataItemContainer extends Component {
               : containerLineDimensions.visible && (
                 <DataLine
                   axisWidth={axisWidth}
-                  position={position}
-                  transformX={transformX}
+                  positionTransformX={positionTransformX}
                   id={id}
                   options={containerLineDimensions}
-                  lineType="CONTAINER"
+                  lineType="SINGLE"
                   startDate={startDate}
                   endDate={endDate}
                   color={lineBackgroundColor}
@@ -225,8 +196,7 @@ DataItemContainer.propTypes = {
   needDateRangeBuilt: PropTypes.bool,
   layer: PropTypes.object,
   layerPeriod: PropTypes.string,
-  position: PropTypes.number,
-  transformX: PropTypes.number,
+  positionTransformX: PropTypes.number,
 };
 
 export default DataItemContainer;

--- a/web/js/components/timeline/timeline-data/data-item-container.js
+++ b/web/js/components/timeline/timeline-data/data-item-container.js
@@ -1,0 +1,250 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import DataLine from './data-line';
+
+/*
+ * Data Item Container for individual layer data coverage.
+ *
+ * @class DataItemContainer
+ */
+
+class DataItemContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      dataDateRanges: [],
+    };
+  }
+
+  componentDidMount() {
+    const { layer } = this.props;
+    const { dateRanges } = layer;
+    // handle date range query/array building
+    const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
+    this.updateDateRangeState(dateRangesToDisplay);
+
+    // create data line
+
+    // TODO: which state to store position related state for data line? pure component data line preferred
+  }
+
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return true;
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { layer } = this.props;
+    const { dateRanges } = layer;
+
+    const frontDateChanged = prevProps.frontDate !== this.props.frontDate;
+    const backDateChanged = prevProps.backDate !== this.props.backDate;
+    // console.log(frontDateChanged, backDateChanged);
+
+    if (frontDateChanged || backDateChanged) {
+      const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
+      this.updateDateRangeState(dateRangesToDisplay);
+    }
+  }
+
+  /**
+  * @desc getDateRangeToDisplay
+  * @param {Array} dateRanges
+  * @returns {ArrayBuffer} multiDateToDisplay
+  */
+  getDateRangeToDisplay = (dateRanges) => {
+    const { getMaxEndDate, getDatesInDateRange, layer } = this.props;
+    const { inactive } = layer;
+
+    const multiDateToDisplay = dateRanges.reduce((mutliCoverageDates, range, innerIndex) => {
+      const isLastInRange = innerIndex === dateRanges.length - 1;
+      const rangeInterval = Number(range.dateInterval);
+      // multi time unit range - no year time unit
+      const endDateLimit = getMaxEndDate(inactive, isLastInRange);
+      // get dates based on date ranges
+      const dateIntervalStartDates = getDatesInDateRange(layer, range, endDateLimit, isLastInRange);
+      // add date intervals to mutliCoverageDates object to catch repeats
+      dateIntervalStartDates.forEach((dateInt) => {
+        const dateIntFormatted = dateInt.toISOString();
+        const dateIntTime = new Date(dateInt).getTime();
+        const startDateTime = new Date(range.startDate).getTime();
+        const endDateTime = new Date(range.endDate).getTime();
+        // allow overwriting of subsequent date ranges
+        if (dateIntTime >= startDateTime && startDateTime <= endDateTime) {
+          mutliCoverageDates[dateIntFormatted] = { date: dateInt, interval: rangeInterval };
+        }
+      });
+
+      return mutliCoverageDates;
+    }, {});
+
+    return Object.values(multiDateToDisplay);
+  }
+
+  /**
+  * @desc updateDateRangeState
+  * @param {Array} dateRange
+  * @returns {Void}
+  */
+  updateDateRangeState = (dateRange) => {
+    this.setState({
+      dataDateRanges: dateRange,
+    });
+  }
+
+  render() {
+    const {
+      axisWidth,
+      position,
+      transformX,
+      dateRange,
+      layer,
+      layerPeriod,
+      getMatchingCoverageLineDimensions,
+      getRangeDateEndWithAddedInterval,
+      createMatchingCoverageLineDOMEl,
+      timeScale,
+      hoveredLayer,
+      getLayerItemStyles,
+      isValidMultipleRangesLayer,
+      isLayerGreaterZoomWithMultipleCoverage,
+      isLayerEqualZoomWithMultipleCoverage,
+    } = this.props;
+    const {
+      dataDateRanges,
+    } = this.state;
+
+    const {
+      endDate,
+      id,
+      startDate,
+      visible,
+    } = layer;
+
+    // condtional styling for line/background colors
+    const {
+      lineBackgroundColor,
+      // layerItemBackground,
+      // layerItemOutline,
+    } = getLayerItemStyles(visible, id);
+
+    // get line container dimensions
+    const containerLineDimensions = getMatchingCoverageLineDimensions(layer);
+    return (
+      <>
+        <div
+          className="data-panel-coverage-line"
+          style={{
+            // width: `${isValidMultipleRangesLayer ? containerLineDimensions.width : axisWidth}px`,
+            width: `${axisWidth}px`,
+          }}
+        >
+          <svg
+            className="data-panel-coverage-line-svg"
+            width={axisWidth}
+          >
+            <defs>
+              <clipPath id="dataLineBoundary">
+                <rect x={0} y="0" width={axisWidth} height={12} />
+              </clipPath>
+              <pattern
+                id="pattern"
+                width="30"
+                height="12"
+                patternUnits="userSpaceOnUse"
+                patternTransform="rotate(135 50 50)"
+              >
+                <rect fill="rgb(0, 69, 123)" width="30" height="12" />
+                <line stroke="#164e7a" strokeWidth="30" y2="12" />
+              </pattern>
+              <pattern
+                id="pattern2"
+                width="30"
+                height="12"
+                patternUnits="userSpaceOnUse"
+                patternTransform="rotate(135 50 50)"
+              >
+                <rect fill="rgb(116, 116, 116)" width="30" height="12" />
+                <line stroke="#797979" strokeWidth="30" y2="12" />
+              </pattern>
+            </defs>
+            {isValidMultipleRangesLayer && (isLayerGreaterZoomWithMultipleCoverage || isLayerEqualZoomWithMultipleCoverage)
+              ? dataDateRanges.map((itemRange, multiIndex, array) => {
+                const { date, interval } = itemRange;
+                const nextDate = array[multiIndex + 1];
+                const rangeDateEnd = getRangeDateEndWithAddedInterval(date, layerPeriod, interval, nextDate);
+                // get range line dimensions
+                const multiLineRangeOptions = getMatchingCoverageLineDimensions(layer, date, rangeDateEnd);
+                // create DOM line element
+                const key = `${id}-${multiIndex}`;
+                return multiLineRangeOptions.visible
+                  && (
+                    <React.Fragment key={key}>
+                      <DataLine
+                        hoverOnToolTip={this.props.hoverOnToolTip}
+                        hoverOffToolTip={this.props.hoverOffToolTip}
+                        hoveredTooltip={this.props.hoveredTooltip}
+                        axisWidth={axisWidth}
+                        position={position}
+                        transformX={transformX}
+                        id={id}
+                        options={multiLineRangeOptions}
+                        lineType="MULTI"
+                        startDate={date}
+                        endDate={rangeDateEnd}
+                        color={lineBackgroundColor}
+                        layerPeriod={layerPeriod}
+                        index={`${id}-${multiIndex}`}
+                      />
+                    </React.Fragment>
+                  );
+              })
+              : containerLineDimensions.visible && (
+                <DataLine
+                  hoverOnToolTip={this.props.hoverOnToolTip}
+                  hoverOffToolTip={this.props.hoverOffToolTip}
+                  hoveredTooltip={this.props.hoveredTooltip}
+                  axisWidth={axisWidth}
+                  position={position}
+                  transformX={transformX}
+                  id={id}
+                  options={containerLineDimensions}
+                  lineType="CONTAINER"
+                  startDate={new Date(startDate)}
+                  endDate={endDate}
+                  color={lineBackgroundColor}
+                  layerPeriod={layerPeriod}
+                  index={`${id}-0`}
+                />
+              )}
+          </svg>
+        </div>
+      </>
+    );
+  }
+}
+
+DataItemContainer.propTypes = {
+  axisWidth: PropTypes.number,
+  position: PropTypes.number,
+  transformX: PropTypes.number,
+  dateRange: PropTypes.string,
+  frontDate: PropTypes.string,
+  backDate: PropTypes.string,
+  layer: PropTypes.object,
+  layerPeriod: PropTypes.string,
+  getMatchingCoverageLineDimensions: PropTypes.func,
+  getRangeDateEndWithAddedInterval: PropTypes.func,
+  createMatchingCoverageLineDOMEl: PropTypes.func,
+  timeScale: PropTypes.string,
+  hoveredLayer: PropTypes.string,
+  isValidMultipleRangesLayer: PropTypes.bool,
+  isLayerGreaterZoomWithMultipleCoverage: PropTypes.bool,
+  isLayerEqualZoomWithMultipleCoverage: PropTypes.bool,
+  getMaxEndDate: PropTypes.func,
+  getDatesInDateRange: PropTypes.func,
+};
+
+export default DataItemContainer;

--- a/web/js/components/timeline/timeline-data/data-item-container.js
+++ b/web/js/components/timeline/timeline-data/data-item-container.js
@@ -133,13 +133,13 @@ class DataItemContainer extends Component {
           }}
         >
           <svg
-            className={`data-panel-coverage-line-svg data-panel-coverage-line-svg-${id}`}
+            className="data-panel-coverage-line-svg"
             width={axisWidth}
             viewBox={`0 0 ${axisWidth} 64`}
           >
             <defs>
               <clipPath id="dataLineBoundary">
-                <rect x={0} y="0" width={axisWidth} height={12} />
+                <rect x="0" y="0" width={axisWidth} height={12} />
               </clipPath>
               <pattern
                 id="pattern"

--- a/web/js/components/timeline/timeline-data/data-item-container.js
+++ b/web/js/components/timeline/timeline-data/data-item-container.js
@@ -22,24 +22,14 @@ class DataItemContainer extends Component {
     // handle date range query/array building
     const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
     this.updateDateRangeState(dateRangesToDisplay);
-
-    // create data line
-
-    // TODO: which state to store position related state for data line? pure component data line preferred
-  }
-
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return true;
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { layer } = this.props;
+    const { layer, frontDate, backDate } = this.props;
     const { dateRanges } = layer;
 
-    const frontDateChanged = prevProps.frontDate !== this.props.frontDate;
-    const backDateChanged = prevProps.backDate !== this.props.backDate;
-    // console.log(frontDateChanged, backDateChanged);
+    const frontDateChanged = prevProps.frontDate !== frontDate;
+    const backDateChanged = prevProps.backDate !== backDate;
 
     if (frontDateChanged || backDateChanged) {
       const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
@@ -57,21 +47,23 @@ class DataItemContainer extends Component {
     const { inactive } = layer;
 
     const multiDateToDisplay = dateRanges.reduce((mutliCoverageDates, range, innerIndex) => {
+      const { dateInterval, startDate, endDate } = range;
       const isLastInRange = innerIndex === dateRanges.length - 1;
-      const rangeInterval = Number(range.dateInterval);
+      const rangeInterval = Number(dateInterval);
       // multi time unit range - no year time unit
       const endDateLimit = getMaxEndDate(inactive, isLastInRange);
       // get dates based on date ranges
       const dateIntervalStartDates = getDatesInDateRange(layer, range, endDateLimit, isLastInRange);
+
+      const startDateTime = new Date(startDate).getTime();
+      const endDateTime = new Date(endDate).getTime();
       // add date intervals to mutliCoverageDates object to catch repeats
-      dateIntervalStartDates.forEach((dateInt) => {
-        const dateIntFormatted = dateInt.toISOString();
-        const dateIntTime = new Date(dateInt).getTime();
-        const startDateTime = new Date(range.startDate).getTime();
-        const endDateTime = new Date(range.endDate).getTime();
+      dateIntervalStartDates.forEach((dateIntStartDate) => {
+        const dateIntTime = new Date(dateIntStartDate).getTime();
         // allow overwriting of subsequent date ranges
         if (dateIntTime >= startDateTime && startDateTime <= endDateTime) {
-          mutliCoverageDates[dateIntFormatted] = { date: dateInt, interval: rangeInterval };
+          const dateIntFormatted = dateIntStartDate.toISOString();
+          mutliCoverageDates[dateIntFormatted] = { date: dateIntStartDate, interval: rangeInterval };
         }
       });
 
@@ -95,20 +87,16 @@ class DataItemContainer extends Component {
   render() {
     const {
       axisWidth,
-      position,
-      transformX,
-      dateRange,
-      layer,
-      layerPeriod,
+      getLayerItemStyles,
       getMatchingCoverageLineDimensions,
       getRangeDateEndWithAddedInterval,
-      createMatchingCoverageLineDOMEl,
-      timeScale,
-      hoveredLayer,
-      getLayerItemStyles,
-      isValidMultipleRangesLayer,
-      isLayerGreaterZoomWithMultipleCoverage,
       isLayerEqualZoomWithMultipleCoverage,
+      isLayerGreaterZoomWithMultipleCoverage,
+      isValidMultipleRangesLayer,
+      layer,
+      layerPeriod,
+      position,
+      transformX,
     } = this.props;
     const {
       dataDateRanges,
@@ -137,7 +125,7 @@ class DataItemContainer extends Component {
           }}
         >
           <svg
-            className="data-panel-coverage-line-svg"
+            className={`data-panel-coverage-line-svg data-panel-coverage-line-svg-${id}`}
             width={axisWidth}
             viewBox={`0 0 ${axisWidth} 64`}
           >
@@ -179,9 +167,6 @@ class DataItemContainer extends Component {
                   && (
                     <React.Fragment key={key}>
                       <DataLine
-                        hoverOnToolTip={this.props.hoverOnToolTip}
-                        hoverOffToolTip={this.props.hoverOffToolTip}
-                        hoveredTooltip={this.props.hoveredTooltip}
                         axisWidth={axisWidth}
                         position={position}
                         transformX={transformX}
@@ -199,9 +184,6 @@ class DataItemContainer extends Component {
               })
               : containerLineDimensions.visible && (
                 <DataLine
-                  hoverOnToolTip={this.props.hoverOnToolTip}
-                  hoverOffToolTip={this.props.hoverOffToolTip}
-                  hoveredTooltip={this.props.hoveredTooltip}
                   axisWidth={axisWidth}
                   position={position}
                   transformX={transformX}
@@ -224,23 +206,20 @@ class DataItemContainer extends Component {
 
 DataItemContainer.propTypes = {
   axisWidth: PropTypes.number,
-  position: PropTypes.number,
-  transformX: PropTypes.number,
-  dateRange: PropTypes.string,
-  frontDate: PropTypes.string,
   backDate: PropTypes.string,
+  frontDate: PropTypes.string,
+  getDatesInDateRange: PropTypes.func,
+  getLayerItemStyles: PropTypes.func,
+  getMatchingCoverageLineDimensions: PropTypes.func,
+  getMaxEndDate: PropTypes.func,
+  getRangeDateEndWithAddedInterval: PropTypes.func,
+  isLayerEqualZoomWithMultipleCoverage: PropTypes.bool,
+  isLayerGreaterZoomWithMultipleCoverage: PropTypes.bool,
+  isValidMultipleRangesLayer: PropTypes.bool,
   layer: PropTypes.object,
   layerPeriod: PropTypes.string,
-  getMatchingCoverageLineDimensions: PropTypes.func,
-  getRangeDateEndWithAddedInterval: PropTypes.func,
-  createMatchingCoverageLineDOMEl: PropTypes.func,
-  timeScale: PropTypes.string,
-  hoveredLayer: PropTypes.string,
-  isValidMultipleRangesLayer: PropTypes.bool,
-  isLayerGreaterZoomWithMultipleCoverage: PropTypes.bool,
-  isLayerEqualZoomWithMultipleCoverage: PropTypes.bool,
-  getMaxEndDate: PropTypes.func,
-  getDatesInDateRange: PropTypes.func,
+  position: PropTypes.number,
+  transformX: PropTypes.number,
 };
 
 export default DataItemContainer;

--- a/web/js/components/timeline/timeline-data/data-item-container.js
+++ b/web/js/components/timeline/timeline-data/data-item-container.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
-
 import DataLine from './data-line';
 
 /*
@@ -126,8 +124,6 @@ class DataItemContainer extends Component {
     // condtional styling for line/background colors
     const {
       lineBackgroundColor,
-      // layerItemBackground,
-      // layerItemOutline,
     } = getLayerItemStyles(visible, id);
 
     // get line container dimensions
@@ -137,13 +133,13 @@ class DataItemContainer extends Component {
         <div
           className="data-panel-coverage-line"
           style={{
-            // width: `${isValidMultipleRangesLayer ? containerLineDimensions.width : axisWidth}px`,
             width: `${axisWidth}px`,
           }}
         >
           <svg
             className="data-panel-coverage-line-svg"
             width={axisWidth}
+            viewBox={`0 0 ${axisWidth} 64`}
           >
             <defs>
               <clipPath id="dataLineBoundary">
@@ -157,7 +153,7 @@ class DataItemContainer extends Component {
                 patternTransform="rotate(135 50 50)"
               >
                 <rect fill="rgb(0, 69, 123)" width="30" height="12" />
-                <line stroke="#164e7a" strokeWidth="30" y2="12" />
+                <line stroke="#164e7a" strokeWidth="30" y1="12" />
               </pattern>
               <pattern
                 id="pattern2"
@@ -167,7 +163,7 @@ class DataItemContainer extends Component {
                 patternTransform="rotate(135 50 50)"
               >
                 <rect fill="rgb(116, 116, 116)" width="30" height="12" />
-                <line stroke="#797979" strokeWidth="30" y2="12" />
+                <line stroke="#797979" strokeWidth="30" y1="12" />
               </pattern>
             </defs>
             {isValidMultipleRangesLayer && (isLayerGreaterZoomWithMultipleCoverage || isLayerEqualZoomWithMultipleCoverage)

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -1,0 +1,190 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from 'reactstrap';
+
+/*
+ * Data Line for DOM Element layer data coverage.
+ *
+ * @class DataLine
+ */
+
+class DataLine extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  /**
+  * @desc get formatted display dates for line tooltips and selectors
+  * @param {String} lineType
+  * @param {Object} startDate date
+  * @param {Object} endDate date
+  * @param {String} layerPeriod
+  * @returns {Object}
+  *   @param {String} dateRangeStart
+  *   @param {String} dateRangeEnd
+  *   @param {String} toolTipText
+  */
+  getFormattedDisplayDates = (lineType, startDate, endDate, layerPeriod) => {
+    let dateRangeStart;
+    let dateRangeEnd;
+    let toolTipText;
+
+    // eslint-disable-next-line default-case
+    switch (lineType) {
+      case 'CONTAINER':
+        dateRangeStart = (startDate && startDate.toISOString().split('T')[0]) || 'start';
+        dateRangeEnd = (endDate && endDate.toISOString().split('T')[0]) || 'present';
+        toolTipText = `${dateRangeStart} to ${dateRangeEnd}`;
+        break;
+      case 'MULTI':
+        // handle minutes range display text (ex: '14:50 to 15:00')
+        if (layerPeriod === 'minutes') {
+          // eslint-disable-next-line prefer-destructuring
+          dateRangeStart = startDate.toISOString().split('T')[1];
+          // eslint-disable-next-line prefer-destructuring
+          dateRangeEnd = endDate.toISOString().split('T')[1];
+          toolTipText = `${dateRangeStart.split(':', 2).join(':')} to ${dateRangeEnd.split(':', 2).join(':')}`;
+          dateRangeStart = dateRangeStart.replace(/[.:]/g, '_');
+          dateRangeEnd = dateRangeEnd.replace(/[.:]/g, '_');
+        } else {
+          dateRangeStart = startDate.toISOString().replace(/[.:]/g, '_');
+          dateRangeEnd = endDate.toISOString().replace(/[.:]/g, '_');
+          toolTipText = `${dateRangeStart.split('T')[0]} to ${dateRangeEnd.split('T')[0]}`;
+        }
+        break;
+    }
+
+    return {
+      dateRangeStart,
+      dateRangeEnd,
+      toolTipText,
+    };
+  }
+
+  /**
+  * @desc get line DOM element from full/partial (interval) date range with tooltip
+  * @param {String} id
+  * @param {Object} options
+  * @param {String} lineType
+  * @param {String} dateRangeStart
+  * @param {String} dateRangeEnd
+  * @param {String} color
+  * @param {String} layerPeriod
+  * @param {Number/String} index
+  * @returns {DOM Element} line
+  */
+  createMatchingCoverageLineDOMEl = (id, options, lineType, startDate, endDate, color, layerPeriod, index) => {
+    const {
+      position,
+      transformX,
+      hoverOnToolTip,
+      hoverOffToolTip,
+      hoveredTooltip,
+    } = this.props;
+    const {
+      leftOffset,
+      isWidthGreaterThanRendered,
+      width,
+    } = options;
+    const lineWidth = Math.max(width, 0);
+
+    // get formatted dates based on line type
+    const {
+      dateRangeStart,
+      dateRangeEnd,
+      toolTipText,
+    } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
+    const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
+
+    // candy stripe color
+    const patternType = color === 'rgb(0, 69, 123)'
+      ? 'url(#pattern)'
+      : 'url(#pattern2)';
+
+    // allow moving striped background for large width lines
+    const rectTransform = leftOffset === 0 && isWidthGreaterThanRendered
+      ? position + transformX
+      : leftOffset;
+
+    // determine line radius for line start/end vs. partial large width lines
+    const lineRadius = !isWidthGreaterThanRendered
+      || (leftOffset !== 0 && isWidthGreaterThanRendered)
+      ? '6'
+      : '0';
+
+    return (
+      <g
+        key={index}
+        className="data-panel-coverage-line-container"
+      >
+        <rect
+          id={`data-coverage-line-${dateRangeStartEnd}`}
+          className="data-panel-coverage-line"
+          onMouseEnter={() => hoverOnToolTip(`${dateRangeStartEnd}`)}
+          onMouseLeave={() => hoverOffToolTip()}
+          width={`${lineWidth}px`}
+          fill={patternType}
+          rx={lineRadius}
+          style={{
+            transform: `translate(${rectTransform}px, 0)`,
+          }}
+        >
+          <Tooltip
+            isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
+            target={`data-coverage-line-${dateRangeStartEnd}`}
+          >
+            {toolTipText}
+          </Tooltip>
+        </rect>
+      </g>
+    );
+  }
+
+  render() {
+    const {
+      id,
+      options,
+      lineType,
+      startDate,
+      endDate,
+      color,
+      layerPeriod,
+      index,
+    } = this.props;
+    return (
+      <g clipPath="url(#dataLineBoundary)">
+        {this.createMatchingCoverageLineDOMEl(
+          id,
+          options,
+          lineType,
+          startDate,
+          endDate,
+          color,
+          layerPeriod,
+          index,
+        )}
+      </g>
+    );
+  }
+}
+
+DataLine.propTypes = {
+  hoverOnToolTip: PropTypes.func,
+  hoverOffToolTip: PropTypes.func,
+  hoveredTooltip: PropTypes.object,
+  axisWidth: PropTypes.number,
+  position: PropTypes.number,
+  transformX: PropTypes.number,
+  id: PropTypes.string,
+  options: PropTypes.object,
+  lineType: PropTypes.string,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
+  color: PropTypes.string,
+  layerPeriod: PropTypes.string,
+  index: PropTypes.string,
+};
+
+export default DataLine;

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -30,8 +30,8 @@ class DataLine extends Component {
   /**
   * @desc get formatted display dates for line tooltips and selectors
   * @param {String} lineType
-  * @param {Object} startDate date
-  * @param {Object} endDate date
+  * @param {String} startDate date ISO string
+  * @param {String} endDate date ISO string
   * @param {String} layerPeriod
   * @returns {Object}
   *   @param {String} dateRangeStart
@@ -46,23 +46,23 @@ class DataLine extends Component {
     // eslint-disable-next-line default-case
     switch (lineType) {
       case 'CONTAINER':
-        dateRangeStart = (startDate && new Date(startDate).toISOString().split('T')[0]) || 'start';
-        dateRangeEnd = (endDate && new Date(endDate).toISOString().split('T')[0]) || 'present';
+        dateRangeStart = (startDate && startDate.split('T')[0]) || 'start';
+        dateRangeEnd = (endDate && endDate.split('T')[0]) || 'present';
         toolTipText = `${dateRangeStart} to ${dateRangeEnd}`;
         break;
       case 'MULTI':
         // handle minutes range display text (ex: '14:50 to 15:00')
         if (layerPeriod === 'minutes') {
           // eslint-disable-next-line prefer-destructuring
-          dateRangeStart = startDate.toISOString().split('T')[1];
+          dateRangeStart = startDate.split('T')[1];
           // eslint-disable-next-line prefer-destructuring
-          dateRangeEnd = endDate.toISOString().split('T')[1];
+          dateRangeEnd = endDate.split('T')[1];
           toolTipText = `${dateRangeStart.split(':', 2).join(':')} to ${dateRangeEnd.split(':', 2).join(':')}`;
           dateRangeStart = dateRangeStart.replace(/[.:]/g, '_');
           dateRangeEnd = dateRangeEnd.replace(/[.:]/g, '_');
         } else {
-          dateRangeStart = startDate.toISOString().replace(/[.:]/g, '_');
-          dateRangeEnd = endDate.toISOString().replace(/[.:]/g, '_');
+          dateRangeStart = startDate.replace(/[.:]/g, '_');
+          dateRangeEnd = endDate.replace(/[.:]/g, '_');
           toolTipText = `${dateRangeStart.split('T')[0]} to ${dateRangeEnd.split('T')[0]}`;
         }
         break;
@@ -128,13 +128,14 @@ class DataLine extends Component {
       : '0';
 
     // handle "false transform" line edge to simulate line movement for striped background
-    if (leftOffset === 0 && isWidthGreaterThanRendered && layerEndBeforeAxisBack) {
+    if (leftOffset === 0
+      && ((isWidthGreaterThanRendered && layerEndBeforeAxisBack)
+      || (!isWidthGreaterThanRendered && layerStartBeforeAxisFront))) {
       lineWidth -= position + transformX;
       rectTransform += position + transformX;
       lineRadius = '6';
     }
 
-    console.log(leftOffset, lineWidth);
     // handle tooltip offset to keep visible
     const toolTipOffset = isWidthGreaterThanRendered
       ? -(axisWidth * 5) / 2 + axisWidth
@@ -160,7 +161,6 @@ class DataLine extends Component {
             isOpen={isTooltipHovered}
             target={`data-coverage-line-${dateRangeStartEnd}`}
             offset={toolTipOffset}
-            flip={false}
           >
             {toolTipText}
           </Tooltip>
@@ -204,7 +204,7 @@ DataLine.propTypes = {
   id: PropTypes.string,
   options: PropTypes.object,
   lineType: PropTypes.string,
-  startDate: PropTypes.object,
+  startDate: PropTypes.string,
   endDate: PropTypes.string,
   color: PropTypes.string,
   layerPeriod: PropTypes.string,

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -1,32 +1,13 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from 'reactstrap';
 
 /*
  * Data Line for DOM Element layer data coverage.
  *
- * @class DataLine
+ * @class DataLine PureComponent
  */
 
-class DataLine extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isTooltipHovered: false,
-    };
-  }
-
-  /**
-  * @desc handle hovering on line and adding/removing tooltip
-  * @param {Boolean} isHovered
-  * @returns {void}
-  */
-  toggleHoverToolTip = (isHovered) => {
-    this.setState({
-      isTooltipHovered: isHovered,
-    });
-  }
-
+class DataLine extends PureComponent {
   /**
   * @desc get formatted display dates for line tooltips and selectors
   * @param {String} lineType
@@ -91,9 +72,7 @@ class DataLine extends Component {
     const {
       position,
       transformX,
-      axisWidth,
     } = this.props;
-    const { isTooltipHovered } = this.state;
     const {
       leftOffset,
       isWidthGreaterThanRendered,
@@ -102,6 +81,7 @@ class DataLine extends Component {
       layerEndBeforeAxisBack,
     } = options;
     let lineWidth = Math.max(width, 0);
+    const positionTransformCombined = position + transformX;
 
     // get formatted dates based on line type
     const {
@@ -118,7 +98,7 @@ class DataLine extends Component {
 
     // allow moving striped background for large width lines
     let rectTransform = leftOffset === 0 && isWidthGreaterThanRendered && !layerEndBeforeAxisBack
-      ? position + transformX
+      ? positionTransformCombined
       : leftOffset;
 
     // determine line radius for line start/end vs. partial large width lines
@@ -131,15 +111,11 @@ class DataLine extends Component {
     if (leftOffset === 0
       && ((isWidthGreaterThanRendered && layerEndBeforeAxisBack)
       || (!isWidthGreaterThanRendered && layerStartBeforeAxisFront))) {
-      lineWidth -= position + transformX;
-      rectTransform += position + transformX;
+      lineWidth -= positionTransformCombined;
+      rectTransform += positionTransformCombined;
       lineRadius = '6';
     }
 
-    // handle tooltip offset to keep visible
-    const toolTipOffset = isWidthGreaterThanRendered
-      ? -(axisWidth * 5) / 2 + axisWidth
-      : -rectTransform - axisWidth;
     return (
       <g
         key={index}
@@ -148,8 +124,6 @@ class DataLine extends Component {
         <rect
           id={`data-coverage-line-${dateRangeStartEnd}`}
           className="data-panel-coverage-line"
-          onMouseEnter={() => this.toggleHoverToolTip(true)}
-          onMouseLeave={() => this.toggleHoverToolTip(false)}
           width={`${lineWidth}px`}
           fill={patternType}
           rx={lineRadius}
@@ -157,13 +131,7 @@ class DataLine extends Component {
             transform: `translate(${rectTransform}px)`,
           }}
         >
-          <Tooltip
-            isOpen={isTooltipHovered}
-            target={`data-coverage-line-${dateRangeStartEnd}`}
-            offset={toolTipOffset}
-          >
-            {toolTipText}
-          </Tooltip>
+          <title>{toolTipText}</title>
         </rect>
       </g>
     );
@@ -198,7 +166,6 @@ class DataLine extends Component {
 }
 
 DataLine.propTypes = {
-  axisWidth: PropTypes.number,
   position: PropTypes.number,
   transformX: PropTypes.number,
   id: PropTypes.string,

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -12,7 +12,19 @@ class DataLine extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      isTooltipHovered: false,
     };
+  }
+
+  /**
+  * @desc handle hovering on line and adding/removing tooltip
+  * @param {Boolean} isHovered
+  * @returns {void}
+  */
+  toggleHoverToolTip = (isHovered) => {
+    this.setState({
+      isTooltipHovered: isHovered,
+    });
   }
 
   /**
@@ -34,8 +46,8 @@ class DataLine extends Component {
     // eslint-disable-next-line default-case
     switch (lineType) {
       case 'CONTAINER':
-        dateRangeStart = (startDate && startDate.toISOString().split('T')[0]) || 'start';
-        dateRangeEnd = (endDate && endDate.toISOString().split('T')[0]) || 'present';
+        dateRangeStart = (startDate && new Date(startDate).toISOString().split('T')[0]) || 'start';
+        dateRangeEnd = (endDate && new Date(endDate).toISOString().split('T')[0]) || 'present';
         toolTipText = `${dateRangeStart} to ${dateRangeEnd}`;
         break;
       case 'MULTI':
@@ -79,10 +91,9 @@ class DataLine extends Component {
     const {
       position,
       transformX,
-      hoverOnToolTip,
-      hoverOffToolTip,
-      hoveredTooltip,
+      axisWidth,
     } = this.props;
+    const { isTooltipHovered } = this.state;
     const {
       leftOffset,
       isWidthGreaterThanRendered,
@@ -123,6 +134,11 @@ class DataLine extends Component {
       lineRadius = '6';
     }
 
+    console.log(leftOffset, lineWidth);
+    // handle tooltip offset to keep visible
+    const toolTipOffset = isWidthGreaterThanRendered
+      ? -(axisWidth * 5) / 2 + axisWidth
+      : -rectTransform - axisWidth;
     return (
       <g
         key={index}
@@ -131,18 +147,20 @@ class DataLine extends Component {
         <rect
           id={`data-coverage-line-${dateRangeStartEnd}`}
           className="data-panel-coverage-line"
-          onMouseEnter={() => hoverOnToolTip(`${dateRangeStartEnd}`)}
-          onMouseLeave={() => hoverOffToolTip()}
+          onMouseEnter={() => this.toggleHoverToolTip(true)}
+          onMouseLeave={() => this.toggleHoverToolTip(false)}
           width={`${lineWidth}px`}
           fill={patternType}
           rx={lineRadius}
           style={{
-            transform: `translate(${rectTransform}px, 0)`,
+            transform: `translate(${rectTransform}px)`,
           }}
         >
           <Tooltip
-            isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
+            isOpen={isTooltipHovered}
             target={`data-coverage-line-${dateRangeStartEnd}`}
+            offset={toolTipOffset}
+            flip={false}
           >
             {toolTipText}
           </Tooltip>
@@ -180,9 +198,6 @@ class DataLine extends Component {
 }
 
 DataLine.propTypes = {
-  hoverOnToolTip: PropTypes.func,
-  hoverOffToolTip: PropTypes.func,
-  hoveredTooltip: PropTypes.object,
   axisWidth: PropTypes.number,
   position: PropTypes.number,
   transformX: PropTypes.number,
@@ -190,7 +205,7 @@ DataLine.propTypes = {
   options: PropTypes.object,
   lineType: PropTypes.string,
   startDate: PropTypes.object,
-  endDate: PropTypes.object,
+  endDate: PropTypes.string,
   color: PropTypes.string,
   layerPeriod: PropTypes.string,
   index: PropTypes.string,

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -87,8 +87,10 @@ class DataLine extends Component {
       leftOffset,
       isWidthGreaterThanRendered,
       width,
+      layerStartBeforeAxisFront,
+      layerEndBeforeAxisBack,
     } = options;
-    const lineWidth = Math.max(width, 0);
+    let lineWidth = Math.max(width, 0);
 
     // get formatted dates based on line type
     const {
@@ -104,15 +106,22 @@ class DataLine extends Component {
       : 'url(#pattern2)';
 
     // allow moving striped background for large width lines
-    const rectTransform = leftOffset === 0 && isWidthGreaterThanRendered
+    let rectTransform = leftOffset === 0 && isWidthGreaterThanRendered && !layerEndBeforeAxisBack
       ? position + transformX
       : leftOffset;
 
     // determine line radius for line start/end vs. partial large width lines
-    const lineRadius = !isWidthGreaterThanRendered
+    let lineRadius = !isWidthGreaterThanRendered
       || (leftOffset !== 0 && isWidthGreaterThanRendered)
       ? '6'
       : '0';
+
+    // handle "false transform" line edge to simulate line movement for striped background
+    if (leftOffset === 0 && isWidthGreaterThanRendered && layerEndBeforeAxisBack) {
+      lineWidth -= position + transformX;
+      rectTransform += position + transformX;
+      lineRadius = '6';
+    }
 
     return (
       <g

--- a/web/js/components/timeline/timeline-data/data-line.js
+++ b/web/js/components/timeline/timeline-data/data-line.js
@@ -26,7 +26,7 @@ class DataLine extends PureComponent {
 
     // eslint-disable-next-line default-case
     switch (lineType) {
-      case 'CONTAINER':
+      case 'SINGLE':
         dateRangeStart = (startDate && startDate.split('T')[0]) || 'start';
         dateRangeEnd = (endDate && endDate.split('T')[0]) || 'present';
         toolTipText = `${dateRangeStart} to ${dateRangeEnd}`;
@@ -70,8 +70,7 @@ class DataLine extends PureComponent {
   */
   createMatchingCoverageLineDOMEl = (id, options, lineType, startDate, endDate, color, layerPeriod, index) => {
     const {
-      position,
-      transformX,
+      positionTransformX,
     } = this.props;
     const {
       leftOffset,
@@ -81,7 +80,6 @@ class DataLine extends PureComponent {
       layerEndBeforeAxisBack,
     } = options;
     let lineWidth = Math.max(width, 0);
-    const positionTransformCombined = position + transformX;
 
     // get formatted dates based on line type
     const {
@@ -93,12 +91,12 @@ class DataLine extends PureComponent {
 
     // candy stripe color
     const patternType = color === 'rgb(0, 69, 123)'
-      ? 'url(#pattern)'
-      : 'url(#pattern2)';
+      ? 'url(#data-line-pattern)'
+      : 'url(#data-line-pattern-hidden)';
 
     // allow moving striped background for large width lines
     let rectTransform = leftOffset === 0 && isWidthGreaterThanRendered && !layerEndBeforeAxisBack
-      ? positionTransformCombined
+      ? positionTransformX
       : leftOffset;
 
     // determine line radius for line start/end vs. partial large width lines
@@ -111,8 +109,8 @@ class DataLine extends PureComponent {
     if (leftOffset === 0
       && ((isWidthGreaterThanRendered && layerEndBeforeAxisBack)
       || (!isWidthGreaterThanRendered && layerStartBeforeAxisFront))) {
-      lineWidth -= positionTransformCombined;
-      rectTransform += positionTransformCombined;
+      lineWidth -= positionTransformX;
+      rectTransform += positionTransformX;
       lineRadius = '6';
     }
 
@@ -125,11 +123,12 @@ class DataLine extends PureComponent {
           id={`data-coverage-line-${dateRangeStartEnd}`}
           className="data-panel-coverage-line"
           width={`${lineWidth}px`}
+          height="12px"
+          x="0"
+          y="0"
           fill={patternType}
           rx={lineRadius}
-          style={{
-            transform: `translate(${rectTransform}px)`,
-          }}
+          transform={`translate(${rectTransform})`}
         >
           <title>{toolTipText}</title>
         </rect>
@@ -166,8 +165,7 @@ class DataLine extends PureComponent {
 }
 
 DataLine.propTypes = {
-  position: PropTypes.number,
-  transformX: PropTypes.number,
+  positionTransformX: PropTypes.number,
   id: PropTypes.string,
   options: PropTypes.object,
   lineType: PropTypes.string,

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -327,8 +327,7 @@ class LayerDataItems extends Component {
       frontDate,
       getMatchingCoverageLineDimensions,
       timeScale,
-      position,
-      transformX,
+      positionTransformX,
     } = this.props;
     const emptyLayers = activeLayers.length === 0;
     return (
@@ -410,8 +409,7 @@ class LayerDataItems extends Component {
                   getMaxEndDate={this.getMaxEndDate}
                   getDatesInDateRange={this.getDatesInDateRange}
                   axisWidth={axisWidth}
-                  position={position}
-                  transformX={transformX}
+                  positionTransformX={positionTransformX}
                   layer={layer}
                   layerPeriod={layerPeriod}
                   getMatchingCoverageLineDimensions={getMatchingCoverageLineDimensions}
@@ -436,9 +434,8 @@ LayerDataItems.propTypes = {
   frontDate: PropTypes.string,
   getMatchingCoverageLineDimensions: PropTypes.func,
   hoveredLayer: PropTypes.string,
-  position: PropTypes.number,
+  positionTransformX: PropTypes.number,
   timeScale: PropTypes.string,
-  transformX: PropTypes.number,
 };
 
 export default LayerDataItems;

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { Tooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { datesinDateRangesDataPanel } from '../../../modules/layers/util';
+import { datesinDateRanges } from '../../../modules/layers/util';
 import util from '../../../util/util';
 import {
   timeScaleToNumberKey,
@@ -282,7 +282,7 @@ hoverOffToolTip = () => {
       minMinute + minuteAdd,
     );
 
-    let rangeDateEnd = new Date(rangeDateEndLocal.getTime() - (rangeDateEndLocal.getTimezoneOffset() * 60000));
+    let rangeDateEnd = util.getTimezoneOffsetDate(rangeDateEndLocal);
     // check if next date cuts off this range
     // (e.g., 8 day interval with: currentDate = 12-27-1999, and nextDate = 1-1-2000)
     if (nextDate) {
@@ -414,7 +414,7 @@ hoverOffToolTip = () => {
 
       const layerIdDates = `${appNow.toISOString()}-${frontDate}-${backDate}`;
       if (this.layerDateArrayCache[id][layerIdDates] === undefined) {
-        dateIntervalStartDates = datesinDateRangesDataPanel(def, startDateLimit, endDateLimit, appNow);
+        dateIntervalStartDates = datesinDateRanges(def, startDateLimit, startDateLimit, endDateLimit, appNow);
         this.layerDateArrayCache[id][layerIdDates] = dateIntervalStartDates;
       } else {
         dateIntervalStartDates = this.layerDateArrayCache[id][layerIdDates];

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { Tooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { datesinDateRanges } from '../../../modules/layers/util';
+import { DATAPANELdatesinDateRanges } from '../../../modules/layers/util';
 import util from '../../../util/util';
 import {
   timeScaleToNumberKey,
@@ -369,9 +369,8 @@ class LayerDataItems extends Component {
     if (startLessThanOrEqualToEndDateLimit && endGreaterThanOrEqualToStartDateLimit) {
       const inputStartDate = new Date(startDateLimit);
       const inputEndDate = new Date(endDateLimit);
-      dateIntervalStartDates = datesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate);
+      dateIntervalStartDates = DATAPANELdatesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate);
     }
-
     return dateIntervalStartDates;
   }
 

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -264,11 +264,13 @@ hoverOffToolTip = () => {
   */
   getRangeDateEndWithAddedInterval = (rangeDate, layerPeriod, itemRangeInterval, nextDate) => {
     const { appNow } = this.props;
-    const minYear = rangeDate.getUTCFullYear();
-    const minMonth = rangeDate.getUTCMonth();
-    const minDay = rangeDate.getUTCDate();
-    const minHour = rangeDate.getUTCHours();
-    const minMinute = rangeDate.getUTCMinutes();
+    const {
+      minYear,
+      minMonth,
+      minDay,
+      minHour,
+      minMinute,
+    } = util.getUTCNumbers(rangeDate, 'min');
     const yearAdd = layerPeriod === 'years' ? itemRangeInterval : 0;
     const monthAdd = layerPeriod === 'months' ? itemRangeInterval : 0;
     const dayAdd = layerPeriod === 'days' ? itemRangeInterval : 0;

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -25,33 +25,9 @@ const ignoredLayer = {
 class LayerDataItems extends Component {
   constructor(props) {
     super(props);
-    this.state = {
-      hoveredTooltip: {},
-    };
 
     // cache for queried date arrays
     this.layerDateArrayCache = {};
-  }
-
-  /**
-  * @desc handle hovering on line and adding active tooltip
-  * @param {String} input
-  * @returns {void}
-  */
-  hoverOnToolTip = (input) => {
-    this.setState({
-      hoveredTooltip: { [input]: true },
-    });
-  }
-
-  /**
-  * @desc handle hovering off line and removing active tooltip
-  * @returns {void}
-  */
-  hoverOffToolTip = () => {
-    this.setState({
-      hoveredTooltip: {},
-    });
   }
 
   /**
@@ -168,9 +144,10 @@ class LayerDataItems extends Component {
   */
   getFormattedDateRange = (layer) => {
     // get start date -or- 'start'
+    const { endDate, startDate } = layer;
     let dateRangeStart;
-    if (layer.startDate) {
-      const yearMonthDaySplit = layer.startDate.split('T')[0].split('-');
+    if (startDate) {
+      const yearMonthDaySplit = startDate.split('T')[0].split('-');
       const year = yearMonthDaySplit[0];
       const month = yearMonthDaySplit[1];
       const day = yearMonthDaySplit[2];
@@ -184,8 +161,8 @@ class LayerDataItems extends Component {
 
     // get end date -or- 'present'
     let dateRangeEnd;
-    if (layer.endDate) {
-      const yearMonthDaySplit = layer.endDate.split('T')[0].split('-');
+    if (endDate) {
+      const yearMonthDaySplit = endDate.split('T')[0].split('-');
       const year = yearMonthDaySplit[0];
       const month = yearMonthDaySplit[1];
       const day = yearMonthDaySplit[2];
@@ -340,11 +317,15 @@ class LayerDataItems extends Component {
     const {
       activeLayers,
       axisWidth,
+      backDate,
+      frontDate,
       getMatchingCoverageLineDimensions,
+      hoveredLayer,
       timeScale,
       position,
       transformX,
     } = this.props;
+    // const { hoveredTooltip } = this.state;
     const emptyLayers = activeLayers.length === 0;
     return (
       <div className="data-panel-layer-list">
@@ -417,29 +398,26 @@ class LayerDataItems extends Component {
                 }}
               >
                 <DataItemContainer
-                  frontDate={this.props.frontDate}
-                  backDate={this.props.backDate}
+                  frontDate={frontDate}
+                  backDate={backDate}
                   getLayerItemStyles={this.getLayerItemStyles}
-                  getHeaderDOMEl={this.getHeaderDOMEl}
+                  // getHeaderDOMEl={this.getHeaderDOMEl}
                   getMaxEndDate={this.getMaxEndDate}
                   getDatesInDateRange={this.getDatesInDateRange}
                   axisWidth={axisWidth}
                   position={position}
                   transformX={transformX}
-                  dateRange={dateRange}
+                  // dateRange={dateRange}
                   layer={layer}
-                  hoverOnToolTip={this.hoverOnToolTip}
-                  hoverOffToolTip={this.hoverOffToolTip}
-                  hoveredTooltip={this.state.hoveredTooltip}
                   layerPeriod={layerPeriod}
                   getMatchingCoverageLineDimensions={getMatchingCoverageLineDimensions}
                   getRangeDateEndWithAddedInterval={this.getRangeDateEndWithAddedInterval}
-                  timeScale={timeScale}
-                  hoveredLayer={this.props.hoveredLayer}
+                  // timeScale={timeScale}
+                  // hoveredLayer={hoveredLayer}
                   isValidMultipleRangesLayer={isValidMultipleRangesLayer}
                   isLayerGreaterZoomWithMultipleCoverage={isLayerGreaterZoomWithMultipleCoverage}
                   isLayerEqualZoomWithMultipleCoverage={isLayerEqualZoomWithMultipleCoverage}
-                  isLayerGreaterIncrementThanZoom={isLayerGreaterIncrementThanZoom}
+                  // isLayerGreaterIncrementThanZoom={isLayerGreaterIncrementThanZoom}
                 />
               </div>
             </div>

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { Tooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
-import { DATAPANELdatesinDateRanges } from '../../../modules/layers/util';
+import { datesinDateRangesDataPanel } from '../../../modules/layers/util';
 import util from '../../../util/util';
 import {
   timeScaleToNumberKey,
@@ -369,7 +369,7 @@ class LayerDataItems extends Component {
     if (startLessThanOrEqualToEndDateLimit && endGreaterThanOrEqualToStartDateLimit) {
       const inputStartDate = new Date(startDateLimit);
       const inputEndDate = new Date(endDateLimit);
-      dateIntervalStartDates = DATAPANELdatesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate);
+      dateIntervalStartDates = datesinDateRangesDataPanel(layer, inputStartDate, inputStartDate, inputEndDate);
     }
     return dateIntervalStartDates;
   }

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -10,6 +10,7 @@ import util from '../../../util/util';
 import {
   timeScaleToNumberKey,
 } from '../../../modules/date/constants';
+import DataItemContainer from './data-item-container';
 
 // ignore multiple date ranges due to WV config not building to
 // handle varying periods in same layer (example: M and D)
@@ -102,58 +103,6 @@ hoverOffToolTip = () => {
     );
   }
 
-  /**
-  * @desc get formatted display dates for line tooltips and selectors
-  * @param {String} lineType
-  * @param {Object} startDate date
-  * @param {Object} endDate date
-  * @param {String} layerPeriod
-  * @returns {Object}
-  *   @param {String} dateRangeStart
-  *   @param {String} dateRangeEnd
-  *   @param {String} toolTipText
-  */
-  getFormattedDisplayDates = (lineType, startDate, endDate, layerPeriod) => {
-    let dateRangeStart;
-    let dateRangeEnd;
-    let toolTipText;
-
-    // eslint-disable-next-line default-case
-    switch (lineType) {
-      case 'CONTAINER':
-        dateRangeStart = (startDate && startDate.split('T')[0]) || 'start';
-        dateRangeEnd = (endDate && endDate.split('T')[0]) || 'present';
-        toolTipText = `${dateRangeStart} to ${dateRangeEnd}`;
-        break;
-      case 'MULTI':
-        // handle minutes range display text (ex: '14:50 to 15:00')
-        if (layerPeriod === 'minutes') {
-          // eslint-disable-next-line prefer-destructuring
-          dateRangeStart = startDate.toISOString().split('T')[1];
-          // eslint-disable-next-line prefer-destructuring
-          dateRangeEnd = endDate.toISOString().split('T')[1];
-          toolTipText = `${dateRangeStart.split(':', 2).join(':')} to ${dateRangeEnd.split(':', 2).join(':')}`;
-          dateRangeStart = dateRangeStart.replace(/[.:]/g, '_');
-          dateRangeEnd = dateRangeEnd.replace(/[.:]/g, '_');
-        } else {
-          dateRangeStart = startDate.toISOString().replace(/[.:]/g, '_');
-          dateRangeEnd = endDate.toISOString().replace(/[.:]/g, '_');
-          toolTipText = `${dateRangeStart.split('T')[0]} to ${dateRangeEnd.split('T')[0]}`;
-        }
-        break;
-      case 'SINGLE':
-        dateRangeStart = startDate.replace(/:/g, '_');
-        dateRangeEnd = endDate.replace(/:/g, '_');
-        toolTipText = `${dateRangeStart.split('T')[0]} to ${dateRangeEnd.split('T')[0]}`;
-        break;
-    }
-
-    return {
-      dateRangeStart,
-      dateRangeEnd,
-      toolTipText,
-    };
-  }
 
   /**
   * @desc get formatted time period name
@@ -179,80 +128,83 @@ hoverOffToolTip = () => {
   * @param {Number/String} index
   * @returns {DOM Element} line
   */
-  createMatchingCoverageLineDOMEl = (id, options, lineType, startDate, endDate, color, layerPeriod, index) => {
-    const {
-      axisWidth,
-      position,
-      transformX,
-    } = this.props;
-    const { hoveredTooltip } = this.state;
-    const {
-      borderRadius,
-      leftOffset,
-      isWidthGreaterThanRendered,
-      width,
-    } = options;
-    const lineWidth = Math.max(width, 0);
+  // TODO: switch to individual data item components with state based location that is updated vs
+  // TODO: everything being re-rendered - use SVGs (add clipPaths)
+  // TODO: may need PARENT CONTAINER -> DATA ITEM CONTAINER (with header/date range text) -> DATA LINE
+  // createMatchingCoverageLineDOMEl = (id, options, lineType, startDate, endDate, color, layerPeriod, index) => {
+  //   const {
+  //     axisWidth,
+  //     position,
+  //     transformX,
+  //   } = this.props;
+  //   const { hoveredTooltip } = this.state;
+  //   const {
+  //     borderRadius,
+  //     leftOffset,
+  //     isWidthGreaterThanRendered,
+  //     width,
+  //   } = options;
+  //   const lineWidth = Math.max(width, 0);
 
-    // get formatted dates based on line type
-    const {
-      dateRangeStart,
-      dateRangeEnd,
-      toolTipText,
-    } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
-    const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
+  //   // get formatted dates based on line type
+  //   const {
+  //     dateRangeStart,
+  //     dateRangeEnd,
+  //     toolTipText,
+  //   } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
+  //   const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
 
-    // handle tooltip positioning
-    const toolTipOffset = -leftOffset - (lineWidth < axisWidth ? leftOffset : axisWidth / 2);
-    const toolTipPlacement = 'auto';
+  //   // handle tooltip positioning
+  //   const toolTipOffset = -leftOffset - (lineWidth < axisWidth ? leftOffset : axisWidth / 2);
+  //   const toolTipPlacement = 'auto';
 
-    // candy stripe color
-    const altLineColor = color === 'rgb(0, 69, 123)'
-      ? '#164e7a'
-      : '#797979';
-    const stripeBackground = `repeating-linear-gradient(45deg,
-      ${color},
-      ${color} 20px,
-      ${altLineColor} 20px,
-      ${altLineColor} 40px)`;
-    const backgroundPositionCalculated = `${leftOffset + lineWidth + position + transformX}px 0`;
-    const backgroundPosition = !isWidthGreaterThanRendered
-      || (leftOffset !== 0 && isWidthGreaterThanRendered)
-      ? 0
-      : backgroundPositionCalculated;
+  //   // candy stripe color
+  //   const altLineColor = color === 'rgb(0, 69, 123)'
+  //     ? '#164e7a'
+  //     : '#797979';
+  //   const stripeBackground = `repeating-linear-gradient(45deg,
+  //     ${color},
+  //     ${color} 20px,
+  //     ${altLineColor} 20px,
+  //     ${altLineColor} 40px)`;
+  //   const backgroundPositionCalculated = `${leftOffset + lineWidth + position + transformX}px 0`;
+  //   const backgroundPosition = !isWidthGreaterThanRendered
+  //     || (leftOffset !== 0 && isWidthGreaterThanRendered)
+  //     ? 0
+  //     : backgroundPositionCalculated;
 
-    return (
-      <div
-        key={index}
-        className="data-panel-coverage-line-container"
-      >
-        <div
-          id={`data-coverage-line-${dateRangeStartEnd}`}
-          className="data-panel-coverage-line"
-          onMouseEnter={() => this.hoverOnToolTip(`${dateRangeStartEnd}`)}
-          onMouseLeave={() => this.hoverOffToolTip()}
-          style={{
-            transform: `translate(${leftOffset}px, 0)`,
-            width: `${lineWidth}px`,
-            borderRadius,
-            background: stripeBackground,
-            backgroundPosition,
-          }}
-        >
-          <Tooltip
-            placement={toolTipPlacement}
-            boundariesElement={`data-coverage-line-${dateRangeStartEnd}`}
-            offset={toolTipOffset}
-            container={`.data-item-${id}`}
-            isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
-            target={`data-coverage-line-${dateRangeStartEnd}`}
-          >
-            {toolTipText}
-          </Tooltip>
-        </div>
-      </div>
-    );
-  }
+  //   return (
+  //     <div
+  //       key={index}
+  //       className="data-panel-coverage-line-container"
+  //     >
+  //       <div
+  //         id={`data-coverage-line-${dateRangeStartEnd}`}
+  //         className="data-panel-coverage-line"
+  //         onMouseEnter={() => this.hoverOnToolTip(`${dateRangeStartEnd}`)}
+  //         onMouseLeave={() => this.hoverOffToolTip()}
+  //         style={{
+  //           transform: `translate(${leftOffset}px, 0)`,
+  //           width: `${lineWidth}px`,
+  //           borderRadius,
+  //           background: stripeBackground,
+  //           backgroundPosition,
+  //         }}
+  //       >
+  //         <Tooltip
+  //           placement={toolTipPlacement}
+  //           boundariesElement={`data-coverage-line-${dateRangeStartEnd}`}
+  //           offset={toolTipOffset}
+  //           container={`.data-item-${id}`}
+  //           isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
+  //           target={`data-coverage-line-${dateRangeStartEnd}`}
+  //         >
+  //           {toolTipText}
+  //         </Tooltip>
+  //       </div>
+  //     </div>
+  //   );
+  // }
 
   /**
   * @desc get range date end with added interval based on period
@@ -470,6 +422,8 @@ hoverOffToolTip = () => {
       axisWidth,
       getMatchingCoverageLineDimensions,
       timeScale,
+      position,
+      transformX,
     } = this.props;
     const emptyLayers = activeLayers.length === 0;
     return (
@@ -512,11 +466,9 @@ hoverOffToolTip = () => {
           // concat (ex: day to days) for moment manipulation below
           layerPeriod += 's';
 
-          // get line container dimensions
-          const containerLineDimensions = getMatchingCoverageLineDimensions(layer);
           // condtional styling for line/background colors
           const {
-            lineBackgroundColor,
+            // lineBackgroundColor,
             layerItemBackground,
             layerItemOutline,
           } = this.getLayerItemStyles(visible, id);
@@ -527,11 +479,11 @@ hoverOffToolTip = () => {
             ? Number(dateRanges[0].dateInterval)
             : 1;
 
-          const multipleCoverageRangesDateIntervals = {};
-          const isValidMultipleRangesLayer = !ignoredLayer[id] && dateRanges;
-          const isLayerGreaterZoomWithMultipleCoverage = isLayerGreaterIncrementThanZoom && (multipleCoverageRanges || dateRangeIntervalZeroIndex);
-          const isLayerEqualZoomWithMultipleCoverage = isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex && dateRangeIntervalZeroIndex !== 1;
+          const isValidMultipleRangesLayer = !!(!ignoredLayer[id] && dateRanges);
+          const isLayerGreaterZoomWithMultipleCoverage = !!(isLayerGreaterIncrementThanZoom && (multipleCoverageRanges || dateRangeIntervalZeroIndex));
+          const isLayerEqualZoomWithMultipleCoverage = !!(isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex && dateRangeIntervalZeroIndex !== 1);
           const key = index;
+
           return (
             <div
               key={key}
@@ -550,97 +502,31 @@ hoverOffToolTip = () => {
                   maxWidth: `${axisWidth}px`,
                 }}
               >
-                {isValidMultipleRangesLayer && (isLayerGreaterZoomWithMultipleCoverage || isLayerEqualZoomWithMultipleCoverage)
-                // multiple coverage ranges
-                  ? (
-                    <div
-                      className="data-panel-coverage-line"
-                      style={{
-                        width: `${containerLineDimensions.width}px`,
-                      }}
-                    >
-                      {dateRanges && dateRanges.map((range, innerIndex) => {
-                        const isLastInRange = innerIndex === dateRanges.length - 1;
-                        const rangeInterval = Number(range.dateInterval);
-                        // multi time unit range - no year time unit
-                        if (isLayerGreaterIncrementThanZoom || (rangeInterval !== 1 && timeScale !== 'year')) {
-                          const endDateLimit = this.getMaxEndDate(inactive, isLastInRange);
-                          // get dates based on date ranges
-                          const dateIntervalStartDates = this.getDatesInDateRange(layer, range, endDateLimit, isLastInRange);
-                          // add date intervals to multipleCoverageRangesDateIntervals object to catch repeats
-                          dateIntervalStartDates.forEach((dateInt) => {
-                            const dateIntFormatted = dateInt.toISOString();
-                            const dateIntTime = new Date(dateInt).getTime();
-                            const startDateTime = new Date(range.startDate).getTime();
-                            const endDateTime = new Date(range.endDate).getTime();
-                            // allow overwriting of subsequent date ranges
-                            if (dateIntTime >= startDateTime && startDateTime <= endDateTime) {
-                              multipleCoverageRangesDateIntervals[dateIntFormatted] = { date: dateInt, interval: rangeInterval };
-                            }
-                          });
-                          // if at the end of dateRanges array, display results from multipleCoverageRangesDateIntervals
-                          if (isLastInRange) {
-                            const multiDateToDisplay = Object.values(multipleCoverageRangesDateIntervals);
-                            return multiDateToDisplay.map((itemRange, multiIndex) => {
-                              const { date, interval } = itemRange;
-                              const nextDate = multiDateToDisplay[multiIndex + 1];
-                              const rangeDateEnd = this.getRangeDateEndWithAddedInterval(date, layerPeriod, interval, nextDate);
-                              // get range line dimensions
-                              const multiLineRangeOptions = getMatchingCoverageLineDimensions(layer, date, rangeDateEnd);
-                              // create DOM line element
-                              return multiLineRangeOptions.visible
-                                && this.createMatchingCoverageLineDOMEl(
-                                  id,
-                                  multiLineRangeOptions,
-                                  'MULTI',
-                                  date,
-                                  rangeDateEnd,
-                                  lineBackgroundColor,
-                                  layerPeriod,
-                                  `${id}-${multiIndex}`,
-                                );
-                            });
-                          }
-                          return null;
-                        }
-                        // handle single coverage
-                        const rangeStart = range.startDate;
-                        let rangeEnd = range.endDate;
-                        if (range.startDate === range.endDate) {
-                          rangeEnd = moment.utc(range.startDate).add(rangeInterval + 1, layerPeriod).format();
-                        } else {
-                          rangeEnd = moment.utc(rangeEnd).endOf(layerPeriod).format();
-                        }
-
-                        // get range line dimensions
-                        const singleLineOptions = getMatchingCoverageLineDimensions(layer, rangeStart, rangeEnd);
-                        // create DOM line element
-                        return singleLineOptions.visible
-                          && this.createMatchingCoverageLineDOMEl(
-                            id,
-                            singleLineOptions,
-                            'SINGLE',
-                            rangeStart,
-                            rangeEnd,
-                            lineBackgroundColor,
-                            layerPeriod,
-                            `${id}-${innerIndex}`,
-                          );
-                      })}
-                    </div>
-                  )
-                  // single start -> end date range coverage
-                  : containerLineDimensions.visible
-                  && this.createMatchingCoverageLineDOMEl(
-                    id,
-                    containerLineDimensions,
-                    'CONTAINER',
-                    startDate,
-                    endDate,
-                    lineBackgroundColor,
-                    layerPeriod,
-                    `${id}-0`,
-                  )}
+                <DataItemContainer
+                  frontDate={this.props.frontDate}
+                  backDate={this.props.backDate}
+                  getLayerItemStyles={this.getLayerItemStyles}
+                  getHeaderDOMEl={this.getHeaderDOMEl}
+                  getMaxEndDate={this.getMaxEndDate}
+                  getDatesInDateRange={this.getDatesInDateRange}
+                  axisWidth={axisWidth}
+                  position={position}
+                  transformX={transformX}
+                  dateRange={dateRange}
+                  layer={layer}
+                  hoverOnToolTip={this.hoverOnToolTip}
+                  hoverOffToolTip={this.hoverOffToolTip}
+                  hoveredTooltip={this.state.hoveredTooltip}
+                  layerPeriod={layerPeriod}
+                  getMatchingCoverageLineDimensions={getMatchingCoverageLineDimensions}
+                  getRangeDateEndWithAddedInterval={this.getRangeDateEndWithAddedInterval}
+                  timeScale={timeScale}
+                  hoveredLayer={this.props.hoveredLayer}
+                  isValidMultipleRangesLayer={isValidMultipleRangesLayer}
+                  isLayerGreaterZoomWithMultipleCoverage={isLayerGreaterZoomWithMultipleCoverage}
+                  isLayerEqualZoomWithMultipleCoverage={isLayerEqualZoomWithMultipleCoverage}
+                  isLayerGreaterIncrementThanZoom={isLayerGreaterIncrementThanZoom}
+                />
               </div>
             </div>
           );

--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Tooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { datesinDateRanges } from '../../../modules/layers/util';
@@ -23,7 +22,6 @@ const ignoredLayer = {
  *
  * @class LayerDataItems
  */
-
 class LayerDataItems extends Component {
   constructor(props) {
     super(props);
@@ -35,28 +33,26 @@ class LayerDataItems extends Component {
     this.layerDateArrayCache = {};
   }
 
-
   /**
   * @desc handle hovering on line and adding active tooltip
   * @param {String} input
   * @returns {void}
   */
- hoverOnToolTip = (input) => {
-   this.setState({
-     hoveredTooltip: { [input]: true },
-   });
- }
+  hoverOnToolTip = (input) => {
+    this.setState({
+      hoveredTooltip: { [input]: true },
+    });
+  }
 
-/**
-* @desc handle hovering off line and removing active tooltip
-* @returns {void}
-*/
-hoverOffToolTip = () => {
-  this.setState({
-    hoveredTooltip: {},
-  });
-}
-
+  /**
+  * @desc handle hovering off line and removing active tooltip
+  * @returns {void}
+  */
+  hoverOffToolTip = () => {
+    this.setState({
+      hoveredTooltip: {},
+    });
+  }
 
   /**
   * @desc get layer header with title, subtitle, and full date range
@@ -69,6 +65,7 @@ hoverOffToolTip = () => {
   getHeaderDOMEl = (layer, visible, dateRange, layerItemBackground) => {
     const titleColor = visible ? '#000' : '#999';
     const textColor = visible ? '#222' : '#999';
+    const { subtitle, title } = layer;
     return (
       <>
         <div className="data-panel-layer-item-header">
@@ -78,7 +75,7 @@ hoverOffToolTip = () => {
               color: titleColor,
             }}
           >
-            {layer.title}
+            {title}
             {' '}
             <span
               className="data-panel-layer-item-subtitle"
@@ -86,7 +83,7 @@ hoverOffToolTip = () => {
                 color: textColor,
               }}
             >
-              {layer.subtitle}
+              {subtitle}
             </span>
           </div>
           <div
@@ -103,7 +100,6 @@ hoverOffToolTip = () => {
     );
   }
 
-
   /**
   * @desc get formatted time period name
   * @param {String} period
@@ -116,95 +112,6 @@ hoverOffToolTip = () => {
       : period === 'yearly'
         ? 'year'
         : 'minute')
-
-  /**
-  * @desc get line DOM element from full/partial (interval) date range with tooltip
-  * @param {String} id
-  * @param {Object} options
-  * @param {String} dateRangeStart
-  * @param {String} dateRangeEnd
-  * @param {String} color
-  * @param {String} toolTipText
-  * @param {Number/String} index
-  * @returns {DOM Element} line
-  */
-  // TODO: switch to individual data item components with state based location that is updated vs
-  // TODO: everything being re-rendered - use SVGs (add clipPaths)
-  // TODO: may need PARENT CONTAINER -> DATA ITEM CONTAINER (with header/date range text) -> DATA LINE
-  // createMatchingCoverageLineDOMEl = (id, options, lineType, startDate, endDate, color, layerPeriod, index) => {
-  //   const {
-  //     axisWidth,
-  //     position,
-  //     transformX,
-  //   } = this.props;
-  //   const { hoveredTooltip } = this.state;
-  //   const {
-  //     borderRadius,
-  //     leftOffset,
-  //     isWidthGreaterThanRendered,
-  //     width,
-  //   } = options;
-  //   const lineWidth = Math.max(width, 0);
-
-  //   // get formatted dates based on line type
-  //   const {
-  //     dateRangeStart,
-  //     dateRangeEnd,
-  //     toolTipText,
-  //   } = this.getFormattedDisplayDates(lineType, startDate, endDate, layerPeriod);
-  //   const dateRangeStartEnd = `${id}-${dateRangeStart}-${dateRangeEnd}`;
-
-  //   // handle tooltip positioning
-  //   const toolTipOffset = -leftOffset - (lineWidth < axisWidth ? leftOffset : axisWidth / 2);
-  //   const toolTipPlacement = 'auto';
-
-  //   // candy stripe color
-  //   const altLineColor = color === 'rgb(0, 69, 123)'
-  //     ? '#164e7a'
-  //     : '#797979';
-  //   const stripeBackground = `repeating-linear-gradient(45deg,
-  //     ${color},
-  //     ${color} 20px,
-  //     ${altLineColor} 20px,
-  //     ${altLineColor} 40px)`;
-  //   const backgroundPositionCalculated = `${leftOffset + lineWidth + position + transformX}px 0`;
-  //   const backgroundPosition = !isWidthGreaterThanRendered
-  //     || (leftOffset !== 0 && isWidthGreaterThanRendered)
-  //     ? 0
-  //     : backgroundPositionCalculated;
-
-  //   return (
-  //     <div
-  //       key={index}
-  //       className="data-panel-coverage-line-container"
-  //     >
-  //       <div
-  //         id={`data-coverage-line-${dateRangeStartEnd}`}
-  //         className="data-panel-coverage-line"
-  //         onMouseEnter={() => this.hoverOnToolTip(`${dateRangeStartEnd}`)}
-  //         onMouseLeave={() => this.hoverOffToolTip()}
-  //         style={{
-  //           transform: `translate(${leftOffset}px, 0)`,
-  //           width: `${lineWidth}px`,
-  //           borderRadius,
-  //           background: stripeBackground,
-  //           backgroundPosition,
-  //         }}
-  //       >
-  //         <Tooltip
-  //           placement={toolTipPlacement}
-  //           boundariesElement={`data-coverage-line-${dateRangeStartEnd}`}
-  //           offset={toolTipOffset}
-  //           container={`.data-item-${id}`}
-  //           isOpen={hoveredTooltip[`${dateRangeStartEnd}`]}
-  //           target={`data-coverage-line-${dateRangeStartEnd}`}
-  //         >
-  //           {toolTipText}
-  //         </Tooltip>
-  //       </div>
-  //     </div>
-  //   );
-  // }
 
   /**
   * @desc get range date end with added interval based on period
@@ -416,6 +323,19 @@ hoverOffToolTip = () => {
     };
   }
 
+  /**
+  * @desc get empty layers message DOM element
+  * @returns {DOM Element} div contained message
+  */
+  createEmptyLayersDOMEl = () => (
+    <div className="data-panel-layer-empty">
+      <div className="data-item-empty">
+        <FontAwesomeIcon icon={faExclamationTriangle} className="error-icon" />
+        <p>No visible layers with defined coverage. Add layers or toggle &quot;Include Hidden Layers&quot; if current layers are hidden.</p>
+      </div>
+    </div>
+  )
+
   render() {
     const {
       activeLayers,
@@ -428,21 +348,15 @@ hoverOffToolTip = () => {
     const emptyLayers = activeLayers.length === 0;
     return (
       <div className="data-panel-layer-list">
-        {emptyLayers
-          && (
-          <div className="data-panel-layer-empty">
-            <div className="data-item-empty">
-              <FontAwesomeIcon icon={faExclamationTriangle} className="error-icon" />
-              <p>No visible layers with defined coverage. Add layers or toggle &quot;Include Hidden Layers&quot; if current layers are hidden.</p>
-            </div>
-          </div>
-          )}
-        {activeLayers.map((layer, index) => {
+        {/* Empty layer data message */
+          emptyLayers && this.createEmptyLayersDOMEl()
+        }
+
+        {/* Build individual layer data components */
+        activeLayers.map((layer, index) => {
           const {
             dateRanges,
-            endDate,
             id,
-            inactive,
             period,
             startDate,
             visible,
@@ -468,7 +382,6 @@ hoverOffToolTip = () => {
 
           // condtional styling for line/background colors
           const {
-            // lineBackgroundColor,
             layerItemBackground,
             layerItemOutline,
           } = this.getLayerItemStyles(visible, id);
@@ -481,7 +394,8 @@ hoverOffToolTip = () => {
 
           const isValidMultipleRangesLayer = !!(!ignoredLayer[id] && dateRanges);
           const isLayerGreaterZoomWithMultipleCoverage = !!(isLayerGreaterIncrementThanZoom && (multipleCoverageRanges || dateRangeIntervalZeroIndex));
-          const isLayerEqualZoomWithMultipleCoverage = !!(isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex && dateRangeIntervalZeroIndex !== 1);
+          // const isLayerEqualZoomWithMultipleCoverage = !!(isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex && dateRangeIntervalZeroIndex !== 1);
+          const isLayerEqualZoomWithMultipleCoverage = !!(isLayerEqualIncrementThanZoom && dateRangeIntervalZeroIndex > 1);
           const key = index;
 
           return (
@@ -530,7 +444,8 @@ hoverOffToolTip = () => {
               </div>
             </div>
           );
-        })}
+        })
+        }
       </div>
     );
   }

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -273,7 +273,6 @@ class TimelineData extends Component {
     } = this.props;
     const {
       activeLayers,
-      // hoveredTooltip,
       shouldIncludeHiddenLayers,
     } = this.state;
     // filter current active layers

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -148,11 +148,13 @@ class TimelineData extends Component {
       visible = false;
     }
 
+    console.log(visible, layer, rangeStart, rangeEnd);
+
     let leftOffset = 0;
     let borderRadiusLeft = '0';
     let borderRadiusRight = '0';
 
-    let width = axisWidth * 2;
+    let width = axisWidth * 5;
     if (visible) {
       if (layerStart <= axisFrontDate) {
         leftOffset = 0;
@@ -336,7 +338,8 @@ class TimelineData extends Component {
                 toggle={() => this.addMatchingCoverageToTimeline(!shouldIncludeHiddenLayers)}
               />
             </header>
-            <Scrollbars style={{ maxHeight: maxHeightScrollBar }}>
+            {/* <Scrollbars style={{ maxHeight: maxHeightScrollBar }}> */}
+            <div style={{ maxHeight: maxHeightScrollBar, overflowY: 'scroll' }}>
               <LayerDataItems
                 activeLayers={activeLayers}
                 appNow={appNow}
@@ -349,7 +352,8 @@ class TimelineData extends Component {
                 position={position}
                 transformX={transformX}
               />
-            </Scrollbars>
+            </div>
+            {/* </Scrollbars> */}
           </div>
           )}
         </div>

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -152,7 +152,7 @@ class TimelineData extends Component {
     const isWidthGreaterThanRendered = layerStart < axisFrontDate || layerEnd > axisBackDate;
     const layerStartBeforeAxisFront = layerStart <= axisFrontDate;
     const layerEndBeforeAxisBack = layerEnd <= axisBackDate;
-
+    // oversized width allows axis drag buffer
     let width = axisWidth * 5;
     if (visible) {
       if (layerStartBeforeAxisFront) {
@@ -278,9 +278,11 @@ class TimelineData extends Component {
 
     const emptyLayers = activeLayers.length === 0;
 
-    // handle conditional styling
+    // handle conditional container styling
     const maxHeightScrollBar = '203px';
-    const layerListItemHeigthConstant = emptyLayers ? 41 : layers.length * 41;
+    const layerListItemHeigthConstant = emptyLayers
+      ? 41
+      : layers.length * 41;
 
     const dataAvailabilityHandleTopOffset = `${Math.max(-54 - layerListItemHeigthConstant, -259)}px`;
 
@@ -332,8 +334,7 @@ class TimelineData extends Component {
                 toggle={() => this.addMatchingCoverageToTimeline(!shouldIncludeHiddenLayers)}
               />
             </header>
-            {/* <Scrollbars style={{ maxHeight: maxHeightScrollBar }}> */}
-            <div style={{ maxHeight: maxHeightScrollBar, overflowY: 'scroll' }}>
+            <Scrollbars style={{ maxHeight: maxHeightScrollBar }}>
               <LayerDataItems
                 activeLayers={activeLayers}
                 appNow={appNow}
@@ -346,8 +347,7 @@ class TimelineData extends Component {
                 position={position}
                 transformX={transformX}
               />
-            </div>
-            {/* </Scrollbars> */}
+            </Scrollbars>
           </div>
           )}
         </div>

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -24,7 +24,6 @@ class TimelineData extends Component {
     this.state = {
       activeLayers: [],
       shouldIncludeHiddenLayers: false,
-      hoveredTooltip: {},
     };
   }
 
@@ -38,6 +37,24 @@ class TimelineData extends Component {
     document.querySelector('.timeline-data-panel-container').addEventListener('wheel', (e) => e.stopPropagation(), { passive: false });
     // init populate of activeLayers
     this.addMatchingCoverageToTimeline(shouldIncludeHiddenLayers, layers);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const {
+      timeScale,
+      frontDate,
+      backDate,
+    } = this.props;
+
+    // prevent repeated rendering on timescale change updates
+    if (nextProps.timeScale !== timeScale) {
+      const isFrontDateSame = nextProps.frontDate === frontDate;
+      const isBackDateSame = nextProps.backDate === backDate;
+      if (isFrontDateSame && isBackDateSame) {
+        return false;
+      }
+    }
+    return true;
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -169,27 +186,6 @@ class TimelineData extends Component {
   }
 
   /**
-  * @desc handle hovering on line and adding active tooltip
-  * @param {String} input
-  * @returns {void}
-  */
-  hoverOnToolTip = (input) => {
-    this.setState({
-      hoveredTooltip: { [input]: true },
-    });
-  }
-
-  /**
-  * @desc handle hovering off line and removing active tooltip
-  * @returns {void}
-  */
-  hoverOffToolTip = () => {
-    this.setState({
-      hoveredTooltip: {},
-    });
-  }
-
-  /**
   * @desc handle open/close modal from clicking handle
   * @returns {void}
   */
@@ -277,7 +273,7 @@ class TimelineData extends Component {
     } = this.props;
     const {
       activeLayers,
-      hoveredTooltip,
+      // hoveredTooltip,
       shouldIncludeHiddenLayers,
     } = this.state;
     // filter current active layers
@@ -350,9 +346,6 @@ class TimelineData extends Component {
                 frontDate={frontDate}
                 getMatchingCoverageLineDimensions={this.getMatchingCoverageLineDimensions}
                 hoveredLayer={hoveredLayer}
-                hoveredTooltip={hoveredTooltip}
-                hoverOffToolTip={this.hoverOffToolTip}
-                hoverOnToolTip={this.hoverOnToolTip}
                 timeScale={timeScale}
                 position={position}
                 transformX={transformX}

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -111,7 +111,7 @@ class TimelineData extends Component {
   * @param {Object} layer
   * @param {String} rangeStart
   * @param {String} rangeEnd
-  * @returns {Object} visible, leftOffset, width, borderRadius, isWidthGreaterThanRendered
+  * @returns {Object} visible, leftOffset, width, isWidthGreaterThanRendered
   */
   getMatchingCoverageLineDimensions = (layer, rangeStart, rangeEnd) => {
     const {
@@ -148,42 +148,36 @@ class TimelineData extends Component {
       visible = false;
     }
 
-    console.log(visible, layer, rangeStart, rangeEnd);
-
     let leftOffset = 0;
-    let borderRadiusLeft = '0';
-    let borderRadiusRight = '0';
+    const isWidthGreaterThanRendered = layerStart < axisFrontDate || layerEnd > axisBackDate;
+    const layerStartBeforeAxisFront = layerStart <= axisFrontDate;
+    const layerEndBeforeAxisBack = layerEnd <= axisBackDate;
 
     let width = axisWidth * 5;
     if (visible) {
-      if (layerStart <= axisFrontDate) {
+      if (layerStartBeforeAxisFront) {
         leftOffset = 0;
       } else {
         // positive diff means layerStart more recent than axisFrontDate
         const diff = moment.utc(layerStart).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         leftOffset = gridDiff + postionTransformX;
-        borderRadiusLeft = '6px';
       }
-
-      if (layerEnd <= axisBackDate) {
+      if (layerEndBeforeAxisBack) {
         // positive diff means layerEnd earlier than back date
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         width = gridDiff + postionTransformX - leftOffset;
-        borderRadiusRight = '6px';
       }
     }
-
-    const isWidthGreaterThanRendered = layerStart < axisFrontDate || layerEnd > axisBackDate;
-    const borderRadius = `${borderRadiusLeft} ${borderRadiusRight} ${borderRadiusRight} ${borderRadiusLeft}`;
 
     return {
       visible,
       leftOffset,
       width,
-      borderRadius,
       isWidthGreaterThanRendered,
+      layerStartBeforeAxisFront,
+      layerEndBeforeAxisBack,
     };
   }
 

--- a/web/js/components/timeline/timeline-data/timeline-data.js
+++ b/web/js/components/timeline/timeline-data/timeline-data.js
@@ -119,13 +119,11 @@ class TimelineData extends Component {
       axisWidth,
       backDate,
       frontDate,
-      position,
+      positionTransformX,
       timeScale,
       timelineStartDateLimit,
-      transformX,
     } = this.props;
 
-    const postionTransformX = position + transformX;
     const { gridWidth } = timeScaleOptions[timeScale].timeAxis;
     const axisFrontDate = new Date(frontDate).getTime();
     const axisBackDate = new Date(backDate).getTime();
@@ -161,13 +159,13 @@ class TimelineData extends Component {
         // positive diff means layerStart more recent than axisFrontDate
         const diff = moment.utc(layerStart).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
-        leftOffset = gridDiff + postionTransformX;
+        leftOffset = gridDiff + positionTransformX;
       }
       if (layerEndBeforeAxisBack) {
         // positive diff means layerEnd earlier than back date
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
-        width = gridDiff + postionTransformX - leftOffset;
+        width = gridDiff + positionTransformX - leftOffset;
       }
     }
 
@@ -263,9 +261,8 @@ class TimelineData extends Component {
       hoveredLayer,
       isDataCoveragePanelOpen,
       parentOffset,
-      position,
+      positionTransformX,
       timeScale,
-      transformX,
     } = this.props;
     const {
       activeLayers,
@@ -344,8 +341,7 @@ class TimelineData extends Component {
                 getMatchingCoverageLineDimensions={this.getMatchingCoverageLineDimensions}
                 hoveredLayer={hoveredLayer}
                 timeScale={timeScale}
-                position={position}
-                transformX={transformX}
+                positionTransformX={positionTransformX}
               />
             </Scrollbars>
           </div>
@@ -398,13 +394,12 @@ TimelineData.propTypes = {
   isDataCoveragePanelOpen: PropTypes.bool,
   isProductPickerOpen: PropTypes.bool,
   parentOffset: PropTypes.number,
-  position: PropTypes.number,
+  positionTransformX: PropTypes.number,
   projection: PropTypes.string,
   setMatchingTimelineCoverage: PropTypes.func,
   timelineStartDateLimit: PropTypes.string,
   timeScale: PropTypes.string,
   toggleDataCoveragePanel: PropTypes.func,
-  transformX: PropTypes.number,
 };
 
 export default connect(

--- a/web/js/components/timeline/timeline-draggers/dragger-container.js
+++ b/web/js/components/timeline/timeline-draggers/dragger-container.js
@@ -235,6 +235,10 @@ class DraggerContainer extends PureComponent {
       draggerVisibleB,
     } = this.props;
 
+    const {
+      draggerWidth,
+    } = this.state;
+
     const sharedProps = {
       axisWidth,
       toggleShowDraggerTime,
@@ -243,10 +247,23 @@ class DraggerContainer extends PureComponent {
       handleDragDragger: this.handleDragDragger,
       selectDragger: this.selectDragger,
     };
+
+    const selectedDraggerClipAClipWidth = Math.max(draggerWidth, draggerWidth + draggerPosition);
+    const selectedDraggerClipBClipWidth = Math.max(draggerWidth, draggerWidth + draggerPositionB);
     return (
       draggerSelected === 'selectedB'
         ? (
-          <svg className="dragger-container" width={axisWidth} height={83}>
+          <svg className="dragger-container" width={axisWidth} height={65}>
+            <defs>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipA">
+                <rect width={selectedDraggerClipAClipWidth} height="65" />
+              </clipPath>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipB">
+                <rect width={selectedDraggerClipBClipWidth} height="65" />
+              </clipPath>
+            </defs>
             {isCompareModeActive
               ? (
                 <Dragger
@@ -268,7 +285,17 @@ class DraggerContainer extends PureComponent {
           </svg>
         )
         : (
-          <svg className="dragger-container" width={axisWidth} height={83}>
+          <svg className="dragger-container" width={axisWidth} height={65}>
+            <defs>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipA">
+                <rect width={selectedDraggerClipAClipWidth} height="65" />
+              </clipPath>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipB">
+                <rect width={selectedDraggerClipBClipWidth} height="65" />
+              </clipPath>
+            </defs>
             {isCompareModeActive
               ? (
                 <Dragger

--- a/web/js/components/timeline/timeline-draggers/timeline-dragger.js
+++ b/web/js/components/timeline/timeline-draggers/timeline-dragger.js
@@ -124,7 +124,9 @@ class Dragger extends PureComponent {
       isHoveredDragging,
     } = this.state;
     // handle isHovered that may include a mouse up event while not hovered over dragger
-    const isHovered = !isHoveredDrag && !isHoveredDragging ? false : isHoveredDrag || isHoveredDragging;
+    const isHovered = !isHoveredDrag && !isHoveredDragging
+      ? false
+      : isHoveredDrag || isHoveredDragging;
     // handle fill for hover vs non-hover and slightly different A/B draggers
     const draggerFill = disabled
       ? isHovered
@@ -135,6 +137,16 @@ class Dragger extends PureComponent {
           ? '#a3a3a3'
           : '#8e8e8e'
         : '#ccc';
+
+    const draggerStroke = isHovered
+      ? '#ccc'
+      : '#333';
+    const draggerRectFill = isHovered
+      ? '#ccc'
+      : '#515151';
+    const draggerLetter = draggerName === 'selected'
+      ? 'A'
+      : 'B';
     return (
       draggerVisible
         ? (
@@ -142,7 +154,7 @@ class Dragger extends PureComponent {
             axis="x"
             onMouseDown={this.selectDragger}
             onDrag={this.handleDragDragger}
-            position={{ x: draggerPosition + 25, y: 19 }}
+            position={{ x: draggerPosition + 25, y: 0 }}
             onStart={this.startShowDraggerTime}
             onStop={this.stopShowDraggerTime}
             disabled={disabled}
@@ -152,14 +164,15 @@ class Dragger extends PureComponent {
                 cursor: 'pointer',
                 display: draggerVisible ? 'block' : 'none',
               }}
-              className={`timeline-dragger dragger${draggerName === 'selected' ? 'A' : 'B'}`}
+              className={`timeline-dragger dragger${draggerLetter}`}
               transform={`translate(${transformX}, 0)`}
               onMouseEnter={this.handleHoverMouseEnter}
               onMouseLeave={this.handleHoverMouseLeave}
+              clipPath={`url(#selectedDraggerClip${draggerLetter})`}
             >
               <path
                 fill={draggerFill}
-                stroke={isHovered ? '#ccc' : '#333'}
+                stroke={draggerStroke}
                 strokeWidth="1px"
                 d="M5.706 47.781
               C2.77 47.781.39 45.402.39 42.467
@@ -168,6 +181,7 @@ class Dragger extends PureComponent {
               v16.592
               c0 2.935-2.38 5.314-5.316 5.314
               h-34.932z"
+                shapeRendering="optimizeSpeed"
               />
               {isCompareModeActive
                 ? (
@@ -180,14 +194,14 @@ class Dragger extends PureComponent {
                     transform="translate(4, 30)"
                     textRendering="optimizeLegibility"
                   >
-                    {draggerName === 'selected' ? 'A' : 'B'}
+                    {draggerLetter}
                   </text>
                 )
                 : (
                   <>
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="15"
@@ -195,7 +209,7 @@ class Dragger extends PureComponent {
                     />
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="21"
@@ -203,7 +217,7 @@ class Dragger extends PureComponent {
                     />
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="27"

--- a/web/js/components/timeline/timeline-draggers/timeline-dragger.js
+++ b/web/js/components/timeline/timeline-draggers/timeline-dragger.js
@@ -162,10 +162,9 @@ class Dragger extends PureComponent {
             <g
               style={{
                 cursor: 'pointer',
-                display: draggerVisible ? 'block' : 'none',
               }}
               className={`timeline-dragger dragger${draggerLetter}`}
-              transform={`translate(${transformX}, 0)`}
+              transform={`translate(${transformX})`}
               onMouseEnter={this.handleHoverMouseEnter}
               onMouseLeave={this.handleHoverMouseLeave}
               clipPath={`url(#selectedDraggerClip${draggerLetter})`}
@@ -181,17 +180,15 @@ class Dragger extends PureComponent {
               v16.592
               c0 2.935-2.38 5.314-5.316 5.314
               h-34.932z"
-                shapeRendering="optimizeSpeed"
               />
               {isCompareModeActive
                 ? (
                   <text
                     fontSize="26px"
                     fontWeight="400"
-                    x="11"
-                    y="8"
+                    x="14"
+                    y="37"
                     fill={disabled ? '#ccc' : '#000'}
-                    transform="translate(4, 30)"
                     textRendering="optimizeLegibility"
                   >
                     {draggerLetter}

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1231,8 +1231,7 @@ class Timeline extends React.Component {
                       {/* Data Coverage Panel */}
                       <TimelineData
                         appNow={appNow}
-                        position={position}
-                        transformX={transformX}
+                        positionTransformX={position + transformX}
                         timeScale={timeScale}
                         frontDate={frontDate}
                         backDate={backDate}

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -401,7 +401,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic positioning update based on simple drag
   * @param {Object} args
-    * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} draggerPosition
     * @param {Number} draggerPositionB
@@ -410,7 +409,6 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioningOnSimpleDrag = ({
-    isTimelineDragging,
     position,
     draggerPosition,
     draggerPositionB,
@@ -418,7 +416,7 @@ class Timeline extends React.Component {
     animationEndLocation,
   }) => {
     this.setState({
-      isTimelineDragging,
+      isTimelineDragging: true,
       showHoverLine: false,
       position,
       draggerPosition,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -97,7 +97,6 @@ class Timeline extends React.Component {
       isTimelineDragging: false,
       initialLoadComplete: false,
       timelineHidden: false,
-      hasMoved: false,
       rangeSelectorMax: {
         end: false, start: false, startOffset: -50, width: 50000,
       },
@@ -354,7 +353,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic position changes from axis that affect dragger and range select
   * @param {Object} args
-    * @param {Boolean} hasMoved
     * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} transformX
@@ -370,7 +368,6 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioning = ({
-    hasMoved,
     isTimelineDragging,
     position,
     transformX,
@@ -385,7 +382,6 @@ class Timeline extends React.Component {
   // eslint-disable-next-line react/destructuring-assignment
   }, hoverTime = this.state.hoverTime) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
       showHoverLine: false,
       position,
@@ -405,7 +401,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic positioning update based on simple drag
   * @param {Object} args
-    * @param {Boolean} hasMoved
     * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} draggerPosition
@@ -415,7 +410,6 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioningOnSimpleDrag = ({
-    hasMoved,
     isTimelineDragging,
     position,
     draggerPosition,
@@ -424,7 +418,6 @@ class Timeline extends React.Component {
     animationEndLocation,
   }) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
       showHoverLine: false,
       position,
@@ -438,7 +431,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic positioning update based on axis drag stop event
   * @param {Object} args
-    * @param {Boolean} hasMoved
     * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} transformX
@@ -446,14 +438,12 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioningOnAxisStopDrag = ({
-    hasMoved,
     isTimelineDragging,
     position,
     transformX,
   // eslint-disable-next-line react/destructuring-assignment
   }, hoverTime = this.state.hoverTime) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
       showHoverLine: false,
       position,
@@ -464,13 +454,11 @@ class Timeline extends React.Component {
 
   /**
   * @desc update is timeline moved (drag timeline vs. click) and if timeline is dragging
-  * @param {Boolean} hasMoved
   * @param {Boolean} isTimelineDragging
   * @returns {void}
   */
-  updateTimelineMoveAndDrag = (hasMoved, isTimelineDragging) => {
+  updateTimelineMoveAndDrag = (isTimelineDragging) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
     });
   }
@@ -799,10 +787,9 @@ class Timeline extends React.Component {
   * @param {Number} draggerPositionArg
   * @param {Boolean} draggerVisibleArg
   * @param {Boolean} otherDraggerVisibleArg
-  * @param {Boolean} hasMovedArg
   * @returns {void}
   */
-  updateDraggerDatePosition = (newDate, draggerSelected, draggerPositionArg, draggerVisibleArg, otherDraggerVisibleArg, hasMovedArg) => {
+  updateDraggerDatePosition = (newDate, draggerSelected, draggerPositionArg, draggerVisibleArg, otherDraggerVisibleArg) => {
     const {
       draggerPosition,
       draggerPositionB,
@@ -810,7 +797,6 @@ class Timeline extends React.Component {
       draggerVisibleB,
       draggerTimeState,
       draggerTimeStateB,
-      hasMoved,
     } = this.state;
     if (draggerSelected === 'selected') {
       this.setState({
@@ -818,7 +804,6 @@ class Timeline extends React.Component {
         draggerVisible: draggerVisibleArg || draggerVisible,
         draggerVisibleB: otherDraggerVisibleArg || draggerVisibleB,
         draggerTimeState: newDate || draggerTimeState,
-        hasMoved: hasMovedArg || hasMoved,
       });
       if (newDate) {
         this.onDateChange(newDate, 'selected');
@@ -829,7 +814,6 @@ class Timeline extends React.Component {
         draggerVisible: otherDraggerVisibleArg || draggerVisible,
         draggerVisibleB: draggerVisibleArg || draggerVisibleB,
         draggerTimeStateB: newDate || draggerTimeStateB,
-        hasMoved: hasMovedArg || hasMoved,
       });
       if (newDate) {
         this.onDateChange(newDate, 'selectedB');
@@ -1043,7 +1027,6 @@ class Timeline extends React.Component {
       showHoverLine,
       showDraggerTime,
       hoverLinePosition,
-      hasMoved,
       shouldIncludeHiddenLayers,
     } = this.state;
     const selectedDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
@@ -1229,7 +1212,6 @@ class Timeline extends React.Component {
                         isAnimationDraggerDragging={isAnimationDraggerDragging}
                         isDraggerDragging={isDraggerDragging}
                         isTimelineDragging={isTimelineDragging}
-                        hasMoved={hasMoved}
                         matchingTimelineCoverage={matchingTimelineCoverage}
                       />
 

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -212,9 +212,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     // Don't key by time if this is a static layer--it is valid for
     // every date.
     if (def.period) {
-      date = util.toISOStringSeconds(
-        util.roundTimeOneMinute(self.getRequestDates(def, options).closestDate),
-      );
+      date = util.toISOStringSeconds(util.roundTimeOneMinute(options.date));
     }
     if (isPaletteActive(def.id, activeGroupStr, state)) {
       style = getPaletteKeys(def.id, undefined, state);
@@ -302,7 +300,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
       throw new Error(`${def.id}: Undefined matrix set: ${def.matrixSet}`);
     }
     let date = options.date || state.date[activeDateStr];
-    if (def.period === 'subdaily') {
+    if (def.period === 'subdaily' && !date) {
       date = self.getRequestDates(def, options).closestDate;
       date = new Date(date.getTime());
     }

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -198,7 +198,7 @@ const getDateArrayLastDateInOrder = (timeUnit, dateArray) => {
 const getMinStartDate = (timeDiff, period, interval, startDateLimit, minYear, minMonth, minDay) => {
   const startDateLimitTime = startDateLimit.getTime();
   let minStartDate;
-  let prevDate = '';
+  let prevDate;
   for (let i = 0; i <= (timeDiff + 1); i += 1) {
     if (!minStartDate) {
       let timeUnit;
@@ -675,19 +675,26 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit, appNo
             dateArray.push(minDate);
           }
           hitMaxLimitOfRange = true;
+          return;
         }
+      }
+      // handle single date coverage by adding date to date array
+      if (startDate === endDate) {
+        dateArray.push(minDate);
         return;
       }
     }
 
-    // handle single date coverage by adding date to date array
-    if (startDate === endDate) {
-      dateArray.push(minDate);
-      return;
-    }
-
     // DATA PANEL SPECIFIC
     if (rangeLimitsProvided) {
+      // handle single date coverage by adding date to date array
+      if (startDate === endDate) {
+        if (minDateTime >= inputStartDateTime && maxDate <= inputEndDateTime) {
+          dateArray.push(minDate);
+        }
+        return;
+      }
+
       // revise currentDate to minDate to reduce earlier minDate than needed
       const minDateWithinRangeLimits = minDateTime > inputStartDateTime && minDateTime < inputEndDateTime;
       const runningMinDateAndLastDateEarlier = runningMinDate && lastDateInDateArray > minDate;

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -1008,6 +1008,34 @@ export default (function(self) {
     return value;
   };
 
+  /**
+   * Returns offset date object
+   *
+   * @method getTimezoneOffsetDate
+   * @param  {Object} date        A date object
+   * @return {Object} offsetDate  An offset date object
+   */
+  self.getTimezoneOffsetDate = (date) => {
+    const offsetDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    return offsetDate;
+  };
+
+  /**
+   * Returns absolute UTC date timeunit numbers object
+   *
+   * @method getUTCNumbers
+   * @param  {Object} date    A date object
+   * @param  {String} prefix  Prefix min/max for timeunits in object
+   * @return {Object}         An object of UTC date timeunit numbers
+   */
+  self.getUTCNumbers = (date, prefix) => ({
+    [`${prefix}Year`]: date.getUTCFullYear(),
+    [`${prefix}Month`]: date.getUTCMonth(),
+    [`${prefix}Day`]: date.getUTCDate(),
+    [`${prefix}Hour`]: date.getUTCHours(),
+    [`${prefix}Minute`]: date.getUTCMinutes(),
+  });
+
   // Returns the number of months between two dates
   self.yearDiff = function(startDate, endDate) {
     const year1 = startDate.getFullYear();

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -1,7 +1,6 @@
 import {
   isObject as lodashIsObject,
   each as lodashEach,
-  isNull as lodashIsNull,
 } from 'lodash';
 import Cache from 'cachai';
 import moment from 'moment';
@@ -31,20 +30,6 @@ export default (function(self) {
     'NOV',
     'DEC',
   ];
-
-  // Needed anymore?
-  self.LAYER_GROUPS = {
-    baselayers: {
-      id: 'baselayers',
-      camel: 'BaseLayers',
-      description: 'Base Layers',
-    },
-    overlays: {
-      id: 'overlays',
-      camel: 'Overlays',
-      description: 'Overlays',
-    },
-  };
 
   self.repeat = function(value, length) {
     let result = '';
@@ -166,22 +151,6 @@ export default (function(self) {
   };
 
   /**
-   * Gets a pixel RGBA value from Canvas
-   *
-   * @method getCanvasPixelData
-   * @static
-   * @param canvas {Object} DOM canvas Element
-   * @param x {Number} X value on canvas
-   * @return y {Number} Y value on canvas
-   * @return {Object} Canvas image data.
-   */
-  self.getCanvasPixelData = function(canvas, x, y) {
-    const context = canvas.getContext('2d');
-    return context.getImageData(x, y, 1, 1)
-      .data;
-  };
-
-  /**
    * Parses a UTC ISO 8601 date.
    *
    * @method parseDateUTC
@@ -240,14 +209,6 @@ export default (function(self) {
     }
     self.warn(`Is not an object: ${item}`);
     return '';
-  };
-  /**
-   * Test if is valid Date
-   * @param {Object} d | Date object
-   */
-  self.isValidDate = function(d) {
-    // eslint-disable-next-line no-restricted-globals
-    return d instanceof Date && !isNaN(d);
   };
   /**
    * Parses a UTC ISO 8601 date to a non UTC date
@@ -332,19 +293,6 @@ export default (function(self) {
     context.font = font;
     const metrics = context.measureText(text);
     return metrics.width;
-  };
-
-  /**
-   * Julian date, padded with two zeros
-   * (to ensure the julian date is always in DDD format).
-   *
-   * @param  {Date} date {Date} the date to convert
-   * @return {string} Julian date string in the form of `YYYYDDD`
-   */
-  self.toJulianDate = function(date) {
-    const jStart = self.parseDateUTC(`${date.getUTCFullYear()}-01-01`);
-    const jDate = `00${1 + Math.ceil((date.getTime() - jStart) / 86400000)}`;
-    return date.getUTCFullYear() + jDate.substr(jDate.length - 3);
   };
 
   /**
@@ -697,45 +645,6 @@ export default (function(self) {
   };
 
   /**
-   * Converts a date into a compact string representation.
-   *
-   * @method toCompactTimestamp
-   * @static
-   * @param date {Date} the date to convert
-   * @return {String} string representation in the form of
-   * ``YYYYMMDDHHMMSSsss``
-   */
-  self.toCompactTimestamp = function(date) {
-    return date.toISOString()
-      .replace(/[-:TZ.]/g, '');
-  };
-
-  /**
-   * Converts a compact timestamp into a date.
-   *
-   * @method fromCompactTimestamp
-   * @static
-   * @param str {String} the string to convert in the form of
-   * ``YYYYMMDDHHMMSSsss``.
-   * @return {Date} the converted date object.
-   */
-  self.fromCompactTimestamp = function(str) {
-    const v = str.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})/);
-    if (lodashIsNull(v)) {
-      throw new Error(`Invalid timestamp:${str}`);
-    }
-    return new Date(Date.UTC(
-      parseInt(v[1], 10),
-      parseInt(v[2] - 1, 10),
-      parseInt(v[3], 10),
-      parseInt(v[4], 10),
-      parseInt(v[5], 10),
-      parseInt(v[6], 10),
-      parseInt(v[7], 10),
-    ));
-  };
-
-  /**
    * Gets the current time. Use this instead of the Date methods to allow
    * debugging alternate "now" times.
    *
@@ -748,10 +657,6 @@ export default (function(self) {
   };
 
   self.now = now;
-
-  self.resetNow = function() {
-    self.now = now;
-  };
 
   /**
    * Gets the current day. Use this instead of the Date methods to allow
@@ -1125,17 +1030,13 @@ export default (function(self) {
   };
 
   self.dayDiff = function(startDate, endDate) {
-    const date1 = new Date(startDate);
-    const date2 = new Date(endDate);
-    const timeDiff = Math.abs(date2.getTime() - date1.getTime());
+    const timeDiff = Math.abs(endDate.getTime() - startDate.getTime());
     const dayDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
     return dayDiff;
   };
 
   self.minuteDiff = function(startDate, endDate) {
-    const date1 = new Date(startDate);
-    const date2 = new Date(endDate);
-    const timeDiff = Math.abs(date2.getTime() - date1.getTime());
+    const timeDiff = Math.abs(endDate.getTime() - startDate.getTime());
     const minuteDiff = Math.ceil(timeDiff / 60000);
     return minuteDiff;
   };
@@ -1174,18 +1075,6 @@ export default (function(self) {
       }
     }
     return false;
-  };
-
-  /**
-   * Check if objects have the same keys
-   *
-   * @param  {array} comment seperated list of objects
-   * @return {bool}
-   */
-  self.objectsHaveSameKeys = function(...objects) {
-    const allKeys = objects.reduce((keys, object) => keys.concat(Object.keys(object)), []);
-    const union = new Set(allKeys);
-    return objects.every((object) => union.size === Object.keys(object).length);
   };
 
   return self;

--- a/web/js/util/util.test.js
+++ b/web/js/util/util.test.js
@@ -69,11 +69,6 @@ describe('parseDateUTC', () => {
   });
 });
 
-test('toJulianDate', () => {
-  const d = new Date(Date.UTC(2013, 0, 15));
-  expect(util.toJulianDate(d)).toBe('2013015');
-});
-
 test('toISOStringDate', () => {
   const d = new Date(Date.UTC(2013, 0, 15));
   expect(util.toISOStringDate(d)).toBe('2013-01-15');
@@ -87,23 +82,6 @@ test('toISOStringSeconds', () => {
 test('toHourMinutes', () => {
   const d = new Date(Date.UTC(2013, 0, 15, 11, 22, 33));
   expect(util.toHourMinutes(d)).toBe('11:22');
-});
-
-test('toCompactTimestamp', () => {
-  const d = new Date(Date.UTC(2013, 0, 15, 11, 22, 33, 444));
-  expect(util.toCompactTimestamp(d)).toBe('20130115112233444');
-});
-
-describe('fromCompactTimestamp', () => {
-  test('parses timestamp', () => {
-    const answer = new Date(Date.UTC(2013, 0, 15, 11, 22, 33, 444));
-    const result = util.fromCompactTimestamp('20130115112233444');
-    expect(answer.getTime()).toEqual(result.getTime());
-  });
-
-  test('invalid', () => {
-    expect(() => util.fromCompactTimestamp('x0130115112233444')).toThrow();
-  });
 });
 
 test('clearTimeUTC', () => {


### PR DESCRIPTION
## Description

Fixes #2433  .

This PR addresses #2433 by shortening date ranges returned by `datesinDateRanges` used in the app for layer building, timeline data panel, and product picker. Changes within the ` datesinDateRanges` and related functions allow for performance increases shown through reduced run time.

- [x] Break up `datesinDateRanges` period specific date range traversals into separate methods and cleanup/remove repeated logic where possible.
- [x] Add `getLimitedDateRange` to use on layers with a single date range and a date interval of 1 for limited dates of previous, current, and next dates (if available). This helps cut down time and increase performance of date array building. This is one of the biggest performance increases which cuts the `dateArray` down from a length of ~7200 to 3 for typical daily layers (e.g. Terra CR).
- [x] Remove extra `datesinDateRanges` invocation within layerbuilder that resulted in running the date array building twice.
- [x] Add conditions to catch additional `availableAtDate` layer def cases and prevent full `datesinDateRanges` method call.

Additional fixes:
- [x] Refactor using `getTimezoneOffsetDate` and `getUTCNumbers` util methods where possible.
- [x] Add `layer-data-items.js` layer cache to reduce frequent function calls from `getDatesInDateRange` that occurs on timeline axis drag, but not updating total array of dates within timeline axis.
- [x] Pull in tooltip hovering state and methods into `layer-data-items.js` to reduce re-renders.
- [x] Remove `hasMoved` as `timeline.js` state and passed down `timeline-axis.js` props since it is not being used.
- [x] Remove dead code, refactor, destructure, and cleanup along the way.

## Further comments

Here are some comparison metrics to show performance timing savings based on how long affected functions took to complete in this PR vs the current develop branch:

**Pull Request:**

**1) Map load, date change, layer add**

**_Pageload default:_**
util.js:734 datesinDateRanges took0.10999999358318746ms
util.js:734 datesinDateRanges took0.014999997802078724ms
util.js:734 datesinDateRanges took0.00999998883344233ms
util.js:734 datesinDateRanges took0.010000017937272787ms
util.js:734 datesinDateRanges took0.0050000089686363935ms
util.js:734 datesinDateRanges took0.014999997802078724ms

- **_Total datesInDateRanges time: 0.16500000492 ms_**

**_Next, click left date arrow 1 day back:_**
util.js:734 datesinDateRanges took0.48499999684281647ms
util.js:734 datesinDateRanges took0.050000002374872565ms
util.js:734 datesinDateRanges took0.06500000017695129ms
**_Next, add AOD Aqua/MODIS from categories/dust storms:_**
util.js:734 datesinDateRanges took0.06500000017695129ms

**2) Type in ‘a’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took3.7299999967217445ms

**3) Type in ‘terr’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took1.369999983580783ms

**4) Measurement row -> fires -> AOD**
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.06000002031214535ms
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.0050000089686363935ms

**Develop branch:**

**1) Map load, date change, layer add**

**_Pageload default:_**
util.js:437 datesinDateRanges took8.050000004004687ms
util.js:437 datesinDateRanges took14.629999990575016ms
util.js:437 datesinDateRanges took6.340000021737069ms
util.js:437 datesinDateRanges took7.349999999860302ms
util.js:437 datesinDateRanges took1.724999980069697ms
util.js:437 datesinDateRanges took1.7700000025797635ms
util.js:437 datesinDateRanges took0.00999998883344233ms
util.js:437 datesinDateRanges took0.0050000089686363935ms
util.js:437 datesinDateRanges took0.014999997802078724ms

- **_Total datesInDateRanges time: 39.8949999944 ms_**

**_Next, click left date arrow 1 day back:_**
util.js:437 datesinDateRanges took8.874999999534339ms
util.js:437 datesinDateRanges took11.454999999841675ms
util.js:437 datesinDateRanges took7.970000006025657ms
util.js:437 datesinDateRanges took8.375000004889444ms
util.js:437 datesinDateRanges took1.7349999980069697ms
util.js:437 datesinDateRanges took1.4899999951012433ms
**_Next, add AOD Aqua/MODIS from categories/dust storms:_**
util.js:437 datesinDateRanges took4.940000013448298ms
util.js:437 datesinDateRanges took6.130000023404136ms
util.js:437 datesinDateRanges took4.79000000632368ms
util.js:437 datesinDateRanges took5.915000016102567ms
util.js:437 datesinDateRanges took5.235000018728897ms
util.js:437 datesinDateRanges took5.690000019967556ms
util.js:437 datesinDateRanges took5.134999984875321ms
util.js:437 datesinDateRanges took4.9149999977089465ms
util.js:437 datesinDateRanges took5.124999996041879ms
util.js:437 datesinDateRanges took0.00999998883344233ms

**2) Type in ‘a’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took801.4449999900535ms

**3) Type in ‘terr’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took256.39500000397675ms

**4) Measurement row -> fires -> AOD**
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took2.6350000116508454ms
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.020000006770715117ms


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
