### PR TITLE
Hide vector pointer when layer is not visible

### DIFF
--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -151,7 +151,7 @@ class Layer extends React.Component {
 
   renderVectorIcon() {
     const {
-      isVectorLayer, hasClickableFeature, openVectorAlertModal, runningObject,
+      hasClickableFeature, openVectorAlertModal, runningObject,
     } = this.props;
     const clasNames = hasClickableFeature
       ? 'layer-pointer-icon'
@@ -159,7 +159,7 @@ class Layer extends React.Component {
     const title = hasClickableFeature
       ? 'You can click the features of this layer to see metadata associated with the feature.'
       : 'Zoom in further to click features.';
-    return isVectorLayer ? (
+    return (
       <div title={title} className={runningObject ? `${clasNames} running` : clasNames} onClick={openVectorAlertModal}>
         {' '}
         <FontAwesomeIcon
@@ -167,7 +167,7 @@ class Layer extends React.Component {
           fixedWidth
         />
       </div>
-    ) : null;
+    );
   }
 
   render() {
@@ -185,6 +185,7 @@ class Layer extends React.Component {
       zot,
       isInProjection,
       tracksForLayer,
+      isVectorLayer,
     } = this.props;
 
     const containerClass = isDisabled
@@ -257,7 +258,7 @@ class Layer extends React.Component {
                 <p dangerouslySetInnerHTML={{ __html: names.subtitle }} />
                 {hasPalette ? this.getPaletteLegend() : ''}
               </div>
-              {this.renderVectorIcon()}
+              {isVectorLayer && isVisible ? this.renderVectorIcon() : null}
               {tracksForLayer.length > 0 && (
               <div className="layer-tracks">
                 {tracksForLayer.map((track) => (


### PR DESCRIPTION
## Description

- [x] Hide vector-pointer indicator when layer isn't visible.
<img width="314" alt="Screen Shot 2020-06-10 at 11 05 02 AM" src="https://user-images.githubusercontent.com/3605988/84289116-1944ff00-ab10-11ea-9a63-5e7bd4389900.png">


## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
