### PR TITLE
Add dropdown height offset to scrollbar maxheight

### DIFF
--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -48,6 +48,9 @@ function Events(props) {
   const ALL_CATEGORY = 'All Event Categories';
   const [selectedCategory, selectCategory] = useState(ALL_CATEGORY);
 
+  const dropdownHeight = 34;
+  const scrollbarMaxHeight = height - dropdownHeight;
+
   let showInactiveEventAlert = selected.id && !selected.date;
 
   const initRequests = () => {
@@ -123,7 +126,7 @@ function Events(props) {
       </Dropdown>
 
       <Scrollbars
-        style={{ maxHeight: `${height}px` }}
+        style={{ maxHeight: `${scrollbarMaxHeight}px` }}
       >
         <div id="wv-events">
           {(isLoading || hasRequestError) && (


### PR DESCRIPTION
## Description

Fixes #3223  .

- [X] Add dropdown height offset to scrollbar `maxHeight` to prevent covering up Layers/Events tabs in mobile.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
