### PR TITLE
Fix A|B opacity compare tooltip

### DIFF
--- a/web/css/rc-slider-overrides.css
+++ b/web/css/rc-slider-overrides.css
@@ -15,3 +15,6 @@
 .rc-slider-handle-dragging.rc-slider-handle-dragging.rc-slider-handle-dragging {
   box-shadow: none;
 }
+.rc-slider-tooltip-inner {
+  min-width: 40px;
+}


### PR DESCRIPTION
## Description

Fixes #3035 

- [x] Fix A | B opacity compare tooltip width to fit with text

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
