### PR TITLE
Fix sources facet inconsistencies

### DIFF
--- a/web/js/modules/product-picker/format-config.js
+++ b/web/js/modules/product-picker/format-config.js
@@ -22,10 +22,10 @@ function setLayerProp (layer, prop, value) {
   if (!layer || featuredMeasurement) {
     return;
   }
-  if (layer[prop] && !layer[prop].includes(value)) {
-    layer[prop].push(value);
-  } else if (value) {
+  if (!layer[prop]) {
     layer[prop] = [value];
+  } else if (!layer[prop].includes(value)) {
+    layer[prop].push(value);
   }
 }
 

--- a/web/js/modules/product-picker/format-config.js
+++ b/web/js/modules/product-picker/format-config.js
@@ -34,7 +34,6 @@ function setMeasurementSourceFacetProps (layers, measurements) {
     lodashForEach(measureObj.sources, ({ settings = [] }, sourceKey) => {
       settings.forEach((id) => {
         setLayerProp(layers[id], 'measurements', measureKey);
-        setLayerProp(layers[id], 'sources', sourceKey);
       });
     });
   });
@@ -123,6 +122,7 @@ export default function buildLayerFacetProps(config, selectedDate) {
   return lodashMap(layers, (layer) => {
     setCoverageFacetProp(layer, selectedDate);
     setLayerPeriodFacetProps(layer);
+    setLayerProp(layer, 'sources', layer.subtitle);
     if (layer.daynight && layer.daynight.length) {
       if (typeof layer.daynight === 'string') {
         layer.daynight = [layer.daynight];


### PR DESCRIPTION
## Description

Fixes #3061 

Switched to use the `subtitle` to derive the sources facet since the same information is in this field and this approach produces more consistent facet choices.
