### PR TITLE
resolve webpack alaises config for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,10 @@
   "settings": {
     "react": {
       "version": "detect"
+    },
+    "import/resolver": {
+      "node": {}, // Needed for node core modules (https://github.com/benmosher/eslint-plugin-import/issues/1396)
+      "webpack": {}
     }
   },
   "rules": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4397,6 +4397,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -7792,13 +7798,80 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.15.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
           }
+        }
+      }
+    },
+    "eslint-import-resolver-webpack": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.12.1.tgz",
+      "integrity": "sha512-O/sUAXk6GWrICiN8JUkkjdt9uZpqZHP+FVnTxtEILL6EZMaPSrnP4lGPSFwcKsv7O211maqq4Nz60+dh236hVg==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "debug": "^2.6.9",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.2.0",
+        "lodash": "^4.17.15",
+        "node-libs-browser": "^1.0.0 || ^2.0.0",
+        "resolve": "^1.13.1",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+          "dev": true
         }
       }
     },
@@ -8955,6 +9028,12 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "eslint": "^6.1.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-standard": "^14.1.0",
+    "eslint-import-resolver-node": "^0.3.3",
+    "eslint-import-resolver-webpack": "^0.12.1",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { each as lodashEach } from 'lodash';
 // eslint-disable-next-line no-unused-vars
 import whatInput from 'what-input';
-
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 // Utils

--- a/web/js/components/animation-widget/gif-post-creation.js
+++ b/web/js/components/animation-widget/gif-post-creation.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { capitalize as lodashCapitalize } from 'lodash';
 import FileSaver from 'file-saver';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { Modal, ModalBody, ModalHeader } from 'reactstrap';
 import util from '../../util/util';

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import {
   imageSizeValid,

--- a/web/js/components/layer/product-picker/product-picker.js
+++ b/web/js/components/layer/product-picker/product-picker.js
@@ -8,7 +8,6 @@ import {
   includes as lodashIncludes,
 } from 'lodash';
 import lodashDebounce from 'lodash/debounce';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import {
   ModalBody,

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Button } from 'reactstrap';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRuler } from '@fortawesome/free-solid-svg-icons';

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodashFind from 'lodash/find';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/web/js/components/sidebar/product.js
+++ b/web/js/components/sidebar/product.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import util from '../../util/util';
 

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -5,7 +5,6 @@ import {
   get as lodashGet,
   cloneDeep as lodashCloneDeep,
 } from 'lodash';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import PropTypes from 'prop-types';
 import Slider, { Handle } from 'rc-slider';

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import {
   openCustomContent,

--- a/web/js/containers/projection.js
+++ b/web/js/containers/projection.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get as lodashGet } from 'lodash';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import changeProjection from '../modules/projection/actions';
 import { onToggle } from '../modules/modal/actions';

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import {

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { get as lodashGet } from 'lodash';
 import { connect } from 'react-redux';

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Draggable } from 'react-beautiful-dnd';
 import { isEmpty as lodashIsEmpty, get as lodashGet } from 'lodash';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get as lodashGet } from 'lodash';
 import { TabContent, TabPane } from 'reactstrap';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import Layers from './layers';
 import Events from './events';

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 import {

--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { findIndex as lodashFindIndex, get as lodashGet, uniqBy } from 'lodash';
 import update from 'immutability-helper';

--- a/web/js/map/data/ui.js
+++ b/web/js/map/data/ui.js
@@ -1,7 +1,6 @@
 import lodashSize from 'lodash/size';
 import lodashEach from 'lodash/each';
 import lodashFind from 'lodash/find';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import * as olExtent from 'ol/extent';
 import { dataHandlerGetByName } from './handler';

--- a/web/js/map/natural-events/markers.js
+++ b/web/js/map/natural-events/markers.js
@@ -9,7 +9,6 @@ import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
 import OlGeomPolygon from 'ol/geom/Polygon';
 import * as olProj from 'ol/proj';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import { selectEvent as selectEventAction } from '../../modules/natural-events/actions';
 

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -11,7 +11,6 @@ import {
   isArray,
 } from 'lodash';
 
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import update from 'immutability-helper';
 import { addLayer, resetLayers } from './selectors';

--- a/web/js/modules/tour/util.js
+++ b/web/js/modules/tour/util.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 import update from 'immutability-helper';
 import util from '../../util/util';

--- a/web/js/modules/ui/actions.js
+++ b/web/js/modules/ui/actions.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 import { TOGGLE_DISTRACTION_FREE_MODE } from './constants';


### PR DESCRIPTION
## Description
Resolve webpack alaises config for eslint so that disable comments are not necessary each time aliased module is imported 

- [x] add import/resolver/webpack
- [x] add import/resolver/node so eslint doesn't complain when core node modules aren't in the `package.json`

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
