### PR TITLE
Inactive events alert

### DIFF
--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -134,6 +134,15 @@ module.exports = {
       c.assert.equal(tabs.value.length, 2);
     });
   },
+  'Loading an inactive event shows an alert': (c) => {
+    const inactiveEventAlert = '#event-unavailable-alert';
+    const inactiveAlertMsgContainer = `${inactiveEventAlert} .wv-alert-message`;
+    const inactiveEventMsg = 'The event with an id of EONET_5133 is no longer active.';
+
+    c.url(c.globals.url + localQuerystrings.closedEvent);
+    c.expect.element(inactiveEventAlert).to.be.present;
+    c.assert.containsText(inactiveAlertMsgContainer, inactiveEventMsg);
+  },
   after(c) {
     c.end();
   },

--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -19,6 +19,16 @@ module.exports = {
   before(c) {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
   },
+  'Loading an inactive event shows an alert': (c) => {
+    const inactiveEventAlert = '#event-unavailable-alert';
+    const inactiveAlertMsgContainer = `${inactiveEventAlert} .wv-alert-message`;
+    const inactiveEventMsg = 'The event with an id of EONET_5133 is no longer active.';
+
+    c.url(c.globals.url + localQuerystrings.closedEvent);
+    c.waitForElementVisible(inactiveEventAlert, TIME_LIMIT);
+    c.expect.element(inactiveEventAlert).to.be.present;
+    c.assert.containsText(inactiveAlertMsgContainer, inactiveEventMsg);
+  },
   'Make sure that 4 fire layers are not present in layer list: use mock': (c) => {
     c.url(c.globals.url + localQuerystrings.mockEvents);
     c.waitForElementVisible(
@@ -133,15 +143,6 @@ module.exports = {
     c.windowHandles((tabs) => {
       c.assert.equal(tabs.value.length, 2);
     });
-  },
-  'Loading an inactive event shows an alert': (c) => {
-    const inactiveEventAlert = '#event-unavailable-alert';
-    const inactiveAlertMsgContainer = `${inactiveEventAlert} .wv-alert-message`;
-    const inactiveEventMsg = 'The event with an id of EONET_5133 is no longer active.';
-
-    c.url(c.globals.url + localQuerystrings.closedEvent);
-    c.expect.element(inactiveEventAlert).to.be.present;
-    c.assert.containsText(inactiveAlertMsgContainer, inactiveEventMsg);
   },
   after(c) {
     c.end();

--- a/e2e/features/measure/measure-test.js
+++ b/e2e/features/measure/measure-test.js
@@ -16,7 +16,6 @@ const {
   sidebarContainer,
   unitOfMeasureToggle,
   downloadGeojsonBtn,
-  downloadShapefileBtn,
 } = localSelectors;
 
 function createDistanceMeasurement(c, [startX, startY], [endX, endY]) {
@@ -59,18 +58,13 @@ module.exports = {
     if (c.options.desiredCapabilities.browserName === 'firefox') { // right click doesn't work in firefox
       return;
     }
-    c.useCss().click(measureBtn);
-    c.waitForElementVisible(measureMenu);
-    c.waitForElementVisible(measureDistanceBtn, TIME_LIMIT);
-    c.click(measureDistanceBtn);
-    c.pause(300);
     c.moveToElement('#wv-map-geographic', 200, 110)
       .mouseButtonClick(0)
       .moveTo(null, 200, 210)
       .mouseButtonClick(1)
       .mouseButtonClick(0);
     c.pause(300);
-    // c.expect.element('#measurement-alert').to.not.be.present;
+    c.expect.element('#measurement-alert').to.not.be.present;
     c.expect.element(sidebarContainer)
       .to.have.css('max-height').which.does.not.equal('0px');
   },
@@ -112,7 +106,6 @@ module.exports = {
     }
     c.click(measureBtn);
     c.waitForElementVisible(downloadGeojsonBtn);
-    c.waitForElementVisible(downloadShapefileBtn);
     c.click('.modal');
   },
   'Switching to arctic projection, no measurements show': (c) => {
@@ -128,7 +121,6 @@ module.exports = {
     }
     c.click(measureBtn);
     c.expect.element(downloadGeojsonBtn).to.not.be.present;
-    c.expect.element(downloadShapefileBtn).to.not.be.present;
     c.click('.modal');
   },
   'Creating measurements in arctic projection causes tooltips to show': (c) => {

--- a/e2e/reuseables/querystrings.js
+++ b/e2e/reuseables/querystrings.js
@@ -25,6 +25,7 @@ module.exports = {
   // events
   eventsTabActive: '?e=true',
   mockEvents: '?p=geographic&l=VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Labels(hidden),Reference_Features(hidden),Coastlines&t=2018-05-02-T00%3A00%3A00Z&z=3&v=-409.00147812273656,-205.62883007565202,270.5880270080828,219.11461063111003&e=true&mockEvents=20170530',
+  closedEvent: '?e=EONET_5133',
 
   // layers
   multipleDataLayers: '?p=geographic&l=MODIS_Terra_Aerosol,MODIS_Terra_Brightness_Temp_Band31_Day&t=2017-03-22&z=3&v=136.07019188386334,14.722152527011556,155.59817576644127,24.312819167567586',

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import lodashFind from 'lodash/find';
 import googleTagManager from 'googleTagManager';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { getDefaultEventDate } from '../../map/natural-events/util';
 import util from '../../util/util';
 
 function Event (props) {
@@ -34,10 +35,32 @@ function Event (props) {
     }
   }, [isSelected]);
 
+
+  /**
+   *
+   * @param {String} date | Date of event clicked
+   * @param {Boolean} isSelected | Is this event already selected
+   * @param {Object} e | Event Object
+   */
+  function onEventSelect(date) {
+    if (isSelected && (!date || date === selectedDate)) {
+      deselectEvent();
+    } else {
+      const selectedEventDate = date || getDefaultEventDate(event);
+      selectEvent(event.id, selectedEventDate);
+      googleTagManager.pushEvent({
+        event: 'natural_event_selected',
+        natural_events: {
+          category: event.categories[0].title,
+        },
+      });
+    }
+  }
+
   /**
    * Return date list for selected event
    */
-  function getDateLists() {
+  function renderDateLists() {
     if (event.geometry.length > 1) {
       return (
         <ul
@@ -51,7 +74,7 @@ function Event (props) {
                 <a
                   onClick={(e) => {
                     e.stopPropagation();
-                    onClick(date);
+                    onEventSelect(date);
                   }}
                   className={
                     selectedDate === date
@@ -70,29 +93,9 @@ function Event (props) {
   }
 
   /**
-   *
-   * @param {String} date | Date of event clicked
-   * @param {Boolean} isSelected | Is this event already selected
-   * @param {Object} e | Event Object
-   */
-  function onClick(date) {
-    if (isSelected && (!date || date === selectedDate)) {
-      deselectEvent();
-    } else {
-      selectEvent(event.id, date);
-      googleTagManager.pushEvent({
-        event: 'natural_event_selected',
-        natural_events: {
-          category: event.categories[0].title,
-        },
-      });
-    }
-  }
-
-  /**
    * Return reference list for an event
    */
-  function getReferenceList() {
+  function renderReferenceList() {
     if (!isSelected) return;
 
     const references = Array.isArray(event.sources)
@@ -132,7 +135,7 @@ function Event (props) {
       className={itemClass}
       onClick={(e) => {
         e.stopPropagation();
-        onClick();
+        onEventSelect();
       }}
     >
       <i
@@ -144,8 +147,8 @@ function Event (props) {
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: `${event.title}<br />${dateString}` }}
       />
-      <p className="subtitle">{getReferenceList()}</p>
-      {getDateLists()}
+      <p className="subtitle">{renderReferenceList()}</p>
+      {renderDateLists()}
     </li>
   );
 }

--- a/web/js/containers/alerts.js
+++ b/web/js/containers/alerts.js
@@ -41,7 +41,7 @@ class DismissableAlerts extends React.Component {
     if (isSmall || !HAS_LOCAL_STORAGE) return null;
     return (
       <>
-        {!hasDismissedEvents && isEventsActive ? (
+        {!hasDismissedEvents && isEventsActive && (
           <AlertUtil
             id="event-alert"
             isOpen
@@ -50,8 +50,8 @@ class DismissableAlerts extends React.Component {
             onDismiss={() => this.dismissAlert(DISMISSED_EVENT_VIS_ALERT, 'hasDismissedEvents')}
             message="Events may not be visible at all times."
           />
-        ) : null}
-        {!hasDismissedCompare && isCompareActive ? (
+        )}
+        {!hasDismissedCompare && isCompareActive && (
           <AlertUtil
             isOpen
             noPortal
@@ -59,8 +59,8 @@ class DismissableAlerts extends React.Component {
             onDismiss={() => this.dismissAlert(DISMISSED_COMPARE_ALERT, 'hasDismissedCompare')}
             message="You are now in comparison mode."
           />
-        ) : null}
-        {isVectorAlertPresent ? (
+        )}
+        {isVectorAlertPresent && (
           <AlertUtil
             isOpen
             noPortal
@@ -68,7 +68,7 @@ class DismissableAlerts extends React.Component {
             onDismiss={dismissVectorAlert}
             message="Vector features may not be clickable at all zoom levels."
           />
-        ) : null}
+        )}
       </>
     );
   }

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -48,7 +48,7 @@ function Events(props) {
   const ALL_CATEGORY = 'All Event Categories';
   const [selectedCategory, selectCategory] = useState(ALL_CATEGORY);
 
-  const [showInactiveEventAlert, setInactiveEventAlert] = useState(selected.id && !selected.date);
+  let showInactiveEventAlert = selected.id && !selected.date;
 
   const initRequests = () => {
     let eventsRequestURL = `${apiURL}/events`;
@@ -160,7 +160,7 @@ function Events(props) {
         <AlertUtil
           id="event-unavailable-alert"
           isOpen
-          onDismiss={() => { setInactiveEventAlert(false); }}
+          onDismiss={() => { showInactiveEventAlert = false; }}
           message={`The event with an id of ${selected.id} is no longer active.`}
         />
       )}

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -18,6 +18,7 @@ import { collapseSidebar } from '../../modules/sidebar/actions';
 import { selectDate } from '../../modules/date/actions';
 import getSelectedDate from '../../modules/date/selectors';
 import { getEventCategories } from '../../modules/natural-events/selectors';
+import AlertUtil from '../../components/util/alert';
 
 function Events(props) {
   const {
@@ -47,6 +48,7 @@ function Events(props) {
   const ALL_CATEGORY = 'All Event Categories';
   const [selectedCategory, selectCategory] = useState(ALL_CATEGORY);
 
+  const [showInactiveEventAlert, setInactiveEventAlert] = useState(selected.id && !selected.date);
 
   const initRequests = () => {
     let eventsRequestURL = `${apiURL}/events`;
@@ -154,6 +156,14 @@ function Events(props) {
         </div>
       </Scrollbars>
 
+      {showInactiveEventAlert && (
+        <AlertUtil
+          id="event-unavailable-alert"
+          isOpen
+          onDismiss={() => { setInactiveEventAlert(false); }}
+          message={`The event with an id of ${selected.id} is no longer active.`}
+        />
+      )}
     </div>
   );
 }

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -73,9 +73,10 @@ function Events(props) {
     initRequests();
   }
 
-  if (selected.id && !visibleWithinMapExtent[selected.id] && events && events.length) {
+  if (selected.id && selected.date && !visibleWithinMapExtent[selected.id] && events && events.length) {
     deselectEvent();
   }
+
   const errorOrLoadingText = isLoading
     ? 'Loading...'
     : hasRequestError
@@ -167,7 +168,7 @@ const mapDispatchToProps = (dispatch) => ({
       dispatch(selectDate(new Date(dateStr)));
     }
   },
-  deselectEvent: (id, date) => {
+  deselectEvent: () => {
     dispatch(deselectEventActionCreator());
   },
   requestEvents: (url) => {

--- a/web/js/map/natural-events/track.js
+++ b/web/js/map/natural-events/track.js
@@ -13,7 +13,6 @@ import {
   debounce as lodashDebounce,
 } from 'lodash';
 
-import { naturalEventsUtilGetEventById } from './util';
 import {
   naturalEventsClusterPointToGeoJSON,
   naturalEventsClusterGetPoints,
@@ -30,6 +29,7 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
   const self = {};
   self.trackDetails = {};
   self.active = false;
+
   /**
    * @return {void}
    */
@@ -161,16 +161,13 @@ export default function naturalEventsTrack(ui, store, selectedMap) {
   };
 
   const debounceTrackUpdate = lodashDebounce(() => {
-    const selectedEvent = ui.naturalEvents.selected;
+    const { eventsData, selected } = ui.naturalEvents;
 
-    if (!selectedEvent.id || !selectedEvent.date) {
+    if (!selected.id || !selected.date) {
       return;
     }
-    const event = naturalEventsUtilGetEventById(
-      ui.naturalEvents.eventsData,
-      selectedEvent.id,
-    );
-    self.update(event, selectedEvent.date, (id, date) => {
+    const event = eventsData.find((e) => e.id === selected.id);
+    self.update(event, selected.date, (id, date) => {
       store.dispatch(selectEventAction(id, date));
     });
   }, 250);

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -8,11 +8,8 @@ import util from '../../util/util';
 import { CHANGE_TAB as CHANGE_SIDEBAR_TAB } from '../../modules/sidebar/constants';
 import * as EVENT_CONSTANTS from '../../modules/natural-events/constants';
 import { activateLayersForEventCategory } from '../../modules/layers/actions';
-import {
-  deselectEvent as deselectEventAction,
-  selected as selectedAction,
-} from '../../modules/natural-events/actions';
-import { getDefaultEventDate, naturalEventsUtilGetEventById } from './util';
+import { selected as selectedAction } from '../../modules/natural-events/actions';
+import { getDefaultEventDate } from './util';
 import { selectDate } from '../../modules/date/actions';
 import { UPDATE_MAP_UI } from '../../modules/map/constants';
 import { LOCATION_POP_ACTION } from '../../redux-location-state-customs';
@@ -166,7 +163,7 @@ export default function naturalEventsUI(ui, config, store, models) {
           filterEventList();
         }
         if (self.selected.date) {
-          const event = naturalEventsUtilGetEventById(self.eventsData, self.selected.id);
+          const event = self.eventsData.find((e) => e.id === self.selected.id);
           setTimeout(() => {
             naturalEventsTrack.update(event, self.selected.date);
             zoomToEvent(event, self.selected.date, null, false);
@@ -244,9 +241,9 @@ export default function naturalEventsUI(ui, config, store, models) {
   const selectEvent = function(id, date, rotation, isInitialLoad) {
     const isIdChange = !self.selected || self.selected.id !== id;
     const prevId = self.selected.id ? self.selected.id : false;
-    const prevEvent = prevId && naturalEventsUtilGetEventById(self.eventsData, prevId);
+    const prevEvent = prevId && self.eventsData.find((e) => e.id === prevId);
     const prevCategory = prevEvent ? prevEvent.categories[0].title : false;
-    const event = naturalEventsUtilGetEventById(self.eventsData, id);
+    const event = self.eventsData.find((e) => e.id === id);
     const category = event && event.categories[0].title;
     const isSameCategory = category === prevCategory;
     if (!event) {
@@ -314,7 +311,7 @@ export default function naturalEventsUI(ui, config, store, models) {
       self.markers = naturalEventMarkers.draw();
       naturalEventsTrack.update(null);
     }
-    store.dispatch(deselectEventAction);
+    // store.dispatch(deselectEventAction);
     self.events.trigger('change');
   };
 

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -3,7 +3,6 @@ import * as olProj from 'ol/proj';
 import { forOwn as lodashForOwn, find as lodashFind } from 'lodash';
 import markers from './markers';
 import track from './track';
-import wvui from '../../ui/ui';
 import util from '../../util/util';
 import { CHANGE_TAB as CHANGE_SIDEBAR_TAB } from '../../modules/sidebar/constants';
 import * as EVENT_CONSTANTS from '../../modules/natural-events/constants';

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -261,7 +261,7 @@ export default function naturalEventsUI(ui, config, store, models) {
       !isIdChange,
       isInitialLoad,
     );
-    // highlightEventInList(id, date);
+
     // Remove previously stored markers
     naturalEventMarkers.remove(self.markers);
     // Store markers so the can be referenced later
@@ -285,7 +285,9 @@ export default function naturalEventsUI(ui, config, store, models) {
             selectDate(util.dateAdd(util.parseDateUTC(date), 'day', 1)),
           );
         }
-      } else if (!isInitialLoad) store.dispatch(selectDate(util.parseDateUTC(date)));
+      } else if (!isInitialLoad) {
+        store.dispatch(selectDate(util.parseDateUTC(date)));
+      }
       self.selecting = false;
       if (isIdChange && !isSameCategory && !isInitialLoad) {
         activateLayersForCategory(event.categories[0].title);

--- a/web/js/map/natural-events/ui.js
+++ b/web/js/map/natural-events/ui.js
@@ -247,7 +247,6 @@ export default function naturalEventsUI(ui, config, store, models) {
     const category = event && event.categories[0].title;
     const isSameCategory = category === prevCategory;
     if (!event) {
-      wvui.notify(`The event with an id of ${id} is no longer active.`);
       return;
     }
     date = date || getDefaultEventDate(event);

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -3,18 +3,6 @@ import * as olProj from 'ol/proj';
 import * as olExtent from 'ol/extent';
 
 /**
- * Find event in array of events
- * using event id
- *
- * @param  {Array} events Array of Eonet Events
- * @param  {String} id Event Id
- * @return {Object} Eonet Event Object
- */
-export function naturalEventsUtilGetEventById(events, id) {
-  return lodashFind(events, (e) => e.id === id);
-}
-
-/**
  *
  * @param {*} event
  */

--- a/web/js/modules/natural-events/actions.js
+++ b/web/js/modules/natural-events/actions.js
@@ -47,8 +47,6 @@ export function selectEvent(id, date) {
 export function deselectEvent(id, date) {
   return {
     type: DESELECT_EVENT,
-    id,
-    date,
   };
 }
 


### PR DESCRIPTION
## Description

Fixes #3186.

- [x] make sure alert shows only when event is not available
- [x] replace old alert type with new one

## To Test:

1. Go to [http://localhost:3000/?e=EONET_5133](http://localhost:3000/?e=EONET_5133)
2. Confirm alert shows
3. Close alert
4. Click various other events, confirm they load properly 
5. Confirm alert does not show when clicking other events