### PR TITLE
Remove map zoom buttons on mobile

### DIFF
--- a/web/css/map.css
+++ b/web/css/map.css
@@ -68,6 +68,12 @@
   border-bottom-right-radius: 10px;
 }
 
+@media (max-width: 740px) {
+  .wv-map-zoom-in, .wv-map-zoom-out {
+    display: none;
+  }
+}
+
 @media only screen and (max-device-width: 740px) and (orientation: landscape) {
   .wv-map-reset-rotation {
     top: auto;


### PR DESCRIPTION
## Description

Fixes #3156  .

- [x] Remove map zoom buttons on mobile and handle dynamic re-adding, event listener removal, and minor `isMobile` replacement of `isSmall`

## Further comments

Note: This is a precursor to further style related work within the geosearch feature branch of UI buttons including the toolbar, zoom, rotate, measure buttons, and consistent mobile breakpoints app-wide. I wanted to get this out since it is more functional.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
