### PR TITLE
Use getElementsByClassName method

### DIFF
--- a/web/js/components/timeline/timeline-controls/axis-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/axis-timescale-change.js
@@ -44,8 +44,8 @@ class AxisTimeScaleChange extends PureComponent {
 
   // Toggle visibility of map scales
   disableMapScales = (disable) => {
-    const imperialMapScale = document.querySelectorAll('.wv-map-scale-imperial');
-    const metricMapScale = document.querySelectorAll('.wv-map-scale-metric');
+    const imperialMapScale = document.getElementsByClassName('wv-map-scale-imperial');
+    const metricMapScale = document.getElementsByClassName('wv-map-scale-metric');
     if (disable) {
       for (const el of imperialMapScale) {
         el.style.display = 'none';


### PR DESCRIPTION
## Description

- [X] Use `getElementsByClassName` method instead of `querySelectorAll` for a minor performance/best practices improvement.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
