### PR TITLE
Patch tile size wms 512

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -566,6 +566,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
       tileGrid: new OlTileGridTileGrid({
         origin: start,
         resolutions: res,
+        tileSize: def.tileSize || [512, 512],
       }),
     };
     if (isPaletteActive(def.id, options.group, state)) {


### PR DESCRIPTION
## Description


Request larger images from `WMS` by default to prevent overloading of tile requests.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
