### PR TITLE
Prevent future dates from being selected in date state

### DIFF
--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -27,13 +27,19 @@ export function initSecondDate() {
 }
 export function selectDate(value) {
   return (dispatch, getState) => {
-    const compareState = getState().compare;
-    const activeString = compareState.isCompareA ? 'selected' : 'selectedB';
+    const state = getState();
+    const { compare, date } = state;
+    const activeString = compare.isCompareA ? 'selected' : 'selectedB';
+    const { appNow } = date;
+
+    const selectedDate = value > appNow
+      ? appNow
+      : value;
 
     dispatch({
       type: SELECT_DATE,
       activeString,
-      value,
+      value: selectedDate,
     });
   };
 }


### PR DESCRIPTION
## Description

Fixes #3081 .

- [x] Check if selected date `value` passed to update date state is in the future and if so use `appNow` instead. This mainly addresses natural event dates that are in the future.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
