### PR TITLE
3167 encode ids when used as CSS selectors

### DIFF
--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -1,6 +1,6 @@
 const TIME_LIMIT = 30000;
 const mockParam = '?mockAlerts=';
-const layerNoticesTestParams = '?l=Coastlines,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
+const layerNoticesTestParams = '?l=Coastlines,MODIS_Aqua_CorrectedReflectance_TrueColor,Particulate_Matter_Below_2.5micrometers_2001-2010';
 const { addLayers, layersSearchField, categoriesNav } = require('../../reuseables/selectors.js');
 
 // Selectors
@@ -14,10 +14,10 @@ const alertContentHightlighted = '#notification_list_modal .alert-notification-i
 const outageContentHightlighted = '#notification_list_modal .outage-notification-item';
 const messageContentHightlighted = '#notification_list_modal .message-notification-item';
 const aquaNotice = 'The Aqua / MODIS Corrected Reflectance (True Color) layer is currently unavailable.';
-const aquaTerraNotice = 'Several Aqua and Terra MODIS layers are experiencing delays in processing.';
+const multiNotice = 'Several layers are experiencing delays in processing.';
 const tooltipSelector = '.tooltip-inner div';
 const aquaZot = '#MODIS_Aqua_CorrectedReflectance_TrueColor-zot';
-const terraZot = '#MODIS_Terra_CorrectedReflectance_TrueColor-zot';
+const particulateZot = '#Particulate_Matter_Below_2__2E__5micrometers_2001-2010-zot';
 
 module.exports = {
   'No visible notifications with mockAlert parameter set to no_types': function(c) {
@@ -73,12 +73,12 @@ module.exports = {
     c.moveToElement(aquaZot, 2, 2);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
-    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, multiNotice);
 
-    c.expect.element(terraZot).to.be.present;
-    c.moveToElement(terraZot, 2, 2);
+    c.expect.element(particulateZot).to.be.present;
+    c.moveToElement(particulateZot, 2, 2);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
-    c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
+    c.assert.containsText(`${tooltipSelector} div`, multiNotice);
   },
   'Verify that warning shows in the product picker category/measurement rows': function(c) {
     c.click(addLayers);
@@ -87,13 +87,7 @@ module.exports = {
     c.moveToElement('#checkbox-case-MODIS_Aqua_CorrectedReflectance_TrueColor', 2, 2);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
-    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
-
-    c.click('#terra-modis-4-source-Nav');
-    c.waitForElementVisible('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', TIME_LIMIT);
-    c.moveToElement('#checkbox-case-MODIS_Terra_CorrectedReflectance_TrueColor', 5, 5);
-    c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
-    c.assert.containsText(`${tooltipSelector} div`, aquaTerraNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, multiNotice);
   },
   'Verify that warning shows in the product picker search results rows': function(c) {
     if (c.options.desiredCapabilities.browserName === 'firefox') {
@@ -106,7 +100,7 @@ module.exports = {
     c.moveToElement('#MODIS_Aqua_CorrectedReflectance_TrueColor-notice-info', 12, 12);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);
     c.assert.containsText(`${tooltipSelector} div:first-of-type`, aquaNotice);
-    c.assert.containsText(`${tooltipSelector} div:last-of-type`, aquaTerraNotice);
+    c.assert.containsText(`${tooltipSelector} div:last-of-type`, multiNotice);
   },
   after(c) {
     c.end();

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -15,6 +15,7 @@ import { getActiveLayers } from '../../../../modules/layers/selectors';
 import RenderSplitLayerTitle from '../renderSplitTitle';
 import getSelectedDate from '../../../../modules/date/selectors';
 import { getLayerNoticesForLayer } from '../../../../modules/notifications/util';
+import util from '../../../../util/util';
 
 /**
  * A single layer search result row
@@ -100,6 +101,7 @@ class SearchLayerRow extends React.Component {
     } = this.props;
     const { showDeleteIcon } = this.state;
     const { id } = layer;
+    const encodedId = util.encodeId(id);
     const isMetadataShowing = selectedLayer && id === selectedLayer.id;
     const rowClass = isMetadataShowing
       ? 'search-row layers-all-layer selected'
@@ -112,7 +114,7 @@ class SearchLayerRow extends React.Component {
 
     return (
       <div
-        id={`${id}-search-row`}
+        id={`${encodedId}-search-row`}
         className={rowClass}
         ref={this.ref}
         onMouseEnter={() => this.toggleDeleteIcon(true)}
@@ -121,8 +123,8 @@ class SearchLayerRow extends React.Component {
         <div className={checkboxClass}>
           <input
             type="checkbox"
-            id={`${id}-checkbox`}
-            name={`${id}-checkbox`}
+            id={`${encodedId}-checkbox`}
+            name={`${encodedId}-checkbox`}
             checked={isEnabled}
             onChange={this.toggleEnabled}
           />
@@ -130,14 +132,14 @@ class SearchLayerRow extends React.Component {
         {layerNotices && (
           <div className="layer-notice-wrapper">
             <FontAwesomeIcon
-              id={`${id}-notice-info`}
+              id={`${encodedId}-notice-info`}
               className="layer-notice-icon"
               icon={faExclamationTriangle}
             />
             <UncontrolledTooltip
               className="zot-tooltip"
               placement="top"
-              target={`${id}-notice-info`}
+              target={`${encodedId}-notice-info`}
               trigger="hover"
               autohide={isMobile}
               delay={isMobile ? { show: 300, hide: 300 } : { show: 50, hide: 300 }}

--- a/web/js/components/timeline/timeline-data/data-item-list.js
+++ b/web/js/components/timeline/timeline-data/data-item-list.js
@@ -387,7 +387,7 @@ class DataItemList extends Component {
           return (
             <div
               key={key}
-              className={`data-panel-layer-item data-item-${id}`}
+              className="data-panel-layer-item"
               style={{
                 background: layerItemBackground,
                 outline: layerItemOutline,
@@ -397,7 +397,7 @@ class DataItemList extends Component {
                 this.getHeaderDOMEl(layer, visible, dateRange, layerItemBackground)
               }
               <div
-                className={`data-panel-layer-coverage-line-container data-line-${id}`}
+                className="data-panel-layer-coverage-line-container"
                 style={{
                   maxWidth: `${axisWidth}px`,
                 }}

--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
+import util from '../../util/util';
 
 export default function Zot (props) {
   const { zot, layer, isMobile } = props;
@@ -24,13 +25,13 @@ export default function Zot (props) {
 
   return (
     <div
-      id={`${layer}-zot`}
+      id={`${util.encodeId(layer)}-zot`}
       className={className}
     >
       <UncontrolledTooltip
         className="zot-tooltip"
         boundariesElement="window"
-        target={`${layer}-zot`}
+        target={`${util.encodeId(layer)}-zot`}
         placement="right"
         trigger="hover"
         autohide={isMobile}

--- a/web/mock/notify_all_types.json
+++ b/web/mock/notify_all_types.json
@@ -56,7 +56,7 @@
     {
       "id": 1181,
       "notification_type": "alert",
-      "message": "Several Aqua and Terra MODIS layers are experiencing delays in processing.  ",
+      "message": "Several layers are experiencing delays in processing.",
       "updated_at": "2020-09-11T10:37:00.049-04:00",
       "created_at": "2020-09-04T11:21:38.569-04:00",
       "starttime": null,
@@ -64,7 +64,7 @@
       "applications":["Worldview (OPS)"],
       "domains":["https://worldview.earthdata.nasa.gov"],
       "dismissible": true,
-      "path": "/layer-notice/MODIS_Aqua_CorrectedReflectance_TrueColor/MODIS_Terra_CorrectedReflectance_TrueColor"
+      "path": "/layer-notice/MODIS_Aqua_CorrectedReflectance_TrueColor/Particulate_Matter_Below_2.5micrometers_2001-2010"
     }
   ]
 }


### PR DESCRIPTION
## Description

Fixes #3167.

- [x] encode ids
- [x] add tests with layer that needs encoding 

@nasa-gibs/worldview
