### PR TITLE
Layer specific notifications

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -12,7 +12,7 @@
             "id": "GTM-WNP7MLF"
         },
         "notification": {
-            "url": "https://status.earthdata.nasa.gov/api/v1/notifications?domain=https%3A%2F%2Fworldview.earthdata.nasa.gov",
+            "url": "https://status.earthdata.nasa.gov/api/v1/notifications",
             "releases": "https://github.com/nasa-gibs/worldview/releases"
         },
         "imageDownload": {

--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -1,7 +1,7 @@
 const TIME_LIMIT = 30000;
 const mockParam = '?mockAlerts=';
 const layerNoticesTestParams = '?l=Coastlines,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
-const { addLayers, categoriesNav } = require('../../reuseables/selectors.js');
+const { addLayers, layersSearchField, categoriesNav } = require('../../reuseables/selectors.js');
 
 // Selectors
 const infoButton = '#wv-info-button';
@@ -80,7 +80,7 @@ module.exports = {
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
   },
-  'Verify that warning shows in the product picker next to the layers which have notices': function(c) {
+  'Verify that warning shows in the product picker category/measurement rows': function(c) {
     c.click(addLayers);
     c.waitForElementVisible(categoriesNav, TIME_LIMIT);
     c.click('#layer-category-item-air-quality-corrected-reflectance');
@@ -94,6 +94,15 @@ module.exports = {
     c.moveToElement('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', 5, 5);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
+  },
+  'Verify that warning shows in the product picker search results rows': function(c) {
+    c.setValue(layersSearchField, 'MODIS_Aqua_CorrectedReflectance_TrueColor');
+    c.waitForElementVisible('#MODIS_Aqua_CorrectedReflectance_TrueColor-search-row', TIME_LIMIT);
+    c.expect.element('#MODIS_Aqua_CorrectedReflectance_TrueColor-notice-info').present;
+    c.moveToElement('#MODIS_Aqua_CorrectedReflectance_TrueColor-notice-info', 5, 5);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
+    c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
   },
   after(c) {
     c.end();

--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -91,7 +91,7 @@ module.exports = {
 
     c.click('#terra-modis-4-source-Nav');
     c.waitForElementVisible('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', TIME_LIMIT);
-    c.moveToElement('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', 2, 2);
+    c.moveToElement('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', 5, 5);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
   },

--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -67,7 +67,6 @@ module.exports = {
   },
 
   // Layer notice tests
-  // TODO confirm that notices in UAT don't affect this test (e.g. that mock notifications override them)
   'Verify that zots show for the layers that have notices': function(c) {
     c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
     c.expect.element(aquaZot).to.be.present;

--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -1,81 +1,102 @@
 const TIME_LIMIT = 30000;
 const mockParam = '?mockAlerts=';
+const layerNoticesTestParams = '?l=Coastlines,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
+const { addLayers, categoriesNav } = require('../../reuseables/selectors.js');
+
 // Selectors
 const infoButton = '#wv-info-button';
 const infoButtonIcon = '#wv-info-button svg.svg-inline--fa';
 const infoMenu = '#toolbar_info';
 const giftListItem = '#toolbar_info li.gift';
 const boltListItem = '#toolbar_info li.bolt';
-const exclamationListItem = '#notifications_info_item .fa-exclamation-circle';
+const notificationsListItem = '#notifications_info_item .fa-exclamation-circle';
 const alertContentHightlighted = '#notification_list_modal .alert-notification-item';
 const outageContentHightlighted = '#notification_list_modal .outage-notification-item';
 const messageContentHightlighted = '#notification_list_modal .message-notification-item';
+const aquaNotice = 'The Aqua / MODIS Corrected Reflectance (True Color) layer is currently unavailable.';
+const aquaTerraNotice = 'Several Aqua and Terra MODIS layers are experiencing delays in processing.';
+const tooltipSelector = '.tooltip-inner div';
+const aquaZot = '#MODIS_Aqua_CorrectedReflectance_TrueColor-zot';
+const terraZot = '#MODIS_Terra_CorrectedReflectance_TrueColor-zot';
 
 module.exports = {
-  'No visible notifications with mockAlert parameter set to no_types': function(
-    client,
-  ) {
-    client.url(`${client.globals.url + mockParam}no_types`);
-    client.waitForElementVisible(infoButtonIcon, TIME_LIMIT, () => {
-      client.useCss().click(infoButtonIcon);
-      client.pause(2000);
-      client
-        .useCss()
-        .expect.element(infoMenu)
-        .text.not.contains('Notifications');
-      client.expect.element(giftListItem).to.not.be.present;
-      client.expect.element(boltListItem).to.not.be.present;
-    });
+  'No visible notifications with mockAlert parameter set to no_types': function(c) {
+    c.url(`${c.globals.url + mockParam}no_types`);
+    c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
+    c.click(infoButtonIcon);
+    c.pause(2000);
+    c.expect.element(infoMenu).text.not.contains('Notifications');
+    c.expect.element(giftListItem).to.not.be.present;
+    c.expect.element(boltListItem).to.not.be.present;
   },
-  'Outage takes precedence when all three notifications are present': function(
-    client,
-  ) {
-    client.url(`${client.globals.url + mockParam}all_types`);
-    client.waitForElementVisible(infoButtonIcon, TIME_LIMIT, () => {
-      client.expect.element(`${infoButton}.wv-status-outage`).to.be.present;
-      client.useCss().click(infoButtonIcon);
-      client.pause(2000);
-      client.useCss().assert.containsText(infoMenu, 'Notifications');
-      client.expect.element(exclamationListItem).to.be.present;
-    });
+  'Outage takes precedence when all three notifications are present': function(c) {
+    c.url(`${c.globals.url + layerNoticesTestParams}&mockAlerts=all_types`);
+    c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
+    c.expect.element(`${infoButton}.wv-status-outage`).to.be.present;
+    c.click(infoButtonIcon);
+    c.pause(2000);
+    c.assert.containsText(infoMenu, 'Notifications');
+    c.expect.element(notificationsListItem).to.be.present;
   },
-  'alert, outage, and message content is highlighted and found in modal': function(
-    client,
-  ) {
-    client.useCss().click(exclamationListItem);
-    client.waitForElementVisible(outageContentHightlighted, TIME_LIMIT, () => {
-      client
-        .useCss()
-        .assert.containsText(
-          `${outageContentHightlighted} span`,
-          'Posted 20 May 2018',
-        );
-      client
-        .useCss()
-        .assert.containsText(
-          `${alertContentHightlighted} p`,
-          'learn how to visualize global satellite imagery',
-        );
-      client
-        .useCss()
-        .assert.containsText(
-          `${messageContentHightlighted} p`,
-          'This is a message test',
-        );
-    });
+  'Verify that layer notices don\'t show up in the nofication list or contribute to the count': function(c) {
+    c.waitForElementVisible('#notifications_info_item', TIME_LIMIT);
+    c.expect.element('span.badge').to.be.present;
+    c.assert.containsText('span.badge', '3');
   },
-  'Verify that the user is only alerted if he has not already stored all items in localStorage': function(
-    client,
-  ) {
-    client
-      .useCss()
-      .click('#notification_list_modal .close')
+  'alert, outage, and message content is highlighted and found in modal': function(c) {
+    c.click(notificationsListItem);
+    c.waitForElementVisible(outageContentHightlighted, TIME_LIMIT);
+    c.assert.containsText(
+      `${outageContentHightlighted} span`,
+      'Posted 20 May 2018',
+    );
+    c.assert.containsText(
+      `${alertContentHightlighted} p`,
+      'learn how to visualize global satellite imagery',
+    );
+    c.assert.containsText(
+      `${messageContentHightlighted} p`,
+      'This is a message test',
+    );
+  },
+  'Verify that the user is only alerted if he has not already stored all items in localStorage': function(c) {
+    c.click('#notification_list_modal .close')
       .pause(500);
-    client.waitForElementVisible(infoButtonIcon, TIME_LIMIT, () => {
-      client.expect.element(`${infoButton}.wv-status-hide`).to.be.present;
-    });
+    c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
+    c.expect.element(`${infoButton}.wv-status-hide`).to.be.present;
   },
-  after(client) {
-    client.end();
+
+  // Layer notice tests
+  // TODO confirm that notices in UAT don't affect this test (e.g. that mock notifications override them)
+  'Verify that zots show for the layers that have notices': function(c) {
+    c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
+    c.expect.element(aquaZot).to.be.present;
+    c.moveToElement(aquaZot, 2, 2);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
+    c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
+
+    c.expect.element(terraZot).to.be.present;
+    c.moveToElement(terraZot, 2, 2);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
+    c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
+  },
+  'Verify that warning shows in the product picker next to the layers which have notices': function(c) {
+    c.click(addLayers);
+    c.waitForElementVisible(categoriesNav, TIME_LIMIT);
+    c.click('#layer-category-item-air-quality-corrected-reflectance');
+    c.moveToElement('#checkbox-case-MODIS_Aqua_CorrectedReflectance_TrueColor', 2, 2);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
+    c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
+
+    c.click('#terra-modis-4-source-Nav');
+    c.waitForElementVisible('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', TIME_LIMIT);
+    c.moveToElement('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', 2, 2);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
+    c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
+  },
+  after(c) {
+    c.end();
   },
 };

--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -198,15 +198,20 @@
 
 .layers-all-layer.search-row {
   padding: 8px 5px;
+
   .layer-notice-icon {
     color: #eee;
+    height: 24px;
     width: 24px;
-    height: 18px;
+    display: inline;
     position: absolute;
-    right: 6px;
+    left: 40px;
   }
   .layers-all-header {
-    padding: 0 35px 0 40px;
+    padding: 0 0 0 40px;
+    &.notice {
+      padding: 0 0 0 70px;
+    }
   }
   &:hover {
     .wv-checkbox::before {

--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -203,10 +203,10 @@
     width: 24px;
     height: 18px;
     position: absolute;
-    bottom: 6px;
+    right: 6px;
   }
   .layers-all-header {
-    padding: 0 0 0 40px;
+    padding: 0 35px 0 40px;
   }
   &:hover {
     .wv-checkbox::before {

--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -38,6 +38,9 @@
     border-top: 1px solid #ddd;
     border-bottom: 1px solid #ddd;
     border-right: 1px solid #ddd;
+    & .layer-notice-icon {
+      color: #666;
+    }
     & .layers-all-header > h3 {
       transition: all 200ms ease;
       color: #000;
@@ -195,6 +198,13 @@
 
 .layers-all-layer.search-row {
   padding: 8px 5px;
+  .layer-notice-icon {
+    color: #eee;
+    width: 24px;
+    height: 18px;
+    position: absolute;
+    bottom: 6px;
+  }
   .layers-all-header {
     padding: 0 0 0 40px;
   }

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -116,7 +116,9 @@
     position: relative;
     left: 0;
     height: 50px;
-    font-size: 16px;
+    span {
+      font-size: 18px;
+    }
   }
 
   #selected-category .ui-tabs-panel {

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -424,8 +424,11 @@ li.item.productsitem.inmotion,
   display: block;
 }
 
-.zot-tooltip .tooltip-inner div {
-  margin: 6px 0;
+.zot-tooltip .tooltip-inner {
+  max-width: 300px;
+  div {
+    margin: 6px 0;
+  }
 }
 
 .productsitem a.button.wv-layers-close {

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -388,6 +388,12 @@ li.item.productsitem.inmotion,
   background: #dacf00;
   cursor: default;
   display: none;
+  &.layer-notice {
+    background-color: #f90;
+    &:hover {
+      background: #ff6900;
+    }
+  }
   &:hover {
     background: #fff200;
   }

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -425,9 +425,10 @@ li.item.productsitem.inmotion,
 }
 
 .zot-tooltip .tooltip-inner {
-  max-width: 300px;
+  max-width: 280px;
   div {
-    margin: 6px 0;
+    margin: 8px 0;
+    line-height: 16px;
   }
 }
 

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -388,25 +388,27 @@ li.item.productsitem.inmotion,
   background: #dacf00;
   cursor: default;
   display: none;
-}
-
-.productsitem div.zot:hover {
-  background: #fff200;
-}
-
-.productsitem div.zot b {
-  text-align: center;
-  height: 20px;
-  line-height: 20px;
-  position: absolute;
-  top: 50%;
-  left: 0;
-  right: 0;
-  margin-top: -10px;
+  &:hover {
+    background: #fff200;
+  }
+  b {
+    text-align: center;
+    height: 20px;
+    line-height: 20px;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    margin-top: -10px;
+  }
 }
 
 .productsitem.zotted div.zot {
   display: block;
+}
+
+.zot-tooltip div {
+  margin: 6px 0;
 }
 
 .productsitem a.button.wv-layers-close {

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -496,3 +496,41 @@ li.item.productsitem.inmotion,
 .productsitem.disabled.layer-hidden a.hdanchor:hover svg.svg-inline--fa {
   color: #c5c5c8;
 }
+
+@media (max-width: 739px) {
+  .sidebar-panel li.item {
+    h4 {
+      font-size: 16px;
+      padding: 6px 4px 4px;
+    }
+    p {
+      font-size: 12px;
+    }
+  }
+
+  .productsitem {
+    .layer-main {
+      margin-left: 45px;
+    }
+    div.zot {
+      margin-left: 45px;
+      width: 32px;
+      b {
+        font-size: 22px;
+      }
+    }
+    &.zotted .layer-main {
+      margin-left: 78px;
+    }
+    .layer-info {
+      min-height: 44px;
+    }
+    .layer-eye-icon {
+      top: 18px;
+      font-size: 26px;
+    }
+    a.hdanchor.hideReg {
+      width: 44px;
+    }
+  }
+}

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -385,17 +385,28 @@ li.item.productsitem.inmotion,
   top: 0;
   bottom: 0;
   width: 10px;
-  background: #dacf00;
+
   cursor: default;
   display: none;
+  &.overzoom {
+    background: #dacf00;
+    &:hover {
+      background: #fff200;
+    }
+  }
   &.layer-notice {
-    background-color: #f90;
+    background-color: #f60;
     &:hover {
       background: #ff6900;
     }
   }
-  &:hover {
-    background: #fff200;
+  &.overzoom.layer-notice {
+    background: #f60;
+    background: linear-gradient(280deg, rgba(255, 102, 0, 0.9) 40%, rgba(255, 252, 3, 0.9) 60%);
+    &:hover {
+      background: #e50;
+      background: linear-gradient(280deg, rgba(255, 102, 0, 1) 40%, rgba(255, 252, 3, 1) 60%);
+    }
   }
   b {
     text-align: center;

--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -407,7 +407,7 @@ li.item.productsitem.inmotion,
   display: block;
 }
 
-.zot-tooltip div {
+.zot-tooltip .tooltip-inner div {
   margin: 6px 0;
 }
 

--- a/web/js/components/layer/product-picker/browse/category-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/category-layer-row.js
@@ -92,7 +92,7 @@ class CategoryLayerRow extends React.Component {
       <div>
         {LayerSouceList.length > 0
           ? (
-            <ListGroup className="source-settings source-sub-group">
+            <ListGroup className="source-sub-group">
               {LayerSouceList}
             </ListGroup>
           )

--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -31,8 +31,8 @@ function MeasurementLayerRow (props) {
     selectedDate,
     layerNotices,
   } = props;
-  const layerIsAvailable = available(layer.id, selectedDate, [layer]);
-  const listItemClass = !layerIsAvailable || layerNotices ? 'unavailable' : '';
+  const layerIsUnavailable = !available(layer.id, selectedDate, [layer]);
+  const listItemClass = layerIsUnavailable || layerNotices ? 'unavailable' : '';
   // Replace periods in id since period causes issue with tooltip targeting
   const itemElementId = `checkbox-case-${layer.id.split('.').join('-')}`;
   const checkboxId = `${layer.id.split('.').join('-')}-checkbox`;
@@ -59,18 +59,19 @@ function MeasurementLayerRow (props) {
         label={title}
         classNames="settings-check"
       >
-        {!layerIsAvailable && (<FontAwesomeIcon icon={faBan} id="availability-info" />)}
+        {layerIsUnavailable && (<FontAwesomeIcon icon={faBan} id="availability-info" />)}
         {layerNotices && (<FontAwesomeIcon icon={faExclamationTriangle} id="notice-info" />)}
-        {(layerNotices || !layerIsAvailable) && (
+        {(layerNotices || layerIsUnavailable) && (
           <UncontrolledTooltip
             target={itemElementId}
+            boundariesElement="window"
             className="zot-tooltip"
-            placement="top"
+            placement="right"
             trigger="hover"
             autohide={isMobile}
-            delay={isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 }}
+            delay={isMobile ? { show: 300, hide: 300 } : { show: 50, hide: 300 }}
           >
-            {!layerIsAvailable && (
+            {layerIsUnavailable && (
               <div>
                 This layer has no visible content on the selected date:
                 <br />
@@ -79,9 +80,7 @@ function MeasurementLayerRow (props) {
                 </span>
               </div>
             )}
-            {layerNotices
-              ? (<div dangerouslySetInnerHTML={{ __html: layerNotices }} />)
-              : ''}
+            {layerNotices && (<div dangerouslySetInnerHTML={{ __html: layerNotices }} />)}
           </UncontrolledTooltip>
         )}
       </Checkbox>

--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -19,7 +19,7 @@ import { getLayerNoticesForLayer } from '../../../../modules/notifications/util'
  * @class LayerList
  * @extends React.Component
  */
-export function MeasurementLayerRow (props) {
+function MeasurementLayerRow (props) {
   const {
     isEnabled, removeLayer, addLayer, layer, measurementId, title, selectedDate, layerNotices,
   } = props;

--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { ListGroupItem, Tooltip } from 'reactstrap';
+import { ListGroupItem, UncontrolledTooltip } from 'reactstrap';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBan, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
@@ -21,9 +21,16 @@ import { getLayerNoticesForLayer } from '../../../../modules/notifications/util'
  */
 function MeasurementLayerRow (props) {
   const {
-    isEnabled, removeLayer, addLayer, layer, measurementId, title, selectedDate, layerNotices,
+    isEnabled,
+    isMobile,
+    removeLayer,
+    addLayer,
+    layer,
+    measurementId,
+    title,
+    selectedDate,
+    layerNotices,
   } = props;
-  const [tooltipVisible, toggleTooltip] = useState(false);
   const layerIsAvailable = available(layer.id, selectedDate, [layer]);
   const listItemClass = !layerIsAvailable || layerNotices ? 'unavailable' : '';
   // Replace periods in id since period causes issue with tooltip targeting
@@ -55,12 +62,13 @@ function MeasurementLayerRow (props) {
         {!layerIsAvailable && (<FontAwesomeIcon icon={faBan} id="availability-info" />)}
         {layerNotices && (<FontAwesomeIcon icon={faExclamationTriangle} id="notice-info" />)}
         {(layerNotices || !layerIsAvailable) && (
-          <Tooltip
+          <UncontrolledTooltip
+            target={itemElementId}
             className="zot-tooltip"
             placement="top"
-            isOpen={tooltipVisible}
-            target={itemElementId}
-            toggle={() => toggleTooltip(!tooltipVisible)}
+            trigger="hover"
+            autohide={isMobile}
+            delay={isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 }}
           >
             {!layerIsAvailable && (
               <div>
@@ -74,7 +82,7 @@ function MeasurementLayerRow (props) {
             {layerNotices
               ? (<div dangerouslySetInnerHTML={{ __html: layerNotices }} />)
               : ''}
-          </Tooltip>
+          </UncontrolledTooltip>
         )}
       </Checkbox>
     </ListGroupItem>
@@ -84,6 +92,7 @@ function MeasurementLayerRow (props) {
 MeasurementLayerRow.propTypes = {
   addLayer: PropTypes.func,
   isEnabled: PropTypes.bool,
+  isMobile: PropTypes.bool,
   layer: PropTypes.object,
   layerNotices: PropTypes.string,
   measurementId: PropTypes.string,
@@ -93,11 +102,12 @@ MeasurementLayerRow.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const { notifications } = state;
+  const { notifications, browser } = state;
   const activeLayerMap = getActiveLayers(state);
   const { id } = ownProps.layer;
   return {
     isEnabled: !!activeLayerMap[id],
+    isMobile: browser.lessThan.medium,
     selectedDate: getSelectedDate(state),
     layerNotices: getLayerNoticesForLayer(id, notifications),
   };

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -91,6 +91,7 @@ class SearchLayerRow extends React.Component {
   render() {
     const {
       isEnabled,
+      isMobile,
       layer,
       selectedLayer,
       categoryType,
@@ -125,6 +126,9 @@ class SearchLayerRow extends React.Component {
               className="zot-tooltip"
               placement="top"
               target={`${id}-notice-info`}
+              trigger="hover"
+              autohide={isMobile}
+              delay={isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 }}
             >
               <div dangerouslySetInnerHTML={{ __html: layerNotices }} />
             </UncontrolledTooltip>
@@ -163,7 +167,7 @@ SearchLayerRow.propTypes = {
   isEnabled: PropTypes.bool,
   isMobile: PropTypes.bool,
   layer: PropTypes.object,
-  layerNotices: PropTypes.array,
+  layerNotices: PropTypes.string,
   removeLayer: PropTypes.func,
   scrollIntoView: PropTypes.bool,
   selectedLayer: PropTypes.object,

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -106,6 +106,9 @@ class SearchLayerRow extends React.Component {
       : 'search-row layers-all-layer';
     const checkboxClass = isEnabled ? 'wv-checkbox checked' : 'wv-checkbox';
     const recentLayerMode = categoryType === 'recent';
+    const headerClassName = layerNotices
+      ? 'layers-all-header notice'
+      : 'layers-all-header';
 
     return (
       <div
@@ -115,8 +118,17 @@ class SearchLayerRow extends React.Component {
         onMouseEnter={() => this.toggleDeleteIcon(true)}
         onMouseLeave={() => this.toggleDeleteIcon(false)}
       >
+        <div className={checkboxClass}>
+          <input
+            type="checkbox"
+            id={`${id}-checkbox`}
+            name={`${id}-checkbox`}
+            checked={isEnabled}
+            onChange={this.toggleEnabled}
+          />
+        </div>
         {layerNotices && (
-          <>
+          <div className="layer-notice-wrapper">
             <FontAwesomeIcon
               id={`${id}-notice-info`}
               className="layer-notice-icon"
@@ -132,18 +144,9 @@ class SearchLayerRow extends React.Component {
             >
               <div dangerouslySetInnerHTML={{ __html: layerNotices }} />
             </UncontrolledTooltip>
-          </>
+          </div>
         )}
-        <div className={checkboxClass}>
-          <input
-            type="checkbox"
-            id={`${id}-checkbox`}
-            name={`${id}-checkbox`}
-            checked={isEnabled}
-            onChange={this.toggleEnabled}
-          />
-        </div>
-        <div className="layers-all-header" onClick={this.toggleShowMetadata}>
+        <div className={headerClassName} onClick={this.toggleShowMetadata}>
           <RenderSplitLayerTitle layer={layer} />
           {recentLayerMode && showDeleteIcon && (
             <Button

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -140,7 +140,7 @@ class SearchLayerRow extends React.Component {
               target={`${id}-notice-info`}
               trigger="hover"
               autohide={isMobile}
-              delay={isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 }}
+              delay={isMobile ? { show: 300, hide: 300 } : { show: 50, hide: 300 }}
             >
               <div dangerouslySetInnerHTML={{ __html: layerNotices }} />
             </UncontrolledTooltip>

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { Button } from 'reactstrap';
+import { faTrash, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { Button, UncontrolledTooltip } from 'reactstrap';
 import {
   addLayer as addLayerAction,
   removeLayer as removeLayerAction,
@@ -14,6 +14,7 @@ import {
 import { getActiveLayers } from '../../../../modules/layers/selectors';
 import RenderSplitLayerTitle from '../renderSplitTitle';
 import getSelectedDate from '../../../../modules/date/selectors';
+import { getLayerNoticesForLayer } from '../../../../modules/notifications/util';
 
 /**
  * A single layer search result row
@@ -89,7 +90,12 @@ class SearchLayerRow extends React.Component {
 
   render() {
     const {
-      isEnabled, layer, selectedLayer, categoryType, clearSingleRecentLayer,
+      isEnabled,
+      layer,
+      selectedLayer,
+      categoryType,
+      clearSingleRecentLayer,
+      layerNotices,
     } = this.props;
     const { showDeleteIcon } = this.state;
     const { id } = layer;
@@ -108,6 +114,22 @@ class SearchLayerRow extends React.Component {
         onMouseEnter={() => this.toggleDeleteIcon(true)}
         onMouseLeave={() => this.toggleDeleteIcon(false)}
       >
+        {layerNotices && (
+          <>
+            <FontAwesomeIcon
+              id={`${id}-notice-info`}
+              className="layer-notice-icon"
+              icon={faExclamationTriangle}
+            />
+            <UncontrolledTooltip
+              className="zot-tooltip"
+              placement="top"
+              target={`${id}-notice-info`}
+            >
+              <div dangerouslySetInnerHTML={{ __html: layerNotices }} />
+            </UncontrolledTooltip>
+          </>
+        )}
         <div className={checkboxClass}>
           <input
             type="checkbox"
@@ -141,6 +163,7 @@ SearchLayerRow.propTypes = {
   isEnabled: PropTypes.bool,
   isMobile: PropTypes.bool,
   layer: PropTypes.object,
+  layerNotices: PropTypes.array,
   removeLayer: PropTypes.func,
   scrollIntoView: PropTypes.bool,
   selectedLayer: PropTypes.object,
@@ -148,13 +171,14 @@ SearchLayerRow.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const { productPicker, browser } = state;
+  const { productPicker, browser, notifications } = state;
   const activeLayerMap = getActiveLayers(state);
   const { categoryType, selectedLayer } = productPicker;
   return {
     scrollIntoView: browser.screenWidth < 1024,
     isEnabled: !!activeLayerMap[ownProps.layer.id],
     isMobile: browser.lessThan.medium,
+    layerNotices: getLayerNoticesForLayer(ownProps.layer.id, notifications),
     selectedDate: getSelectedDate(state),
     selectedLayer,
     categoryType,

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -1,29 +1,45 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import googleTagManager from 'googleTagManager';
 import {
   openCustomContent,
 } from '../modules/modal/actions';
-import toggleDistractionFreeMode from '../modules/ui/actions';
+import toggleDistractionFreeModeAction from '../modules/ui/actions';
 import AboutPage from '../components/about/about-page';
 import IconList from '../components/util/list';
 import onClickFeedback from '../modules/feedback/util';
 import { addToLocalStorage } from '../modules/notifications/util';
 
 import initFeedback from '../modules/feedback/actions';
-import { startTour, endTour } from '../modules/tour/actions';
+import {
+  startTour as startTourAction,
+  endTour as endTourAction,
+} from '../modules/tour/actions';
 import { notificationsSeen } from '../modules/notifications/actions';
 import Notifications from './notifications';
 
-class InfoList extends Component {
-  getNotificationListItem(obj) {
-    const { notifications, notificationClick } = this.props;
-    const { number, type, object } = notifications;
+function InfoList (props) {
+  const {
+    sendFeedback,
+    feedbackIsInitiated,
+    aboutClick,
+    config,
+    startTour,
+    isDistractionFreeModeActive,
+    isTourActive,
+    isMobile,
+    toggleDistractionFreeMode,
+    notifications,
+    notificationClick,
+  } = props;
 
+  function getNotificationListItem(obj) {
+    const { number, type, object } = notifications;
     return {
       text: 'Notifications',
       iconClass: 'ui-icon',
+      // eslint-disable-next-line no-nested-ternary
       iconName: type === 'message'
         ? 'faGift'
         : type === 'outage'
@@ -38,19 +54,7 @@ class InfoList extends Component {
     };
   }
 
-  getListArray() {
-    const {
-      sendFeedback,
-      feedbackIsInitiated,
-      aboutClick,
-      notifications,
-      config,
-      startTour,
-      isDistractionFreeModeActive,
-      isTourActive,
-      isMobile,
-      toggleDistractionFreeMode,
-    } = this.props;
+  function getListArray() {
     const distractionFreeObj = {
       text: isDistractionFreeModeActive ? 'Exit Distraction Free' : 'Distraction Free',
       iconClass: 'ui-icon',
@@ -125,36 +129,35 @@ class InfoList extends Component {
         arr.push(distractionFreeObj);
       }
       if (notifications.isActive) {
-        const obj = this.getNotificationListItem();
-        arr.splice(4, 0, obj);
+        arr.splice(4, 0, getNotificationListItem());
       }
       return arr;
     }
     return [distractionFreeObj];
   }
 
-  render() {
-    const infoArray = this.getListArray();
-    return <IconList list={infoArray} size="small" />;
-  }
+
+  return (<IconList list={getListArray()} size="small" />);
 }
 
 function mapStateToProps(state) {
-  const { isInitiated } = state.feedback;
+  const {
+    ui, feedback, tour, notifications, config, models, browser,
+  } = state;
 
   return {
-    feedbackIsInitiated: isInitiated,
-    isDistractionFreeModeActive: state.ui.isDistractionFreeModeActive,
-    isTourActive: state.tour.active,
-    notifications: state.notifications,
-    config: state.config,
-    models: state.models,
-    isMobile: state.browser.lessThan.medium,
+    feedbackIsInitiated: feedback.isInitiated,
+    isDistractionFreeModeActive: ui.isDistractionFreeModeActive,
+    isTourActive: tour.active,
+    notifications,
+    config,
+    models,
+    isMobile: browser.lessThan.medium,
   };
 }
 const mapDispatchToProps = (dispatch) => ({
   toggleDistractionFreeMode: () => {
-    dispatch(toggleDistractionFreeMode());
+    dispatch(toggleDistractionFreeModeAction());
   },
   sendFeedback: (isInitiated) => {
     onClickFeedback(isInitiated);
@@ -178,12 +181,12 @@ const mapDispatchToProps = (dispatch) => ({
   },
   startTour: (isTourActive) => {
     if (isTourActive) {
-      dispatch(endTour());
+      dispatch(endTourAction());
       setTimeout(() => {
-        dispatch(startTour());
+        dispatch(startTourAction());
       }, 100);
     } else {
-      dispatch(startTour());
+      dispatch(startTourAction());
     }
   },
   aboutClick: () => {

--- a/web/js/containers/notifications.js
+++ b/web/js/containers/notifications.js
@@ -6,22 +6,30 @@ import { getNumberOfTypeNotSeen } from '../modules/notifications/util';
 
 const Notifications = (props) => {
   const { object } = props;
+  const {
+    messages, outages, alerts, layerNotices,
+  } = object;
   return (
     <div className="wv-notify-modal">
       <NotificationBlock
-        arr={object.outages}
+        arr={outages}
         type="outage"
-        numberNotSeen={getNumberOfTypeNotSeen('outage', object.outages)}
+        numberNotSeen={getNumberOfTypeNotSeen('outage', outages)}
       />
       <NotificationBlock
-        arr={object.alerts}
+        arr={alerts}
         type="alert"
-        numberNotSeen={getNumberOfTypeNotSeen('alert', object.alerts)}
+        numberNotSeen={getNumberOfTypeNotSeen('alert', alerts)}
       />
       <NotificationBlock
-        arr={object.messages}
+        arr={messages}
         type="message"
-        numberNotSeen={getNumberOfTypeNotSeen('message', object.messages)}
+        numberNotSeen={getNumberOfTypeNotSeen('message', messages)}
+      />
+      <NotificationBlock
+        arr={layerNotices}
+        type="message"
+        numberNotSeen={getNumberOfTypeNotSeen('layerNotices', layerNotices)}
       />
     </div>
   );

--- a/web/js/containers/notifications.js
+++ b/web/js/containers/notifications.js
@@ -7,7 +7,7 @@ import { getNumberOfTypeNotSeen } from '../modules/notifications/util';
 const Notifications = (props) => {
   const { object } = props;
   const {
-    messages, outages, alerts, layerNotices,
+    messages, outages, alerts,
   } = object;
   return (
     <div className="wv-notify-modal">
@@ -25,11 +25,6 @@ const Notifications = (props) => {
         arr={messages}
         type="message"
         numberNotSeen={getNumberOfTypeNotSeen('message', messages)}
-      />
-      <NotificationBlock
-        arr={layerNotices}
-        type="message"
-        numberNotSeen={getNumberOfTypeNotSeen('layerNotices', layerNotices)}
       />
     </div>
   );

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -132,7 +132,7 @@ class LayerList extends React.Component {
                     key={object.id}
                     index={i}
                     layerClasses="item productsitem"
-                    zot={zots[object.id] ? zots[object.id].value : null}
+                    zot={zots[object.id]}
                     names={getNames(object.id)}
                     checkerBoardPattern={checkerBoardPattern}
                     isDisabled={!available(object.id)}
@@ -186,7 +186,7 @@ function mapStateToProps(state, ownProps) {
   const { id } = proj;
   const activeLayers = state.layers[layerGroupName];
   const zots = lodashGet(map, 'ui.selected')
-    ? getZotsForActiveLayers(config, proj, map, activeLayers)
+    ? getZotsForActiveLayers(state)
     : {};
   return {
     zots,

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -424,6 +424,6 @@ Layer.propTypes = {
   hasClickableFeature: PropTypes.bool,
   tracksForLayer: PropTypes.array,
   openVectorAlertModal: PropTypes.func,
-  zot: PropTypes.number,
+  zot: PropTypes.object,
   isVectorLayer: PropTypes.bool,
 };

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -26,6 +26,7 @@ import {
   layerHover,
 } from '../../modules/layers/actions';
 import OrbitTrack from './orbit-track';
+import Zot from './zot';
 import { isVectorLayerClickable } from '../../modules/layers/util';
 import { MODAL_PROPERTIES } from '../../modules/alerts/constants';
 
@@ -212,10 +213,6 @@ class Layer extends React.Component {
         ? faEyeSlash
         : faEye;
 
-    const zotTitle = zot
-      ? `Layer is overzoomed by ${zot.toString()}x its maximum zoom level`
-      : '';
-
     return (
       <Draggable
         draggableId={`${util.encodeId(layer.id)}-${layerGroupName}`}
@@ -245,12 +242,7 @@ class Layer extends React.Component {
               <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" />
             </a>
 
-            <div
-              className="zot"
-              title={zotTitle}
-            >
-              <b>!</b>
-            </div>
+            <Zot zot={zot} layer={layer.id} />
 
             <div className="layer-main">
               <div className="layer-info">

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 /* eslint-disable no-nested-ternary */
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -175,6 +176,7 @@ class Layer extends React.Component {
   render() {
     const {
       layerGroupName,
+      isMobile,
       toggleVisibility,
       hover,
       layer,
@@ -242,7 +244,7 @@ class Layer extends React.Component {
               <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" />
             </a>
 
-            <Zot zot={zot} layer={layer.id} />
+            <Zot zot={zot} layer={layer.id} isMobile={isMobile} />
 
             <div className="layer-main">
               <div className="layer-info">

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -6,12 +6,12 @@ export default function Zot (props) {
   const { zot, layer, isMobile } = props;
   let className = 'zot';
   let tooltipString = '';
-  const delay = isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 500 };
+  const delay = isMobile ? { show: 300, hide: 300 } : { show: 50, hide: 500 };
   if (zot) {
     const { overZoomValue, layerNotices } = zot;
     if (overZoomValue) {
       className = 'zot overzoom';
-      tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
+      tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level. <br/>`;
     }
     if (layerNotices) {
       tooltipString += zot.layerNotices;
@@ -29,6 +29,7 @@ export default function Zot (props) {
     >
       <UncontrolledTooltip
         className="zot-tooltip"
+        boundariesElement="window"
         target={`${layer}-zot`}
         placement="right"
         trigger="hover"

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -1,12 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from 'reactstrap';
+import { UncontrolledTooltip } from 'reactstrap';
 
 export default function Zot (props) {
-  const { zot, layer } = props;
-  const [tooltipVisible, toggleTooltip] = useState(false);
+  const { zot, layer, isMobile } = props;
   let className = 'zot';
   let tooltipString = '';
+  const delay = isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 };
+
   if (zot && zot.overZoomValue) {
     tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
   }
@@ -20,22 +21,22 @@ export default function Zot (props) {
       id={`${layer}-zot`}
       className={className}
     >
-      <Tooltip
+      <UncontrolledTooltip
         className="zot-tooltip"
-        isOpen={tooltipVisible}
         target={`${layer}-zot`}
         placement="right"
-        toggle={() => toggleTooltip(!tooltipVisible)}
-        delay={{ show: 0, hide: 300 }}
+        trigger="hover"
+        delay={delay}
       >
         <div dangerouslySetInnerHTML={{ __html: tooltipString }} />
-      </Tooltip>
+      </UncontrolledTooltip>
       <b>!</b>
     </div>
   );
 }
 
 Zot.propTypes = {
+  isMobile: PropTypes.bool,
   layer: PropTypes.string,
   zot: PropTypes.object,
 };

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -7,13 +7,19 @@ export default function Zot (props) {
   let className = 'zot';
   let tooltipString = '';
   const delay = isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 };
-
-  if (zot && zot.overZoomValue) {
-    tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
-  }
-  if (zot && zot.layerNotices) {
-    tooltipString += zot.layerNotices;
-    className = 'zot layer-notice';
+  if (zot) {
+    const { overZoomValue, layerNotices } = zot;
+    if (overZoomValue) {
+      className = 'zot overzoom';
+      tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
+    }
+    if (layerNotices) {
+      tooltipString += zot.layerNotices;
+      className = 'zot layer-notice';
+    }
+    if (overZoomValue && layerNotices) {
+      className = 'zot overzoom layer-notice';
+    }
   }
 
   return (

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -5,19 +5,20 @@ import { Tooltip } from 'reactstrap';
 export default function Zot (props) {
   const { zot, layer } = props;
   const [tooltipVisible, toggleTooltip] = useState(false);
-
-  let zotString = '';
+  let className = 'zot';
+  let tooltipString = '';
   if (zot && zot.overZoomValue) {
-    zotString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
+    tooltipString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
   }
   if (zot && zot.layerNotices) {
-    zotString += zot.layerNotices;
+    tooltipString += zot.layerNotices;
+    className = 'zot layer-notice';
   }
 
   return (
     <div
       id={`${layer}-zot`}
-      className="zot"
+      className={className}
     >
       <Tooltip
         className="zot-tooltip"
@@ -27,7 +28,7 @@ export default function Zot (props) {
         toggle={() => toggleTooltip(!tooltipVisible)}
         delay={{ show: 0, hide: 300 }}
       >
-        <div dangerouslySetInnerHTML={{ __html: zotString }} />
+        <div dangerouslySetInnerHTML={{ __html: tooltipString }} />
       </Tooltip>
       <b>!</b>
     </div>

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -6,7 +6,7 @@ export default function Zot (props) {
   const { zot, layer, isMobile } = props;
   let className = 'zot';
   let tooltipString = '';
-  const delay = isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 300 };
+  const delay = isMobile ? { show: 300, hide: 300 } : { show: 0, hide: 500 };
   if (zot) {
     const { overZoomValue, layerNotices } = zot;
     if (overZoomValue) {
@@ -32,6 +32,7 @@ export default function Zot (props) {
         target={`${layer}-zot`}
         placement="right"
         trigger="hover"
+        autohide={isMobile}
         delay={delay}
       >
         <div dangerouslySetInnerHTML={{ __html: tooltipString }} />

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from 'reactstrap';
+
+export default function Zot (props) {
+  const { zot, layer } = props;
+  const [tooltipVisible, toggleTooltip] = useState(false);
+
+  let zotString = '';
+  if (zot && zot.overZoomValue) {
+    zotString += `Layer is overzoomed by ${zot.overZoomValue.toString()}x its maximum zoom level <br/>`;
+  }
+  if (zot && zot.layerNotices) {
+    zotString += zot.layerNotices;
+  }
+
+  return (
+    <div
+      id={`${layer}-zot`}
+      className="zot"
+    >
+      <Tooltip
+        className="zot-tooltip"
+        isOpen={tooltipVisible}
+        target={`${layer}-zot`}
+        placement="right"
+        toggle={() => toggleTooltip(!tooltipVisible)}
+        delay={{ show: 0, hide: 300 }}
+      >
+        <div dangerouslySetInnerHTML={{ __html: zotString }} />
+      </Tooltip>
+      <b>!</b>
+    </div>
+  );
+}
+
+Zot.propTypes = {
+  layer: PropTypes.string,
+  zot: PropTypes.object,
+};

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -129,16 +129,21 @@ class toolbarContainer extends Component {
 
   requestNotifications() {
     const { config, requestNotifications } = this.props;
-    if (config.features.notification) {
-      let notificationURL = config.features.notification.url
-        ? config.features.notification.url
+    const { parameters, features } = config;
+    const { notification } = features;
+    const domain = window.location.origin;
+
+    if (notification) {
+      let notificationURL = notification.url && !domain.includes('localhost')
+        // Use the deployed domain (SIT, UAT, PROD) when possible
+        ? `${notification.url}?domain=${domain}`
+        // Use the PROD domain when running locally
         : STATUS_REQUEST_URL;
-      if (config.parameters.mockAlerts) {
-        notificationURL = `mock/notify_${config.parameters.mockAlerts}.json`;
-      } else if (config.parameters.notificationURL) {
-        console.log('mock notificationURL');
-        notificationURL = `https://status.earthdata.nasa.gov/api/v1/notifications?domain=${
-          config.parameters.notificationURL}`;
+
+      if (parameters.mockAlerts) {
+        notificationURL = `mock/notify_${parameters.mockAlerts}.json`;
+      } else if (parameters.notificationURL) {
+        notificationURL = `${notification.url}?domain=${parameters.notificationURL}`;
       }
       requestNotifications(notificationURL);
     }

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -24,7 +24,6 @@ import {
   setNotifications,
 } from '../modules/notifications/actions';
 import {
-  STATUS_REQUEST_URL,
   REQUEST_NOTIFICATIONS,
 } from '../modules/notifications/constants';
 import { clearCustoms, refreshPalettes } from '../modules/palettes/actions';
@@ -138,7 +137,7 @@ class toolbarContainer extends Component {
         // Use the deployed domain (SIT, UAT, PROD) when possible
         ? `${notification.url}?domain=${domain}`
         // Use the PROD domain when running locally
-        : STATUS_REQUEST_URL;
+        : `${notification.url}?domain=https%3A%2F%2Fworldview.uat.earthdata.nasa.gov`;
 
       if (parameters.mockAlerts) {
         notificationURL = `mock/notify_${parameters.mockAlerts}.json`;

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -131,12 +131,14 @@ class toolbarContainer extends Component {
     const { parameters, features } = config;
     const { notification } = features;
     const domain = window.location.origin;
+    const testDomains = ['localhost', 'worldview.sit', 'worldview.uat', 'uat.gibs'];
+    const isTestInstance = testDomains.some((href) => domain.includes(href));
 
     if (notification) {
-      let notificationURL = notification.url && !domain.includes('localhost')
-        // Use the deployed domain (SIT, UAT, PROD) when possible
+      let notificationURL = !isTestInstance
+        // Use the configured domain in production
         ? `${notification.url}?domain=${domain}`
-        // Use the PROD domain when running locally
+        // Use the UAT domain for test instances
         : `${notification.url}?domain=https%3A%2F%2Fworldview.uat.earthdata.nasa.gov`;
 
       if (parameters.mockAlerts) {

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -11,6 +11,7 @@ import {
 import { createSelector } from 'reselect';
 import update from 'immutability-helper';
 import util from '../../util/util';
+import { getLayerNoticesForLayer } from '../notifications/util';
 
 // State selectors
 const getLayersState = ({ layers }) => layers;
@@ -475,16 +476,23 @@ export function replaceSubGroup(
   return pushToBottom(layerId, layers, layerSplit);
 }
 
-export function getZotsForActiveLayers(config, projection, map, activeLayers) {
+export function getZotsForActiveLayers(state) {
+  const {
+    config, proj, map, notifications,
+  } = state;
   const zotObj = {};
   const { sources } = config;
-  const proj = projection.selected.id;
+  const projection = proj.selected.id;
   const zoom = map.ui.selected.getView().getZoom();
-  lodashEach(activeLayers, (layer) => {
-    if (layer.projections[proj]) {
-      const overZoomValue = getZoomLevel(layer, zoom, proj, sources);
-      if (overZoomValue) {
-        zotObj[layer.id] = { value: overZoomValue };
+  lodashEach(getActiveLayers(state), (layer) => {
+    if (layer.projections[projection]) {
+      const overZoomValue = getZoomLevel(layer, zoom, projection, sources);
+      const layerNotices = getLayerNoticesForLayer(layer.id, notifications);
+      if (overZoomValue || layerNotices.length) {
+        zotObj[layer.id] = {
+          overZoomValue,
+          layerNotices,
+        };
       }
     }
   });

--- a/web/js/modules/notifications/actions.js
+++ b/web/js/modules/notifications/actions.js
@@ -1,18 +1,22 @@
 import { requestAction } from '../core/actions';
-
 import {
   REQUEST_NOTIFICATIONS,
   SET_NOTIFICATIONS,
   NOTIFICATIONS_SEEN,
 } from './constants';
+import { getActiveLayers } from '../layers/selectors';
 
 export function requestNotifications(location, type) {
   return (dispatch) => requestAction(dispatch, REQUEST_NOTIFICATIONS, location);
 }
 export function setNotifications(array) {
-  return {
-    type: SET_NOTIFICATIONS,
-    array,
+  return (dispatch, getState) => {
+    const activeLayers = getActiveLayers(getState());
+    dispatch({
+      type: SET_NOTIFICATIONS,
+      array,
+      activeLayers,
+    });
   };
 }
 export function notificationsSeen() {

--- a/web/js/modules/notifications/actions.js
+++ b/web/js/modules/notifications/actions.js
@@ -4,19 +4,14 @@ import {
   SET_NOTIFICATIONS,
   NOTIFICATIONS_SEEN,
 } from './constants';
-import { getActiveLayers } from '../layers/selectors';
 
 export function requestNotifications(location, type) {
   return (dispatch) => requestAction(dispatch, REQUEST_NOTIFICATIONS, location);
 }
 export function setNotifications(array) {
-  return (dispatch, getState) => {
-    const activeLayers = getActiveLayers(getState());
-    dispatch({
-      type: SET_NOTIFICATIONS,
-      array,
-      activeLayers,
-    });
+  return {
+    type: SET_NOTIFICATIONS,
+    array,
   };
 }
 export function notificationsSeen() {

--- a/web/js/modules/notifications/constants.js
+++ b/web/js/modules/notifications/constants.js
@@ -6,6 +6,7 @@ export const SET_NOTIFICATIONS = 'NOTIFICATIONS/SET_NOTIFICATION_RESPONSE';
 export const NOTIFICATIONS_SEEN = 'NOTIFICATIONS/NOTIFICATIONS_HAVE_BEEN_SEEN';
 
 export const STATUS_REQUEST_URL = 'https://status.earthdata.nasa.gov/api/v1/notifications?domain=https%3A%2F%2Fworldview.earthdata.nasa.gov';
+
 export const MOCK_RESPONSE_BODY = [
   {
     id: 537,
@@ -21,26 +22,15 @@ export const MOCK_RESPONSE_BODY = [
     path: '',
   },
 ];
+
 export const MOCK_RESPONSE = {
   success: true,
   notifications: MOCK_RESPONSE_BODY,
 };
+
 export const MOCK_SORTED_NOTIFICATIONS = {
   messages: [],
-  outages: [
-    {
-      id: 537,
-      notification_type: 'outage',
-      message: 'This is a test Outage',
-      updated_at: '2018-05-20T16:26:43.013-04:00',
-      created_at: '2018-05-20T16:23:37.049-04:00',
-      starttime: null,
-      endtime: null,
-      applications: ['Worldview (OPS)'],
-      domains: ['https://worldview.earthdata.nasa.gov'],
-      dismissible: true,
-      path: '',
-    },
-  ],
+  outages: MOCK_RESPONSE_BODY,
   alerts: [],
+  layerNotices: [],
 };

--- a/web/js/modules/notifications/reducers.js
+++ b/web/js/modules/notifications/reducers.js
@@ -29,7 +29,7 @@ export function notificationsReducer(state = notificationReducerState, action) {
 
         return {
           ...state,
-          number: getCount(notificationsByType, action.activeLayers),
+          number: getCount(notificationsByType),
           type: getPriority(notificationsByType),
           isActive: true,
           object: notificationsByType,

--- a/web/js/modules/notifications/reducers.js
+++ b/web/js/modules/notifications/reducers.js
@@ -1,6 +1,9 @@
-import { assign } from 'lodash';
 import { requestReducer } from '../core/reducers';
-import { getCount, separateByType, getPriority } from './util';
+import {
+  getCount,
+  separateByType,
+  getPriority,
+} from './util';
 import {
   REQUEST_NOTIFICATIONS,
   SET_NOTIFICATIONS,
@@ -22,20 +25,25 @@ export function notificationsReducer(state = notificationReducerState, action) {
   switch (action.type) {
     case SET_NOTIFICATIONS:
       if (action.array.length > 0) {
-        const sortedNotificationObject = separateByType(action.array);
-        return assign({}, state, {
-          number: getCount(sortedNotificationObject),
-          type: getPriority(sortedNotificationObject),
+        const notificationsByType = separateByType(action.array);
+
+        return {
+          ...state,
+          number: getCount(notificationsByType, action.activeLayers),
+          type: getPriority(notificationsByType),
           isActive: true,
-          object: sortedNotificationObject,
-        });
-      } return state;
+          object: notificationsByType,
+        };
+      }
+      return state;
+
     case NOTIFICATIONS_SEEN:
-      return assign({}, state, {
+      return {
+        ...state,
         number: null,
         type: '',
         isActive: true,
-      });
+      };
     default:
       return state;
   }

--- a/web/js/modules/notifications/reducers.test.js
+++ b/web/js/modules/notifications/reducers.test.js
@@ -44,7 +44,7 @@ describe('notificationsReducer', () => {
   });
   test(
     `${constants.SET_NOTIFICATIONS
-    }action type should return object containing sorted mock object`,
+    } action type should return object containing sorted mock object`,
     () => {
       expect(
         notificationsReducer([], {
@@ -61,7 +61,7 @@ describe('notificationsReducer', () => {
   );
   test(
     `${constants.SET_NOTIFICATIONS
-    }action type should return object containing sorted mock object`,
+    } action type should return object containing sorted mock object`,
     () => {
       expect(
         notificationsReducer(notificationReducerState, {

--- a/web/js/modules/notifications/util.js
+++ b/web/js/modules/notifications/util.js
@@ -13,30 +13,34 @@ const {
  * @param {object} obj - array from API
  * @returns {void}
  */
-export function separateByType(array) {
-  let type;
-  let subObj;
+export function separateByType(notifications) {
   const messages = [];
   const alerts = [];
   const outages = [];
+  const layerNotices = [];
 
-  for (let i = 0, len = array.length; i < len; i += 1) {
-    subObj = array[i];
-    type = subObj.notification_type;
+  notifications.forEach((notification) => {
+    const { notification_type: type, path } = notification;
+
+    if (path.contains('layer-notice')) {
+      layerNotices.push(notification);
+      return;
+    }
 
     if (type === NOTIFICATION_MSG) {
-      messages.push(subObj);
+      messages.push(notification);
     } else if (type === NOTIFICATION_ALERT) {
-      alerts.push(subObj);
-    } else {
-      outages.push(subObj);
+      alerts.push(notification);
+    } else if (type === NOTIFICATION_OUTAGE) {
+      outages.push(notification);
     }
-  }
+  });
 
   return {
     messages: orderByDate(messages),
     alerts: orderByDate(alerts),
     outages: orderByDate(outages),
+    layerNotices: orderByDate(layerNotices),
   };
 }
 /**

--- a/web/js/modules/notifications/util.js
+++ b/web/js/modules/notifications/util.js
@@ -76,9 +76,6 @@ export function getPriority(sortedNotifications) {
   if (outage && !objectAlreadySeen(outage)) {
     priority = NOTIFICATION_OUTAGE;
   }
-
-  // TODO need to determine how and when layer notices affect priority
-
   return priority;
 }
 

--- a/web/js/modules/notifications/util.js
+++ b/web/js/modules/notifications/util.js
@@ -30,7 +30,7 @@ export function separateByType(notifications) {
   notifications.forEach((notification) => {
     const { notification_type: type, path } = notification;
 
-    if (path.contains(LAYER_NOTICE)) {
+    if (path.includes(LAYER_NOTICE)) {
       layerNotices.push(notification);
       return;
     }
@@ -88,26 +88,15 @@ export function getPriority(sortedNotifications) {
  * @private
  * @returns {Number}
  */
-export function getCount(notifications, activeLayers) {
+export function getCount(notifications) {
   const {
-    messages, outages, alerts, layerNotices,
+    messages, outages, alerts,
   } = notifications;
-  const activeLayerIds = Object.keys(activeLayers);
   const messageCount = getNumberOfTypeNotSeen(NOTIFICATION_MSG, messages);
   const alertCount = getNumberOfTypeNotSeen(NOTIFICATION_ALERT, alerts);
   const outageCount = getNumberOfTypeNotSeen(NOTIFICATION_OUTAGE, outages);
 
-
-  // If any of the layers marked in layerNotices array are currently active,
-  // include in the count.
-  let layerNoticeCount = 0;
-  layerNotices.forEach((notice) => {
-    if (activeLayerIds.some((id) => notice.layers.includes(id))) {
-      layerNoticeCount += 1;
-    }
-  });
-
-  return messageCount + outageCount + alertCount + layerNoticeCount;
+  return messageCount + outageCount + alertCount;
 }
 
 export function addToLocalStorage({ messages, outages, alerts }) {

--- a/web/mock/notify_all_types.json
+++ b/web/mock/notify_all_types.json
@@ -39,6 +39,32 @@
       "domains":["https://worldview.earthdata.nasa.gov"],
       "dismissible":true,
       "path":""
+    },
+    {
+      "id": 1185,
+      "notification_type": "outage",
+      "message": "The Aqua / MODIS Corrected Reflectance (True Color) layer is currently unavailable.",
+      "updated_at": "2020-09-11T10:37:41.393-04:00",
+      "created_at": "2020-09-11T10:37:41.393-04:00",
+      "starttime": null,
+      "endtime": null,
+      "applications":["Worldview (OPS)"],
+      "domains":["https://worldview.earthdata.nasa.gov"],
+      "dismissible": true,
+      "path": "/layer-notice/MODIS_Aqua_CorrectedReflectance_TrueColor/"
+    },
+    {
+      "id": 1181,
+      "notification_type": "alert",
+      "message": "Several Aqua and Terra MODIS layers are experiencing delays in processing.  ",
+      "updated_at": "2020-09-11T10:37:00.049-04:00",
+      "created_at": "2020-09-04T11:21:38.569-04:00",
+      "starttime": null,
+      "endtime": null,
+      "applications":["Worldview (OPS)"],
+      "domains":["https://worldview.earthdata.nasa.gov"],
+      "dismissible": true,
+      "path": "/layer-notice/MODIS_Aqua_CorrectedReflectance_TrueColor/MODIS_Terra_CorrectedReflectance_TrueColor"
     }
   ]
 }


### PR DESCRIPTION
## Description

Fixes #3066.

* These changes allow for posting notification messages about specific layers that will only show when viewing those layers (either in the product picker, or in the sidebar) within the app.
* Any status app notification that has `/layer-notice/` included in the `path` field will be considered a layer notice.
* Targeted layers should be included after this prefix with each additional layer separated by a slash, for example:
  * `/layer-notice/MODIS_Aqua_CorrectedReflectance_TrueColor/MODIS_Terra_CorrectedReflectance_TrueColor`
  * The alert type, (outage, alert, message) is irrelevant for layer notices and is not used
* When running Worldview locally, status notifications will now be pulled from the Worldview (UAT) status app account.  This means that, while testing this PR, you can set up test notifications for this account and you should be able to see and test them locally.  
* Loading the app with the `mockAlerts=no_types` or `mockAlerts=all_types` will ignore these UAT notifications and only show the mock alerts that are configured in the repo

TODO 
- [x] Document how to properly configure a notification as a "layer notice"
- [x] Display notices in "search" mode of product picker

