### PR TITLE
Fix mobile date picker button heights to fit within group container

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -716,6 +716,12 @@ button:focus {
   border-radius: 5px;
   cursor: pointer;
   height: 44px;
+
+  & .button-action-group {
+    height: 37px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+  }
 }
 
 .datepicker.android-dark .datepicker-header {


### PR DESCRIPTION

## Description

Fixes #3119  .

- [x] Fix mobile date picker button heights to fit within group container
- [x] Round button corners to keep with rounded mobile styling

Test by comparing moible date picker buttons in PROD to this branch - white underlying areas of the map make the issue more apparent.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
