### PR TITLE
reversed sensor/satellite order

### DIFF
--- a/config/default/common/config/metadata/layers/amsua/BrightnessTemperature.md
+++ b/config/default/common/config/metadata/layers/amsua/BrightnessTemperature.md
@@ -1,4 +1,3 @@
 ### Brightness Temperature (Channel 01 - 15)
-AMSU-A/NOAA-15: 3 August 1998 - present
-AMSU-A/NOAA-16: 27 May 2001 - 3 March 2008
-AMSU-A/NOAA-17: 21 July 2002 - 28 October 2003
+NOAA-15/AMSU-A: 3 August 1998 - present; NOAA-16/AMSU-A: 27 May 2001 - 3 March 2008;
+NOAA-17/AMSU-A: 21 July 2002 - 28 October 2003

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_1.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_1.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_1": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_1",
       "title": "Brightness Temperature (Channel 01)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_1",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_10.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_10.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_10": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_10",
       "title": "Brightness Temperature (Channel 10)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_10",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_11.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_11.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_11": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_11",
       "title": "Brightness Temperature (Channel 11)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_11",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_12.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_12.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_12": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_12",
       "title": "Brightness Temperature (Channel 12)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_12",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_13.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_13.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_13": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_13",
       "title": "Brightness Temperature (Channel 13)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_13",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_14.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_14.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_14": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_14",
       "title": "Brightness Temperature (Channel 14)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_14",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_15.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_15.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_15": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_15",
       "title": "Brightness Temperature (Channel 15)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_15",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_2.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_2.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_2": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_2",
       "title": "Brightness Temperature (Channel 02)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_2",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_3.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_3.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_3": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_3",
       "title": "Brightness Temperature (Channel 03)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_3",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_4.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_4.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_4": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_4",
       "title": "Brightness Temperature (Channel 04)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_4",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_5.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_5.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_5": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_5",
       "title": "Brightness Temperature (Channel 05)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_5",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_6.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_6.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_6": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_6",
       "title": "Brightness Temperature (Channel 06)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_6",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_7.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_7.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_7": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_7",
       "title": "Brightness Temperature (Channel 07)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_7",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_8.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_8.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_8": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_8",
       "title": "Brightness Temperature (Channel 08)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_8",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_9.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA15_Brightness_Temp_Channel_9.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA15_Brightness_Temp_Channel_9": {
       "id": "AMSUA_NOAA15_Brightness_Temp_Channel_9",
       "title": "Brightness Temperature (Channel 09)",
-      "subtitle": "AMSU-A / NOAA-15",
+      "subtitle": "NOAA-15 / AMSU-A",
       "description": "amsua/AMSUA_NOAA15_Brightness_Temp_Channel_9",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_1.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_1.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_1": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_1",
       "title": "Brightness Temperature (Channel 01)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_1",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_10.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_10.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_10": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_10",
       "title": "Brightness Temperature (Channel 10)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_10",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_11.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_11.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_11": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_11",
       "title": "Brightness Temperature (Channel 11)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_11",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_12.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_12.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_12": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_12",
       "title": "Brightness Temperature (Channel 12)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_12",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_13.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_13.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_13": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_13",
       "title": "Brightness Temperature (Channel 13)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_13",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_14.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_14.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_14": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_14",
       "title": "Brightness Temperature (Channel 14)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_14",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_15.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_15.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_15": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_15",
       "title": "Brightness Temperature (Channel 15)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_15",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_2.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_2.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_2": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_2",
       "title": "Brightness Temperature (Channel 02)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_2",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_3.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_3.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_3": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_3",
       "title": "Brightness Temperature (Channel 03)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_3",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_4.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_4.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_4": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_4",
       "title": "Brightness Temperature (Channel 04)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_4",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_5.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_5.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_5": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_5",
       "title": "Brightness Temperature (Channel 05)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_5",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_6.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_6.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_6": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_6",
       "title": "Brightness Temperature (Channel 06)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_6",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_7.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_7.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_7": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_7",
       "title": "Brightness Temperature (Channel 07)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_7",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_8.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_8.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_8": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_8",
       "title": "Brightness Temperature (Channel 08)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_8",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_9.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA16_Brightness_Temp_Channel_9.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA16_Brightness_Temp_Channel_9": {
       "id": "AMSUA_NOAA16_Brightness_Temp_Channel_9",
       "title": "Brightness Temperature (Channel 09)",
-      "subtitle": "AMSU-A / NOAA-16",
+      "subtitle": "NOAA-16 / AMSU-A",
       "description": "amsua/AMSUA_NOAA16_Brightness_Temp_Channel_9",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_1.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_1.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_1": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_1",
       "title": "Brightness Temperature (Channel 01)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_1",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_10.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_10.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_10": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_10",
       "title": "Brightness Temperature (Channel 10)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_10",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_11.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_11.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_11": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_11",
       "title": "Brightness Temperature (Channel 11)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_11",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_12.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_12.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_12": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_12",
       "title": "Brightness Temperature (Channel 12)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_12",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_13.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_13.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_13": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_13",
       "title": "Brightness Temperature (Channel 13)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_13",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_14.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_14.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_14": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_14",
       "title": "Brightness Temperature (Channel 14)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_14",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_15.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_15.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_15": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_15",
       "title": "Brightness Temperature (Channel 15)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_15",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_2.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_2.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_2": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_2",
       "title": "Brightness Temperature (Channel 02)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_2",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_3.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_3.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_3": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_3",
       "title": "Brightness Temperature (Channel 03)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_3",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_4.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_4.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_4": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_4",
       "title": "Brightness Temperature (Channel 04)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_4",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_5.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_5.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_5": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_5",
       "title": "Brightness Temperature (Channel 05)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_5",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_6.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_6.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_6": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_6",
       "title": "Brightness Temperature (Channel 06)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_6",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_7.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_7.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_7": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_7",
       "title": "Brightness Temperature (Channel 07)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_7",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_8.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_8.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_8": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_8",
       "title": "Brightness Temperature (Channel 08)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_8",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_9.json
+++ b/config/default/common/config/wv.json/layers/amsua/AMSUA_NOAA17_Brightness_Temp_Channel_9.json
@@ -3,7 +3,7 @@
     "AMSUA_NOAA17_Brightness_Temp_Channel_9": {
       "id": "AMSUA_NOAA17_Brightness_Temp_Channel_9",
       "title": "Brightness Temperature (Channel 09)",
-      "subtitle": "AMSU-A / NOAA-17",
+      "subtitle": "NOAA-17 / AMSU-A",
       "description": "amsua/AMSUA_NOAA17_Brightness_Temp_Channel_9",
       "group": "overlays",
       "layergroup": [

--- a/config/default/common/config/wv.json/measurements/Brightness Temperature.json
+++ b/config/default/common/config/wv.json/measurements/Brightness Temperature.json
@@ -3,7 +3,7 @@
         "Brightness Temperature": {
             "id": "brightness-temperature",
             "title":    "Brightness Temperature",
-            "subtitle": "Aqua/AMSR-E, Aqua/MODIS, Terra/MODIS, GCOM-W1/AMSR2, GPM/GMI,  NOAA-20/VIIRS, TRMM, SMAP/Radar/Radiometer, Suomi NPP/VIIRS, AMSU-A/NOAA-15, AMSU-A/NOAA-16, AMSU-A/NOAA-17",
+            "subtitle": "Aqua/AMSR-E, Aqua/MODIS, Terra/MODIS, GCOM-W1/AMSR2, GPM/GMI,  NOAA-20/VIIRS, TRMM, SMAP/Radar/Radiometer, Suomi NPP/VIIRS, NOAA-15/AMSU-A, NOAA-16/AMSU-A, NOAA-17/AMSU-A",
             "sources": {
                 "Aqua/AMSR-E": {
                     "id": "aqua-amsre",
@@ -151,9 +151,9 @@
                         "OrbitTracks_Suomi_NPP_Descending"
                     ]
                 },
-                "AMSU-A/NOAA-15": {
-                    "id": "amsua-noaa15",
-                    "title": "AMSU-A/NOAA-15",
+                "NOAA-15/AMSU-A": {
+                    "id": "noaa15-amsua",
+                    "title": "NOAA-15/AMSU-A",
                     "description": "amsua/BrightnessTemperature",
                     "image": "",
                     "settings": [
@@ -174,9 +174,9 @@
                       "AMSUA_NOAA15_Brightness_Temp_Channel_15"
                     ]
                 },
-                "AMSU-A/NOAA-16": {
-                    "id": "amsua-noaa16",
-                    "title": "AMSU-A/NOAA-16",
+                "NOAA-16/AMSU-A": {
+                    "id": "noaa16-amsua",
+                    "title": "NOAA-16/AMSU-A",
                     "description": "amsua/BrightnessTemperature",
                     "image": "",
                     "settings": [
@@ -197,9 +197,9 @@
                       "AMSUA_NOAA16_Brightness_Temp_Channel_15"
                     ]
                 },
-                "AMSU-A/NOAA-17": {
-                    "id": "amsua-noaa17",
-                    "title": "AMSU-A/NOAA-17",
+                "NOAA-17/AMSU-A": {
+                    "id": "noaa17-amsua",
+                    "title": "NOAA-17/AMSU-A",
                     "description": "amsua/BrightnessTemperature",
                     "image": "",
                     "settings": [


### PR DESCRIPTION
## Description

Fixes #3116  .

Reverse sensor/satellite to the correct satellite/sensor order for the AMSU-A layers. 

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
