### PR TITLE
fix issue with selecting granules near dateline

### DIFF
--- a/web/js/map/data/map.js
+++ b/web/js/map/data/map.js
@@ -350,9 +350,12 @@ export default function dataMap(store, maps, dataUi, ui) {
   };
 
   const clickCheck = function(event) {
+    const clickedFeatures = {};
     const pixel = map.getEventPixel(event.originalEvent);
     map.forEachFeatureAtPixel(pixel, (feature, layer) => {
-      if (feature.button) {
+      const id = feature.ol_uid;
+      if (feature.button && !clickedFeatures[id]) {
+        clickedFeatures[id] = true;
         store.dispatch(toggleGranule(feature.granule));
         hovering = false;
         hoverCheck(event);


### PR DESCRIPTION
## Description

Fixes #3054 

For some reason granules near the dateline were being returned twice by  OpenLayers in `forEachFeatureAtPixel`, causing them to be selected then immediately unselected when clicked once.  This fix is a little hacky (would be better to figure out why the feature is being iterated over twice) but, since we are moving away from data download soon this seemed to suffice.

@nasa-gibs/worldview
