### PR TITLE
Timeline axis SVG gridrange and dragger cleanups, remove unused hasMoved state

### DIFF
--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -75,7 +75,7 @@ class AxisHoverLine extends PureComponent {
             x2="0"
             y1="0"
             y2={lineHeightInner}
-            transform={`translate(${linePosition + 1}, 0)`}
+            transform={`translate(${linePosition + 1})`}
           />
         </svg>
       )

--- a/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/grid-range.js
@@ -48,7 +48,10 @@ class GridRange extends PureComponent {
     } = this.props;
     const tileTextCondition = tileTextConditionOptions[timeScale];
     return (
-      <g className="axis-grid-container" transform={`translate(${transformX}, 0)`}>
+      <g
+        className="axis-grid-container"
+        transform={`translate(${transformX})`}
+      >
         <>
           {timeRange.map((item, index) => (
             item.withinRange

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-rect.js
@@ -87,6 +87,7 @@ class TileRect extends PureComponent {
     const tileOptions = tileRectTimeScaleOptions[timeScale]();
     const lineLengthY = tileOptions.lineLengthY(item);
     const whiteLineStrokeWidth = lineLengthY !== 10 ? 2 : 1;
+    const indexGridWithCoeff = index * gridWidth;
     return (
       <>
         <g onMouseMove={this.showHover}>
@@ -94,40 +95,37 @@ class TileRect extends PureComponent {
             className="axis-grid-rect"
             width={gridWidth}
             height={65}
-            transform={`translate(${index * gridWidth}, 0)`}
-            fill={item.withinRange ? 'rgba(0,0,0,0)' : 'black'}
+            x={indexGridWithCoeff}
+            fill="transparent"
           />
           <line
             className="axis-grid-line"
             stroke="black"
             strokeLinecap="round"
             strokeWidth="0.2"
-            x1="0"
-            x2="0"
+            x1={indexGridWithCoeff + 2.2}
+            x2={indexGridWithCoeff + 2.2}
             y1="0"
             y2={lineLengthY}
-            transform={`translate(${index * gridWidth + 2.2}, 0)`}
           />
           <line
             className="axis-grid-line"
             stroke="#555"
             strokeWidth={1}
-            x1="0"
-            x2={gridWidth}
+            x1={indexGridWithCoeff + 1}
+            x2={indexGridWithCoeff + 1 + gridWidth}
             y1="46"
             y2="46"
-            transform={`translate(${index * gridWidth + 1}, 0)`}
           />
           <line
             className="axis-grid-line"
             stroke="white"
             strokeLinecap="round"
             strokeWidth={whiteLineStrokeWidth}
-            x1="0"
-            x2="0"
+            x1={indexGridWithCoeff + 1}
+            x2={indexGridWithCoeff + 1}
             y1="0"
             y2={lineLengthY}
-            transform={`translate(${index * gridWidth + 1}, 0)`}
           />
         </g>
       </>

--- a/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
+++ b/web/js/components/timeline/timeline-axis/grid-range/tile-text.js
@@ -8,6 +8,7 @@ import React from 'react';
 * @returns {Object} svg text DOM object
 */
 const axisScaleTextElementWrapper = (item, index, gridWidth) => {
+  const indexGridWithCoeff = index * gridWidth;
   let dateText;
   let dateTextYear;
   if (item.timeScale === 'day') {
@@ -30,30 +31,32 @@ const axisScaleTextElementWrapper = (item, index, gridWidth) => {
   }
   return (
     <>
-      <text
-        className={`axis-grid-text axis-grid-text-${item.timeScale}`}
-        x="0"
-        y="42"
-        fill={item.withinRange ? 'white' : ''}
-        transform={`translate(${(index * gridWidth) + xOffsetAdded}, 20)`}
-        clipPath="url(#textDisplay)"
+      <g
+        transform={`translate(${indexGridWithCoeff + xOffsetAdded})`}
       >
-        {dateText}
-      </text>
-      {item.timeScale === 'day'
-        ? (
-          <text
-            className="axis-grid-text axis-grid-text-year"
-            x="0"
-            y="42"
-            fill={item.withinRange ? '#cccccc' : ''}
-            transform={`translate(${(index * gridWidth) + xOffsetAdded + 40}, 20)`}
-            clipPath="url(#textDisplay)"
-          >
-            {dateTextYear}
-          </text>
-        )
-        : null}
+        <text
+          className={`axis-grid-text axis-grid-text-${item.timeScale}`}
+          x="0"
+          y="62"
+          fill="white"
+          clipPath="url(#textDisplay)"
+        >
+          {dateText}
+        </text>
+        {item.timeScale === 'day'
+          ? (
+            <text
+              className="axis-grid-text axis-grid-text-year"
+              x="40"
+              y="62"
+              fill="#cccccc"
+              clipPath="url(#textDisplay)"
+            >
+              {dateTextYear}
+            </text>
+          )
+          : null}
+      </g>
     </>
   );
 };

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -420,7 +420,6 @@ class TimelineAxis extends Component {
     draggerPosition = draggerPosition - pixelsToAdd + position - draggerWidth + boundsDiff;
     draggerPositionB = draggerPositionB - pixelsToAdd + position - draggerWidth + boundsDiff;
     const updatePositioningArguments = {
-      hasMoved: false,
       isTimelineDragging: false,
       position,
       transformX,
@@ -1014,12 +1013,11 @@ class TimelineAxis extends Component {
   */
   handleStartDrag = () => {
     const {
-      hasMoved,
       isTimelineDragging,
       updateTimelineMoveAndDrag,
     } = this.props;
     if (!isTimelineDragging) {
-      updateTimelineMoveAndDrag(hasMoved, true);
+      updateTimelineMoveAndDrag(true);
     }
   }
 
@@ -1035,16 +1033,12 @@ class TimelineAxis extends Component {
       e.preventDefault();
     }
     const {
-      currentTimeRange,
       gridWidth,
       dragSentinelChangeNumber,
       dragSentinelCount,
     } = this.state;
     const {
-      draggerVisible,
-      draggerVisibleB,
       timeScale,
-      transformX,
       updatePositioning,
       updatePositioningOnSimpleDrag,
     } = this.props;
@@ -1063,27 +1057,16 @@ class TimelineAxis extends Component {
     animationStartLocation += deltaX;
     animationEndLocation += deltaX;
     // update not necessary for year or month since all units are displayed
-    if (timeScale === 'year' || timeScale === 'month') {
-      const frontDate = currentTimeRange[0].rawDate;
-      const backDate = currentTimeRange[currentTimeRange.length - 1].rawDate;
-      const updatePositioningArguments = {
-        hasMoved: true,
-        isTimelineDragging: true,
+    if (timeScale === 'month' || timeScale === 'year') {
+      const updateSimplePositioningArguments = {
         position,
-        transformX,
-        frontDate,
-        backDate,
         draggerPosition,
         draggerPositionB,
-        draggerVisible,
-        draggerVisibleB,
         animationStartLocation,
         animationEndLocation,
       };
-      this.setState({
-        dragSentinelCount: dragSentinelCount + deltaX,
-      });
-      updatePositioning(updatePositioningArguments);
+
+      updatePositioningOnSimpleDrag(updateSimplePositioningArguments);
       // handle all timescale other than year and month to add new groups of tile item dates
     } else if (deltaX > 0) {
       // dragging right - exposing past dates
@@ -1113,7 +1096,6 @@ class TimelineAxis extends Component {
         const frontDate = newCurrentTimeRange[0].rawDate;
         const backDate = newCurrentTimeRange[newCurrentTimeRange.length - 1].rawDate;
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           transformX,
@@ -1138,8 +1120,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          hasMoved: true,
-          isTimelineDragging: true,
           position,
           draggerPosition,
           draggerPositionB,
@@ -1180,7 +1160,6 @@ class TimelineAxis extends Component {
         const frontDate = newCurrentTimeRange[0].rawDate;
         const backDate = newCurrentTimeRange[newCurrentTimeRange.length - 1].rawDate;
         const updatePositioningArguments = {
-          hasMoved: true,
           isTimelineDragging: true,
           position,
           transformX,
@@ -1205,8 +1184,6 @@ class TimelineAxis extends Component {
           : dragSentinelCount + deltaX;
 
         const updatePositioningArguments = {
-          hasMoved: true,
-          isTimelineDragging: true,
           position,
           draggerPosition,
           draggerPositionB,
@@ -1264,7 +1241,6 @@ class TimelineAxis extends Component {
     rightBound += midPoint - d.x;
 
     const updatePositioningArguments = {
-      hasMoved,
       isTimelineDragging: false,
       position: midPoint,
       transformX: newTransformX,
@@ -1353,9 +1329,13 @@ class TimelineAxis extends Component {
     }
 
     let leftOffset = 0;
+    const layerStartBeforeAxisFront = layerStart < axisFrontDate;
+    const layerEndBeforeAxisBack = layerEnd <= axisBackDate;
+
+    // oversized width allows axis drag buffer
     let width = axisWidth * 2;
     if (visible) {
-      if (layerStart <= axisFrontDate) {
+      if (layerStartBeforeAxisFront) {
         leftOffset = 0;
       } else {
         // positive diff means layerStart more recent than axisFrontDate
@@ -1364,13 +1344,14 @@ class TimelineAxis extends Component {
         leftOffset = gridDiff + postionTransformX;
       }
 
-      if (layerEnd <= axisBackDate) {
+      if (layerEndBeforeAxisBack) {
         // positive diff means layerEnd earlier than back date
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
         width = Math.max(gridDiff + postionTransformX - leftOffset, 0);
       }
     }
+
     return {
       visible,
       leftOffset,
@@ -1384,28 +1365,32 @@ class TimelineAxis extends Component {
   * @param {Number} transformX
   * @returns {Object} DOM SVG object
   */
-  createMatchingCoverageLineDOMEl = (lineCoverageOptions, transformX) => (
-    <g
-      className="axis-data-coverage-line"
-      transform={`translate(${-transformX}, 0)`}
-    >
-      <rect
-        style={{
-          left: lineCoverageOptions.leftOffset,
-          visibility: lineCoverageOptions.visible ? 'visible' : 'hidden',
-          margin: '0 0 6px 0',
-        }}
-        rx={0}
-        ry={0}
-        width={lineCoverageOptions.width}
-        height={10}
-        transform={`translate(${transformX + lineCoverageOptions.leftOffset}, 0)`}
-        fill="rgba(0, 119, 212, 0.5)"
-        stroke="rgba(0, 69, 123, 0.8)"
-        strokeWidth={3}
-      />
-    </g>
-  )
+  createMatchingCoverageLineDOMEl = (lineCoverageOptions, transformX) => {
+    const { leftOffset, visible, width } = lineCoverageOptions;
+    return (
+      <g
+        className="axis-data-coverage-line"
+        transform={`translate(${-transformX})`}
+        clipPath="url(#matchingCoverage)"
+      >
+        <rect
+          style={{
+            left: leftOffset,
+            visibility: visible ? 'visible' : 'hidden',
+            margin: '0 0 6px 0',
+          }}
+          rx={0}
+          ry={0}
+          width={width}
+          height={10}
+          transform={`translate(${transformX + leftOffset})`}
+          fill="rgba(0, 119, 212, 0.5)"
+          stroke="rgba(0, 69, 123, 0.8)"
+          strokeWidth={3}
+        />
+      </g>
+    );
+  };
 
   render() {
     const {
@@ -1430,12 +1415,13 @@ class TimelineAxis extends Component {
       lineCoverageOptions = this.getMatchingCoverageLineDimensions();
     }
     const shouldDisplayMatchingCoverageLine = matchingTimelineCoverage && lineCoverageOptions;
+    const axisWidthStr = `${axisWidth}px`;
 
     return (
       <>
         <div
           className="timeline-axis-container"
-          style={{ width: `${axisWidth}px` }}
+          style={{ width: axisWidthStr }}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.setLineTime}
           onWheel={this.handleWheelType}
@@ -1449,19 +1435,23 @@ class TimelineAxis extends Component {
               <svg
                 className="timeline-axis-svg"
                 id="timeline-footer-svg"
-                width={axisWidth}
-                height={64}
+                width={axisWidthStr}
+                height="64px"
                 viewBox={`0 0 ${axisWidth} 64`}
                 preserveAspectRatio="xMinYMin slice"
               >
                 <defs>
                   {/* clip axis grid text */}
                   <clipPath id="textDisplay">
-                    <rect width="200" height="64" />
+                    <rect width="84px" height="64px" />
+                  </clipPath>
+                  {/* clip matching coverage data line */}
+                  <clipPath id="matchingCoverage">
+                    <rect x={transformX} y="0" width={axisWidthStr} height="64px" />
                   </clipPath>
                   {/* clip axis grid overflow */}
                   <clipPath id="timelineBoundary">
-                    <rect width={axisWidth} height={64} />
+                    <rect x={-position} y="0" width={axisWidthStr} height="64px" />
                   </clipPath>
                 </defs>
                 {shouldDisplayMatchingCoverageLine
@@ -1477,7 +1467,7 @@ class TimelineAxis extends Component {
                     left: leftBound, top: 0, bottom: 0, right: rightBound,
                   }}
                 >
-                  <g>
+                  <g clipPath="url(#timelineBoundary)">
                     <GridRange
                       showHover={showHover}
                       timeScale={timeScale}
@@ -1513,7 +1503,6 @@ TimelineAxis.propTypes = {
   draggerVisible: PropTypes.bool,
   draggerVisibleB: PropTypes.bool,
   frontDate: PropTypes.string,
-  hasMoved: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
   hoverTime: PropTypes.string,
   isAnimationDraggerDragging: PropTypes.bool,

--- a/web/js/components/timeline/timeline-draggers/dragger-container.js
+++ b/web/js/components/timeline/timeline-draggers/dragger-container.js
@@ -235,6 +235,10 @@ class DraggerContainer extends PureComponent {
       draggerVisibleB,
     } = this.props;
 
+    const {
+      draggerWidth,
+    } = this.state;
+
     const sharedProps = {
       axisWidth,
       toggleShowDraggerTime,
@@ -243,10 +247,23 @@ class DraggerContainer extends PureComponent {
       handleDragDragger: this.handleDragDragger,
       selectDragger: this.selectDragger,
     };
+
+    const selectedDraggerClipAClipWidth = Math.max(draggerWidth, draggerWidth + draggerPosition);
+    const selectedDraggerClipBClipWidth = Math.max(draggerWidth, draggerWidth + draggerPositionB);
     return (
       draggerSelected === 'selectedB'
         ? (
-          <svg className="dragger-container" width={axisWidth} height={83}>
+          <svg className="dragger-container" width={axisWidth} height={65}>
+            <defs>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipA">
+                <rect width={selectedDraggerClipAClipWidth} height="65" />
+              </clipPath>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipB">
+                <rect width={selectedDraggerClipBClipWidth} height="65" />
+              </clipPath>
+            </defs>
             {isCompareModeActive
               ? (
                 <Dragger
@@ -268,7 +285,17 @@ class DraggerContainer extends PureComponent {
           </svg>
         )
         : (
-          <svg className="dragger-container" width={axisWidth} height={83}>
+          <svg className="dragger-container" width={axisWidth} height={65}>
+            <defs>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipA">
+                <rect width={selectedDraggerClipAClipWidth} height="65" />
+              </clipPath>
+              {/* clip dragger */}
+              <clipPath id="selectedDraggerClipB">
+                <rect width={selectedDraggerClipBClipWidth} height="65" />
+              </clipPath>
+            </defs>
             {isCompareModeActive
               ? (
                 <Dragger

--- a/web/js/components/timeline/timeline-draggers/timeline-dragger.js
+++ b/web/js/components/timeline/timeline-draggers/timeline-dragger.js
@@ -124,7 +124,9 @@ class Dragger extends PureComponent {
       isHoveredDragging,
     } = this.state;
     // handle isHovered that may include a mouse up event while not hovered over dragger
-    const isHovered = !isHoveredDrag && !isHoveredDragging ? false : isHoveredDrag || isHoveredDragging;
+    const isHovered = !isHoveredDrag && !isHoveredDragging
+      ? false
+      : isHoveredDrag || isHoveredDragging;
     // handle fill for hover vs non-hover and slightly different A/B draggers
     const draggerFill = disabled
       ? isHovered
@@ -135,6 +137,16 @@ class Dragger extends PureComponent {
           ? '#a3a3a3'
           : '#8e8e8e'
         : '#ccc';
+
+    const draggerStroke = isHovered
+      ? '#ccc'
+      : '#333';
+    const draggerRectFill = isHovered
+      ? '#ccc'
+      : '#515151';
+    const draggerLetter = draggerName === 'selected'
+      ? 'A'
+      : 'B';
     return (
       draggerVisible
         ? (
@@ -142,7 +154,7 @@ class Dragger extends PureComponent {
             axis="x"
             onMouseDown={this.selectDragger}
             onDrag={this.handleDragDragger}
-            position={{ x: draggerPosition + 25, y: 19 }}
+            position={{ x: draggerPosition + 25, y: 0 }}
             onStart={this.startShowDraggerTime}
             onStop={this.stopShowDraggerTime}
             disabled={disabled}
@@ -150,16 +162,16 @@ class Dragger extends PureComponent {
             <g
               style={{
                 cursor: 'pointer',
-                display: draggerVisible ? 'block' : 'none',
               }}
-              className={`timeline-dragger dragger${draggerName === 'selected' ? 'A' : 'B'}`}
-              transform={`translate(${transformX}, 0)`}
+              className={`timeline-dragger dragger${draggerLetter}`}
+              transform={`translate(${transformX})`}
               onMouseEnter={this.handleHoverMouseEnter}
               onMouseLeave={this.handleHoverMouseLeave}
+              clipPath={`url(#selectedDraggerClip${draggerLetter})`}
             >
               <path
                 fill={draggerFill}
-                stroke={isHovered ? '#ccc' : '#333'}
+                stroke={draggerStroke}
                 strokeWidth="1px"
                 d="M5.706 47.781
               C2.77 47.781.39 45.402.39 42.467
@@ -174,20 +186,19 @@ class Dragger extends PureComponent {
                   <text
                     fontSize="26px"
                     fontWeight="400"
-                    x="11"
-                    y="8"
+                    x="14"
+                    y="37"
                     fill={disabled ? '#ccc' : '#000'}
-                    transform="translate(4, 30)"
                     textRendering="optimizeLegibility"
                   >
-                    {draggerName === 'selected' ? 'A' : 'B'}
+                    {draggerLetter}
                   </text>
                 )
                 : (
                   <>
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="15"
@@ -195,7 +206,7 @@ class Dragger extends PureComponent {
                     />
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="21"
@@ -203,7 +214,7 @@ class Dragger extends PureComponent {
                     />
                     <rect
                       pointerEvents="none"
-                      fill={isHovered ? '#ccc' : '#515151'}
+                      fill={draggerRectFill}
                       width="3"
                       height="20"
                       x="27"

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
+// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 import {
@@ -96,7 +97,6 @@ class Timeline extends React.Component {
       isTimelineDragging: false,
       initialLoadComplete: false,
       timelineHidden: false,
-      hasMoved: false,
       rangeSelectorMax: {
         end: false, start: false, startOffset: -50, width: 50000,
       },
@@ -353,7 +353,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic position changes from axis that affect dragger and range select
   * @param {Object} args
-    * @param {Boolean} hasMoved
     * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} transformX
@@ -369,7 +368,6 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioning = ({
-    hasMoved,
     isTimelineDragging,
     position,
     transformX,
@@ -384,7 +382,6 @@ class Timeline extends React.Component {
   // eslint-disable-next-line react/destructuring-assignment
   }, hoverTime = this.state.hoverTime) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
       showHoverLine: false,
       position,
@@ -404,8 +401,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic positioning update based on simple drag
   * @param {Object} args
-    * @param {Boolean} hasMoved
-    * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} draggerPosition
     * @param {Number} draggerPositionB
@@ -414,8 +409,6 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioningOnSimpleDrag = ({
-    hasMoved,
-    isTimelineDragging,
     position,
     draggerPosition,
     draggerPositionB,
@@ -423,8 +416,7 @@ class Timeline extends React.Component {
     animationEndLocation,
   }) => {
     this.setState({
-      hasMoved,
-      isTimelineDragging,
+      isTimelineDragging: true,
       showHoverLine: false,
       position,
       draggerPosition,
@@ -437,7 +429,6 @@ class Timeline extends React.Component {
   /**
   * @desc handles dynamic positioning update based on axis drag stop event
   * @param {Object} args
-    * @param {Boolean} hasMoved
     * @param {Boolean} isTimelineDragging
     * @param {Number} position
     * @param {Number} transformX
@@ -445,14 +436,12 @@ class Timeline extends React.Component {
   * @returns {void}
   */
   updatePositioningOnAxisStopDrag = ({
-    hasMoved,
     isTimelineDragging,
     position,
     transformX,
   // eslint-disable-next-line react/destructuring-assignment
   }, hoverTime = this.state.hoverTime) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
       showHoverLine: false,
       position,
@@ -463,13 +452,11 @@ class Timeline extends React.Component {
 
   /**
   * @desc update is timeline moved (drag timeline vs. click) and if timeline is dragging
-  * @param {Boolean} hasMoved
   * @param {Boolean} isTimelineDragging
   * @returns {void}
   */
-  updateTimelineMoveAndDrag = (hasMoved, isTimelineDragging) => {
+  updateTimelineMoveAndDrag = (isTimelineDragging) => {
     this.setState({
-      hasMoved,
       isTimelineDragging,
     });
   }
@@ -798,10 +785,9 @@ class Timeline extends React.Component {
   * @param {Number} draggerPositionArg
   * @param {Boolean} draggerVisibleArg
   * @param {Boolean} otherDraggerVisibleArg
-  * @param {Boolean} hasMovedArg
   * @returns {void}
   */
-  updateDraggerDatePosition = (newDate, draggerSelected, draggerPositionArg, draggerVisibleArg, otherDraggerVisibleArg, hasMovedArg) => {
+  updateDraggerDatePosition = (newDate, draggerSelected, draggerPositionArg, draggerVisibleArg, otherDraggerVisibleArg) => {
     const {
       draggerPosition,
       draggerPositionB,
@@ -809,7 +795,6 @@ class Timeline extends React.Component {
       draggerVisibleB,
       draggerTimeState,
       draggerTimeStateB,
-      hasMoved,
     } = this.state;
     if (draggerSelected === 'selected') {
       this.setState({
@@ -817,7 +802,6 @@ class Timeline extends React.Component {
         draggerVisible: draggerVisibleArg || draggerVisible,
         draggerVisibleB: otherDraggerVisibleArg || draggerVisibleB,
         draggerTimeState: newDate || draggerTimeState,
-        hasMoved: hasMovedArg || hasMoved,
       });
       if (newDate) {
         this.onDateChange(newDate, 'selected');
@@ -828,7 +812,6 @@ class Timeline extends React.Component {
         draggerVisible: otherDraggerVisibleArg || draggerVisible,
         draggerVisibleB: draggerVisibleArg || draggerVisibleB,
         draggerTimeStateB: newDate || draggerTimeStateB,
-        hasMoved: hasMovedArg || hasMoved,
       });
       if (newDate) {
         this.onDateChange(newDate, 'selectedB');
@@ -1047,7 +1030,6 @@ class Timeline extends React.Component {
       showHoverLine,
       showDraggerTime,
       hoverLinePosition,
-      hasMoved,
       shouldIncludeHiddenLayers,
     } = this.state;
     const selectedDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
@@ -1233,7 +1215,6 @@ class Timeline extends React.Component {
                         isAnimationDraggerDragging={isAnimationDraggerDragging}
                         isDraggerDragging={isDraggerDragging}
                         isTimelineDragging={isTimelineDragging}
-                        hasMoved={hasMoved}
                         matchingTimelineCoverage={matchingTimelineCoverage}
                       />
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import moment from 'moment';
-// eslint-disable-next-line import/no-unresolved
 import googleTagManager from 'googleTagManager';
 
 import {


### PR DESCRIPTION
## Description

Originally part of #2864 , sequentially 3 of 3 PRs.

- [x] Clean up some transforms/positioning in gridrange and draggers. Add clipPath to dragger container for SVG.
- [x] Remove `hasMoved` as `timeline.js` state and passed down `timeline-axis.js` props since it is not being used.
- [x] Update timeline axis drag for month/year to simplify parent update by switching to use `updatePositioningOnSimpleDrag`

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
