### PR TITLE
Revise babel-loader to add react-refresh on dev server only

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,7 +158,7 @@ module.exports = {
           options: {
             compact: false, // fixes https://stackoverflow.com/questions/29576341/what-does-the-code-generator-has-deoptimised-the-styling-of-some-file-as-it-e
             cacheDirectory: devMode,
-            plugins: [devMode && require.resolve('react-refresh/babel')].filter(Boolean),
+            plugins: [isDevServer && require.resolve('react-refresh/babel')].filter(Boolean),
           },
         },
         exclude: babelLoaderExcludes,


### PR DESCRIPTION
## Description

Fixes #3008 .

- [x] Revise `babel-loader` to add `react-refresh` on dev server only.

  **Tested to make sure it works on Windows using:**
`npm run build && npm start`
`npm run build:prod && npm start` 
`npm run watch`

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
