### PR TITLE
Remove constrainResolution on ol mouse wheel map ui

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -809,7 +809,6 @@ export default function mapui(models, config, store, ui) {
         }),
         new OlInteractionMouseWheelZoom({
           duration: animationDuration,
-          constrainResolution: true,
         }),
         new OlInteractionDragZoom({
           duration: animationDuration,


### PR DESCRIPTION
## Description

Fixes #3109  .

- [x] Remove `constrainResolution` on ol mouse wheel in map ui - defaults to false. 

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
