### PR TITLE
Optimize datesinDateRanges date coverage array building

### DIFF
--- a/web/js/components/timeline/timeline-data/layer-data-items.js
+++ b/web/js/components/timeline/timeline-data/layer-data-items.js
@@ -369,7 +369,7 @@ class LayerDataItems extends Component {
     if (startLessThanOrEqualToEndDateLimit && endGreaterThanOrEqualToStartDateLimit) {
       const inputStartDate = new Date(startDateLimit);
       const inputEndDate = new Date(endDateLimit);
-      dateIntervalStartDates = datesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate);
+      dateIntervalStartDates = datesinDateRanges(layer, inputStartDate, inputStartDate, inputEndDate, appNow);
     }
 
     return dateIntervalStartDates;

--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -218,8 +218,15 @@ fixtures.config = function() {
       'terra-cr': {
         id: 'terra-cr',
         group: 'baselayers',
+        dateRanges: [
+          {
+            dateInterval: '1',
+            endDate: '2020-05-20T00:00:00Z',
+            startDate: '2000-02-24T00:00:00Z',
+          },
+        ],
         period: 'daily',
-        startDate: '2000-01-01',
+        startDate: '2000-02-24T00:00:00Z',
         projections: {
           geographic: {},
           arctic: {},

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -212,9 +212,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     // Don't key by time if this is a static layer--it is valid for
     // every date.
     if (def.period) {
-      date = util.toISOStringSeconds(
-        util.roundTimeOneMinute(self.getRequestDates(def, options).closestDate),
-      );
+      date = util.toISOStringSeconds(util.roundTimeOneMinute(options.date));
     }
     if (isPaletteActive(def.id, activeGroupStr, state)) {
       style = getPaletteKeys(def.id, undefined, state);
@@ -302,7 +300,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
       throw new Error(`${def.id}: Undefined matrix set: ${def.matrixSet}`);
     }
     let date = options.date || state.date[activeDateStr];
-    if (def.period === 'subdaily') {
+    if (def.period === 'subdaily' && !date) {
       date = self.getRequestDates(def, options).closestDate;
       date = new Date(date.getTime());
     }

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -729,8 +729,6 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit, appNo
               dateArray.pop();
               dateArray.push(minDate);
               dateArray.push(lastDateInDateArray);
-            } else {
-              dateArray.push(minDate);
             }
           } else {
             dateArray.push(minDate);
@@ -738,11 +736,6 @@ export function datesinDateRanges(def, date, startDateLimit, endDateLimit, appNo
           hitMaxLimitOfRange = true;
           return;
         }
-      }
-      // handle single date coverage by adding date to date array
-      if (startDate === endDate) {
-        dateArray.push(minDate);
-        return;
       }
     }
 

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -211,7 +211,7 @@ const getMinStartDate = (timeDiff, period, interval, startDateLimit, minYear, mi
       timeUnit = util.getTimezoneOffsetDate(timeUnit);
       const timeUnitTime = timeUnit.getTime();
 
-      if (timeUnitTime >= startDateLimitTime) {
+      if (timeUnitTime > startDateLimitTime) {
         minStartDate = prevDate;
       } else {
         prevDate = timeUnit;

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -25,14 +25,27 @@ import util from '../../util/util';
   * @returns {Boolean} - True if layer is available at date, otherwise false
   */
 export function availableAtDate(def, date) {
-  const availableDates = datesinDateRanges(def, date);
   // Some vector layers
   if (!def.startDate && !def.dateRanges) {
     return true;
   }
+  // set inactive in config
   if (def.endDate && def.inactive) {
     return date < new Date(def.endDate) && date > new Date(def.startDate);
   }
+  // no endDate may indicate ongoing
+  if (def.startDate && !def.endDate) {
+    if (!def.dateRanges) {
+      return date > new Date(def.startDate);
+    }
+    // if only one date range, substitute def.endDate with def.dateRanges[0].endDate
+    if (def.dateRanges.length === 1) {
+      const rangeEndDate = def.dateRanges[0].endDate;
+      return date > new Date(def.startDate) && rangeEndDate && date < new Date(rangeEndDate);
+    }
+  }
+  // need to traverse available layer date range
+  const availableDates = datesinDateRanges(def, date);
   if (!availableDates.length && !def.endDate && !def.inactive) {
     return date > new Date(def.startDate);
   }
@@ -82,8 +95,7 @@ export function nearestInterval(def, date) {
 export function prevDateInDateRange(def, date, dateArray) {
   const closestAvailableDates = [];
   const currentDateValue = date.getTime();
-  const currentDate = new Date(currentDateValue);
-  const currentDateOffsetCheck = new Date(currentDateValue + (currentDate.getTimezoneOffset() * 60000));
+  const currentDateOffsetCheck = util.getTimezoneOffsetDate(date);
 
   const isFirstDayOfMonth = currentDateOffsetCheck.getDate() === 1;
   const isFirstDayOfYear = currentDateOffsetCheck.getMonth() === 0;
@@ -122,16 +134,16 @@ export function prevDateInDateRange(def, date, dateArray) {
  * Return revised maxEndDate based on given start/end date limits
  *
  * @method getRevisedMaxEndDate
- * @param  {object} maxEndDate     A date object
- * @param  {object} startDateLimit A date object (optional) used as start date of timeline range for available data
- * @param  {object} endDateLimit   A date object (optional) used as end date of timeline range for available data
- * @param  {object} minDate        A date object
- * @return {object}                A date object
+ * @param  {Object} minDate        A date object
+ * @param  {Object} maxEndDate     A date object
+ * @param  {Object} startDateLimit   A date object used as start date of timeline range for available data
+ * @param  {Object} endDateLimit   A date object used as end date of timeline range for available data
+ * @return {Object}                A date object
  */
-const getRevisedMaxEndDate = (maxEndDate, startDateLimit, endDateLimit, minDate) => {
-  const startDateLimitTime = startDateLimit.getTime();
+const getRevisedMaxEndDate = (minDate, maxEndDate, startDateLimit, endDateLimit) => {
   const minDateTime = minDate.getTime();
   const maxEndDateTime = maxEndDate.getTime();
+  const startDateLimitTime = startDateLimit.getTime();
   const endDateLimitTime = endDateLimit.getTime();
   const frontDateWithinRange = startDateLimitTime >= minDateTime && startDateLimitTime <= maxEndDateTime;
   const backDateWithinRange = endDateLimitTime <= maxEndDateTime && endDateLimitTime >= minDateTime;
@@ -152,14 +164,13 @@ const getRevisedMaxEndDate = (maxEndDate, startDateLimit, endDateLimit, minDate)
 const getDateArrayLastDateInOrder = (timeUnit, dateArray) => {
   const newDateArray = [...dateArray];
   const arrLastIndex = newDateArray.length - 1;
+  const timeUnitTime = timeUnit.getTime();
   if (timeUnit < newDateArray[arrLastIndex]) {
     let endDateFound = false;
     for (let j = arrLastIndex; j >= 0; j -= 1) {
       if (!endDateFound) {
         const dateCheck = newDateArray[j];
-        const timeUnitTime = timeUnit.getTime();
         const dateCheckTime = dateCheck.getTime();
-
         if (timeUnitTime <= dateCheckTime) {
           newDateArray.pop();
         } else {
@@ -178,27 +189,29 @@ const getDateArrayLastDateInOrder = (timeUnit, dateArray) => {
  * @method getMinStartDate
  * @param  {Number} timeDiff time difference based on intervals and unit
  * @param  {String} period
- * @param  {Number} dateInterval
+ * @param  {Number} interval
  * @param  {Object} startDateLimit A date object
  * @param  {Number} minYear
  * @param  {Number} minMonth
  * @param  {Number} minDay
  * @return {Object} minStartDate A date object
  */
-const getMinStartDate = (timeDiff, period, dateInterval, startDateLimit, minYear, minMonth, minDay) => {
+const getMinStartDate = (timeDiff, period, interval, startDateLimit, minYear, minMonth, minDay) => {
+  const startDateLimitTime = startDateLimit.getTime();
   let minStartDate;
-  let prevDate = '';
+  let prevDate;
   for (let i = 0; i <= (timeDiff + 1); i += 1) {
     if (!minStartDate) {
       let timeUnit;
       if (period === 'monthly') {
-        timeUnit = new Date(minYear, minMonth + i * dateInterval, minDay);
+        timeUnit = new Date(minYear, minMonth + i * interval, minDay);
       } else if (period === 'daily') {
-        timeUnit = new Date(minYear, minMonth, minDay + i * dateInterval);
+        timeUnit = new Date(minYear, minMonth, minDay + i * interval);
       }
-      timeUnit = new Date(timeUnit.getTime() - (timeUnit.getTimezoneOffset() * 60000));
+      timeUnit = util.getTimezoneOffsetDate(timeUnit);
+      const timeUnitTime = timeUnit.getTime();
 
-      if (timeUnit > startDateLimit || timeUnit.getTime() === startDateLimit.getTime()) {
+      if (timeUnitTime >= startDateLimitTime) {
         minStartDate = prevDate;
       } else {
         prevDate = timeUnit;
@@ -209,225 +222,516 @@ const getMinStartDate = (timeDiff, period, dateInterval, startDateLimit, minYear
 };
 
 /**
+   * Return an array of limited dates of previous, current, and next dates (if available)
+   * Used on layers with a single date range and a date interval of 1
+   *
+   * @method getLimitedDateRange
+   * @param  {Object} def            A layer object
+   * @param  {Object} currentDate    A date object
+   * @return {Array}                An array of dates - previous, current, and next dates (if available)
+   */
+const getLimitedDateRange = (def, currentDate) => {
+  const { period, dateRanges } = def;
+  const dateRange = dateRanges[0];
+  const { startDate, endDate } = dateRange;
+
+  const rangeStartDate = new Date(startDate);
+  const rangeEndDate = new Date(endDate);
+  const currentDateTime = currentDate.getTime();
+  const breakMinDateTime = rangeStartDate.getTime();
+
+  // build test max date to determine if date is within max date range
+  const {
+    breakMaxYear,
+    breakMaxMonth,
+    breakMaxDay,
+  } = util.getUTCNumbers(rangeEndDate, 'breakMax');
+  let breakMaxDate;
+  if (period === 'yearly') {
+    breakMaxDate = new Date(breakMaxYear + 1, breakMaxMonth, breakMaxDay);
+  }
+  if (period === 'monthly') {
+    breakMaxDate = new Date(breakMaxYear, breakMaxMonth + 1, breakMaxDay);
+  }
+  if (period === 'daily') {
+    breakMaxDate = new Date(breakMaxYear, breakMaxMonth, breakMaxDay + 1);
+  }
+  const breakMaxDateTime = breakMaxDate.getTime();
+
+  // get limitedDateRange of previous, current, and next dates (if available)
+  const limitedDateRange = [];
+  if (currentDateTime >= breakMinDateTime && currentDateTime <= breakMaxDateTime) {
+    // get date building components
+    const {
+      minCurrentYear,
+      minCurrentMonth,
+      minCurrentDay,
+    } = util.getUTCNumbers(currentDate, 'minCurrent');
+    const {
+      minStartMonth,
+      minStartDay,
+    } = util.getUTCNumbers(rangeStartDate, 'minStart');
+
+    // period specific date addition/subtraction building
+    let dayBeforeCurrent;
+    let currentDateZeroed;
+    let dayAfterCurrent;
+    if (period === 'yearly') {
+      dayBeforeCurrent = new Date(minCurrentYear - 1, minStartMonth, minStartDay);
+      currentDateZeroed = new Date(minCurrentYear, minStartMonth, minStartDay);
+      dayAfterCurrent = new Date(minCurrentYear + 1, minStartMonth, minStartDay);
+    }
+    if (period === 'monthly') {
+      dayBeforeCurrent = new Date(minCurrentYear, minCurrentMonth - 1, minStartDay);
+      currentDateZeroed = new Date(minCurrentYear, minCurrentMonth, minStartDay);
+      dayAfterCurrent = new Date(minCurrentYear, minCurrentMonth + 1, minStartDay);
+    }
+    if (period === 'daily') {
+      dayBeforeCurrent = new Date(minCurrentYear, minCurrentMonth, minCurrentDay - 1);
+      currentDateZeroed = new Date(minCurrentYear, minCurrentMonth, minCurrentDay);
+      dayAfterCurrent = new Date(minCurrentYear, minCurrentMonth, minCurrentDay + 1);
+    }
+
+    // handle previous date
+    const dayBeforeCurrentTime = dayBeforeCurrent.getTime();
+    if (dayBeforeCurrentTime >= breakMinDateTime) {
+      const dayBeforeDate = util.getTimezoneOffsetDate(dayBeforeCurrent);
+      limitedDateRange.push(dayBeforeDate);
+    }
+
+    // handle current date
+    const currentDateDate = util.getTimezoneOffsetDate(currentDateZeroed);
+    limitedDateRange.push(currentDateDate);
+
+    // handle next date
+    const dayAfterCurrentTime = dayAfterCurrent.getTime();
+    if (dayAfterCurrentTime <= breakMaxDateTime) {
+      const dayAfterDate = util.getTimezoneOffsetDate(dayAfterCurrent);
+      limitedDateRange.push(dayAfterDate);
+    }
+  }
+  return limitedDateRange;
+};
+
+/**
+   * Return an array of dates from a yearly period layer based on the dateRange the current date falls in.
+   *
+   * @method getYearDateRange
+   * @param  {Number} currentDateTime  Current date milliseconds
+   * @param  {Object} minDate          A date object used as min date
+   * @param  {Object} maxDate          A date object used as max date
+   * @param  {Number} interval         Temporal interval
+   * @param  {Array} dateArray         An array of dates
+   * @return {Array}                   An array of dates with normalized timezones
+   */
+const getYearDateRange = (currentDateTime, minDate, maxDate, interval, dateArray) => {
+  const newDateArray = [...dateArray];
+  const { maxYear, maxMonth, maxDay } = util.getUTCNumbers(maxDate, 'max');
+  const { minYear, minMonth, minDay } = util.getUTCNumbers(minDate, 'min');
+
+  const minDateTime = minDate.getTime();
+  const maxYearDate = new Date(maxYear + interval, maxMonth, maxDay);
+  const maxYearDateTime = maxYearDate.getTime();
+
+  let yearDifference;
+  if (currentDateTime >= minDateTime && currentDateTime <= maxYearDateTime) {
+    yearDifference = util.yearDiff(minDate, maxYearDate);
+  }
+
+  for (let i = 0; i <= (yearDifference + 1); i += 1) {
+    let year = new Date(minYear + i * interval, minMonth, minDay);
+    if (year.getTime() < maxYearDateTime) {
+      year = util.getTimezoneOffsetDate(year);
+      newDateArray.push(year);
+    }
+  }
+  return newDateArray;
+};
+
+/**
+   * Return an array of dates from a monthly period layer based on the dateRange the current date falls in.
+   *
+   * @method getMonthDateRange
+   * @param  {Boolean} isDataPanel     Is data panel query
+   * @param  {Number} currentDateTime  Current date milliseconds
+   * @param  {Object} startDateLimit   A date object used as start date of timeline range for available data
+   * @param  {Object} endDateLimit     A date object used as end date of timeline range for available data
+   * @param  {Object} minDate          A date object used as min date
+   * @param  {Object} maxDate          A date object used as max date
+   * @param  {Number} interval         Temporal interval
+   * @param  {Array} dateArray         An array of dates
+   * @return {Array}                   An array of dates with normalized timezones
+   */
+const getMonthDateRange = (isDataPanel, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, interval, dateArray) => {
+  let newDateArray = [...dateArray];
+  const { maxYear, maxMonth, maxDay } = util.getUTCNumbers(maxDate, 'max');
+  const { minYear, minMonth, minDay } = util.getUTCNumbers(minDate, 'min');
+
+  // conditional revision of maxEndDate for data availability partial coverage
+  const minDateTime = minDate.getTime();
+  let maxMonthDate = new Date(maxYear, maxMonth + interval, maxDay);
+  maxMonthDate = util.getTimezoneOffsetDate(maxMonthDate);
+
+  let maxEndDate;
+  let maxEndDateTime;
+  if (isDataPanel) {
+    maxEndDate = getRevisedMaxEndDate(minDate, maxMonthDate, startDateLimit, endDateLimit);
+    maxEndDateTime = maxEndDate.getTime();
+  } else {
+    maxEndDateTime = maxMonthDate.getTime();
+  }
+
+  let monthDifference;
+  if (currentDateTime >= minDateTime && currentDateTime <= maxEndDateTime) {
+    monthDifference = util.monthDiff(minDate, maxMonthDate);
+    // handle non-1 month intervals to prevent over pushing unused dates to dateArray
+    monthDifference = Math.ceil(monthDifference / interval);
+  }
+
+  let minStartMonthDate;
+  if (isDataPanel) {
+    // get minStartDate for partial range coverage starting date
+    minStartMonthDate = monthDifference
+      && getMinStartDate(monthDifference, 'monthly', interval, startDateLimit, minYear, minMonth, minDay);
+  }
+
+  for (let i = 0; i <= (monthDifference + 1); i += 1) {
+    let month = new Date(minYear, minMonth + i * interval, minDay);
+    month = util.getTimezoneOffsetDate(month);
+    const monthTime = month.getTime();
+    if (monthTime < maxEndDateTime) {
+      if (isDataPanel) {
+        if (newDateArray.length > 0) {
+          newDateArray = getDateArrayLastDateInOrder(month, newDateArray);
+        }
+        if (minStartMonthDate) {
+          const minStartMonthDateTime = minStartMonthDate.getTime();
+          const monthWithinRange = month > minStartMonthDate && month < maxMonthDate;
+          if (monthTime === minStartMonthDateTime || monthWithinRange) {
+            newDateArray.push(month);
+          }
+        } else {
+          newDateArray.push(month);
+        }
+      } else {
+        newDateArray.push(month);
+      }
+    }
+  }
+  return newDateArray;
+};
+
+/**
+   * Return an array of dates from a daily period layer based on the dateRange the current date falls in.
+   *
+   * @method getDayDateRange
+   * @param  {Boolean} isDataPanel     Is data panel query
+   * @param  {Number} currentDateTime  Current date milliseconds
+   * @param  {Object} startDateLimit   A date object used as start date of timeline range for available data
+   * @param  {Object} endDateLimit     A date object used as end date of timeline range for available data
+   * @param  {Object} minDate          A date object used as min date
+   * @param  {Object} maxDate          A date object used as max date
+   * @param  {Number} interval         Temporal interval
+   * @param  {Array} dateArray         An array of dates
+   * @return {Array}                   An array of dates with normalized timezones
+   */
+const getDayDateRange = (isDataPanel, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, interval, dateArray) => {
+  let newDateArray = [...dateArray];
+  const { maxYear, maxMonth, maxDay } = util.getUTCNumbers(maxDate, 'max');
+  const { minYear, minMonth, minDay } = util.getUTCNumbers(minDate, 'min');
+
+  // conditional revision of maxEndDate for data availability partial coverage
+  const minDateTime = minDate.getTime();
+  const maxDayDate = new Date(maxYear, maxMonth, maxDay + interval);
+  let maxEndDateTime;
+  let maxEndDate;
+  if (isDataPanel) {
+    maxEndDate = getRevisedMaxEndDate(minDate, maxDayDate, startDateLimit, endDateLimit);
+    maxEndDateTime = maxEndDate.getTime();
+  } else {
+    maxEndDate = maxDayDate;
+    maxEndDateTime = maxDayDate.getTime();
+  }
+
+  let dayDifference;
+  if (currentDateTime >= minDateTime && currentDateTime <= maxEndDateTime) {
+    dayDifference = util.dayDiff(minDate, maxEndDate);
+    // handle non-1 day intervals to prevent over pushing unused dates to dateArray
+    dayDifference = Math.ceil(dayDifference / interval);
+  }
+
+  let minStartDayDate;
+  if (isDataPanel) {
+    // get minStartDate for partial range coverage starting date
+    minStartDayDate = dayDifference
+    && getMinStartDate(dayDifference, 'daily', interval, startDateLimit, minYear, minMonth, minDay);
+  }
+
+  for (let i = 0; i <= (dayDifference + 1); i += 1) {
+    let day = new Date(minYear, minMonth, minDay + i * interval);
+    day = util.getTimezoneOffsetDate(day);
+    const dayTime = day.getTime();
+    if (dayTime < maxEndDateTime) {
+      if (isDataPanel) {
+        if (newDateArray.length > 0) {
+          newDateArray = getDateArrayLastDateInOrder(day, newDateArray);
+        }
+        if (minStartDayDate) {
+          const minStartDayDateTime = minStartDayDate.getTime();
+          const dayWithinRange = day > minStartDayDate && day < maxDayDate;
+          if (dayTime === minStartDayDateTime || dayWithinRange) {
+            newDateArray.push(day);
+          }
+        } else {
+          newDateArray.push(day);
+        }
+      } else {
+        newDateArray.push(day);
+      }
+    }
+  }
+  return newDateArray;
+};
+
+/**
+   * Return an array of dates from a subdaily period layer based on the dateRange the current date falls in.
+   *
+   * @method getSubdailyDateRange
+   * @param  {Boolean} isDataPanel     Is data panel query
+   * @param  {Number} currentDateTime  Current date milliseconds
+   * @param  {Object} startDateLimit   A date object used as start date of timeline range for available data
+   * @param  {Object} endDateLimit     A date object used as end date of timeline range for available data
+   * @param  {Object} minDate          A date object used as min date
+   * @param  {Object} maxDate          A date object used as max date
+   * @param  {Number} interval         Temporal interval
+   * @param  {Array} dateArray         An array of dates
+   * @return {Array}                   An array of dates with normalized timezones
+   */
+const getSubdailyDateRange = (isDataPanel, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, interval, dateArray) => {
+  const newDateArray = [...dateArray];
+  const {
+    maxYear,
+    maxMonth,
+    maxDay,
+    maxHour,
+    maxMinute,
+  } = util.getUTCNumbers(maxDate, 'max');
+  const {
+    minYear,
+    minMonth,
+    minDay,
+    minHour,
+    minMinute,
+  } = util.getUTCNumbers(minDate, 'min');
+
+  let maxMinuteDate = new Date(maxYear, maxMonth, maxDay, maxHour, maxMinute + interval);
+  let minMinuteDateMinusInterval;
+  let minMinuteDateMinusIntervalOffset;
+  let hourBeforeStartDateLimit;
+  let hourAfterEndDateLimit;
+  if (isDataPanel) {
+    minMinuteDateMinusInterval = new Date(minYear, minMonth, minDay, minHour, minMinute - interval);
+    minMinuteDateMinusIntervalOffset = util.getTimezoneOffsetDate(minMinuteDateMinusInterval);
+
+    const startDateLimitOffset = startDateLimit.getTimezoneOffset() * 60000;
+    const endDateLimitOffset = endDateLimit.getTimezoneOffset() * 60000;
+    const startDateLimitSetMinutes = new Date(startDateLimit).setMinutes(minMinute);
+    const endDateLimitSetMinutes = new Date(endDateLimit).setMinutes(minMinute);
+
+    hourBeforeStartDateLimit = new Date(startDateLimitSetMinutes - startDateLimitOffset - (60 * 60000));
+    hourAfterEndDateLimit = new Date(endDateLimitSetMinutes - endDateLimitOffset + (60 * 60000));
+  } else {
+    // limit date range request to +/- one hour from current date
+    const currentSetMinutes = new Date(currentDateTime).setMinutes(minMinute);
+    hourBeforeStartDateLimit = new Date(currentSetMinutes - (60 * 60000));
+    hourAfterEndDateLimit = new Date(currentSetMinutes + (60 * 60000));
+  }
+  let minMinuteDate;
+  if (isDataPanel) {
+  // eslint-disable-next-line no-nested-ternary
+    minMinuteDate = hourBeforeStartDateLimit < minDate
+      ? hourBeforeStartDateLimit
+      : hourBeforeStartDateLimit > minMinuteDateMinusIntervalOffset
+        ? hourBeforeStartDateLimit
+        : minDate;
+  } else {
+    minMinuteDate = hourBeforeStartDateLimit < minDate
+      ? minDate
+      : hourBeforeStartDateLimit;
+  }
+  maxMinuteDate = hourAfterEndDateLimit > maxMinuteDate
+    ? maxMinuteDate
+    : hourAfterEndDateLimit;
+
+  const minMinuteDateTime = minMinuteDate.getTime();
+  const maxMinuteDateTime = maxMinuteDate.getTime();
+  let currentDateTimeCheck;
+  if (isDataPanel) {
+    const minCurrentDate = util.getTimezoneOffsetDate(new Date(currentDateTime));
+    const minCurrentDateTime = minCurrentDate.getTime();
+    currentDateTimeCheck = minCurrentDateTime;
+  } else {
+    currentDateTimeCheck = currentDateTime;
+  }
+
+  let minuteDifference;
+  if (currentDateTimeCheck >= minMinuteDateTime && currentDateTimeCheck <= maxMinuteDateTime) {
+    minuteDifference = util.minuteDiff(minMinuteDate, maxMinuteDate);
+  }
+
+  for (let i = 0; i <= (minuteDifference + 1); i += interval) {
+    let subdailyTime = new Date(
+      minMinuteDate.getUTCFullYear(),
+      minMinuteDate.getUTCMonth(),
+      minMinuteDate.getUTCDate(),
+      minMinuteDate.getUTCHours(),
+      minMinuteDate.getUTCMinutes() + i,
+      0,
+    );
+    if (!isDataPanel) {
+      subdailyTime = util.getTimezoneOffsetDate(subdailyTime);
+    }
+    if (subdailyTime.getTime() >= minMinuteDateTime) {
+      newDateArray.push(subdailyTime);
+    }
+  }
+  return newDateArray;
+};
+
+/**
    * Return an array of dates based on the dateRange the current date falls in.
    *
-   * @method datesinDateRanges
-   * @param  {object} def            A layer object
-   * @param  {object} date           A date object
-   * @param  {object} startDateLimit A date object (optional) used as start date of timeline range for available data
-   * @param  {object} endDateLimit   A date object (optional) used as end date of timeline range for available data
-   * @return {array}                An array of dates with normalized timezones
+   * @method datesinDateRangesDataPanel
+   * @param  {Object} def            A layer object
+   * @param  {Object} date           A date object for currently selected date
+   * @param  {Object} startDateLimit A date object used as start date of timeline range for available data
+   * @param  {Object} endDateLimit   A date object used as end date of timeline range for available data
+   * @param  {Object} appNow         A date object of appNow (current date or set explicitly)
+   * @return {Array}                An array of dates with normalized timezones
    */
-export function datesinDateRanges(def, date, startDateLimit, endDateLimit) {
-  const inactiveLayer = def.inactive;
+export function datesinDateRanges(def, date, startDateLimit, endDateLimit, appNow) {
+  const {
+    dateRanges,
+    period,
+    inactive,
+  } = def;
   const rangeLimitsProvided = startDateLimit && endDateLimit;
   let dateArray = [];
-  let currentDate = new Date(date.getTime());
+  let currentDate = new Date(date);
+
+  let inputStartDate;
+  let inputEndDate;
+  let inputStartDateTime;
+  let inputEndDateTime;
+  let singleDateRangeAndInterval;
+  if (rangeLimitsProvided) {
+    inputStartDate = new Date(startDateLimit);
+    inputEndDate = new Date(endDateLimit);
+    inputStartDateTime = inputStartDate.getTime();
+    inputEndDateTime = inputEndDate.getTime();
+  } else {
+    singleDateRangeAndInterval = dateRanges
+    && dateRanges.length === 1
+    && dateRanges[0].dateInterval === '1';
+  }
+
+  // at end of range, used to add "next" date
+  let hitMaxLimitOfRange = false;
   // runningMinDate used for overlapping ranges
   let runningMinDate;
-  lodashEach(def.dateRanges, (dateRange, index) => {
-    const { period } = def;
-    const dateInterval = Number(dateRange.dateInterval);
-    let yearDifference;
-    let monthDifference;
-    let dayDifference;
-    let minuteDifference;
-    let minDate = new Date(dateRange.startDate);
-    let maxDate = new Date(dateRange.endDate);
+  lodashEach(dateRanges, (dateRange, index) => {
+    const {
+      startDate,
+      endDate,
+      dateInterval,
+    } = dateRange;
+    const dateIntervalNum = Number(dateInterval);
+    let currentDateTime = currentDate.getTime();
+    const lastDateInDateArray = dateArray[dateArray.length - 1];
+    const minDate = new Date(startDate);
+    let maxDate = new Date(endDate);
 
-    // explicit min/max ranges provided
-    if (rangeLimitsProvided) {
-      // handle single date coverage
-      if (dateRange.startDate === dateRange.endDate) {
-        const dateTime = new Date(minDate.getTime());
-        dateArray.push(dateTime);
+    const minDateTime = minDate.getTime();
+    const maxDateTime = maxDate.getTime();
+
+    const currentDateLessThanMinDate = currentDateTime < minDateTime;
+    const currentDateGreaterThanMaxDate = currentDateTime > maxDateTime;
+
+    // LAYER DATE RANGE SPECIFIC
+    if (!rangeLimitsProvided) {
+      // break out if currentDate is not within range by skipping current date range
+      if (currentDateLessThanMinDate || currentDateGreaterThanMaxDate) {
+        // handle adding next date (if available/not at end of range) as final date
+        if (!hitMaxLimitOfRange && currentDateLessThanMinDate) {
+          if (lastDateInDateArray) {
+            // reorder last dates from overlapping end/start dateRanges
+            if (lastDateInDateArray > minDate) {
+              dateArray.pop();
+              dateArray.push(minDate);
+              dateArray.push(lastDateInDateArray);
+            } else {
+              dateArray.push(minDate);
+            }
+          } else {
+            dateArray.push(minDate);
+          }
+          hitMaxLimitOfRange = true;
+          return;
+        }
+      }
+      // handle single date coverage by adding date to date array
+      if (startDate === endDate) {
+        dateArray.push(minDate);
         return;
-      }
-      const startDateLimitTime = startDateLimit.getTime();
-      const endDateLimitTime = endDateLimit.getTime();
-      const minDateTime = minDate.getTime();
-      const minDateWithinRangeLimits = minDateTime > startDateLimitTime && minDateTime < endDateLimitTime;
-      if (currentDate.getTime() < minDateTime && minDateWithinRangeLimits) {
-        currentDate = minDate;
-      }
-
-      // set maxDate to current date if layer coverage is ongoing
-      if (index === def.dateRanges.length - 1 && !inactiveLayer) {
-        maxDate = new Date();
       }
     }
 
-    const maxYear = maxDate.getUTCFullYear();
-    const maxMonth = maxDate.getUTCMonth();
-    const maxDay = maxDate.getUTCDate();
-    const minYear = minDate.getUTCFullYear();
-    const minMonth = minDate.getUTCMonth();
-    const minDay = minDate.getUTCDate();
+    // DATA PANEL SPECIFIC
+    if (rangeLimitsProvided) {
+      // handle single date coverage by adding date to date array
+      if (startDate === endDate) {
+        if (minDateTime >= inputStartDateTime && maxDate <= inputEndDateTime) {
+          dateArray.push(minDate);
+        }
+        return;
+      }
 
-    let i;
+      // revise currentDate to minDate to reduce earlier minDate than needed
+      const minDateWithinRangeLimits = minDateTime > inputStartDateTime && minDateTime < inputEndDateTime;
+      const runningMinDateAndLastDateEarlier = runningMinDate && lastDateInDateArray > minDate;
+      if (currentDateLessThanMinDate && (minDateWithinRangeLimits || runningMinDateAndLastDateEarlier)) {
+        currentDate = minDate;
+        currentDateTime = currentDate.getTime();
+      }
+      // set maxDate to current date if layer coverage is ongoing
+      if (index === dateRanges.length - 1 && !inactive) {
+        maxDate = new Date(appNow);
+      }
+    }
+
+    // single date range and interval allows only returning prev, current, and next dates
+    // (if available) instead of full range traversal
+    if (singleDateRangeAndInterval) {
+      const limitedDateRange = getLimitedDateRange(def, currentDate);
+      return limitedDateRange;
+    }
 
     // Yearly layers
     if (period === 'yearly') {
-      const maxYearDate = new Date(maxYear + dateInterval, maxMonth, maxDay);
-      if (currentDate >= minDate && currentDate <= maxYearDate) {
-        yearDifference = util.yearDiff(minDate, maxYearDate);
-      }
-      for (i = 0; i <= (yearDifference + 1); i += 1) {
-        let year = new Date(minYear + i * dateInterval, minMonth, minDay);
-        if (year.getTime() < maxYearDate.getTime()) {
-          year = new Date(year.getTime() - (year.getTimezoneOffset() * 60000));
-          dateArray.push(year);
-        }
-      }
+      const yearArray = getYearDateRange(currentDateTime, minDate, maxDate, dateIntervalNum, dateArray);
+      dateArray = [...yearArray];
       // Monthly layers
     } else if (period === 'monthly') {
-      let maxMonthDate = new Date(maxYear, maxMonth + dateInterval, maxDay);
-      maxMonthDate = new Date(maxMonthDate.getTime() - (maxMonthDate.getTimezoneOffset() * 60000));
-
-      if (runningMinDate && dateArray[dateArray.length - 1] > minDate) {
-        currentDate = minDate;
-      }
-
-      // conditional revision of maxEndDate for data availability partial coverage
-      let maxEndDate = maxMonthDate;
-      if (rangeLimitsProvided) {
-        maxEndDate = getRevisedMaxEndDate(new Date(maxEndDate), startDateLimit, endDateLimit, minDate);
-      }
-
-      if (currentDate <= maxMonthDate) {
-        monthDifference = util.monthDiff(minDate, maxMonthDate);
-        // handle non-1 month intervals to prevent over pushing unused dates to dateArray
-        monthDifference = Math.ceil(monthDifference / dateInterval);
-      }
-
-      // get minStartDate for partial range coverage starting date
-      const minStartMonthDate = rangeLimitsProvided
-        && monthDifference
-        && getMinStartDate(monthDifference, period, dateInterval, startDateLimit, minYear, minMonth, minDay);
-
-      for (i = 0; i <= (monthDifference + 1); i += 1) {
-        let month = new Date(minYear, minMonth + i * dateInterval, minDay);
-        month = new Date(month.getTime() - (month.getTimezoneOffset() * 60000));
-        const monthTime = month.getTime();
-        if (monthTime < maxEndDate.getTime()) {
-          if (rangeLimitsProvided && dateArray.length > 0) {
-            dateArray = getDateArrayLastDateInOrder(month, dateArray);
-          }
-
-          if (minStartMonthDate) {
-            const minStartMonthDateTime = minStartMonthDate.getTime();
-            const monthWithinRange = month > minStartMonthDate && month < maxMonthDate;
-            if (monthTime === minStartMonthDateTime || monthWithinRange) {
-              dateArray.push(month);
-            }
-          } else {
-            dateArray.push(month);
-          }
-        }
-      }
+      const monthArray = getMonthDateRange(rangeLimitsProvided, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, dateIntervalNum, dateArray);
+      dateArray = [...monthArray];
       // Daily layers
     } else if (period === 'daily') {
-      const maxDayDate = new Date(maxYear, maxMonth, maxDay + dateInterval);
-      if (runningMinDate && dateArray[dateArray.length - 1] > minDate) {
-        currentDate = minDate;
-      }
-
-      // conditional revision of maxEndDate for data availability partial coverage
-      let maxEndDate = maxDayDate;
-      if (rangeLimitsProvided) {
-        maxEndDate = getRevisedMaxEndDate(new Date(maxEndDate), startDateLimit, endDateLimit, minDate);
-      }
-
-      if (currentDate >= minDate && currentDate <= maxEndDate) {
-        dayDifference = util.dayDiff(minDate, maxEndDate);
-        // handle non-1 day intervals to prevent over pushing unused dates to dateArray
-        dayDifference = Math.ceil(dayDifference / dateInterval);
-      }
-
-      // get minStartDate for partial range coverage starting date
-      const minStartDayDate = rangeLimitsProvided
-        && dayDifference
-        && getMinStartDate(dayDifference, period, dateInterval, startDateLimit, minYear, minMonth, minDay);
-
-      for (i = 0; i <= (dayDifference + 1); i += 1) {
-        let day = new Date(minYear, minMonth, minDay + i * dateInterval);
-        day = new Date(day.getTime() - (day.getTimezoneOffset() * 60000));
-        const dayTime = day.getTime();
-        if (dayTime < maxEndDate.getTime()) {
-          if (rangeLimitsProvided && dateArray.length > 0) {
-            dateArray = getDateArrayLastDateInOrder(day, dateArray);
-          }
-
-          if (minStartDayDate) {
-            const minStartDayDateTime = minStartDayDate.getTime();
-
-            if (dayTime === minStartDayDateTime || (day > minStartDayDate && day < maxDayDate)) {
-              dateArray.push(day);
-            }
-          } else {
-            dateArray.push(day);
-          }
-        }
-      }
+      const dayArray = getDayDateRange(rangeLimitsProvided, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, dateIntervalNum, dateArray);
+      dateArray = [...dayArray];
       // Subdaily layers
     } else if (period === 'subdaily') {
-      const maxHours = maxDate.getUTCHours();
-      const minHours = minDate.getUTCHours();
-      const maxMinutes = maxDate.getUTCMinutes();
-      const minMinutes = minDate.getUTCMinutes();
-      const minMinuteDate = new Date(minDate);
-      const minMinuteDateTime = minMinuteDate.getTime();
-      let maxMinuteDate = new Date(maxYear, maxMonth, maxDay, maxHours, maxMinutes + dateInterval);
-      const minMinuteDateMinusInterval = new Date(minYear, minMonth, minDay, minHours, minMinutes - dateInterval);
-
-      let currentDateOffset;
-      let hourBeforeCurrentDate;
-      let hourAfterCurrentDate;
-      if (rangeLimitsProvided) {
-        currentDateOffset = startDateLimit.getTimezoneOffset() * 60000;
-        hourBeforeCurrentDate = new Date(startDateLimit.setMinutes(minMinutes) - currentDateOffset - (60 * 60000));
-        hourAfterCurrentDate = new Date(endDateLimit.setMinutes(minMinutes) - currentDateOffset + (60 * 60000));
-
-        const minMinuteDateMinusIntervalOffset = new Date(minMinuteDateMinusInterval.getTime() - (minMinuteDateMinusInterval.getTimezoneOffset() * 60000));
-
-        // eslint-disable-next-line no-nested-ternary
-        minDate = hourBeforeCurrentDate < minDate
-          ? hourBeforeCurrentDate
-          : hourBeforeCurrentDate > minMinuteDateMinusIntervalOffset
-            ? hourBeforeCurrentDate
-            : minDate;
-
-        maxMinuteDate = hourAfterCurrentDate > maxMinuteDate ? maxMinuteDate : hourAfterCurrentDate;
-      } else {
-        currentDateOffset = currentDate.getTimezoneOffset() * 60000;
-        hourBeforeCurrentDate = new Date(currentDate.setMinutes(minMinutes) - currentDateOffset - (60 * 60000));
-        hourAfterCurrentDate = new Date(currentDate.setMinutes(minMinutes) - currentDateOffset + (60 * 60000));
-        minDate = hourBeforeCurrentDate < minDate
-          ? minDate
-          : hourBeforeCurrentDate;
-        maxMinuteDate = hourAfterCurrentDate > maxMinuteDate
-          ? maxMinuteDate
-          : hourAfterCurrentDate;
-      }
-
-      currentDate = new Date(currentDate.getTime() - currentDateOffset);
-      if (currentDate >= minDate && currentDate <= maxMinuteDate) {
-        minuteDifference = util.minuteDiff(minDate, maxMinuteDate);
-      }
-      for (i = 0; i <= (minuteDifference + 1); i += dateInterval) {
-        const time = new Date(
-          minDate.getUTCFullYear(),
-          minDate.getUTCMonth(),
-          minDate.getUTCDate(),
-          minDate.getUTCHours(),
-          minDate.getUTCMinutes() + i,
-          0,
-        );
-
-        if (time.getTime() >= minMinuteDateTime) {
-          dateArray.push(time);
-        }
-      }
+      const subdailyArray = getSubdailyDateRange(rangeLimitsProvided, currentDateTime, startDateLimit, endDateLimit, minDate, maxDate, dateIntervalNum, dateArray);
+      dateArray = [...subdailyArray];
     }
     runningMinDate = minDate;
   });
@@ -589,19 +893,6 @@ export function dateOverlap(period, dateRanges) {
 
   // return the final results
   return result;
-}
-// Takes a layer id and returns a true or false value
-// if the layer exists in the active layer list
-//
-// LODASH Find() essentially does the same thing
-export function exists(layer, activeLayers) {
-  let found = false;
-  lodashEach(activeLayers, (current) => {
-    if (layer === current.id) {
-      found = true;
-    }
-  });
-  return found;
 }
 // Permalink versions 1.0 and 1.1
 export function layersParse11(str, config) {

--- a/web/js/modules/layers/util.test.js
+++ b/web/js/modules/layers/util.test.js
@@ -1,5 +1,6 @@
 import { assign } from 'lodash';
 import {
+  datesinDateRanges,
   serializeLayers,
   layersParse12,
   removeLayer,
@@ -237,5 +238,69 @@ describe('permalink 1.1', () => {
     const activeLayers = stateFromLocation.layers.active;
     expect(activeLayers[0].id).toBe('terra-cr');
     expect(activeLayers[0].visible).toBeFalsy();
+  });
+  test('test limited date range returned for layer with single date range and interval', () => {
+    const parameters = {
+      products: 'terra-cr',
+    };
+
+    const stateFromLocation = mapLocationToLayerState(
+      parameters,
+      defaultStateFromLocation,
+      globalState,
+      config,
+    );
+    const activeLayers = stateFromLocation.layers.active;
+    const dates = datesinDateRanges(activeLayers[0], new Date('2020-01-01'));
+    expect(dates.length).toBe(3);
+  });
+  test('test only next date returned (out of range past)', () => {
+    const parameters = {
+      products: 'terra-cr',
+    };
+
+    const stateFromLocation = mapLocationToLayerState(
+      parameters,
+      defaultStateFromLocation,
+      globalState,
+      config,
+    );
+    const activeLayers = stateFromLocation.layers.active;
+    const dates = datesinDateRanges(activeLayers[0], new Date('1990-01-01'));
+    expect(dates.length).toBe(1);
+  });
+  test('test no dates returned (out of range future)', () => {
+    const parameters = {
+      products: 'terra-cr',
+    };
+
+    const stateFromLocation = mapLocationToLayerState(
+      parameters,
+      defaultStateFromLocation,
+      globalState,
+      config,
+    );
+    const activeLayers = stateFromLocation.layers.active;
+    const dates = datesinDateRanges(activeLayers[0], new Date('2030-01-01'));
+    expect(dates.length).toBe(0);
+  });
+  test('test date range returned from given start/end date range for data panel', () => {
+    const parameters = {
+      products: 'terra-cr',
+    };
+
+    const stateFromLocation = mapLocationToLayerState(
+      parameters,
+      defaultStateFromLocation,
+      globalState,
+      config,
+    );
+    const activeLayers = stateFromLocation.layers.active;
+    const dates = datesinDateRanges(activeLayers[0], new Date('2018-01-01'), new Date('2017-12-01'), new Date('2018-02-01'), new Date('2020-01-01'));
+    const isFirstDateEqual = dates[0].toISOString() === '2017-12-01T00:00:00.000Z';
+    const isLastDateEqual = dates[dates.length - 1].toISOString() === '2018-01-31T00:00:00.000Z';
+    expect(dates.length).toBe(62);
+    expect(isFirstDateEqual).toBeTruthy();
+    expect(isLastDateEqual).toBeTruthy();
   });
 });

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -1,7 +1,6 @@
 import {
   isObject as lodashIsObject,
   each as lodashEach,
-  isNull as lodashIsNull,
 } from 'lodash';
 import Cache from 'cachai';
 import moment from 'moment';
@@ -31,20 +30,6 @@ export default (function(self) {
     'NOV',
     'DEC',
   ];
-
-  // Needed anymore?
-  self.LAYER_GROUPS = {
-    baselayers: {
-      id: 'baselayers',
-      camel: 'BaseLayers',
-      description: 'Base Layers',
-    },
-    overlays: {
-      id: 'overlays',
-      camel: 'Overlays',
-      description: 'Overlays',
-    },
-  };
 
   self.repeat = function(value, length) {
     let result = '';
@@ -166,22 +151,6 @@ export default (function(self) {
   };
 
   /**
-   * Gets a pixel RGBA value from Canvas
-   *
-   * @method getCanvasPixelData
-   * @static
-   * @param canvas {Object} DOM canvas Element
-   * @param x {Number} X value on canvas
-   * @return y {Number} Y value on canvas
-   * @return {Object} Canvas image data.
-   */
-  self.getCanvasPixelData = function(canvas, x, y) {
-    const context = canvas.getContext('2d');
-    return context.getImageData(x, y, 1, 1)
-      .data;
-  };
-
-  /**
    * Parses a UTC ISO 8601 date.
    *
    * @method parseDateUTC
@@ -240,14 +209,6 @@ export default (function(self) {
     }
     self.warn(`Is not an object: ${item}`);
     return '';
-  };
-  /**
-   * Test if is valid Date
-   * @param {Object} d | Date object
-   */
-  self.isValidDate = function(d) {
-    // eslint-disable-next-line no-restricted-globals
-    return d instanceof Date && !isNaN(d);
   };
   /**
    * Parses a UTC ISO 8601 date to a non UTC date
@@ -332,19 +293,6 @@ export default (function(self) {
     context.font = font;
     const metrics = context.measureText(text);
     return metrics.width;
-  };
-
-  /**
-   * Julian date, padded with two zeros
-   * (to ensure the julian date is always in DDD format).
-   *
-   * @param  {Date} date {Date} the date to convert
-   * @return {string} Julian date string in the form of `YYYYDDD`
-   */
-  self.toJulianDate = function(date) {
-    const jStart = self.parseDateUTC(`${date.getUTCFullYear()}-01-01`);
-    const jDate = `00${1 + Math.ceil((date.getTime() - jStart) / 86400000)}`;
-    return date.getUTCFullYear() + jDate.substr(jDate.length - 3);
   };
 
   /**
@@ -697,45 +645,6 @@ export default (function(self) {
   };
 
   /**
-   * Converts a date into a compact string representation.
-   *
-   * @method toCompactTimestamp
-   * @static
-   * @param date {Date} the date to convert
-   * @return {String} string representation in the form of
-   * ``YYYYMMDDHHMMSSsss``
-   */
-  self.toCompactTimestamp = function(date) {
-    return date.toISOString()
-      .replace(/[-:TZ.]/g, '');
-  };
-
-  /**
-   * Converts a compact timestamp into a date.
-   *
-   * @method fromCompactTimestamp
-   * @static
-   * @param str {String} the string to convert in the form of
-   * ``YYYYMMDDHHMMSSsss``.
-   * @return {Date} the converted date object.
-   */
-  self.fromCompactTimestamp = function(str) {
-    const v = str.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{3})/);
-    if (lodashIsNull(v)) {
-      throw new Error(`Invalid timestamp:${str}`);
-    }
-    return new Date(Date.UTC(
-      parseInt(v[1], 10),
-      parseInt(v[2] - 1, 10),
-      parseInt(v[3], 10),
-      parseInt(v[4], 10),
-      parseInt(v[5], 10),
-      parseInt(v[6], 10),
-      parseInt(v[7], 10),
-    ));
-  };
-
-  /**
    * Gets the current time. Use this instead of the Date methods to allow
    * debugging alternate "now" times.
    *
@@ -748,10 +657,6 @@ export default (function(self) {
   };
 
   self.now = now;
-
-  self.resetNow = function() {
-    self.now = now;
-  };
 
   /**
    * Gets the current day. Use this instead of the Date methods to allow
@@ -1103,6 +1008,34 @@ export default (function(self) {
     return value;
   };
 
+  /**
+   * Returns offset date object
+   *
+   * @method getTimezoneOffsetDate
+   * @param  {Object} date        A date object
+   * @return {Object} offsetDate  An offset date object
+   */
+  self.getTimezoneOffsetDate = (date) => {
+    const offsetDate = new Date(date.getTime() - (date.getTimezoneOffset() * 60000));
+    return offsetDate;
+  };
+
+  /**
+   * Returns absolute UTC date timeunit numbers object
+   *
+   * @method getUTCNumbers
+   * @param  {Object} date    A date object
+   * @param  {String} prefix  Prefix min/max for timeunits in object
+   * @return {Object}         An object of UTC date timeunit numbers
+   */
+  self.getUTCNumbers = (date, prefix) => ({
+    [`${prefix}Year`]: date.getUTCFullYear(),
+    [`${prefix}Month`]: date.getUTCMonth(),
+    [`${prefix}Day`]: date.getUTCDate(),
+    [`${prefix}Hour`]: date.getUTCHours(),
+    [`${prefix}Minute`]: date.getUTCMinutes(),
+  });
+
   // Returns the number of months between two dates
   self.yearDiff = function(startDate, endDate) {
     const year1 = startDate.getFullYear();
@@ -1125,17 +1058,13 @@ export default (function(self) {
   };
 
   self.dayDiff = function(startDate, endDate) {
-    const date1 = new Date(startDate);
-    const date2 = new Date(endDate);
-    const timeDiff = Math.abs(date2.getTime() - date1.getTime());
+    const timeDiff = Math.abs(endDate.getTime() - startDate.getTime());
     const dayDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
     return dayDiff;
   };
 
   self.minuteDiff = function(startDate, endDate) {
-    const date1 = new Date(startDate);
-    const date2 = new Date(endDate);
-    const timeDiff = Math.abs(date2.getTime() - date1.getTime());
+    const timeDiff = Math.abs(endDate.getTime() - startDate.getTime());
     const minuteDiff = Math.ceil(timeDiff / 60000);
     return minuteDiff;
   };
@@ -1174,18 +1103,6 @@ export default (function(self) {
       }
     }
     return false;
-  };
-
-  /**
-   * Check if objects have the same keys
-   *
-   * @param  {array} comment separated list of objects
-   * @return {bool}
-   */
-  self.objectsHaveSameKeys = function(...objects) {
-    const allKeys = objects.reduce((keys, object) => keys.concat(Object.keys(object)), []);
-    const union = new Set(allKeys);
-    return objects.every((object) => union.size === Object.keys(object).length);
   };
 
   return self;

--- a/web/js/util/util.test.js
+++ b/web/js/util/util.test.js
@@ -69,11 +69,6 @@ describe('parseDateUTC', () => {
   });
 });
 
-test('toJulianDate', () => {
-  const d = new Date(Date.UTC(2013, 0, 15));
-  expect(util.toJulianDate(d)).toBe('2013015');
-});
-
 test('toISOStringDate', () => {
   const d = new Date(Date.UTC(2013, 0, 15));
   expect(util.toISOStringDate(d)).toBe('2013-01-15');
@@ -87,23 +82,6 @@ test('toISOStringSeconds', () => {
 test('toHourMinutes', () => {
   const d = new Date(Date.UTC(2013, 0, 15, 11, 22, 33));
   expect(util.toHourMinutes(d)).toBe('11:22');
-});
-
-test('toCompactTimestamp', () => {
-  const d = new Date(Date.UTC(2013, 0, 15, 11, 22, 33, 444));
-  expect(util.toCompactTimestamp(d)).toBe('20130115112233444');
-});
-
-describe('fromCompactTimestamp', () => {
-  test('parses timestamp', () => {
-    const answer = new Date(Date.UTC(2013, 0, 15, 11, 22, 33, 444));
-    const result = util.fromCompactTimestamp('20130115112233444');
-    expect(answer.getTime()).toEqual(result.getTime());
-  });
-
-  test('invalid', () => {
-    expect(() => util.fromCompactTimestamp('x0130115112233444')).toThrow();
-  });
 });
 
 test('clearTimeUTC', () => {


### PR DESCRIPTION
## Description

Originally part of #2864 , sequentially 1 of 3 PRs.

Fixes #2433  .

This PR addresses #2433 by shortening date ranges returned by `datesinDateRanges` used in the app for layer building, timeline data panel, and product picker. Changes within the ` datesinDateRanges` and related functions allow for performance increases shown through reduced run time.

- [x] Break up `datesinDateRanges` period specific date range traversals into separate methods and cleanup/remove repeated logic where possible.
- [x] Add `getLimitedDateRange` to use on layers with a single date range and a date interval of 1 for limited dates of previous, current, and next dates (if available). This helps cut down time and increase performance of date array building. This is one of the biggest performance increases which cuts the `dateArray` down from a length of ~7200 to 3 for typical daily layers (e.g. Terra CR).
- [x] Remove extra `datesinDateRanges` invocation within layerbuilder that resulted in running the date array building twice.
- [x] Add conditions to catch additional `availableAtDate` layer def cases and prevent full `datesinDateRanges` method call.

Additional fixes:
- [x] Refactor using `getTimezoneOffsetDate` and `getUTCNumbers` util methods where possible.
- [x] Remove dead code, refactor, destructure, and cleanup along the way.

## Further comments

Here are some comparison metrics to show performance timing savings based on how long affected functions took to complete in this PR vs the current develop branch:

**Pull Request:**

**1) Map load, date change, layer add**

**_Pageload default:_**
util.js:734 datesinDateRanges took0.10999999358318746ms
util.js:734 datesinDateRanges took0.014999997802078724ms
util.js:734 datesinDateRanges took0.00999998883344233ms
util.js:734 datesinDateRanges took0.010000017937272787ms
util.js:734 datesinDateRanges took0.0050000089686363935ms
util.js:734 datesinDateRanges took0.014999997802078724ms

- **_Total datesInDateRanges time: 0.16500000492 ms_**

**_Next, click left date arrow 1 day back:_**
util.js:734 datesinDateRanges took0.48499999684281647ms
util.js:734 datesinDateRanges took0.050000002374872565ms
util.js:734 datesinDateRanges took0.06500000017695129ms
**_Next, add AOD Aqua/MODIS from categories/dust storms:_**
util.js:734 datesinDateRanges took0.06500000017695129ms

**2) Type in ‘a’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took3.7299999967217445ms

**3) Type in ‘terr’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took1.369999983580783ms

**4) Measurement row -> fires -> AOD**
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.06000002031214535ms
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.0050000089686363935ms

**Develop branch:**

**1) Map load, date change, layer add**

**_Pageload default:_**
util.js:437 datesinDateRanges took8.050000004004687ms
util.js:437 datesinDateRanges took14.629999990575016ms
util.js:437 datesinDateRanges took6.340000021737069ms
util.js:437 datesinDateRanges took7.349999999860302ms
util.js:437 datesinDateRanges took1.724999980069697ms
util.js:437 datesinDateRanges took1.7700000025797635ms
util.js:437 datesinDateRanges took0.00999998883344233ms
util.js:437 datesinDateRanges took0.0050000089686363935ms
util.js:437 datesinDateRanges took0.014999997802078724ms

- **_Total datesInDateRanges time: 39.8949999944 ms_**

**_Next, click left date arrow 1 day back:_**
util.js:437 datesinDateRanges took8.874999999534339ms
util.js:437 datesinDateRanges took11.454999999841675ms
util.js:437 datesinDateRanges took7.970000006025657ms
util.js:437 datesinDateRanges took8.375000004889444ms
util.js:437 datesinDateRanges took1.7349999980069697ms
util.js:437 datesinDateRanges took1.4899999951012433ms
**_Next, add AOD Aqua/MODIS from categories/dust storms:_**
util.js:437 datesinDateRanges took4.940000013448298ms
util.js:437 datesinDateRanges took6.130000023404136ms
util.js:437 datesinDateRanges took4.79000000632368ms
util.js:437 datesinDateRanges took5.915000016102567ms
util.js:437 datesinDateRanges took5.235000018728897ms
util.js:437 datesinDateRanges took5.690000019967556ms
util.js:437 datesinDateRanges took5.134999984875321ms
util.js:437 datesinDateRanges took4.9149999977089465ms
util.js:437 datesinDateRanges took5.124999996041879ms
util.js:437 datesinDateRanges took0.00999998883344233ms

**2) Type in ‘a’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took801.4449999900535ms

**3) Type in ‘terr’ in product picker:**
measurement-layer-row.js:132 availableAtDate-product-picker took256.39500000397675ms

**4) Measurement row -> fires -> AOD**
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took2.6350000116508454ms
measurement-layer-row.js:54 availableAtDate-measurement-layer-row took0.020000006770715117ms


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
