### PR TITLE
Fix condition in function used for linkcheck

### DIFF
--- a/tasks/link-check/url-check.js
+++ b/tasks/link-check/url-check.js
@@ -15,7 +15,7 @@ const requestCheck = async(urls) => {
     const url = Object.values(urls[i])[0];
 
     // Skip for mailto email links
-    if (url[0] !== 'h') {
+    if (url[0] === 'h') {
       // eslint-disable-next-line no-await-in-loop
       await fetch(url, { timeout: 10000 })
         .then(async(res) => {


### PR DESCRIPTION
## Description

The `linkcheck` scan was broken after removing a `continue`.

- [x] Fix a condition in a loop that previously used `continue` and changed from lint fixes

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
