### PR TITLE
Prevent features without def from pixel click dialog processing

### DIFF
--- a/web/js/modules/vector-styles/util.js
+++ b/web/js/modules/vector-styles/util.js
@@ -220,10 +220,12 @@ function getModalContentsAtPixel(mapProps, config, compareState) {
   const { pixels, map, swipeOffset } = mapProps;
   map.forEachFeatureAtPixel(pixels, (feature, layer) => {
     const def = lodashGet(layer, 'wv.def');
+    if (!def) {
+      return;
+    }
+
     const type = feature.getType();
-    if (
-      !def
-      || lodashIncludes(def.clickDisabledFeatures, type)
+    if (lodashIncludes(def.clickDisabledFeatures, type)
       || !isFromActiveCompareRegion(map, pixels, layer.wv, compareState, swipeOffset)) {
       return;
     }


### PR DESCRIPTION
## Description

Fixes #2997  .

- [x] Prevents features without `def` from further `getModalContentsAtPixel` function processes. This captures measure tool and (future) granule footprints.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
