### PR TITLE
Events scroll into view and sort by most recent date

### DIFF
--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -20,7 +20,6 @@ module.exports = {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
   },
   'Make sure that 4 fire layers are not present in layer list: use mock': (c) => {
-    console.log(c.globals.url + localQuerystrings.mockEvents);
     c.url(c.globals.url + localQuerystrings.mockEvents);
     c.waitForElementVisible(
       '#sidebar-event-EONET_3931',

--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -8,6 +8,7 @@ const TIME_LIMIT = 10000;
 const listOfEvents = '#wv-events ul.map-item-list';
 const eventIcons = '.marker .event-icon';
 const firstEvent = '#wv-events ul.map-item-list .item:first-child h4';
+const secondEvent = '#wv-events #sidebar-event-EONET_99999';
 const selectedFirstEvent = '#wv-events ul.map-item-list .item-selected:first-child h4';
 const selectedMarker = '.marker-selected';
 const firstExternalEventLink = '#wv-events ul.map-item-list .item:first-child .natural-event-link:first-child';
@@ -15,125 +16,126 @@ const trackMarker = '.track-marker';
 const layersTab = '#layers-sidebar-tab';
 
 module.exports = {
-  before(client) {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  before(c) {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
   },
-  'Make sure that 4 fire layers are not present in layer list: use mock': (client) => {
-    client.url(client.globals.url + localQuerystrings.mockEvents);
-    client.waitForElementVisible(
+  'Make sure that 4 fire layers are not present in layer list: use mock': (c) => {
+    console.log(c.globals.url + localQuerystrings.mockEvents);
+    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.waitForElementVisible(
       '#sidebar-event-EONET_3931',
       TIME_LIMIT,
       () => {
-        client.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Night')
+        c.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Night')
           .to.not.be.present;
-        client.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Day')
+        c.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Day')
           .to.not.be.present;
-        client.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Day').to.not
+        c.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Day').to.not
           .be.present;
-        client.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Night').to
+        c.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Night').to
           .not.be.present;
       },
     );
   },
-  'Click fire event': (client) => {
-    client.click('#sidebar-event-EONET_3931');
+  'Click fire event': (c) => {
+    c.click('#sidebar-event-EONET_3931');
   },
-  'Check that 4 fire layers are now present': (client) => {
-    client.click(layersTab);
-    client.waitForElementPresent(
+  'Check that 4 fire layers are now present': (c) => {
+    c.click(layersTab);
+    c.waitForElementPresent(
       '#active-VIIRS_SNPP_Thermal_Anomalies_375m_Night',
       TIME_LIMIT,
       () => {
-        client.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Day')
+        c.expect.element('#active-VIIRS_SNPP_Thermal_Anomalies_375m_Day')
           .to.be.present;
-        client.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Day').to.be
+        c.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Day').to.be
           .present;
-        client.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Night').to.be
+        c.expect.element('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Night').to.be
           .present;
       },
     );
   },
-  'Use Mock to make sure appropriate number of event markers are appended to map': (client) => {
-    client.url(client.globals.url + localQuerystrings.mockEvents);
-    client.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
-      client.expect.elements(eventIcons).count.to.equal(9);
+  'Use Mock to make sure appropriate number of event markers are appended to map': (c) => {
+    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
+      c.expect.elements(eventIcons).count.to.equal(9);
     });
   },
-  'On events tab click events list is loaded': (client) => {
-    client.url(client.globals.url + localQuerystrings.mockEvents);
-    client.waitForElementVisible(listOfEvents, TIME_LIMIT);
+  'On events tab click events list is loaded': (c) => {
+    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.waitForElementVisible(listOfEvents, TIME_LIMIT);
   },
-  'Use Mock Ensure number of event track points is correct and event markers and tabs are not visible when layer tab is clicked': (client) => {
-    const globalSelectors = client.globals.selectors;
-    client.click(firstEvent);
-    client.waitForElementVisible(trackMarker, TIME_LIMIT, () => {
-      client.expect.elements(trackMarker).count.to.equal(5);
-      client.click(globalSelectors.dataTab).pause(2000);
-      client.expect.element(trackMarker).to.not.be.present;
-      client.expect.element(eventIcons).to.not.be.present;
-      client.click(globalSelectors.eventsTab).pause(2000);
-      client.expect.element(trackMarker).to.be.present;
-      client.expect.element(eventIcons).to.be.present;
+  'Use Mock to ensure number of event track points is correct and event markers and tabs are not visible when layer tab is clicked': (c) => {
+    const globalSelectors = c.globals.selectors;
+    c.click(secondEvent);
+    c.waitForElementVisible(trackMarker, TIME_LIMIT, () => {
+      c.expect.elements(trackMarker).count.to.equal(5);
+      c.click(globalSelectors.dataTab).pause(2000);
+      c.expect.element(trackMarker).to.not.be.present;
+      c.expect.element(eventIcons).to.not.be.present;
+      c.click(globalSelectors.eventsTab).pause(2000);
+      c.expect.element(trackMarker).to.be.present;
+      c.expect.element(eventIcons).to.be.present;
     });
   },
-  'Click Events tab and select an Event from the List': (client) => {
-    client.url(client.globals.url + localQuerystrings.mockEvents);
-    client.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
-      client.click(firstEvent);
-      client.waitForElementVisible(selectedMarker, TIME_LIMIT, () => {
-        client.expect.element(selectedFirstEvent).to.be.visible;
+  'Click Events tab and select an Event from the List': (c) => {
+    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
+      c.click(firstEvent);
+      c.waitForElementVisible(selectedMarker, TIME_LIMIT, () => {
+        c.expect.element(selectedFirstEvent).to.be.visible;
       });
     });
   },
-  'Verify that Url is updated': (client) => {
-    client.assert
+  'Verify that Url is updated': (c) => {
+    c.assert
       .urlParameterEquals('l', true)
       .assert.urlParameterEquals('t', true)
       .assert.urlParameterEquals('v', true)
       .assert.urlParameterEquals('e', true);
   },
-  'Verify Events may not be visible at all times is visible ': (client) => {
-    const globalSelectors = client.globals.selectors;
-    client.waitForElementVisible(
+  'Verify Events may not be visible at all times is visible ': (c) => {
+    const globalSelectors = c.globals.selectors;
+    c.waitForElementVisible(
       globalSelectors.notifyMessage,
       TIME_LIMIT,
       () => {
-        client.assert.containsText(
+        c.assert.containsText(
           globalSelectors.notifyMessage,
           'Events may not be visible at all times',
         );
       },
     );
   },
-  'Clicking event notification opens explanation in dialog': (client) => {
-    const globalSelectors = client.globals.selectors;
+  'Clicking event notification opens explanation in dialog': (c) => {
+    const globalSelectors = c.globals.selectors;
 
-    client.click(globalSelectors.notifyMessage).pause(2000);
-    client.assert.containsText(
+    c.click(globalSelectors.notifyMessage).pause(2000);
+    c.assert.containsText(
       '#event_visibility_info .wv-data-unavailable-header',
       'Why can’t I see an event?',
     );
-    client.click('#event_visibility_info .close').pause(2000);
-    client.expect.element('#event_visibility_info').to.not.be.present;
-    client.click(globalSelectors.notificationDismissButton).pause(2000);
-    client.expect.element(globalSelectors.notificationDismissButton).to.not.be
+    c.click('#event_visibility_info .close').pause(2000);
+    c.expect.element('#event_visibility_info').to.not.be.present;
+    c.click(globalSelectors.notificationDismissButton).pause(2000);
+    c.expect.element(globalSelectors.notificationDismissButton).to.not.be
       .present;
   },
-  'Clicking selected event deselects event': (client) => {
-    client.click(selectedFirstEvent).pause(500);
-    client.expect.element(selectedFirstEvent).to.not.be.present;
+  'Clicking selected event deselects event': (c) => {
+    c.click(selectedFirstEvent).pause(500);
+    c.expect.element(selectedFirstEvent).to.not.be.present;
   },
-  'Check that clicking eternal link opens in new window': (client) => {
-    client.click(firstEvent).pause(500);
-    client.windowHandles((tabs) => {
-      client.assert.equal(tabs.value.length, 1);
+  'Check that clicking eternal link opens in new window': (c) => {
+    c.click(firstEvent).pause(500);
+    c.windowHandles((tabs) => {
+      c.assert.equal(tabs.value.length, 1);
     });
-    client.click(firstExternalEventLink).pause(2000);
-    client.windowHandles((tabs) => {
-      client.assert.equal(tabs.value.length, 2);
+    c.click(firstExternalEventLink).pause(2000);
+    c.windowHandles((tabs) => {
+      c.assert.equal(tabs.value.length, 2);
     });
   },
-  after(client) {
-    client.end();
+  after(c) {
+    c.end();
   },
 };

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -32,11 +32,7 @@ function Event (props) {
 
   useEffect(() => {
     if (isSelected) {
-      ref.current.scrollIntoView({
-        block: 'start',
-        inline: 'nearest',
-        behavior: 'smooth',
-      });
+      ref.current.scrollIntoView();
     }
   }, [isSelected]);
 

--- a/web/js/components/util/scrollbar.js
+++ b/web/js/components/util/scrollbar.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import SimpleBarReact from 'simplebar-react';
 import { debounce } from 'lodash';
@@ -8,13 +8,10 @@ import { debounce } from 'lodash';
  */
 export default function Scrollbars(props) {
   const ref = useRef();
-  const [scrollTop, updateScrollTop] = useState(0);
   const {
     style,
     className,
-    onScroll,
     children,
-    scrollBarVerticalTop,
   } = props;
 
   /**
@@ -43,41 +40,6 @@ export default function Scrollbars(props) {
     }, 50, { leading: true, trailing: true })();
   });
 
-  /**
-   *  Set scroll top when prop changes
-   */
-  useEffect(() => {
-    if (!ref || !ref.current) {
-      return;
-    }
-    function setScrollTop() {
-      const { contentWrapperEl } = ref.current;
-      if (contentWrapperEl) {
-        updateScrollTop(scrollBarVerticalTop);
-        contentWrapperEl.scrollTop = scrollBarVerticalTop;
-      }
-    }
-    setTimeout(setScrollTop, 100);
-  }, [scrollBarVerticalTop]);
-
-  /**
-   * Handle register/deregister of scroll event listener
-   */
-  useEffect(() => {
-    if (!onScroll) return;
-    const { contentWrapperEl } = ref && ref.current;
-    function scrollListener() {
-      // Avoid calling event listener when we are setting scrollTop manually
-      if (contentWrapperEl.scrollTop !== scrollTop) {
-        onScroll(contentWrapperEl);
-      }
-    }
-    contentWrapperEl.addEventListener('scroll', scrollListener);
-    return function cleanUp() {
-      contentWrapperEl.removeEventListener('scroll', scrollListener);
-    };
-  });
-
   return (
     <SimpleBarReact
       autoHide={false}
@@ -93,11 +55,5 @@ export default function Scrollbars(props) {
 Scrollbars.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
-  onScroll: PropTypes.func,
-  scrollBarVerticalTop: PropTypes.number,
   style: PropTypes.object,
-};
-
-Scrollbars.defaultProps = {
-  scrollBarVerticalTop: 0,
 };

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -82,15 +82,6 @@ function Events(props) {
       ? 'There has been an ERROR retrieving events from the EONET events API'
       : '';
 
-  let scrollBarVerticalTop = 0;
-  if (visibleEvents && selected.id) {
-    // find index for scrollBarVerticalTop calculation on selected event
-    const index = Object.keys(visibleEvents).indexOf(selected.id);
-    // 12 === li total top/bottom padding
-    // 32.2 === li height (varies slightly, Chrome 100% browser zoom height used)
-    scrollBarVerticalTop = index ? index * (12 + 32.2) : 0;
-  }
-
   const eventsForSelectedCategory = !isLoading && (events || []).filter((event) => {
     if (selectedCategory === ALL_CATEGORY) return event;
     if (event.categories.find((category) => category.title === selectedCategory)) {
@@ -130,7 +121,6 @@ function Events(props) {
 
       <Scrollbars
         style={{ maxHeight: `${height}px` }}
-        scrollBarVerticalTop={scrollBarVerticalTop}
       >
         <div id="wv-events">
           {(isLoading || hasRequestError) && (

--- a/web/js/modules/natural-events/reducers.js
+++ b/web/js/modules/natural-events/reducers.js
@@ -17,12 +17,18 @@ import {
 import { CHANGE_TAB as CHANGE_SIDEBAR_TAB } from '../sidebar/constants';
 
 const sortEvents = function(events) {
-  return events.map((e) => {
-    e.geometry = lodashOrderBy(e.geometry, 'date', 'desc');
-    // Discard duplicate geometry dates
-    e.geometry = lodashUniqBy(e.geometry, (g) => g.date.split('T')[0]);
-    return e;
-  });
+  return events
+    .map((e) => {
+      e.geometry = lodashOrderBy(e.geometry, 'date', 'desc');
+      // Discard duplicate geometry dates
+      e.geometry = lodashUniqBy(e.geometry, (g) => g.date.split('T')[0]);
+      return e;
+    })
+    .sort((eventA, eventB) => {
+      const dateA = new Date(eventA.geometry[0].date).valueOf();
+      const dateB = new Date(eventB.geometry[0].date).valueOf();
+      return dateB - dateA;
+    });
 };
 
 const formatResponse = function(item, ignored) {


### PR DESCRIPTION
## Description

Fixes #3121.
Fixes #3122.

* Use `Element.scrollIntoView` to make sure event rows are consistently scrolled into view when selected
* Sort events by their most recent date