### PR TITLE
Fix social share e2e test date formatting

### DIFF
--- a/e2e/features/social/share-test.js
+++ b/e2e/features/social/share-test.js
@@ -35,8 +35,10 @@ module.exports = {
     const year = date.getUTCFullYear();
     const month = date.getUTCMonth() + 1;
     const day = date.getUTCDate();
+    const monthText = month < 10 ? `0${month}` : month;
+    const dayText = day < 10 ? `0${day}` : day;
     client.assert.not.urlContains('t=');
-    client.assert.attributeContains(socialLinkInput, 'value', `t=${year}-${month < 10 ? `0${month}` : month}-${day}`);
+    client.assert.attributeContains(socialLinkInput, 'value', `t=${year}-${monthText}-${dayText}`);
   },
   after(client) {
     client.end();


### PR DESCRIPTION
## Description

Fixes SIT/UAT related e2e failed social share test.

- [x] Add zero to days/months less than 10 in order to validate test date against test.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
