### PR TITLE
Only show node version log message on installation if user version doesn't meet the requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "NASA-1.3",
   "repository": "nasa-gibs/worldview",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.16.3"
   },
   "husky": {
     "hooks": {

--- a/tasks/checkNodeVersion.js
+++ b/tasks/checkNodeVersion.js
@@ -37,4 +37,6 @@ if (!satisfiyMinVersion) {
   console.log('\x1b[31m', '\x1b[1m'); // Added styling to warn
   console.log('WARN ', '\x1b[0m', 'The suggested version of node for the installation of Worldview is', '\x1b[32m', '\x1b[1m', requiredVersionText, '\x1b[0m', ' you are using', '\x1b[32m', '\x1b[1m', nodeVersion);
   console.log('\x1b[0m', 'If you have difficulties installing Worldview, please try using the install again using the node version', '\x1b[32m', '\x1b[1m', requiredVersionText, '\x1b[0m');
+} else {
+  console.log('\x1b[0mPreinstall conditions satisfied. Installing...', '\x1b[0m');
 }

--- a/tasks/checkNodeVersion.js
+++ b/tasks/checkNodeVersion.js
@@ -1,11 +1,40 @@
 /* eslint no-console: "off" */
 const pkg = require('../package.json');
 
-const requiredVersion = `v${pkg.engines.node}`;
-const nodeBeingUsed = process.version;
+// modified versionCompare function from https://stackoverflow.com/a/6832721
+const versionCompare = (v1, v2) => {
+  let v1parts = v1.split('.');
+  let v2parts = v2.split('.');
 
-if (requiredVersion !== nodeBeingUsed) {
+  while (v1parts.length < v2parts.length) v1parts.push('0');
+  while (v2parts.length < v1parts.length) v2parts.push('0');
+
+  v1parts = v1parts.map(Number);
+  v2parts = v2parts.map(Number);
+  for (let i = 0; i < v1parts.length; i += 1) {
+    if (v2parts.length === i) {
+      return true;
+    }
+    if (v1parts[i] !== v2parts[i]) {
+      if (v1parts[i] > v2parts[i]) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const requiredVersion = pkg.engines.node;
+const nodeVersion = process.version;
+const requiredVersionSub = requiredVersion.substr(2, requiredVersion.length);
+const nodeVersionSub = nodeVersion.substr(1, nodeVersion.length);
+
+const satisfiyMinVersion = versionCompare(nodeVersionSub, requiredVersionSub);
+if (!satisfiyMinVersion) {
+  const requiredVersionText = `v${requiredVersion}`;
   console.log('\x1b[31m', '\x1b[1m'); // Added styling to warn
-  console.log('WARN ', '\x1b[0m', 'The suggested version of node for the installation of Worldview is', '\x1b[32m', '\x1b[1m', requiredVersion, '\x1b[0m', ' you are using', '\x1b[32m', '\x1b[1m', nodeBeingUsed);
-  console.log('\x1b[0m', 'If you have difficulties installing Worldview, please try using the install again using the node version', '\x1b[32m', '\x1b[1m', requiredVersion, '\x1b[0m');
+  console.log('WARN ', '\x1b[0m', 'The suggested version of node for the installation of Worldview is', '\x1b[32m', '\x1b[1m', requiredVersionText, '\x1b[0m', ' you are using', '\x1b[32m', '\x1b[1m', nodeVersion);
+  console.log('\x1b[0m', 'If you have difficulties installing Worldview, please try using the install again using the node version', '\x1b[32m', '\x1b[1m', requiredVersionText, '\x1b[0m');
 }


### PR DESCRIPTION
## Description

Fixes #2945  .

- [x] Show node version log message during installation only if user node version doesn't meet the required `package.json` engines node version.
- [x] Change required engines node version to use minimum test version `>=10.16.3`.
- [x] Add success message to confirm completion and address character line issues with subsequent installation logs.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
