### PR TITLE
Revert map change:resolution zoom event

### DIFF
--- a/web/js/components/dateline/dateline.js
+++ b/web/js/components/dateline/dateline.js
@@ -16,9 +16,21 @@ class Line extends React.Component {
     super(props);
     this.state = {
       hovered: false,
-      height: props.height,
+      height: 0,
       active: true,
     };
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const { active, height, hovered } = this.state;
+    const checkForStateUpdates = nextState.active === active
+      && nextState.height === height
+      && nextState.hovered === hovered;
+
+    if (checkForStateUpdates) {
+      return false;
+    }
+    return true;
   }
 
   /*
@@ -26,7 +38,7 @@ class Line extends React.Component {
    *
    * return {Void}
    */
-  mouseOver() {
+  mouseOver = () => {
     this.setState({
       hovered: true,
     });
@@ -37,7 +49,7 @@ class Line extends React.Component {
    *
    * return {Void}
    */
-  mouseOut() {
+  mouseOut = () => {
     this.setState({
       hovered: false,
     });
@@ -51,7 +63,7 @@ class Line extends React.Component {
    * @param {Object} e - React event object
    * return {Void}
    */
-  mouseOverHidden(e) {
+  mouseOverHidden = (e) => {
     const {
       lineOver, overlay, lineX, tooltip,
     } = this.props;
@@ -70,7 +82,7 @@ class Line extends React.Component {
    *
    * return {Void}
    */
-  mouseOutHidden() {
+  mouseOutHidden = () => {
     const { lineOut, tooltip } = this.props;
     lineOut(tooltip);
   }
@@ -90,8 +102,8 @@ class Line extends React.Component {
     const { height, active, hovered } = this.state;
     return (
       <svg
-        onMouseOver={this.mouseOver.bind(this)}
-        onMouseOut={this.mouseOut.bind(this)}
+        onMouseOver={this.mouseOver}
+        onMouseOut={this.mouseOut}
         style={svgStyle}
         width={width}
         id={id}
@@ -115,9 +127,9 @@ class Line extends React.Component {
         />
         <line
           className="dateline-hidden"
-          onMouseOver={this.mouseOverHidden.bind(this)}
-          onMouseMove={this.mouseOverHidden.bind(this)}
-          onMouseOut={this.mouseOutHidden.bind(this)}
+          onMouseOver={this.mouseOverHidden}
+          onMouseMove={this.mouseOverHidden}
+          onMouseOut={this.mouseOutHidden}
           style={style}
           opacity="0"
           x1={strokeWidth / 2}
@@ -137,7 +149,6 @@ Line.defaultProps = {
   width: '10',
   strokeWidth: '6',
   color: 'white',
-  height: 200,
   svgStyle: {
     margin: '0 40px 0 40px',
     transform: 'translateX(-43px)',
@@ -148,7 +159,6 @@ Line.propTypes = {
   classes: PropTypes.string,
   color: PropTypes.string,
   dashArray: PropTypes.string,
-  height: PropTypes.number,
   id: PropTypes.string,
   lineOut: PropTypes.func,
   lineOver: PropTypes.func,

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import OlOverlay from 'ol/Overlay';
-
 import util from '../util/util';
 import DateLine from '../components/dateline/dateline';
 import LineText from '../components/dateline/text';

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -77,7 +77,6 @@ export default function mapui(models, config, store, ui) {
   self.mapIsbeingDragged = false;
   self.mapIsbeingZoomed = false;
   self.proj = {}; // One map for each projection
-  self.zoomButtonListeners = []; // Track debounced zoom button listeners
   self.selected = null; // The map for the selected projection
   self.events = util.events();
   const layerBuilder = self.layerBuilder = mapLayerBuilder(
@@ -934,20 +933,6 @@ export default function mapui(models, config, store, ui) {
     $zoomIn.mousemove((e) => e.stopPropagation());
 
     /*
-     * Debounce for below onZoomChange function
-     *
-     * @funct debouncedZoomChange
-     * @static
-     *
-     * @returns {void}
-     *
-     */
-    const debouncedZoomChange = () => {
-      onZoomChange();
-      self.events.trigger('movestart');
-    };
-
-    /*
      * Sets zoom buttons as active or inactive based
      * on the zoom level
      *
@@ -971,7 +956,10 @@ export default function mapui(models, config, store, ui) {
         $zoomOut.button('enable');
       }
     };
-    map.getView().on('change:resolution', lodashDebounce(debouncedZoomChange, 30));
+    map.getView().on('change:resolution', () => {
+      onZoomChange();
+      self.events.trigger('movestart');
+    });
     onZoomChange();
   }
   /*


### PR DESCRIPTION
## Description

Fixes #3187  .

- [x] Revert map `change:resolution` zoom event to remove debounce causing event fire issue used in dateline, revise dateline to prevent unnecessary updates

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
