### PR TITLE
Wait for shortlink request to resolve

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -84,13 +84,14 @@ class ShareLinkContainer extends Component {
   onToggleShorten = () => {
     const { shortLinkKey, isShort, queryString } = this.state;
     if (!isShort && shortLinkKey !== queryString) {
-      this.getShortLink();
-      googleTagManager.pushEvent({
-        event: 'social_link_shorten',
-      });
-      this.setState({
-        shortLinkKey: queryString,
-        isShort: !isShort,
+      this.getShortLink().then(() => {
+        googleTagManager.pushEvent({
+          event: 'social_link_shorten',
+        });
+        this.setState({
+          shortLinkKey: queryString,
+          isShort: !isShort,
+        });
       });
     } else {
       this.setState({

--- a/web/mock/short_link.json
+++ b/web/mock/short_link.json
@@ -1,9 +1,9 @@
 {
-  "created_at": "2020-08-31T17:21:41+0000",
-  "id": "go.nasa.gov/3lzPmPt",
-  "link": "https://go.nasa.gov/3lzPmPt",
+  "created_at": "2020-09-14T17:25:47+0000",
+  "id": "go.nasa.gov/3mmrzmE",
+  "link": "https://go.nasa.gov/3mmrzmE",
   "custom_bitlinks": [],
-  "long_url": "https://worldview.uat.earthdata.nasa.gov/?l=Reference_Labels(hidden),Reference_Features(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor&t=2020-08-31-T17:05:22Z",
+  "long_url": "https://worldview.earthdata.nasa.gov/?t=2020-08-31-T17%3A05%3A22Z&l=Reference_Labels(hidden),Reference_Features(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor",
   "archived": false,
   "tags": [],
   "deeplinks": [],


### PR DESCRIPTION
## Description

Fixes #3107  .

- [x] Wait for shortlink request to resolve - breaking implementation didn't wait and caused props/state issues that relied on the shortlink when updating.
- [x] Remove a mock UAT reference and point to PROD instead. 

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
