### PR TITLE
Measure ghost tooltip

### DIFF
--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -80,6 +80,7 @@ class MeasureButton extends React.Component {
           title="Measure distances &amp; areas"
           onTouchEnd={this.onButtonClick}
           onMouseDown={this.onButtonClick}
+          disabled={isActive}
         >
           <FontAwesomeIcon icon={faRuler} size="2x" />
         </Button>


### PR DESCRIPTION
## Description

Fixes #3072.

Disables the measure button when measuring is active.
