### PR TITLE
change to wrapX for black marble/night lights layers

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/MODIS_Aqua_Data_No_Data.json
+++ b/config/default/common/config/wv.json/layers/reference/MODIS_Aqua_Data_No_Data.json
@@ -9,7 +9,8 @@
       "layergroup": [
         "reference"
       ],
-      "wrapadjacentdays": true,"tracks": [
+      "wrapadjacentdays": true,
+      "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],
       "daynight": [

--- a/config/default/common/config/wv.json/layers/viirs/VIIRS_Black_Marble.json
+++ b/config/default/common/config/wv.json/layers/viirs/VIIRS_Black_Marble.json
@@ -11,7 +11,7 @@
       ],
       "group": "baselayers",
       "inactive": true,
-      "wrapadjacentdays": true,
+      "wrapX": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/viirs/VIIRS_CityLights_2012.json
+++ b/config/default/common/config/wv.json/layers/viirs/VIIRS_CityLights_2012.json
@@ -11,7 +11,7 @@
       ],
       "group": "baselayers",
       "inactive": true,
-      "wrapadjacentdays": true,
+      "wrapX": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/viirs/VIIRS_Night_Lights.json
+++ b/config/default/common/config/wv.json/layers/viirs/VIIRS_Night_Lights.json
@@ -11,7 +11,7 @@
       ],
       "group": "overlays",
       "inactive": true,
-      "wrapadjacentdays": true,
+      "wrapX": true,
       "daynight": [
         "night"
       ]


### PR DESCRIPTION
## Description

Fixes #3114  .

Changed wrapadjacentdays to wrapX for Black Marble, Black Marble lights only, and Earth at Night 2012.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
