### PR TITLE
Check for loop reset on start date and set timeout on animation date queuing

### DIFF
--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -137,6 +137,9 @@ class PlayAnimation extends React.Component {
     ) {
       return this.play(this.currentPlayingDate);
     }
+    if (isLoopStart && currentDate.getTime() === startDate.getTime()) {
+      return this.play(this.currentPlayingDate);
+    }
     this.shiftCache();
   };
 
@@ -296,6 +299,7 @@ class PlayAnimation extends React.Component {
    * @param endDate {object} JS date
    */
   addItemToQueue(currentDate, startDate, endDate) {
+    const { speed } = this.props;
     const nextDate = this.getNextBufferDate(currentDate, startDate, endDate);
     const nextDateStr = util.toISOStringSeconds(nextDate);
 
@@ -305,8 +309,10 @@ class PlayAnimation extends React.Component {
       && nextDate <= endDate
       && nextDate >= startDate
     ) {
-      this.addDate(nextDate);
-      this.checkQueue();
+      setTimeout(() => {
+        this.addDate(nextDate);
+        this.checkQueue();
+      }, Math.floor(1000 / speed));
     }
   }
 

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -69,13 +69,13 @@ class PlayAnimation extends React.Component {
    * @returns {string} Date string
    */
   getLastBufferDateStr = function(currentDate, startDate, endDate) {
-    const { queueLength, loop } = this.props;
+    const { queueLength, isLoopActive } = this.props;
     let day = currentDate;
     let i = 1;
 
     while (i < queueLength) {
       if (this.nextDate(day) > endDate) {
-        if (!loop) {
+        if (!isLoopActive) {
           return util.toISOStringSeconds(day);
         }
         day = startDate;
@@ -144,8 +144,8 @@ class PlayAnimation extends React.Component {
    * Check if we should loop
    */
   checkShouldLoop() {
-    const { loop, startDate, togglePlaying } = this.props;
-    if (loop) {
+    const { isLoopActive, startDate, togglePlaying } = this.props;
+    if (isLoopActive) {
       this.shiftCache();
       this.currentPlayingDate = util.toISOStringSeconds(startDate);
       setTimeout(() => {
@@ -318,14 +318,14 @@ class PlayAnimation extends React.Component {
    */
   isInToPlayGroup(testDate) {
     const {
-      startDate, endDate, loop, queueLength,
+      startDate, endDate, isLoopActive, queueLength,
     } = this.props;
     let i = 0;
     let day = util.parseDateUTC(this.currentPlayingDate);
     const jsTestDate = util.parseDateUTC(testDate);
     while (i < queueLength) {
       if (this.nextDate(day) > endDate) {
-        if (!loop) {
+        if (!isLoopActive) {
           return false;
         }
         day = startDate;
@@ -358,9 +358,9 @@ class PlayAnimation extends React.Component {
     this.addToInQueue(date);
     this.queue
       .add(() => promiseImageryForTime(date, activeLayers))
-      .then((date) => {
+      .then((addedDate) => {
         if (this.mounted) {
-          this.preloadObject[strDate] = date;
+          this.preloadObject[strDate] = addedDate;
           delete this.inQueueObject[strDate];
           this.shiftCache();
           this.checkQueue();
@@ -400,9 +400,8 @@ class PlayAnimation extends React.Component {
       selectDate, endDate, speed, isPlaying,
     } = this.props;
     let currentDateStr = index;
-    let nextDateStr; let
-      nextDateParsed;
-
+    let nextDateStr;
+    let nextDateParsed;
     const player = () => {
       if (!this.mounted) {
         return clearInterval(this.interval);
@@ -488,7 +487,7 @@ PlayAnimation.propTypes = {
   delta: PropTypes.number,
   hasCustomPalettes: PropTypes.bool,
   interval: PropTypes.string,
-  loop: PropTypes.bool,
+  isLoopActive: PropTypes.bool,
   maxQueueLength: PropTypes.number,
   onClose: PropTypes.func,
 };

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -608,7 +608,7 @@ class AnimationWidget extends React.Component {
       <ErrorBoundary>
         {isPlaying && (
           <PlayQueue
-            loop={looping}
+            isLoopActive={looping}
             isPlaying={isPlaying}
             canPreloadAll={queueLength <= maxLength}
             currentDate={snappedCurrentDate}

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -574,7 +574,6 @@ class AnimationWidget extends React.Component {
       layers,
       hasCustomPalettes,
       promiseImageryForTime,
-      map,
       selectDate,
       currentDate,
       isGifActive,
@@ -616,7 +615,6 @@ class AnimationWidget extends React.Component {
             startDate={startDate}
             endDate={endDate}
             hasCustomPalettes={hasCustomPalettes}
-            map={map}
             maxQueueLength={maxLength}
             queueLength={queueLength}
             layers={layers}
@@ -845,7 +843,6 @@ AnimationWidget.propTypes = {
   isRotated: PropTypes.bool,
   layers: PropTypes.array,
   looping: PropTypes.bool,
-  map: PropTypes.object,
   maxDate: PropTypes.object,
   minDate: PropTypes.object,
   notify: PropTypes.func,

--- a/web/js/modules/animation/reducers.js
+++ b/web/js/modules/animation/reducers.js
@@ -23,7 +23,7 @@ export const defaultState = {
   gifActive: false,
   startDate: undefined,
   endDate: undefined,
-  boundares: undefined,
+  boundaries: undefined,
 };
 export function getInitialState(config) {
   return lodashAssign({}, defaultState, {


### PR DESCRIPTION
## Description

Fixes #3029 .

- [x] Add check for start date to fix animation hanging on loop reset
- [x] Add animation speed dependent timeout for adding dates to prevent rapid stream of dates that can cause the animation to run sluggishly trying to catch up with requests

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
