### PR TITLE
Add geosearch distraction free, projections, toolbar E2E tests

### DIFF
--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -1,11 +1,17 @@
 const TIME_LIMIT = 30000;
 const mockParam = '?mockAlerts=';
 const layerNoticesTestParams = '?l=Coastlines,MODIS_Aqua_CorrectedReflectance_TrueColor,Particulate_Matter_Below_2.5micrometers_2001-2010';
-const { addLayers, layersSearchField, categoriesNav } = require('../../reuseables/selectors.js');
+const localSelectors = require('../../reuseables/selectors.js');
+
+const {
+  addLayers,
+  layersSearchField,
+  categoriesNav,
+  infoToolbarButton,
+} = localSelectors;
 
 // Selectors
-const infoButton = '#wv-info-button';
-const infoButtonIcon = '#wv-info-button svg.svg-inline--fa';
+const infoButtonIcon = `${infoToolbarButton} svg.svg-inline--fa`;
 const infoMenu = '#toolbar_info';
 const giftListItem = '#toolbar_info li.gift';
 const boltListItem = '#toolbar_info li.bolt';
@@ -32,7 +38,7 @@ module.exports = {
   'Outage takes precedence when all three notifications are present': function(c) {
     c.url(`${c.globals.url + layerNoticesTestParams}&mockAlerts=all_types`);
     c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
-    c.expect.element(`${infoButton}.wv-status-outage`).to.be.present;
+    c.expect.element(`${infoToolbarButton}.wv-status-outage`).to.be.present;
     c.click(infoButtonIcon);
     c.pause(2000);
     c.assert.containsText(infoMenu, 'Notifications');
@@ -63,7 +69,7 @@ module.exports = {
     c.click('#notification_list_modal .close')
       .pause(500);
     c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);
-    c.expect.element(`${infoButton}.wv-status-hide`).to.be.present;
+    c.expect.element(`${infoToolbarButton}.wv-status-hide`).to.be.present;
   },
 
   // Layer notice tests

--- a/e2e/features/projections/projections-test.js
+++ b/e2e/features/projections/projections-test.js
@@ -1,0 +1,40 @@
+const reuseables = require('../../reuseables/skip-tour.js');
+const localSelectors = require('../../reuseables/selectors.js');
+const { switchProjection } = require('../../reuseables/switch-projection');
+
+const {
+  geographicMap,
+  arcticMap,
+  antarcticMap,
+  projToolbarButton,
+} = localSelectors;
+
+const TIME_LIMIT = 10000;
+
+module.exports = {
+  before: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+  },
+
+  // A button with a projection (globe) icon is visible and unobstructed, map shows data in a geographic projection
+  'Verify default page shows projection toolbar button in geographic projection map': (c) => {
+    c.expect.element(projToolbarButton).to.be.visible;
+    c.expect.element(geographicMap).to.be.visible;
+  },
+
+  // Select "Arctic" from the menu. The map shows data in a stereographic projection centered at the North Pole.
+  'Verify changing projection to arctic switches map to arctic': (c) => {
+    switchProjection(c, 'arctic');
+    c.expect.element(arcticMap).to.be.visible;
+  },
+
+  // Select "Antarctic" from the menu. The map shows data in a stereographic projection centered at the South Pole.
+  'Verify changing projection to antarctic switches map to antarctic': (c) => {
+    switchProjection(c, 'antarctic');
+    c.expect.element(antarcticMap).to.be.visible;
+  },
+
+  after: (c) => {
+    c.end();
+  },
+};

--- a/e2e/features/timeline/date-selector-test.js
+++ b/e2e/features/timeline/date-selector-test.js
@@ -2,6 +2,17 @@ const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 const localQuerystrings = require('../../reuseables/querystrings.js');
 
+const {
+  dayUp,
+  dayDown,
+  dragger,
+} = localSelectors;
+
+const {
+  knownDate,
+  subdailyLayerIntervalTimescale,
+} = localQuerystrings;
+
 const dateSelectorMinuteInput = '#date-selector-main .input-wrapper-minute input';
 const dateSelectorHourInput = '#date-selector-main .input-wrapper-hour input';
 const dateSelectorDayInput = '#date-selector-main .input-wrapper-day input';
@@ -10,127 +21,135 @@ const dateSelectorYearInput = '#date-selector-main .input-wrapper-year input';
 const TIME_LIMIT = 20000;
 
 module.exports = {
-  beforeEach: (client) => {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
-    client.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
+  beforeEach: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    c.waitForElementVisible(dragger, TIME_LIMIT);
   },
 
   // verify subdaily default year, month, day, hour, minute date selector inputs
-  'Verify subdaily default year, month, day, hour, minute date selector inputs': (client) => {
-    client.url(client.globals.url + localQuerystrings.subdailyLayerIntervalTimescale);
-    client.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
-    client.expect.element(dateSelectorMinuteInput).to.be.visible;
-    client.expect.element(dateSelectorHourInput).to.be.visible;
-    client.expect.element(dateSelectorDayInput).to.be.visible;
-    client.expect.element(dateSelectorMonthInput).to.be.visible;
-    client.expect.element(dateSelectorYearInput).to.be.visible;
-    client.end();
+  'Verify subdaily default year, month, day, hour, minute date selector inputs': (c) => {
+    c.url(c.globals.url + subdailyLayerIntervalTimescale);
+    c.waitForElementVisible(dragger, TIME_LIMIT);
+    c.expect.element(dateSelectorMinuteInput).to.be.visible;
+    c.expect.element(dateSelectorHourInput).to.be.visible;
+    c.expect.element(dateSelectorDayInput).to.be.visible;
+    c.expect.element(dateSelectorMonthInput).to.be.visible;
+    c.expect.element(dateSelectorYearInput).to.be.visible;
+    c.end();
   },
 
   // verify change date using left/right date arrows
-  'Change date using left/right arrows': (client) => {
-    client.url(client.globals.url + localQuerystrings.knownDate);
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '22');
-    client.click('#left-arrow-group');
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '21');
-    client.click('#right-arrow-group');
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '22');
+  'Change date using left/right arrows': (c) => {
+    c.url(c.globals.url + knownDate);
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '22');
+    c.click('#left-arrow-group');
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '21');
+    c.click('#right-arrow-group');
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '22');
   },
 
   // verify default left arrow enabled since loaded on current day
-  'Left timeline arrow will not be disabled by default': (client) => {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
-    client.assert.not.cssClassPresent('#left-arrow-group', 'button-disabled');
+  'Left timeline arrow will not be disabled by default': (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    c.assert.not.cssClassPresent('#left-arrow-group', 'button-disabled');
   },
 
   // verify default right arrow disabled since loaded on current day
-  'Right timeline arrow will be disabled by default - unless past 00:00 UTC but before 04:00': (client) => {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  'Right timeline arrow will be disabled by default - unless past 00:00 UTC but before 04:00': (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
     // accomodate for config.initialDate past 00:00 UTC but before 04:00
     if (new Date().getUTCHours() < 3) {
-      client.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+      c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
     } else {
-      client.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
+      c.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
     }
   },
 
   // verify valid right arrow enabled since NOT loaded on current day
-  'Right timeline arrow will not be disabled': (client) => {
-    client.url(client.globals.url + localQuerystrings.knownDate);
-    client.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+  'Right timeline arrow will not be disabled': (c) => {
+    c.url(c.globals.url + knownDate);
+    c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
   },
 
   // verify date selector is populated with date YYYY-MON-DD
-  'Verify date selector is populated with date YYYY-MON-DD': (client) => {
-    client.url(`${client.globals.url}?t=2019-02-22`);
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '22');
-    client.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
-    client.assert.attributeContains(dateSelectorYearInput, 'value', '2019');
+  'Verify date selector is populated with date YYYY-MON-DD': (c) => {
+    c.url(`${c.globals.url}?t=2019-02-22`);
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '22');
+    c.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
+    c.assert.attributeContains(dateSelectorYearInput, 'value', '2019');
   },
 
   // verify subdaily date selector is populated with date YYYY-MON-DD-HH-MM
-  'Verify subdaily date selector is populated with date YYYY-MON-DD-HH-MM': (client) => {
-    client.url(client.globals.url + localQuerystrings.subdailyLayerIntervalTimescale);
+  'Verify subdaily date selector is populated with date YYYY-MON-DD-HH-MM': (c) => {
+    c.url(c.globals.url + subdailyLayerIntervalTimescale);
 
-    client.assert.attributeContains(dateSelectorMinuteInput, 'value', '46');
-    client.assert.attributeContains(dateSelectorHourInput, 'value', '09');
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '04');
-    client.assert.attributeContains(dateSelectorMonthInput, 'value', 'OCT');
-    client.assert.attributeContains(dateSelectorYearInput, 'value', '2019');
+    c.assert.attributeContains(dateSelectorMinuteInput, 'value', '46');
+    c.assert.attributeContains(dateSelectorHourInput, 'value', '09');
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '04');
+    c.assert.attributeContains(dateSelectorMonthInput, 'value', 'OCT');
+    c.assert.attributeContains(dateSelectorYearInput, 'value', '2019');
   },
 
   // verify user can temporarily input incorrect day values in date selector
-  'Allow invalid day values in date selector': (client) => {
-    client.url(`${client.globals.url}?t=2019-02-22`);
-    client
+  'Allow invalid day values in date selector': (c) => {
+    c.url(`${c.globals.url}?t=2019-02-22`);
+    c
       .click(dateSelectorDayInput)
-      .setValue(dateSelectorDayInput, [31, client.Keys.ENTER]);
-    client.assert.cssClassPresent(dateSelectorDayInput, 'invalid-input');
+      .setValue(dateSelectorDayInput, [31, c.Keys.ENTER]);
+    c.assert.cssClassPresent(dateSelectorDayInput, 'invalid-input');
   },
 
   // verify user can change year on invalid date to a valid one and remove invalid-input class
-  'Allow invalid year to valid year values in date selector': (client) => {
-    client.url(`${client.globals.url}?t=2019-02-22`);
-    client
+  'Allow invalid year to valid year values in date selector': (c) => {
+    c.url(`${c.globals.url}?t=2019-02-22`);
+    c
       .click(dateSelectorYearInput)
-      .setValue(dateSelectorYearInput, [2020, client.Keys.ENTER]);
-    client.setValue(dateSelectorMonthInput, ['MAR', client.Keys.ENTER]);
-    client.setValue(dateSelectorDayInput, [31, client.Keys.ENTER]);
-    client.setValue(dateSelectorYearInput, [2019, client.Keys.ENTER]);
-    client.assert.not.cssClassPresent(dateSelectorDayInput, 'invalid-input');
-    client.assert.not.cssClassPresent(dateSelectorMonthInput, 'invalid-input');
-    client.assert.not.cssClassPresent(dateSelectorYearInput, 'invalid-input');
+      .setValue(dateSelectorYearInput, [2020, c.Keys.ENTER]);
+    c.setValue(dateSelectorMonthInput, ['MAR', c.Keys.ENTER]);
+    c.setValue(dateSelectorDayInput, [31, c.Keys.ENTER]);
+    c.setValue(dateSelectorYearInput, [2019, c.Keys.ENTER]);
+    c.assert.not.cssClassPresent(dateSelectorDayInput, 'invalid-input');
+    c.assert.not.cssClassPresent(dateSelectorMonthInput, 'invalid-input');
+    c.assert.not.cssClassPresent(dateSelectorYearInput, 'invalid-input');
+  },
+
+  // verify invalid permalink date rolls over to valid date YYYY-MON-DD (e.g., 2013-02-29 becomes 2013-03-01)
+  'Verify invalid days are rolled over': (c) => {
+    c.url(`${c.globals.url}?t=2013-02-29`);
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '01');
+    c.assert.attributeContains(dateSelectorMonthInput, 'value', 'MAR');
+    c.assert.attributeContains(dateSelectorYearInput, 'value', '2013');
   },
 
   // date selector up arrow rolls over from Feb 28 to 1 (non leap year) and the inverse
-  'Date selector up arrow rolls over from Feb 28 to 1 (non leap year) and the inverse': (client) => {
-    client.url(`${client.globals.url}?t=2013-02-28`);
-    client.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
-    client.click(localSelectors.dayUp).pause(500);
+  'Date selector up arrow rolls over from Feb 28 to 1 (non leap year) and the inverse': (c) => {
+    c.url(`${c.globals.url}?t=2013-02-28`);
+    c.waitForElementVisible(dragger, TIME_LIMIT);
+    c.click(dayUp).pause(500);
 
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '01');
-    client.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
-    client.assert.attributeContains(dateSelectorYearInput, 'value', '2013');
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '01');
+    c.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
+    c.assert.attributeContains(dateSelectorYearInput, 'value', '2013');
 
-    client.click(localSelectors.dayDown).pause(500);
+    c.click(dayDown).pause(500);
 
-    client.assert.attributeContains(dateSelectorDayInput, 'value', '28');
-    client.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
-    client.assert.attributeContains(dateSelectorYearInput, 'value', '2013');
+    c.assert.attributeContains(dateSelectorDayInput, 'value', '28');
+    c.assert.attributeContains(dateSelectorMonthInput, 'value', 'FEB');
+    c.assert.attributeContains(dateSelectorYearInput, 'value', '2013');
   },
 
   // verify right timeline arrow is not disabled for future date
-  'Added future layer and right timeline arrow is not disabled': (client) => {
-    client.url(`${client.globals.url}?mockFutureLayer=VIIRS_SNPP_CorrectedReflectance_TrueColor,3D`);
-    client.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
-    client.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
-    client.click('#right-arrow-group');
-    client.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
-    client.click('#right-arrow-group');
-    client.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+  'Added future layer and right timeline arrow is not disabled': (c) => {
+    c.url(`${c.globals.url}?mockFutureLayer=VIIRS_SNPP_CorrectedReflectance_TrueColor,3D`);
+    c.waitForElementVisible(dragger, TIME_LIMIT);
+    c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+    c.click('#right-arrow-group');
+    c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+    c.click('#right-arrow-group');
+    c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
   },
 
-  after: (client) => {
-    client.end();
+  after: (c) => {
+    c.end();
   },
 };

--- a/e2e/features/tour/tour-test.js
+++ b/e2e/features/tour/tour-test.js
@@ -1,5 +1,10 @@
 const { normalizeViewport } = require('../../reuseables/normalize-viewport.js');
 const { localStorageEnabled } = require('../../reuseables/local-storage-check.js');
+const localSelectors = require('../../reuseables/selectors.js');
+
+const {
+  infoToolbarButton,
+} = localSelectors;
 
 const TIME_LIMIT = 10000;
 const runTour = function(c) {
@@ -32,8 +37,8 @@ module.exports = {
       [],
       function({ value }) {
         if (!value) {
-          c.waitForElementVisible('#wv-info-button', 1000);
-          c.click('#wv-info-button');
+          c.waitForElementVisible(infoToolbarButton, 1000);
+          c.click(infoToolbarButton);
           c.waitForElementVisible('#start_tour_info_item', 1000);
           c.click('#start_tour_info_item');
           runTour(c);

--- a/e2e/features/ui/distraction-free-mode-test.js
+++ b/e2e/features/ui/distraction-free-mode-test.js
@@ -4,10 +4,17 @@ const localSelectors = require('../../reuseables/selectors.js');
 const {
   geosearchMinimizeButton,
   geosearchToolbarButton,
-  sidebarContainer,
+  mapScaleImperial,
+  mapScaleMetric,
   measureBtn,
+  projToolbarButton,
+  shareToolbarButton,
+  sidebarContainer,
+  snapshotToolbarButton,
+  timelineContainer,
+  zoomInButton,
+  zoomOutButton,
 } = localSelectors;
-
 const TIME_LIMIT = 5000;
 
 module.exports = {
@@ -23,17 +30,17 @@ module.exports = {
     c.sendKeys('body', [c.Keys.SHIFT, 'd', c.Keys.NULL]);
     c.pause(300);
 
-    c.waitForElementNotVisible('.timeline-container', TIME_LIMIT);
+    c.waitForElementNotVisible(timelineContainer, TIME_LIMIT);
     c.waitForElementNotVisible(sidebarContainer, TIME_LIMIT);
     c.waitForElementNotVisible(geosearchToolbarButton, TIME_LIMIT);
-    c.waitForElementNotPresent('#wv-link-button', TIME_LIMIT);
-    c.waitForElementNotPresent('#wv-proj-button', TIME_LIMIT);
-    c.waitForElementNotPresent('#wv-image-button', TIME_LIMIT);
+    c.waitForElementNotPresent(shareToolbarButton, TIME_LIMIT);
+    c.waitForElementNotPresent(projToolbarButton, TIME_LIMIT);
+    c.waitForElementNotPresent(snapshotToolbarButton, TIME_LIMIT);
     c.waitForElementNotVisible(measureBtn, TIME_LIMIT);
-    c.waitForElementNotVisible('.wv-map-zoom-in', TIME_LIMIT);
-    c.waitForElementNotVisible('.wv-map-zoom-out', TIME_LIMIT);
-    c.waitForElementNotVisible('.wv-map-scale-metric', TIME_LIMIT);
-    c.waitForElementNotVisible('.wv-map-scale-imperial', TIME_LIMIT);
+    c.waitForElementNotVisible(zoomInButton, TIME_LIMIT);
+    c.waitForElementNotVisible(zoomOutButton, TIME_LIMIT);
+    c.waitForElementNotVisible(mapScaleMetric, TIME_LIMIT);
+    c.waitForElementNotVisible(mapScaleImperial, TIME_LIMIT);
   },
 
   // verify turning off distraction free mode shortcut returns hidden ui elements
@@ -42,17 +49,17 @@ module.exports = {
     c.sendKeys('body', [c.Keys.SHIFT, 'd', c.Keys.NULL]);
     c.pause(300);
 
-    c.waitForElementVisible('.timeline-container', TIME_LIMIT);
+    c.waitForElementVisible(timelineContainer, TIME_LIMIT);
     c.waitForElementVisible(sidebarContainer, TIME_LIMIT);
     c.waitForElementVisible(geosearchToolbarButton, TIME_LIMIT);
-    c.waitForElementVisible('#wv-link-button', TIME_LIMIT);
-    c.waitForElementPresent('#wv-proj-button', TIME_LIMIT);
-    c.waitForElementPresent('#wv-image-button', TIME_LIMIT);
+    c.waitForElementVisible(shareToolbarButton, TIME_LIMIT);
+    c.waitForElementPresent(projToolbarButton, TIME_LIMIT);
+    c.waitForElementPresent(snapshotToolbarButton, TIME_LIMIT);
     c.waitForElementVisible(measureBtn, TIME_LIMIT);
-    c.waitForElementPresent('.wv-map-zoom-in', TIME_LIMIT);
-    c.waitForElementPresent('.wv-map-zoom-out', TIME_LIMIT);
-    c.waitForElementPresent('.wv-map-scale-metric', TIME_LIMIT);
-    c.waitForElementPresent('.wv-map-scale-imperial', TIME_LIMIT);
+    c.waitForElementPresent(zoomInButton, TIME_LIMIT);
+    c.waitForElementPresent(zoomOutButton, TIME_LIMIT);
+    c.waitForElementPresent(mapScaleMetric, TIME_LIMIT);
+    c.waitForElementPresent(mapScaleImperial, TIME_LIMIT);
   },
 
   after: (c) => {

--- a/e2e/features/ui/distraction-free-mode-test.js
+++ b/e2e/features/ui/distraction-free-mode-test.js
@@ -1,50 +1,61 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 
+const {
+  geosearchMinimizeButton,
+  geosearchToolbarButton,
+  sidebarContainer,
+  measureBtn,
+} = localSelectors;
+
 const TIME_LIMIT = 5000;
 
 module.exports = {
-  before: (client) => {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  before: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    // ensure geosearch is minimized
+    c.click(geosearchMinimizeButton);
   },
 
   // verify distraction free mode shortcut hides ui elements
-  'Enabling distraction free mode with shortcut key hides UI elements': (client) => {
-    client.pause(300);
-    client.sendKeys('body', [client.Keys.SHIFT, 'd', client.Keys.NULL]);
-    client.pause(300);
+  'Enabling distraction free mode with shortcut key hides UI elements': (c) => {
+    c.pause(300);
+    c.sendKeys('body', [c.Keys.SHIFT, 'd', c.Keys.NULL]);
+    c.pause(300);
 
-    client.waitForElementNotVisible('.timeline-container', TIME_LIMIT);
-    client.waitForElementNotVisible(localSelectors.sidebarContainer, TIME_LIMIT);
-    client.waitForElementNotPresent('#wv-link-button', TIME_LIMIT);
-    client.waitForElementNotPresent('#wv-proj-button', TIME_LIMIT);
-    client.waitForElementNotPresent('#wv-image-button', TIME_LIMIT);
-    client.waitForElementNotVisible(localSelectors.measureBtn, TIME_LIMIT);
-    client.waitForElementNotVisible('.wv-map-zoom-in', TIME_LIMIT);
-    client.waitForElementNotVisible('.wv-map-zoom-out', TIME_LIMIT);
-    client.waitForElementNotVisible('.wv-map-scale-metric', TIME_LIMIT);
-    client.waitForElementNotVisible('.wv-map-scale-imperial', TIME_LIMIT);
+    c.waitForElementNotVisible('.timeline-container', TIME_LIMIT);
+    c.waitForElementNotVisible(sidebarContainer, TIME_LIMIT);
+    c.waitForElementNotVisible(geosearchToolbarButton, TIME_LIMIT);
+    c.waitForElementNotPresent('#wv-link-button', TIME_LIMIT);
+    c.waitForElementNotPresent('#wv-proj-button', TIME_LIMIT);
+    c.waitForElementNotPresent('#wv-image-button', TIME_LIMIT);
+    c.waitForElementNotVisible(measureBtn, TIME_LIMIT);
+    c.waitForElementNotVisible('.wv-map-zoom-in', TIME_LIMIT);
+    c.waitForElementNotVisible('.wv-map-zoom-out', TIME_LIMIT);
+    c.waitForElementNotVisible('.wv-map-scale-metric', TIME_LIMIT);
+    c.waitForElementNotVisible('.wv-map-scale-imperial', TIME_LIMIT);
   },
 
   // verify turning off distraction free mode shortcut returns hidden ui elements
-  'Disabling distraction free mode with shortcut key returns UI elements': (client) => {
-    client.pause(300);
-    client.sendKeys('body', [client.Keys.SHIFT, 'd', client.Keys.NULL]);
-    client.pause(300);
+  'Disabling distraction free mode with shortcut key returns UI elements': (c) => {
+    c.pause(300);
+    c.sendKeys('body', [c.Keys.SHIFT, 'd', c.Keys.NULL]);
+    c.pause(300);
 
-    client.waitForElementVisible('.timeline-container', TIME_LIMIT);
-    client.waitForElementVisible(localSelectors.sidebarContainer, TIME_LIMIT);
-    client.waitForElementVisible('#wv-link-button', TIME_LIMIT);
-    client.waitForElementPresent('#wv-proj-button', TIME_LIMIT);
-    client.waitForElementPresent('#wv-image-button', TIME_LIMIT);
-    client.waitForElementVisible(localSelectors.measureBtn, TIME_LIMIT);
-    client.waitForElementPresent('.wv-map-zoom-in', TIME_LIMIT);
-    client.waitForElementPresent('.wv-map-zoom-out', TIME_LIMIT);
-    client.waitForElementPresent('.wv-map-scale-metric', TIME_LIMIT);
-    client.waitForElementPresent('.wv-map-scale-imperial', TIME_LIMIT);
+    c.waitForElementVisible('.timeline-container', TIME_LIMIT);
+    c.waitForElementVisible(sidebarContainer, TIME_LIMIT);
+    c.waitForElementVisible(geosearchToolbarButton, TIME_LIMIT);
+    c.waitForElementVisible('#wv-link-button', TIME_LIMIT);
+    c.waitForElementPresent('#wv-proj-button', TIME_LIMIT);
+    c.waitForElementPresent('#wv-image-button', TIME_LIMIT);
+    c.waitForElementVisible(measureBtn, TIME_LIMIT);
+    c.waitForElementPresent('.wv-map-zoom-in', TIME_LIMIT);
+    c.waitForElementPresent('.wv-map-zoom-out', TIME_LIMIT);
+    c.waitForElementPresent('.wv-map-scale-metric', TIME_LIMIT);
+    c.waitForElementPresent('.wv-map-scale-imperial', TIME_LIMIT);
   },
 
-  after: (client) => {
-    client.end();
+  after: (c) => {
+    c.end();
   },
 };

--- a/e2e/features/ui/info-mobile-test.js
+++ b/e2e/features/ui/info-mobile-test.js
@@ -1,6 +1,10 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 
+const {
+  infoToolbarButton,
+} = localSelectors;
+
 const TIME_LIMIT = 5000;
 
 module.exports = {
@@ -11,9 +15,9 @@ module.exports = {
 
   // verify mobile info toolbar is visible and contains valid mobile menu items
   'Mobile info toolbar is visible and contains valid mobile menu items': (client) => {
-    client.expect.element(localSelectors.uiInfoButton).to.be.present;
+    client.expect.element(infoToolbarButton).to.be.present;
     client.pause(500);
-    client.click(localSelectors.uiInfoButton);
+    client.click(infoToolbarButton);
 
     client.waitForElementVisible('#toolbar_info', TIME_LIMIT);
     client.expect.element('#send_feedback_info_item').to.be.present;
@@ -25,8 +29,8 @@ module.exports = {
   // verify mobile source code menu item opens separate tab or window
   'Mobile source code menu item opens separate tab or window': (client) => {
     client.pause(1000);
-    client.waitForElementVisible(localSelectors.uiInfoButton, TIME_LIMIT);
-    client.click(localSelectors.uiInfoButton);
+    client.waitForElementVisible(infoToolbarButton, TIME_LIMIT);
+    client.click(infoToolbarButton);
     client.waitForElementVisible('#toolbar_info', TIME_LIMIT);
 
     client.windowHandles((tabs) => {

--- a/e2e/features/ui/info-test.js
+++ b/e2e/features/ui/info-test.js
@@ -1,40 +1,44 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 
+const {
+  infoToolbarButton,
+} = localSelectors;
+
 const TIME_LIMIT = 5000;
 
 module.exports = {
-  before: (client) => {
-    reuseables.loadAndSkipTour(client, TIME_LIMIT);
+  before: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
   },
 
   // verify info toolbar is visible and contains valid menu items
-  'Info toolbar is visible and contains valid menu items': (client) => {
-    client.expect.element(localSelectors.uiInfoButton).to.be.present;
-    client.click(localSelectors.uiInfoButton);
+  'Info toolbar is visible and contains valid menu items': (c) => {
+    c.expect.element(infoToolbarButton).to.be.present;
+    c.click(infoToolbarButton);
 
-    client.waitForElementVisible('#toolbar_info', TIME_LIMIT);
-    client.expect.element('#send_feedback_info_item').to.be.present;
-    client.expect.element('#start_tour_info_item').to.be.present;
-    client.expect.element('#source_code_info_item').to.be.present;
-    client.expect.element('#whats_new_info_item').to.be.present;
-    client.expect.element('#about_info_item').to.be.present;
-    client.expect.element('#distraction_free_info_item').to.be.present;
+    c.waitForElementVisible('#toolbar_info', TIME_LIMIT);
+    c.expect.element('#send_feedback_info_item').to.be.present;
+    c.expect.element('#start_tour_info_item').to.be.present;
+    c.expect.element('#source_code_info_item').to.be.present;
+    c.expect.element('#whats_new_info_item').to.be.present;
+    c.expect.element('#about_info_item').to.be.present;
+    c.expect.element('#distraction_free_info_item').to.be.present;
   },
 
   // verify about menu item opens about modal
-  'About menu item opens about modal': (client) => {
-    client.waitForElementVisible('#toolbar_info', TIME_LIMIT);
-    client.waitForElementVisible('#about_info_item', TIME_LIMIT);
-    client.click('#about_info_item');
-    client.pause(500);
+  'About menu item opens about modal': (c) => {
+    c.waitForElementVisible('#toolbar_info', TIME_LIMIT);
+    c.waitForElementVisible('#about_info_item', TIME_LIMIT);
+    c.click('#about_info_item');
+    c.pause(500);
 
-    client.expect.element('.about-page').to.be.present;
-    client.expect.element('a[href="mailto:ryan.a.boller@nasa.gov"]').to.be.visible;
+    c.expect.element('.about-page').to.be.present;
+    c.expect.element('a[href="mailto:ryan.a.boller@nasa.gov"]').to.be.visible;
   },
 
-  after: (client) => {
-    client.end();
+  after: (c) => {
+    c.end();
   },
 
 };

--- a/e2e/features/ui/toolbar-test.js
+++ b/e2e/features/ui/toolbar-test.js
@@ -1,0 +1,32 @@
+const reuseables = require('../../reuseables/skip-tour.js');
+const localSelectors = require('../../reuseables/selectors.js');
+
+const {
+  geosearchComponent,
+  geosearchToolbarButton,
+  measureBtn,
+  projToolbarButton,
+  shareToolbarButton,
+  snapshotToolbarButton,
+} = localSelectors;
+
+const TIME_LIMIT = 10000;
+
+module.exports = {
+  before: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+  },
+
+  'Verify toolbar buttons are visible by default - excluding geosearch': (c) => {
+    c.expect.element(geosearchComponent).to.be.visible;
+    c.expect.element(geosearchToolbarButton).to.not.be.visible;
+    c.expect.element(shareToolbarButton).to.be.visible;
+    c.expect.element(projToolbarButton).to.be.visible;
+    c.expect.element(snapshotToolbarButton).to.be.visible;
+    c.expect.element(measureBtn).to.be.visible;
+  },
+
+  after: (c) => {
+    c.end();
+  },
+};

--- a/e2e/reuseables/selectors.js
+++ b/e2e/reuseables/selectors.js
@@ -40,6 +40,7 @@ module.exports = {
   downloadShapefileBtn: '#download-shapefiles-button',
 
   // timeline
+  timelineContainer: '.timeline-container',
   dragger: '.timeline-dragger',
   dayDown: '.input-wrapper-day > div.date-arrows.date-arrow-down',
   dayUp: '.input-wrapper-day > div.date-arrows.date-arrow-up',
@@ -115,8 +116,21 @@ module.exports = {
   measurementMoreButton: '#measurements-facet .sui-facet-view-more',
   sourcesMERRALabel: '#sources-facet [for="example_facet_SourceMERRA-2"]',
 
-  // ui
-  uiInfoButton: '#wv-info-button',
+  // map
+  geographicMap: '#wv-map-geographic',
+  arcticMap: '#wv-map-arctic',
+  antarcticMap: '#wv-map-antarctic',
+  zoomInButton: '.wv-map-zoom-in',
+  zoomOutButton: '.wv-map-zoom-out',
+  mapScaleMetric: '.wv-map-scale-metric',
+  mapScaleImperial: '.wv-map-scale-imperial',
+
+  // ui toolbar
+  geosearchToolbarButton: '#wv-geosearch-button',
+  shareToolbarButton: '#wv-link-button',
+  projToolbarButton: '#wv-proj-button',
+  snapshotToolbarButton: '#wv-image-button',
+  infoToolbarButton: '#wv-info-button',
 
   // social
   socialToolbar: '#toolbar_share_link',
@@ -124,7 +138,6 @@ module.exports = {
   socialLinkInput: '#permalink_content',
 
   // geosearch
-  geosearchToolbarButton: '#wv-geosearch-button',
   geosearchComponent: '.geosearch-component',
   geosearchMobileDialog: '#toolbar_geosearch_mobile',
   geosearchMinimizeButton: '.geosearch-search-minimize-button',

--- a/web/js/components/geosearch/geosearch-modal.js
+++ b/web/js/components/geosearch/geosearch-modal.js
@@ -408,9 +408,11 @@ const mapStateToProps = (state) => {
   const geosearchMobileModalOpen = modal.isOpen && modal.id === 'TOOLBAR_GEOSEARCH_MOBILE';
   // Collapse when image download, GIF, measure tool, or distraction free mode is active
   const measureToggledOff = lastAction.type === 'MEASURE/TOGGLE_MEASURE_ACTIVE' && lastAction.value === false;
+  const distractionFreeModeToggledOff = lastAction.type === 'UI/TOGGLE_DISTRACTION_FREE_MODE';
+  const preventInputFocus = measureToggledOff || distractionFreeModeToggledOff;
 
   return {
-    preventInputFocus: measureToggledOff,
+    preventInputFocus,
     coordinates,
     geosearchMobileModalOpen,
     isCoordinatePairWithinExtent: (targetCoordinates) => areCoordinatesWithinExtent(map, config, targetCoordinates),

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -214,6 +214,7 @@ class toolbarContainer extends Component {
     const {
       config,
       faSize,
+      isDistractionFreeModeActive,
       isGeosearchExpanded,
       isMobile,
       openModal,
@@ -240,7 +241,7 @@ class toolbarContainer extends Component {
     return (
       <Button
         style={{
-          display: buttonDisplayConditions ? 'inline-block' : 'none',
+          display: !isDistractionFreeModeActive && buttonDisplayConditions ? 'inline-block' : 'none',
         }}
         id={buttonId}
         className="wv-toolbar-button"


### PR DESCRIPTION
## Description

Fixes #3240  .

- [x] Add Geosearch distraction free check (when toolbar is visible/ Geosearch component is minimized)
- [x] Prevent Geosearch input focus on exiting distraction free mode
- [x] Add projections E2E tests, UI toolbar, and replace date selector test plan step with E2E
- [x] Clean up some E2E selectors being used

Test bug in `develop` by:
1. Minimizing Geosearch component
2. Triggering distraction free mode
3. The toolbar Geosearch  button will not be removed.

See fix by performing above steps and see Geosearch button is properly removed.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
