### PR TITLE
Add react/no-unused-prop-types to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -120,6 +120,7 @@
 
         // React rules overrides
         "react/jsx-props-no-spreading": "warn", // 17 errors
+        "react/no-unused-prop-types": 2,
         "react/jsx-filename-extension": "off",
         "react/sort-comp": [
           "error",


### PR DESCRIPTION
## Description

Fixes #3231  .

- [x] Add `react/no-unused-prop-types` to eslint - enabling to setting `2` will throw error [https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
