### PR TITLE
adjust colorbar width on mobile fit with box

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -275,7 +275,6 @@ class PaletteLegend extends React.Component {
             id={`${layer.id}-${legend.id}${index}colorbar`}
             width={width}
             height={24}
-            style={{ width }}
             ref={this[`canvas_${index}`]}
             onMouseEnter={!isMobile ? this.onMouseEnter.bind(this) : null}
             onMouseLeave={!isMobile ? this.hideValue.bind(this) : null}


### PR DESCRIPTION
## Description

Fixes #3125 .

- Fixed colorbar width on mobile

<img width="355" alt="Screen Shot 2020-10-06 at 15 34 40" src="https://user-images.githubusercontent.com/26855616/95178396-91cf7a00-07e9-11eb-9e23-21a0bf06d6da.png">


## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
