### PR TITLE
Filter unknown layer ids from recent layers

### DIFF
--- a/web/js/modules/product-picker/util.js
+++ b/web/js/modules/product-picker/util.js
@@ -16,9 +16,11 @@ export function getRecentLayers(layerConfig, proj) {
     if (a.dateAdded > b.dateAdded) return 1;
     if (a.dateAdded < b.dateAdded) return -1;
   };
+
   const toLayerObj = ({ id }) => layerConfig[id];
+  const filterUnknownLayers = (layerDef) => layerDef !== undefined;
   const layers = JSON.parse(safeLocalStorage.getItem(RECENT_LAYERS));
-  return layers ? layers[proj].sort(byUse).map(toLayerObj) : [];
+  return layers ? layers[proj].sort(byUse).map(toLayerObj).filter(filterUnknownLayers) : [];
 }
 
 export function clearRecentLayers() {


### PR DESCRIPTION
## Description

Fixes #3002  .

- [x] Filter unknown layer ids from recent layers that aren't in current branch config. This is more of a development related fix when switching around different branches with varying configs.


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
