### PR TITLE
Fix map zoom buttons to prevent changes while animating, debounce main zoom change function, and constrain mouse wheel

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -798,6 +798,7 @@ export default function mapui(models, config, store, ui) {
         }),
         new OlInteractionMouseWheelZoom({
           duration: animationDuration,
+          constrainResolution: true,
         }),
         new OlInteractionDragZoom({
           duration: animationDuration,
@@ -910,6 +911,20 @@ export default function mapui(models, config, store, ui) {
     $zoomIn.mousemove((e) => e.stopPropagation());
 
     /*
+     * Debounce for below onZoomChange function
+     *
+     * @funct debouncedZoomChange
+     * @static
+     *
+     * @returns {void}
+     *
+     */
+    const debouncedZoomChange = () => {
+      onZoomChange();
+      self.events.trigger('movestart');
+    };
+
+    /*
      * Sets zoom buttons as active or inactive based
      * on the zoom level
      *
@@ -933,11 +948,7 @@ export default function mapui(models, config, store, ui) {
         $zoomOut.button('enable');
       }
     };
-
-    map.getView().on('change:resolution', () => {
-      onZoomChange();
-      self.events.trigger('movestart');
-    });
+    map.getView().on('change:resolution', lodashDebounce(debouncedZoomChange, 30));
     onZoomChange();
   }
 


### PR DESCRIPTION
## Description

Fixes #3052  .

- [x] Modify map zoom to break out if new zoom level is less than minimum or greater than maximum for that projection. Will floor zoom level in the event of quick clicks that return intermediary zoom level numbers. If zoom in/out button is clicked while the map view is animating, the newest click (if within a valid zoom range) will set animation duration to `0`. 
- [x] Debounce zoom change (prevents rapid invocations)
- [x] Constrain resolution zoom with mouse wheel  changes - this basically floors and prevents intermediary zoom level values (prevents edge case clicking zoom button and then using mouse wheel)

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
