### PR TITLE
Geostationary availability feedback

### DIFF
--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
@@ -15,7 +15,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
@@ -18,7 +18,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
@@ -14,7 +14,8 @@
       "wrapX": true,
       "daynight": [
         "day"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
@@ -15,7 +15,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
@@ -18,7 +18,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
@@ -14,7 +14,8 @@
       "wrapX": true,
       "daynight": [
         "day"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
@@ -15,7 +15,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
@@ -18,7 +18,8 @@
       "daynight": [
         "day",
         "night"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
@@ -14,7 +14,8 @@
       "wrapX": true,
       "daynight": [
         "day"
-      ]
+      ],
+      "availableWindow": 30
     }
   }
 }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -114,6 +114,7 @@ The `config/wv.json/layerOrder.json` file must be updated to include the new lay
 - **description**: Point to a markdown file within the metadata folder to provide a layer description.
 - **wrapX**: Wrap the layer across the anti-meridian.
 - **wrapadjacentdays**: Wrap the layer across the anti-meridian but select the previous day when greater than 180 and the next day when less than -180.
+- **availableWindow**:  Number of days, counting backwards from app load time, that a layer has avilable coverage.  Setting this will cause a layer's `startDate` property to be dynamically set at app load time.  Primarily for our geostationary layers which only have historical coverage going back ~30 days.
 
 To display a color palette legend, a *palette* object should exist with the following properties:
 

--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -4,13 +4,12 @@ import { ListGroupItem, Tooltip } from 'reactstrap';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBan } from '@fortawesome/free-solid-svg-icons';
-import { availableAtDate } from '../../../../modules/layers/util';
+import { available, getActiveLayers } from '../../../../modules/layers/selectors';
 import Checkbox from '../../../util/checkbox';
 import {
   addLayer as addLayerAction,
   removeLayer as removeLayerAction,
 } from '../../../../modules/layers/actions';
-import { getActiveLayers } from '../../../../modules/layers/selectors';
 import SelectedDate from '../../../selected-date';
 
 /*
@@ -50,7 +49,7 @@ class MeasurementLayerRow extends React.Component {
       layer, measurementId, title, selectedDate, isEnabled,
     } = this.props;
     const { tooltipOpen } = this.state;
-    const layerIsAvailable = availableAtDate(layer, selectedDate);
+    const layerIsAvailable = available(layer.id, selectedDate, [layer]);
     const listItemClass = !layerIsAvailable ? 'unavailable' : '';
     // Replace periods in id since period causes issue with tooltip targeting
     const itemElementId = `checkbox-case-${layer.id.split('.').join('-')}`;

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -8,7 +8,7 @@ import {
   replaceSubGroup,
   getZotsForActiveLayers,
   getTitles,
-  memoizeAvailable as availableSelector,
+  memoizedAvailable as availableSelector,
 } from '../../modules/layers/selectors';
 import { reorderLayers } from '../../modules/layers/actions';
 

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -8,7 +8,7 @@ import {
   replaceSubGroup,
   getZotsForActiveLayers,
   getTitles,
-  available as availableSelector,
+  memoizeAvailable as availableSelector,
 } from '../../modules/layers/selectors';
 import { reorderLayers } from '../../modules/layers/actions';
 
@@ -135,7 +135,6 @@ class LayerList extends React.Component {
                     zot={zots[object.id] ? zots[object.id].value : null}
                     names={getNames(object.id)}
                     checkerBoardPattern={checkerBoardPattern}
-                    // TODO probably shouldn't call this function on every render?
                     isDisabled={!available(object.id)}
                     isVisible={object.visible}
                     runningObject={
@@ -170,6 +169,7 @@ LayerList.propTypes = {
   title: PropTypes.string,
   zots: PropTypes.object,
 };
+
 function mapStateToProps(state, ownProps) {
   const {
     layers,
@@ -180,11 +180,10 @@ function mapStateToProps(state, ownProps) {
     layerSplit,
   } = ownProps;
   const {
-    proj, compare, config, map, date,
+    proj, config, map,
   } = state;
   const { runningLayers } = state.layers;
   const { id } = proj;
-  const activeDateString = compare.isCompareA ? 'selected' : 'selectedB';
   const activeLayers = state.layers[layerGroupName];
   const zots = lodashGet(map, 'ui.selected')
     ? getZotsForActiveLayers(config, proj, map, activeLayers)
@@ -201,12 +200,10 @@ function mapStateToProps(state, ownProps) {
     checkerBoardPattern,
     layerSplit,
     getNames: (layerId) => getTitles(config, layerId, id),
-    available: (layerId) => {
-      const currentDate = date[activeDateString];
-      return availableSelector(layerId, currentDate, layers, config);
-    },
+    available: (layerId) => availableSelector(state)(layerId),
   };
 }
+
 const mapDispatchToProps = (dispatch) => ({
   reorderLayers: (newLayerArray) => {
     dispatch(reorderLayers(newLayerArray));

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -8,7 +8,7 @@ import {
   replaceSubGroup,
   getZotsForActiveLayers,
   getTitles,
-  available,
+  available as availableSelector,
 } from '../../modules/layers/selectors';
 import { reorderLayers } from '../../modules/layers/actions';
 
@@ -135,6 +135,7 @@ class LayerList extends React.Component {
                     zot={zots[object.id] ? zots[object.id].value : null}
                     names={getNames(object.id)}
                     checkerBoardPattern={checkerBoardPattern}
+                    // TODO probably shouldn't call this function on every render?
                     isDisabled={!available(object.id)}
                     isVisible={object.visible}
                     runningObject={
@@ -179,7 +180,7 @@ function mapStateToProps(state, ownProps) {
     layerSplit,
   } = ownProps;
   const {
-    proj, compare, config, map,
+    proj, compare, config, map, date,
   } = state;
   const { runningLayers } = state.layers;
   const { id } = proj;
@@ -199,10 +200,10 @@ function mapStateToProps(state, ownProps) {
     projId: id,
     checkerBoardPattern,
     layerSplit,
-    getNames: (layerId) => getTitles(state.config, layerId, id),
-    available: (id) => {
-      const date = state.date[activeDateString];
-      return available(id, date, layers, state.config, state);
+    getNames: (layerId) => getTitles(config, layerId, id),
+    available: (layerId) => {
+      const currentDate = date[activeDateString];
+      return availableSelector(layerId, currentDate, layers, config);
     },
   };
 }

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Draggable } from 'react-beautiful-dnd';

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -35,7 +35,6 @@ import {
 } from '../../components/timeline/date-util';
 import {
   hasSubDaily,
-  lastDate as layersLastDateTime,
 } from '../../modules/layers/selectors';
 import {
   selectDate,
@@ -1379,7 +1378,7 @@ function mapStateToProps(state) {
     customInterval,
   } = date;
   const { screenWidth, lessThan } = browser;
-  const { isCompareA, activeString } = compare;
+  const { isCompareA } = compare;
   const isCompareModeActive = compare.active;
   const { isDistractionFreeModeActive } = ui;
   const isSmallScreen = lessThan.medium;
@@ -1390,7 +1389,9 @@ function mapStateToProps(state) {
   const activeLayers = layers[compare.activeString];
   const projection = proj.id;
   const activeLayersFiltered = activeLayers.filter((layer) => layer.startDate && layer.projections[projection]);
-  let hasSubdailyLayers = hasSubDaily(activeLayers);
+  const hasSubdailyLayers = isCompareModeActive
+    ? hasSubDaily(layers.active) || hasSubDaily(layers.activeB)
+    : hasSubDaily(activeLayers);
 
   let updatedInterval = interval;
   let updatedCustomInterval = customInterval;
@@ -1408,21 +1409,11 @@ function mapStateToProps(state) {
     }
   }
 
-  let endTime;
-  if (isCompareModeActive) {
-    hasSubdailyLayers = hasSubDaily(layers.active) || hasSubDaily(layers.activeB);
-    endTime = getEndTime(layers, config);
-  } else {
-    hasSubdailyLayers = hasSubDaily(activeLayers);
-    endTime = layersLastDateTime(layers[activeString], config);
-  }
-  endTime = appNow;
-
   const dimensionsAndOffsetValues = getOffsetValues(
     screenWidth,
     hasSubdailyLayers,
   );
-  const timelineEndDateLimit = getISODateFormatted(endTime);
+  const timelineEndDateLimit = getISODateFormatted(appNow);
 
   const selectedDate = isCompareA ? selected : selectedB;
   const deltaChangeAmt = customSelected ? customDelta : delta;
@@ -1592,11 +1583,6 @@ const getOffsetValues = (innerWidth, hasSubDaily) => {
   return { width, parentOffset };
 };
 
-const getEndTime = (layers, config) => {
-  const endDateA = layersLastDateTime(layers.active, config);
-  const endDateB = layersLastDateTime(layers.activeB, config);
-  return endDateA > endDateB ? endDateA : endDateB;
-};
 /**
  * @param  {Number} delta Date and direction to change
  * @param  {Number} increment Zoom level of change

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -88,19 +88,14 @@ export function hasSubDaily(layers) {
   return false;
 }
 
-export function addLayer(id, spec, layers, layerConfig, overlayLength, projection) {
-  layers = lodashCloneDeep(layers);
+export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection) {
+  let layers = lodashCloneDeep(layersParam);
   if (projection) {
     layers = layers.filter((layer) => layer.projections[projection]);
   }
-  if (
-    lodashFind(layers, {
-      id,
-    })
-  ) {
+  if (lodashFind(layers, { id })) {
     return layers;
   }
-  spec = spec || {};
   const def = lodashCloneDeep(layerConfig[id]);
   if (!def) {
     throw new Error(`No such layer: ${id}`);
@@ -150,8 +145,9 @@ export function resetLayers(startingLayers, layerConfig) {
  */
 export function getTitles(config, layerId, projId) {
   try {
-    let title; let subtitle; let
-      tags;
+    let title;
+    let subtitle;
+    let tags;
     const forProj = lodashGet(
       config,
       `layers.${layerId}.projections.${projId}`,
@@ -182,8 +178,7 @@ export function getTitles(config, layerId, projId) {
  * @param {*} spec
  * @param {*} state
  */
-export function getLayers(layers, spec, state) {
-  spec = spec || {};
+export function getLayers(layers, spec = {}, state) {
   const baselayers = forGroup('baselayers', spec, layers, state);
   const overlays = forGroup('overlays', spec, layers, state);
 
@@ -202,8 +197,7 @@ export function getLayers(layers, spec, state) {
   return baselayers.concat(overlays);
 }
 
-function forGroup(group, spec, activeLayers, state) {
-  spec = spec || {};
+function forGroup(group, spec = {}, activeLayers, state) {
   const projId = spec.proj || state.proj.id;
   let results = [];
   const defs = lodashFilter(activeLayers, {
@@ -238,105 +232,81 @@ function forGroup(group, spec, activeLayers, state) {
 }
 
 /**
- * Determine if a given layer is available
- * @param {*} id
- * @param {*} date
- * @param {*} layers
- * @param {*} config
- */
-export function available(id, date, layers, config) {
-  const range = dateRange({ layer: id }, layers, config);
-  if (range && (date < range.start || date > range.end)) {
-    return false;
-  }
-  return true;
-}
-
-export function replaceSubGroup(
-  layerId,
-  nextLayerId,
-  layers,
-  subGroup,
-  layerSplit,
-) {
-  if (nextLayerId) {
-    return moveBefore(layerId, nextLayerId, layers);
-  }
-  return pushToBottom(layerId, layers, layerSplit);
-}
-
-/**
  * Determine date range for layers
  * @param {*} spec
  * @param {*} activeLayers
  * @param {*} config
  */
-export function dateRange(spec, activeLayers, config) {
-  const layers = spec.layer
-    ? [lodashFind(activeLayers, { id: spec.layer })]
-    : activeLayers;
-  const ignoreRange = config.parameters && (config.parameters.debugGIBS || config.parameters.ignoreDateRange);
+function dateRange(id, activeLayers, config) {
+  const ignoreRange = config.parameters
+    && (config.parameters.debugGIBS
+    || config.parameters.ignoreDateRange);
   if (ignoreRange) {
     return {
       start: new Date(Date.UTC(1970, 0, 1)),
       end: util.now(),
     };
   }
+
   let min = Number.MAX_VALUE;
   let max = 0;
   let range = false;
   const maxDates = [];
-
   // Use the minute ceiling of the current time so that we don't run into an issue where
   // seconds value of current appNow time is greater than a layer's available time range
   const minuteCeilingCurrentTime = util.now().setSeconds(59);
+  const layers = id ? [lodashFind(activeLayers, { id })] : activeLayers;
 
-  lodashEach(layers, (def) => {
-    if (def) {
-      if (def.startDate) {
-        range = true;
-        const start = util.parseDateUTC(def.startDate).getTime();
-        min = Math.min(min, start);
+  layers.forEach((def) => {
+    if (!def) {
+      return;
+    }
+    if (def.startDate) {
+      range = true;
+      const start = util.parseDateUTC(def.startDate).getTime();
+      min = Math.min(min, start);
+    }
+
+    // For now, we assume that any layer with an end date is
+    // an ongoing product unless it is marked as inactive.
+    if (def.futureLayer && def.endDate) {
+      range = true;
+      max = util.parseDateUTC(def.endDate).getTime();
+      maxDates.push(new Date(max));
+    } else if (def.inactive && def.endDate) {
+      range = true;
+      const end = util.parseDateUTC(def.endDate).getTime();
+      max = Math.max(max, end);
+      maxDates.push(new Date(max));
+    } else if (def.endDate) {
+      range = true;
+      max = minuteCeilingCurrentTime;
+      maxDates.push(new Date(max));
+    }
+
+    // If there is a start date but no end date, this is a
+    // product that is currently being created each day, set
+    // the max day to today.
+    if (def.futureLayer && def.futureTime && !def.endDate) {
+      // Calculate endDate + parsed futureTime from layer JSON
+      max = new Date();
+      const { futureTime } = def;
+      const dateType = futureTime.slice(-1);
+      const dateInterval = futureTime.slice(0, -1);
+
+      if (dateType === 'D') {
+        max.setDate(max.getDate() + parseInt(dateInterval, 10));
+        maxDates.push(new Date(max));
+      } else if (dateType === 'M') {
+        max.setMonth(max.getMonth() + parseInt(dateInterval, 10));
+        maxDates.push(new Date(max));
+      } else if (dateType === 'Y') {
+        max.setYear(max.getYear() + parseInt(dateInterval, 10));
+        maxDates.push(new Date(max));
       }
-      // For now, we assume that any layer with an end date is
-      // an ongoing product unless it is marked as inactive.
-      if (def.futureLayer && def.endDate) {
-        range = true;
-        max = util.parseDateUTC(def.endDate).getTime();
-        maxDates.push(new Date(max));
-      } else if (def.inactive && def.endDate) {
-        range = true;
-        const end = util.parseDateUTC(def.endDate).getTime();
-        max = Math.max(max, end);
-        maxDates.push(new Date(max));
-      } else if (def.endDate) {
-        range = true;
-        max = minuteCeilingCurrentTime;
-        maxDates.push(new Date(max));
-      }
-      // If there is a start date but no end date, this is a
-      // product that is currently being created each day, set
-      // the max day to today.
-      if (def.futureLayer && def.futureTime && !def.endDate) {
-        // Calculate endDate + parsed futureTime from layer JSON
-        max = new Date();
-        const { futureTime } = def;
-        const dateType = futureTime.slice(-1);
-        const dateInterval = futureTime.slice(0, -1);
-        if (dateType === 'D') {
-          max.setDate(max.getDate() + parseInt(dateInterval, 10));
-          maxDates.push(new Date(max));
-        } else if (dateType === 'M') {
-          max.setMonth(max.getMonth() + parseInt(dateInterval, 10));
-          maxDates.push(new Date(max));
-        } else if (dateType === 'Y') {
-          max.setYear(max.getYear() + parseInt(dateInterval, 10));
-          maxDates.push(new Date(max));
-        }
-      } else if (def.startDate && !def.endDate) {
-        max = minuteCeilingCurrentTime;
-        maxDates.push(new Date(max));
-      }
+    } else if (def.startDate && !def.endDate) {
+      max = minuteCeilingCurrentTime;
+      maxDates.push(new Date(max));
     }
   });
 
@@ -351,6 +321,92 @@ export function dateRange(spec, activeLayers, config) {
       end: new Date(maxDate),
     };
   }
+}
+
+/**
+ * Determine if a given layer is available
+ * @param {*} id
+ * @param {*} date
+ * @param {*} layers
+ * @param {*} config
+ */
+export function available(id, date, layers, config) {
+  const range = dateRange(id, layers, config);
+  if (range && (date < range.start || date > range.end)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Determine if a layer should be rendered if it would be visible
+ *
+ * @param {*} id
+ * @param {*} activeLayers
+ * @param {*} date
+ * @param {*} state
+ */
+export function isRenderable(id, activeLayers, date, state) {
+  const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
+  date = date || state.date[activeDateStr];
+  const def = lodashFind(activeLayers, { id });
+  const notAvailable = !available(id, date, activeLayers, state.config);
+
+  if (!def || notAvailable || !def.visible || def.opacity === 0) {
+    return false;
+  }
+  if (def.group === 'overlays') {
+    return true;
+  }
+  let obscured = false;
+  lodashEach(
+    getLayers(activeLayers, { group: 'baselayers' }, state),
+    (otherDef) => {
+      if (otherDef.id === def.id) {
+        return false;
+      }
+      if (
+        otherDef.visible
+        && otherDef.opacity === 1.0
+        && available(otherDef.id, date, activeLayers, state.config)
+      ) {
+        obscured = true;
+        return false;
+      }
+    },
+  );
+  return !obscured;
+}
+
+export function activateLayersForEventCategory(activeLayers, state) {
+  const { layers, compare } = state;
+  // Turn off all layers in list first
+  let newLayers = layers[compare.activeString];
+  lodashEach(newLayers, (layer, index) => {
+    newLayers = update(newLayers, {
+      [index]: { visible: { $set: false } },
+    });
+  });
+  // Turn on or add new layers
+  lodashEach(activeLayers, (layer) => {
+    const id = layer[0];
+    const visible = layer[1];
+    const index = lodashFindIndex(newLayers, { id });
+    if (index >= 0) {
+      newLayers = update(newLayers, {
+        [index]: { visible: { $set: visible } },
+      });
+    } else {
+      newLayers = addLayer(
+        id,
+        { visible },
+        newLayers,
+        layers.layerConfig,
+        getLayers(newLayers, { group: 'all' }, state).overlays.length,
+      );
+    }
+  });
+  return newLayers;
 }
 
 export function pushToBottom(id, layers, layerSplit) {
@@ -394,99 +450,17 @@ export function moveBefore(sourceId, targetId, layers) {
   return layers;
 }
 
-/**
- * Determine if a layer should be rendered if it would be visible
- *
- * @param {*} id
- * @param {*} activeLayers
- * @param {*} date
- * @param {*} state
- */
-export function isRenderable(id, activeLayers, date, state) {
-  const activeDateStr = state.compare.isCompareA ? 'selected' : 'selectedB';
-  date = date || state.date[activeDateStr];
-  const def = lodashFind(activeLayers, { id });
-  const notAvailable = !available(id, date, activeLayers, state.config);
-
-  if (!def || notAvailable || !def.visible || def.opacity === 0) {
-    return false;
+export function replaceSubGroup(
+  layerId,
+  nextLayerId,
+  layers,
+  subGroup,
+  layerSplit,
+) {
+  if (nextLayerId) {
+    return moveBefore(layerId, nextLayerId, layers);
   }
-  if (def.group === 'overlays') {
-    return true;
-  }
-  let obscured = false;
-  lodashEach(
-    getLayers(activeLayers, { group: 'baselayers' }, state),
-    (otherDef) => {
-      if (otherDef.id === def.id) {
-        return false;
-      }
-      if (
-        otherDef.visible
-        && otherDef.opacity === 1.0
-        && available(otherDef.id, date, activeLayers, state.config)
-      ) {
-        obscured = true;
-        return false;
-      }
-    },
-  );
-  return !obscured;
-}
-
-export function lastDate(activeLayers, config) {
-  let endDate;
-  const layersDateRange = dateRange({}, activeLayers, config);
-  const today = util.today();
-  if (layersDateRange && layersDateRange.end > today) {
-    endDate = layersDateRange.end;
-  } else {
-    endDate = today;
-  }
-  return endDate;
-}
-
-export function lastDateTime(activeLayers, config) {
-  let endDate;
-  const layersDateRange = dateRange({}, activeLayers, config);
-  const now = util.now();
-  if (layersDateRange && layersDateRange.end > now) {
-    endDate = layersDateRange.end;
-  } else {
-    endDate = now;
-  }
-  return endDate;
-}
-
-export function activateLayersForEventCategory(activeLayers, state) {
-  const { layers, compare } = state;
-  // Turn off all layers in list first
-  let newLayers = layers[compare.activeString];
-  lodashEach(newLayers, (layer, index) => {
-    newLayers = update(newLayers, {
-      [index]: { visible: { $set: false } },
-    });
-  });
-  // Turn on or add new layers
-  lodashEach(activeLayers, (layer) => {
-    const id = layer[0];
-    const visible = layer[1];
-    const index = lodashFindIndex(newLayers, { id });
-    if (index >= 0) {
-      newLayers = update(newLayers, {
-        [index]: { visible: { $set: visible } },
-      });
-    } else {
-      newLayers = addLayer(
-        id,
-        { visible },
-        newLayers,
-        layers.layerConfig,
-        getLayers(newLayers, { group: 'all' }, state).overlays.length,
-      );
-    }
-  });
-  return newLayers;
+  return pushToBottom(layerId, layers, layerSplit);
 }
 
 export function getZotsForActiveLayers(config, projection, map, activeLayers) {

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -331,7 +331,7 @@ function dateRange(id, layers, parameters = {}) {
  * @param {*} layers
  * @param {*} config
  */
-function available(id, date, layers, parameters) {
+export function available(id, date, layers, parameters) {
   const range = dateRange(id, layers, parameters);
   if (range && (date < range.start || date > range.end)) {
     return false;

--- a/web/js/modules/layers/selectors.test.js
+++ b/web/js/modules/layers/selectors.test.js
@@ -66,52 +66,6 @@ test('resets to default layers', () => {
   const layerList = getLayers(layers, {}, getState(layers)).map((x) => x.id);
   expect(layerList).toEqual(['terra-cr', 'terra-aod']);
 });
-test('no date range for static products', () => {
-  const layers = addLayer('mask', {}, [], config.layers, 0);
-  expect(dateRange({}, layers, config)).toBeFalsy();
-});
-
-test('date range for ongoing layers', () => {
-  let layers = addLayer('terra-cr', {}, [], config.layers);
-  layers = addLayer('aqua-cr', {}, layers, config.layers);
-  layers = addLayer('terra-aod', {}, layers, config.layers);
-  layers = addLayer('aqua-aod', {}, layers, config.layers);
-  const range = dateRange({}, layers, config);
-
-  expect(range.start).toEqual(new Date(Date.UTC(2000, 0, 1)));
-  expect(range.start).toEqual(new Date(Date.UTC(2000, 0, 1)));
-});
-
-test('date range for ended layers', () => {
-  const layersConfig = {};
-  layersConfig.end1 = {
-    id: 'end1',
-    group: 'overlays',
-    projections: {
-      geographic: {},
-    },
-    startDate: '1990-01-01',
-    endDate: '2005-01-01',
-    inactive: true,
-  };
-  layersConfig.end2 = {
-    id: 'end1',
-    group: 'overlays',
-    projections: {
-      geographic: {},
-    },
-    startDate: '1992-01-01',
-    endDate: '2007-01-01',
-    inactive: true,
-  };
-  const adjustedConfig = update(config, { layers: { $set: layersConfig } });
-  let layers = addLayer('end1', {}, [], layersConfig);
-  layers = addLayer('end2', {}, layers, layersConfig);
-  const range = dateRange({}, layers, adjustedConfig);
-
-  expect(range.start).toEqual(new Date(Date.UTC(1990, 0, 1)));
-  expect(range.end).toEqual(new Date(Date.UTC(2007, 0, 1)));
-});
 
 test('gets layers in reverse', () => {
   let layers = addLayer('terra-cr', {}, [], config.layers);
@@ -281,7 +235,6 @@ test('move overlay before', () => {
 });
 
 // Date Ranges
-
 function getDateRangesTestState(state) {
   const today = new Date(Date.UTC(2010, 0, 1));
   util.now = () => today;
@@ -320,7 +273,9 @@ function getDateRangesTestState(state) {
       },
     },
   };
-  state = update(state, { date: { selected: { $set: today } } });
+  state = update(state, {
+    date: { selected: { $set: today } },
+  });
   state = update(state, {
     config: { defaults: { projection: { $set: 'geographic' } } },
   });
@@ -330,9 +285,50 @@ function getDateRangesTestState(state) {
   state = update(state, {
     config: { layers: { $set: layers } },
   });
-
   return state;
 }
+
+test('date range for ongoing layers', () => {
+  let layers = addLayer('terra-cr', {}, [], config.layers);
+  layers = addLayer('aqua-cr', {}, layers, config.layers);
+  layers = addLayer('terra-aod', {}, layers, config.layers);
+  layers = addLayer('aqua-aod', {}, layers, config.layers);
+  const range = dateRange({}, layers, config);
+
+  expect(range.start).toEqual(new Date(Date.UTC(2000, 0, 1)));
+  expect(range.start).toEqual(new Date(Date.UTC(2000, 0, 1)));
+});
+
+test('date range for ended layers', () => {
+  const layersConfig = {};
+  layersConfig.end1 = {
+    id: 'end1',
+    group: 'overlays',
+    projections: {
+      geographic: {},
+    },
+    startDate: '1990-01-01',
+    endDate: '2005-01-01',
+    inactive: true,
+  };
+  layersConfig.end2 = {
+    id: 'end1',
+    group: 'overlays',
+    projections: {
+      geographic: {},
+    },
+    startDate: '1992-01-01',
+    endDate: '2007-01-01',
+    inactive: true,
+  };
+  const adjustedConfig = update(config, { layers: { $set: layersConfig } });
+  let layers = addLayer('end1', {}, [], layersConfig);
+  layers = addLayer('end2', {}, layers, layersConfig);
+  const range = dateRange({}, layers, adjustedConfig);
+
+  expect(range.start).toEqual(new Date(Date.UTC(1990, 0, 1)));
+  expect(range.end).toEqual(new Date(Date.UTC(2007, 0, 1)));
+});
 
 test('date range with one layer', () => {
   let state = getState([]);

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -18,45 +18,6 @@ import { getPaletteAttributeArray } from '../palettes/util';
 import { getVectorStyleAttributeArray } from '../vector-styles/util';
 import util from '../../util/util';
 
-/**
-  *
-  * @param {*} def - layer definition
-  * @param {*} date - current selected app date
-  * @returns {Boolean} - True if layer is available at date, otherwise false
-  */
-// export function availableAtDate(def, date) {
-//   const { dateRanges, inactive } = def;
-//   const startDate = def.startDate && new Date(def.startDate);
-//   const endDate = def.endDate && new Date(def.endDate);
-
-//   // Some vector layers
-//   if (!startDate && !dateRanges) {
-//     return true;
-//   }
-//   // set inactive in config
-//   if (endDate && inactive) {
-//     return date < endDate && date > startDate;
-//   }
-//   // no endDate may indicate ongoing
-//   if (startDate && !endDate) {
-//     if (!dateRanges) {
-//       return date > startDate;
-//     }
-
-//     const endRange = dateRanges.length - 1;
-//     const rangeEndDate = new Date(dateRanges[endRange].endDate);
-//     if (inactive) {
-//       // We may need to look at individual date ranges for more accuracy
-//       return date > startDate && rangeEndDate && date < rangeEndDate;
-//     }
-
-//     // TODO do we need to see if current date falls within a start/end
-//     // date of any date range before resorting to simply checking if it falls
-//     // after the start date for an active layer?
-//     return date > startDate;
-//   }
-// }
-
 export function getOrbitTrackTitle(def) {
   const { track } = def;
   const daynightValue = lodashGet(def, 'daynight[0]');

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -24,38 +24,38 @@ import util from '../../util/util';
   * @param {*} date - current selected app date
   * @returns {Boolean} - True if layer is available at date, otherwise false
   */
-export function availableAtDate(def, date) {
-  const { dateRanges, inactive } = def;
-  const startDate = def.startDate && new Date(def.startDate);
-  const endDate = def.endDate && new Date(def.endDate);
+// export function availableAtDate(def, date) {
+//   const { dateRanges, inactive } = def;
+//   const startDate = def.startDate && new Date(def.startDate);
+//   const endDate = def.endDate && new Date(def.endDate);
 
-  // Some vector layers
-  if (!startDate && !dateRanges) {
-    return true;
-  }
-  // set inactive in config
-  if (endDate && inactive) {
-    return date < endDate && date > startDate;
-  }
-  // no endDate may indicate ongoing
-  if (startDate && !endDate) {
-    if (!dateRanges) {
-      return date > startDate;
-    }
+//   // Some vector layers
+//   if (!startDate && !dateRanges) {
+//     return true;
+//   }
+//   // set inactive in config
+//   if (endDate && inactive) {
+//     return date < endDate && date > startDate;
+//   }
+//   // no endDate may indicate ongoing
+//   if (startDate && !endDate) {
+//     if (!dateRanges) {
+//       return date > startDate;
+//     }
 
-    const endRange = dateRanges.length - 1;
-    const rangeEndDate = new Date(dateRanges[endRange].endDate);
-    if (inactive) {
-      // We may need to look at individual date ranges for more accuracy
-      return date > startDate && rangeEndDate && date < rangeEndDate;
-    }
+//     const endRange = dateRanges.length - 1;
+//     const rangeEndDate = new Date(dateRanges[endRange].endDate);
+//     if (inactive) {
+//       // We may need to look at individual date ranges for more accuracy
+//       return date > startDate && rangeEndDate && date < rangeEndDate;
+//     }
 
-    // TODO do we need to see if current date falls within a start/end
-    // date of any date range before resorting to simply checking if it falls
-    // after the start date for an active layer?
-    return date > startDate;
-  }
-}
+//     // TODO do we need to see if current date falls within a start/end
+//     // date of any date range before resorting to simply checking if it falls
+//     // after the start date for an active layer?
+//     return date > startDate;
+//   }
+// }
 
 export function getOrbitTrackTitle(def) {
   const { track } = def;


### PR DESCRIPTION
## Description

Fixes #2893.

* implement a memoized version of the `available` layer selector for use in `layer-list.js` so that we aren't calling it on every render
* make use of `available` selector instead of `availableAtDate` layer util function throughout product picker to determine layer availability
* apply an `adjustStartDate` function in `main.js` to layer config objects before initializing state, which sets a layers `startDate` property based on a calculated number of days (defined by `layer.availableWindow` property) from the current day 
* set `availabileWindow` property on all 9 current geostationary layers

@Benjaki2 -> Code review
@edplato -> Testing
