### PR TITLE
Prevent distraction free mode from triggering from key shortcut when within INPUT

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -99,7 +99,8 @@ class App extends React.Component {
   handleKeyPress(event) {
     const { keyPressAction } = this.props;
     const ctrlOrCmdKey = event.ctrlKey || event.metaKey;
-    keyPressAction(event.keyCode, event.shiftKey, ctrlOrCmdKey);
+    const isInput = event.srcElement.nodeName === 'INPUT';
+    keyPressAction(event.keyCode, event.shiftKey, ctrlOrCmdKey, isInput);
   }
 
   onload() {
@@ -204,8 +205,8 @@ function mapStateToProps(state, ownProps) {
   };
 }
 const mapDispatchToProps = (dispatch) => ({
-  keyPressAction: (keyCode, shiftKey, ctrlOrCmdKey) => {
-    dispatch(keyPress(keyCode, shiftKey, ctrlOrCmdKey));
+  keyPressAction: (keyCode, shiftKey, ctrlOrCmdKey, isInput) => {
+    dispatch(keyPress(keyCode, shiftKey, ctrlOrCmdKey, isInput));
   },
   screenResize: (width, height) => {
     dispatch(calculateResponsiveState(window));

--- a/web/js/modules/key-press/actions.js
+++ b/web/js/modules/key-press/actions.js
@@ -10,8 +10,10 @@ import { CLOSE as CLOSE_MODAL } from '../modal/constants';
  *
  * @param {Number} keyCode
  * @param {Boolean} is shiftKey down
+ * @param {Boolean} is ctrlOrCmdKey down
+ * @param {Boolean} is key pressed within an INPUT element
  */
-export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey) {
+export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey, isInput) {
   return (dispatch, getState) => {
     const {
       modal, animation, tour, ui,
@@ -32,13 +34,13 @@ export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey) {
           type: ANIMATION_KEY_PRESS_ACTION,
           keyCode,
         });
-      } else if (!ctrlOrCmdKey && shiftKey && keyCode === 68) {
+      } else if (!isInput && !ctrlOrCmdKey && shiftKey && keyCode === 68) {
         dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
         if (!isDistractionFreeModeActive && isOpen) {
           dispatch({ type: CLOSE_MODAL });
         }
       } else if (keyCode === 27) {
-        if (isDistractionFreeModeActive) {
+        if (!isInput && isDistractionFreeModeActive) {
           dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
         } else {
           dispatch({ type: CLOSE_MODAL });


### PR DESCRIPTION
## Description

Fixes #2886 .

- [x] Add check for keypress event to prevent distraction free mode action from triggering via `SHIFT-D` key shortcut if pressed within an INPUT.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
