### PR TITLE
Reduce processColormap.py log output

### DIFF
--- a/tasks/python3/processColormap.py
+++ b/tasks/python3/processColormap.py
@@ -194,8 +194,7 @@ if __name__ == "__main__":
             except Exception as e:
                 sys.stderr.write("%s: ERROR: [%s] %s\n" % (prog, id, str(e)))
                 error_count += 1
-
-print("%s: %d error(s), %d file(s)" % (prog, error_count, file_count))
+    print("%s: %d error(s), %d file(s)" % (prog, error_count, file_count))
 
 if error_count > 0:
     sys.exit(1)


### PR DESCRIPTION
## Description

Fix indentation of `print` call in `processColormap.py` so logs only print once for the entire process instead of each thread

### Before
```
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 0 file(s)
processColormap.py: 0 error(s), 599 file(s)
```

### After
```
processColormap.py: 0 error(s), 599 file(s)
```

