### PR TITLE
Add Enable/Disable all option for classifications

### DIFF
--- a/e2e/features/palettes/disable-test.js
+++ b/e2e/features/palettes/disable-test.js
@@ -9,12 +9,12 @@ module.exports = {
     normalizeViewport(client, 1000, 850);
     client.url(client.globals.url + enabledPermalink);
   },
-  'Verify that toggling class updates permalink and layer-legend': function(client) {
+  'Verify that toggling class updates permalink and layer-legend': (client) => {
     client.waitForElementVisible('#active-Last_of_the_Wild_1995-2004', TIME_LIMIT, () => {
       client.expect.element('#active-Last_of_the_Wild_1995-2004 .disabled-classification').to.not.be.present;
       client.click('#active-Last_of_the_Wild_1995-2004 .wv-layers-options');
       client.waitForElementVisible('.layer-classification-toggle', 2000, () => {
-        client.click('.react-switch-case .react-switch-button');
+        client.click('.classification-list .react-switch-case .react-switch-button');
         client.waitForElementVisible(`${classColorBoxId}0.disabled-classification`, TIME_LIMIT, () => {
           client.expect.element(`${classColorBoxId}1.disabled-classification`).to.not.be.present;
           client.assert.urlContains('(disabled=0)');
@@ -22,7 +22,21 @@ module.exports = {
       });
     });
   },
-  'Verify that loaded permalink disables classes': function(client) {
+  'Verify that toggling class-all off updates permalink and layer-legend': (client) => {
+    client.click('.classification-switch-header .react-switch-case .react-switch-button');
+    client.waitForElementVisible(`${classColorBoxId}15.disabled-classification`, TIME_LIMIT, () => {
+      client.expect.element(`${classColorBoxId}0.disabled-classification`).to.be.present;
+      client.expect.element(`${classColorBoxId}1.disabled-classification`).to.be.present;
+      client.assert.urlContains('(disabled=0-1-2-3-4-5-6-7-8-9-10-11-12-13-14-15)');
+    });
+  },
+  'Verify that toggling class-all on updates permalink and layer-legend': (client) => {
+    client.click('.classification-switch-header .react-switch-case .react-switch-button');
+    client.pause(1000);
+    client.expect.element(`${classColorBoxId}0.disabled-classification`).to.not.be.present;
+    client.expect.element(`${classColorBoxId}15.disabled-classification`).to.not.be.present;
+  },
+  'Verify that loaded permalink disables classes': (client) => {
     client.url(client.globals.url + disabledPermalink);
     client.waitForElementVisible(`${classColorBoxId}0`, TIME_LIMIT, () => {
       client.expect.element(`${classColorBoxId}0.disabled-classification`).to.be.present;

--- a/web/css/switch.css
+++ b/web/css/switch.css
@@ -2,11 +2,18 @@
   display: flex;
   margin-bottom: 7px;
 }
-.react-switch.header {
-  margin-bottom: 14px;
-  flex-direction: row-reverse;
-  .switch-label-text {
-    font-size: 14px;
+
+.classification-switch-header {
+ display: flex;
+ justify-content: space-between;
+  .react-switch {
+    flex-direction: row-reverse;
+  }
+  .react-switch-case {
+    width: 30px
+  }
+  .react-switch-label-case{
+    width: 20px
   }
 }
 .react-switch .switch-col {

--- a/web/css/switch.css
+++ b/web/css/switch.css
@@ -2,6 +2,13 @@
   display: flex;
   margin-bottom: 7px;
 }
+.react-switch.header {
+  margin-bottom: 14px;
+  flex-direction: row-reverse;
+  .switch-label-text {
+    font-size: 14px;
+  }
+}
 .react-switch .switch-col {
   align-items: flex-start;
   display: flex;

--- a/web/css/switch.css
+++ b/web/css/switch.css
@@ -4,16 +4,16 @@
 }
 
 .classification-switch-header {
- display: flex;
- justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
   .react-switch {
     flex-direction: row-reverse;
   }
   .react-switch-case {
-    width: 30px
+    width: 30px;
   }
-  .react-switch-label-case{
-    width: 20px
+  .react-switch-label-case {
+    width: 20px;
   }
 }
 .react-switch .switch-col {

--- a/web/js/components/layer/settings/classification-toggle.js
+++ b/web/js/components/layer/settings/classification-toggle.js
@@ -34,7 +34,7 @@ export default function ClassificationToggle(props) {
         />
 
       </div>
-      <Scrollbar style={{ maxHeight: `${height}px` }}>
+      <Scrollbar className="classification-list" style={{ maxHeight: `${height}px` }}>
         {legend.colors.map((color, index) => {
           const id = legend.id + index;
           const tooltip = tooltips[index];

--- a/web/js/components/layer/settings/classification-toggle.js
+++ b/web/js/components/layer/settings/classification-toggle.js
@@ -1,16 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import lodashGet from 'lodash/get';
 import Switch from '../../util/switch';
 import Scrollbar from '../../util/scrollbar';
 
-export default function ClassificationToggle (props) {
+
+export default function ClassificationToggle(props) {
   const {
-    legend, toggle, palette, height,
+    legend, toggle, palette, height, toggleAll,
   } = props;
+  const switchLength = legend.colors.length;
+
+  const [isEnableAllSelected, toggleEnableAll] = useState((lodashGet(palette, 'disabled.length') === switchLength) && switchLength);
+
   const { tooltips } = legend;
+
+
   return (
     <div className="layer-classification-toggle settings-component">
-      <h2 className="wv-header">Disable/Enable</h2>
+      <Switch
+        id="header-disable"
+        key="header-disable"
+        label="Disable/Enable"
+        containerClassAddition="header"
+        active={!isEnableAllSelected}
+        toggle={() => {
+          const arrayOfIndices = !isEnableAllSelected ? [...Array(switchLength).keys()] : [];
+          toggleAll(arrayOfIndices);
+          toggleEnableAll(!isEnableAllSelected);
+        }}
+      />
       <Scrollbar style={{ maxHeight: `${height}px` }}>
         {legend.colors.map((color, index) => {
           const id = legend.id + index;
@@ -37,4 +56,5 @@ ClassificationToggle.propTypes = {
   legend: PropTypes.object,
   palette: PropTypes.object,
   toggle: PropTypes.func,
+  toggleAll: PropTypes.func,
 };

--- a/web/js/components/layer/settings/classification-toggle.js
+++ b/web/js/components/layer/settings/classification-toggle.js
@@ -18,18 +18,22 @@ export default function ClassificationToggle(props) {
 
   return (
     <div className="layer-classification-toggle settings-component">
-      <Switch
-        id="header-disable"
-        key="header-disable"
-        label="Disable/Enable"
-        containerClassAddition="header"
-        active={!isEnableAllSelected}
-        toggle={() => {
-          const arrayOfIndices = !isEnableAllSelected ? [...Array(switchLength).keys()] : [];
-          toggleAll(arrayOfIndices);
-          toggleEnableAll(!isEnableAllSelected);
-        }}
-      />
+      <div className="classification-switch-header">
+        <h2 className="wv-header">Disable/Enable</h2>
+        <Switch
+          id="header-disable"
+          key="header-disable"
+          label="All"
+          active={!isEnableAllSelected}
+          containerClassAddition="header"
+          toggle={() => {
+            const arrayOfIndices = !isEnableAllSelected ? [...Array(switchLength).keys()] : [];
+            toggleAll(arrayOfIndices);
+            toggleEnableAll(!isEnableAllSelected);
+          }}
+        />
+
+      </div>
       <Scrollbar style={{ maxHeight: `${height}px` }}>
         {legend.colors.map((color, index) => {
           const id = legend.id + index;

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -212,20 +212,20 @@ class LayerSettings extends React.Component {
       <>
         {legend.type !== 'classification'
           && (
-          <PaletteThreshold
-            key={`${layer.id}0_threshold`}
-            legend={legend}
-            setRange={setThresholdRange}
-            min={0}
-            max={max}
-            start={start}
-            layerId={layer.id}
-            end={end}
-            squashed={!!palette.squash}
-            groupName={groupName}
-            index={0}
-            palette={palette}
-          />
+            <PaletteThreshold
+              key={`${layer.id}0_threshold`}
+              legend={legend}
+              setRange={setThresholdRange}
+              min={0}
+              max={max}
+              start={start}
+              layerId={layer.id}
+              end={end}
+              squashed={!!palette.squash}
+              groupName={groupName}
+              index={0}
+              palette={palette}
+            />
           )}
         <Palette
           setCustomPalette={setCustomPalette}
@@ -338,7 +338,6 @@ const mapDispatchToProps = (dispatch) => ({
     );
   },
   toggleAllClassification: (layerId, disabledArray, index, groupName) => {
-    console.log(disabledArray);
     dispatch(
       refreshDisabledClassification(layerId, disabledArray, index, groupName),
     );

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -71,7 +71,7 @@ class LayerSettings extends React.Component {
       setThresholdRange,
       layer,
       toggleClassification,
-      toggleAllClassification,
+      toggleAllClassifications,
       screenHeight,
     } = this.props;
     const { activeIndex } = this.state;
@@ -103,7 +103,7 @@ class LayerSettings extends React.Component {
               palette={palette}
               toggle={(classIndex) => toggleClassification(layer.id, classIndex, i, groupName)}
               legend={legend}
-              toggleAll={(disabledArray) => { toggleAllClassification(layer.id, disabledArray, i, groupName); }}
+              toggleAll={(disabledArray) => { toggleAllClassifications(layer.id, disabledArray, i, groupName); }}
             />
           </TabPane>
         );
@@ -184,7 +184,7 @@ class LayerSettings extends React.Component {
       groupName,
       layer,
       toggleClassification,
-      toggleAllClassification,
+      toggleAllClassifications,
       screenHeight,
     } = this.props;
     const paletteLegends = getPaletteLegends(layer.id);
@@ -204,7 +204,7 @@ class LayerSettings extends React.Component {
           palette={palette}
           toggle={(classIndex) => toggleClassification(layer.id, classIndex, 0, groupName)}
           legend={legend}
-          toggleAll={(disabledArray) => { toggleAllClassification(layer.id, disabledArray, 0, groupName); }}
+          toggleAll={(disabledArray) => { toggleAllClassifications(layer.id, disabledArray, 0, groupName); }}
         />
       );
     }
@@ -337,7 +337,7 @@ const mapDispatchToProps = (dispatch) => ({
       setToggledClassification(layerId, classIndex, index, groupName),
     );
   },
-  toggleAllClassification: (layerId, disabledArray, index, groupName) => {
+  toggleAllClassifications: (layerId, disabledArray, index, groupName) => {
     dispatch(
       refreshDisabledClassification(layerId, disabledArray, index, groupName),
     );
@@ -398,6 +398,6 @@ LayerSettings.propTypes = {
   setStyle: PropTypes.func,
   setThresholdRange: PropTypes.func,
   toggleClassification: PropTypes.func,
-  toggleAllClassification: PropTypes.func,
+  toggleAllClassifications: PropTypes.func,
   vectorStyles: PropTypes.object,
 };

--- a/web/js/components/layer/settings/settings.js
+++ b/web/js/components/layer/settings/settings.js
@@ -28,6 +28,7 @@ import {
   setCustomPalette,
   clearCustomPalette,
   setToggledClassification,
+  refreshDisabledClassification,
 } from '../../../modules/palettes/actions';
 import {
   setFilterRange,
@@ -70,6 +71,7 @@ class LayerSettings extends React.Component {
       setThresholdRange,
       layer,
       toggleClassification,
+      toggleAllClassification,
       screenHeight,
     } = this.props;
     const { activeIndex } = this.state;
@@ -96,7 +98,13 @@ class LayerSettings extends React.Component {
       if (legend.type === 'classification' && legend.colors.length > 1) {
         paneItemEl = (
           <TabPane key={`${legend.id}pane`} tabId={i}>
-            <ClassificationToggle height={Math.ceil(screenHeight / 3)} palette={palette} toggle={(classIndex) => toggleClassification(layer.id, classIndex, i, groupName)} legend={legend} />
+            <ClassificationToggle
+              height={Math.ceil(screenHeight / 3)}
+              palette={palette}
+              toggle={(classIndex) => toggleClassification(layer.id, classIndex, i, groupName)}
+              legend={legend}
+              toggleAll={(disabledArray) => { toggleAllClassification(layer.id, disabledArray, i, groupName); }}
+            />
           </TabPane>
         );
       } else if (
@@ -176,6 +184,7 @@ class LayerSettings extends React.Component {
       groupName,
       layer,
       toggleClassification,
+      toggleAllClassification,
       screenHeight,
     } = this.props;
     const paletteLegends = getPaletteLegends(layer.id);
@@ -189,7 +198,15 @@ class LayerSettings extends React.Component {
     if (len > 1) {
       return this.renderMultiColormapCustoms(paletteLegends);
     } if (legend.type === 'classification' && legend.colors.length > 1) {
-      return (<ClassificationToggle height={Math.ceil(screenHeight / 2)} palette={palette} toggle={(classIndex) => toggleClassification(layer.id, classIndex, 0, groupName)} legend={legend} />);
+      return (
+        <ClassificationToggle
+          height={Math.ceil(screenHeight / 2)}
+          palette={palette}
+          toggle={(classIndex) => toggleClassification(layer.id, classIndex, 0, groupName)}
+          legend={legend}
+          toggleAll={(disabledArray) => { toggleAllClassification(layer.id, disabledArray, 0, groupName); }}
+        />
+      );
     }
     return (
       <>
@@ -320,6 +337,12 @@ const mapDispatchToProps = (dispatch) => ({
       setToggledClassification(layerId, classIndex, index, groupName),
     );
   },
+  toggleAllClassification: (layerId, disabledArray, index, groupName) => {
+    console.log(disabledArray);
+    dispatch(
+      refreshDisabledClassification(layerId, disabledArray, index, groupName),
+    );
+  },
   setThresholdRange: (layerId, min, max, squash, index, groupName) => {
     dispatch(
       setThresholdRangeAndSquash(layerId, { min, max, squash }, index, groupName),
@@ -376,5 +399,6 @@ LayerSettings.propTypes = {
   setStyle: PropTypes.func,
   setThresholdRange: PropTypes.func,
   toggleClassification: PropTypes.func,
+  toggleAllClassification: PropTypes.func,
   vectorStyles: PropTypes.object,
 };

--- a/web/js/components/util/switch.js
+++ b/web/js/components/util/switch.js
@@ -27,7 +27,7 @@ const Switch = (props) => {
     toggleActive(active);
   }, [active]);
 
-  function toggleSwitch () {
+  function toggleSwitch() {
     // wait for css animation to complete before firing action
     setTimeout(toggle, 200);
     toggleActive(!isActive);
@@ -90,4 +90,5 @@ Switch.propTypes = {
   toggle: PropTypes.func,
   tooltip: PropTypes.object,
 };
+
 export default Switch;


### PR DESCRIPTION
## Description

Fixes #2931

Add Enable/Disable classifications option.

Testing:

1. [Open page with land cover type layer active](http://localhost:3000/?t=2018-10-24-T17%3A04%3A50Z&l=MODIS_Combined_L3_IGBP_Land_Cover_Type_Annual,Reference_Labels(hidden),Reference_Features(hidden),Coastlines,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor)
2. Go to settings for land cover type

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
