### PR TITLE
lessen acceptable color difference for running data values

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -242,7 +242,7 @@ class PaletteLegend extends React.Component {
     const toolTipLength = legend.tooltips.length;
     // eslint-disable-next-line react/destructuring-assignment
     if (isRunningData && colorHex && this.state.width > 0) {
-      legendObj = getLegendObject(legend, colorHex, 5); // {label,len,index}
+      legendObj = getLegendObject(legend, colorHex, 3); // {label,len,index}
       if (legendObj) {
         percent = this.getPercent(legendObj.len, legendObj.index);
         textWidth = util.getTextWidth(legendObj.label, '10px Open Sans');


### PR DESCRIPTION
## Description

Fixes #2716

What should be zero value for the "Probabilities for Urban Expansion" layer displays as a 1% value for some palettes, and a 0% value for other palettes.

### Steps to reproduce the behavior:

    Go to Add Layers, Add "Probabilities for Urban Expansion"
    Hover over the yellow part, the legend says it's 1%
    Change to Orange 1 palette, hover over the same area, and the legend says it's 1% (was 0% before)


- [x] lessen acceptable color difference for running data values

## Further comments

I think the colorDifference delta is related to this comment: https://github.com/nasa-gibs/worldview/issues/2930#issuecomment-638913062

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
