### PR TITLE
Use require to import react-search-ui-views CSS file 

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -38,7 +38,6 @@ import '../../node_modules/jquery-ui-bundle/jquery-ui.theme.min.css';
 import '../../node_modules/ol/ol.css';
 import '../../node_modules/rc-slider/dist/rc-slider.min.css';
 import '../../node_modules/simplebar/dist/simplebar.min.css';
-import '../../node_modules/@elastic/react-search-ui-views/lib/styles/styles.css';
 import 'react-image-crop/dist/ReactCrop.css';
 import 'react-resizable/css/styles.css';
 // App CSS
@@ -86,6 +85,7 @@ import '../css/orbitTracks.css';
 import '../css/facets.css';
 import '../pages/css/document.css';
 
+require('@elastic/react-search-ui-views/lib/styles/styles.css');
 
 class App extends React.Component {
   constructor(props) {


### PR DESCRIPTION
## Description

- [x] Prod build issue missing was css, use require to import react-search-ui-views CSS style sheet

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
