### PR TITLE
Remove unused ownProps

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -207,7 +207,7 @@ class App extends React.Component {
   }
 }
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   return {
     state,
     isAnimationWidgetActive: state.animation.isActive,
@@ -215,8 +215,6 @@ function mapStateToProps(state, ownProps) {
     tour: state.tour,
     config: state.config,
     parameters: state.parameters,
-    models: ownProps.models,
-    mapMouseEvents: ownProps.mapMouseEvents,
     locationKey: state.location.key,
     modalId: state.modal.id,
   };

--- a/web/js/components/feature-alert/geostationary-modal.js
+++ b/web/js/components/feature-alert/geostationary-modal.js
@@ -81,7 +81,7 @@ class GeostationaryModalBody extends React.Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = (state) => ({
   isMobile: state.browser.lessThan.medium,
 });
 

--- a/web/js/components/layer/product-picker/browse/browse-layers-list.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers-list.js
@@ -50,7 +50,7 @@ BrowseLayerList.propTypes = {
   selectedMeasurement: PropTypes.string,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const {
     productPicker,
     proj,

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -244,7 +244,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const {
     config,
     browser,

--- a/web/js/components/layer/product-picker/browse/category-grid.js
+++ b/web/js/components/layer/product-picker/browse/category-grid.js
@@ -60,7 +60,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const {
     proj,
     config,

--- a/web/js/components/layer/product-picker/browse/category-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/category-layer-row.js
@@ -239,7 +239,7 @@ CategoryLayerRow.propTypes = {
   selectedMeasurementSourceIndex: PropTypes.number,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const {
     config,
     browser,

--- a/web/js/components/layer/product-picker/browse/recent-layers.js
+++ b/web/js/components/layer/product-picker/browse/recent-layers.js
@@ -74,7 +74,7 @@ RecentLayersList.propTypes = {
   recentLayers: PropTypes.array,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { browser, productPicker } = state;
   const {
     selectedLayer,

--- a/web/js/components/layer/product-picker/header.js
+++ b/web/js/components/layer/product-picker/header.js
@@ -259,7 +259,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { productPicker, browser, proj } = state;
   const {
     mode,

--- a/web/js/components/layer/product-picker/search/facets.js
+++ b/web/js/components/layer/product-picker/search/facets.js
@@ -88,7 +88,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const { browser, productPicker } = state;
   const { showMobileFacets, collapsedFacets } = productPicker;
 

--- a/web/js/components/layer/product-picker/search/layer-metadata-detail.js
+++ b/web/js/components/layer/product-picker/search/layer-metadata-detail.js
@@ -218,7 +218,7 @@ LayerMetadataDetail.propTypes = {
   showPreviewImage: PropTypes.bool,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const {
     productPicker,
     proj,

--- a/web/js/components/layer/product-picker/search/search-layers-list.js
+++ b/web/js/components/layer/product-picker/search/search-layers-list.js
@@ -206,7 +206,7 @@ SearchLayerList.propTypes = {
   selectLayer: PropTypes.func,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { productPicker, browser } = state;
   const { selectedLayer, categoryType } = productPicker;
   return {

--- a/web/js/components/layer/product-picker/search/search-layers.js
+++ b/web/js/components/layer/product-picker/search/search-layers.js
@@ -47,7 +47,7 @@ SearchLayers.propTypes = {
   showMobileFacets: PropTypes.bool,
 };
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const { browser, productPicker } = state;
   const { selectedLayer, showMobileFacets } = productPicker;
 

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -96,7 +96,7 @@ class MeasureButton extends React.Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = (state) => ({
   isActive: state.measure.isActive,
   isDistractionFreeModeActive: state.ui.isDistractionFreeModeActive,
 });

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -111,7 +111,7 @@ class MeasureMenu extends Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const {
     modal, map, measure, proj, browser,
   } = state;
@@ -126,7 +126,7 @@ const mapStateToProps = (state, ownProps) => {
     measurementsInProj,
   };
 };
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   onToggleUnits: (unitOfMeasure) => {
     dispatch(changeUnits(unitOfMeasure));
   },

--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -372,7 +372,7 @@ class GIF extends Component {
   }
 }
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const {
     browser, proj, animation, map, date, config,
   } = state;
@@ -417,7 +417,6 @@ function mapStateToProps(state, ownProps) {
       dimensions,
       state,
     ),
-    onClose: ownProps.onClose,
   };
 }
 const mapDispatchToProps = (dispatch) => ({

--- a/web/js/containers/projection.js
+++ b/web/js/containers/projection.js
@@ -90,7 +90,7 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   updateProjection: (id, config) => {
     dispatch(changeProjection(id));
     dispatch(resetProductPickerState(id));

--- a/web/js/containers/sidebar/compare.js
+++ b/web/js/containers/sidebar/compare.js
@@ -89,7 +89,7 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(toggleActiveCompareState());
   },
 });
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   const {
     layers, compare, date,
   } = state;
@@ -102,7 +102,6 @@ function mapStateToProps(state, ownProps) {
     dateStringA: util.toISOStringDate(date.selected),
     dateStringB: util.toISOStringDate(date.selectedB),
     isActive: compare.active,
-    height: ownProps.height,
   };
 }
 CompareCase.propTypes = {

--- a/web/js/containers/sidebar/data.js
+++ b/web/js/containers/sidebar/data.js
@@ -106,7 +106,7 @@ Data.propTypes = {
   tabTypes: PropTypes.object,
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = (dispatch) => ({
   showUnavailableReason: () => {
     dispatch(
       openCustomContent('data_download_no_data_notify', {

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -172,8 +172,7 @@ const mapDispatchToProps = (dispatch) => ({
     );
   },
 });
-function mapStateToProps(state, ownProps) {
-  const { activeTab } = ownProps;
+function mapStateToProps(state) {
   const {
     requestedEvents, config, layers, data, compare, browser,
   } = state;
@@ -187,7 +186,6 @@ function mapStateToProps(state, ownProps) {
 
   return {
     showAll,
-    activeTab,
     events,
     counts,
     isMobile: browser.lessThan.medium,

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -171,14 +171,7 @@ LayerList.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const {
-    layers,
-    groupId,
-    title,
-    layerGroupName,
-    checkerBoardPattern,
-    layerSplit,
-  } = ownProps;
+  const { layerGroupName } = ownProps;
   const {
     proj, config, map,
   } = state;
@@ -190,15 +183,9 @@ function mapStateToProps(state, ownProps) {
     : {};
   return {
     zots,
-    layers,
-    groupId,
-    title,
-    layerGroupName,
     activeLayers,
     runningLayers,
     projId: id,
-    checkerBoardPattern,
-    layerSplit,
     getNames: (layerId) => getTitles(config, layerId, id),
     available: (layerId) => availableSelector(state)(layerId),
   };

--- a/web/js/containers/sidebar/layer.js
+++ b/web/js/containers/sidebar/layer.js
@@ -316,11 +316,7 @@ Layer.defaultProps = {
 function mapStateToProps(state, ownProps) {
   const {
     layer,
-    isDisabled,
     isVisible,
-    layerClasses,
-    names,
-    index,
     layerGroupName,
   } = ownProps;
   const {
@@ -342,12 +338,8 @@ function mapStateToProps(state, ownProps) {
     compare,
     tracksForLayer,
     layer,
-    isDisabled,
     isVisible,
-    layerClasses,
     paletteLegends,
-    names,
-    index,
     isCustomPalette,
     isLoading: palettes.isLoading[paletteName],
     renderedPalette: renderedPalettes[paletteName],

--- a/web/js/containers/sidebar/layers.js
+++ b/web/js/containers/sidebar/layers.js
@@ -45,9 +45,7 @@ const Layers = (props) => {
 
 function mapStateToProps(state, ownProps) {
   const { layers, proj } = state;
-  const {
-    isActive, layerGroupName, height, checkerBoardPattern,
-  } = ownProps;
+  const { layerGroupName } = ownProps;
   const componentLayers = layers[layerGroupName];
   const layerObj = getLayers(componentLayers, { proj: proj.id, group: 'all' });
 
@@ -55,10 +53,6 @@ function mapStateToProps(state, ownProps) {
     baselayers: layerObj.baselayers,
     overlays: layerObj.overlays,
     layerSplit: layerObj.overlays.length,
-    layerGroupName,
-    height,
-    isActive,
-    checkerBoardPattern,
   };
 }
 const mapDispatchToProps = (dispatch) => ({});

--- a/web/js/containers/sidebar/orbit-track.js
+++ b/web/js/containers/sidebar/orbit-track.js
@@ -87,7 +87,6 @@ function mapStateToProps(state, ownProps) {
     isCustomPalette,
     isLoading: palettes.isLoading[paletteName],
     renderedPalette: renderedPalettes[paletteName],
-    layerGroupName,
     isMobile: state.browser.lessThan.medium,
     hasPalette,
     getPalette: (layerId, index) => getPalette(trackLayer.id, index, layerGroupName, state),


### PR DESCRIPTION


## Description

Fixes #3192

- remove `ownProps` param from `mapStateToProps` where not needed
- remove properties being returned from `mapStateToProps` that are already on props
