### PR TITLE
prevent showing unwanted vector metaData 

### DIFF
--- a/web/js/containers/map-interactions.js
+++ b/web/js/containers/map-interactions.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { groupBy as lodashGroupBy, debounce as lodashDebounce, get as lodashGet } from 'lodash';
+import {
+  groupBy as lodashGroupBy,
+  debounce as lodashDebounce,
+  get as lodashGet,
+  includes as lodashIncludes,
+} from 'lodash';
 import OlCoordinates from '../components/map/ol-coordinates';
 import vectorDialog from './vector-dialog';
 import { onMapClickGetVectorFeatures } from '../modules/vector-styles/util';
@@ -78,7 +83,7 @@ export class MapInteractions extends React.Component {
       let isActiveLayer = false;
       map.forEachFeatureAtPixel(pixels, (feature, layer) => {
         const def = lodashGet(layer, 'wv.def');
-        if (!def) return;
+        if (!def || lodashIncludes(def.clickDisabledFeatures, feature.getType())) return;
         const isWrapped = proj.id === 'geographic' && (def.wrapadjacentdays || def.wrapX);
         const isRenderedFeature = isWrapped ? lon > -250 || lon < 250 || lat > -90 || lat < 90 : true;
         if (isRenderedFeature && isFromActiveCompareRegion(map, pixels, layer.wv, compareState, swipeOffset)) {


### PR DESCRIPTION
## Description

Fixes #2729

- [x] prevent showing unwanted vector metaData with `clickDisabledFeatures` config attribute (eg: `"clickDisabledFeatures": ["LineString"]`)
- [x] Break vector click function into smaller pieces
- [x] Add comments and fix some eslint warnings

## Further comments

The motivation for this capability was to be able to prevent showing useless metadata associated with orbit track LineStrings 
<img width="523" alt="Screen Shot 2020-06-19 at 2 53 00 PM" src="https://user-images.githubusercontent.com/3605988/85171395-e94ad980-b23c-11ea-9dee-d93675b7239c.png">


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
