### PR TITLE
Add time parameter to browser URL if other parameter is present

### DIFF
--- a/web/js/location.js
+++ b/web/js/location.js
@@ -3,7 +3,12 @@ import update from 'immutability-helper';
 import { encode } from './modules/link/util';
 // legacy crutches
 import {
-  serializeDate, tryCatchDate, parsePermalinkDate, mapLocationToDateState,
+  serializeDate,
+  serializeDateWrapper,
+  serializeDateBWrapper,
+  tryCatchDate,
+  parsePermalinkDate,
+  mapLocationToDateState,
 } from './modules/date/util';
 import {
   checkTourBuildTimestamp,
@@ -147,54 +152,6 @@ const getParameters = function(config, parameters) {
           ? util.toISOStringSeconds(currentItemState)
           : undefined),
         parse: (str) => tryCatchDate(str, now),
-      },
-    },
-    t: {
-      stateKey: 'date.selected',
-      initialState: new Date(initialDate),
-      type: 'date',
-      options: {
-        serializeNeedsGlobalState: true,
-        setAsEmptyItem: true,
-        serialize: (currentItemState, state) => {
-          const compareIsActive = get(state, 'compare.active');
-          const isCompareA = get(state, 'compare.isCompareA');
-          const dateB = get(state, 'date.selectedB');
-          const initialDateString = util.toISOStringSeconds(initialDate);
-          return !compareIsActive && !isCompareA
-            ? util.toISOStringSeconds(dateB) === initialDateString
-              ? undefined
-              : serializeDate(dateB)
-            : util.toISOStringSeconds(currentItemState) === initialDateString
-              ? undefined
-              : !currentItemState
-                ? undefined
-                : serializeDate(currentItemState);
-        },
-        parse: (str) => parsePermalinkDate(now, str, parameters.l, config),
-      },
-    },
-    t1: {
-      stateKey: 'date.selectedB',
-      initialState: nowMinusSevenDays,
-      type: 'date',
-      options: {
-        serializeNeedsGlobalState: true,
-        setAsEmptyItem: true,
-        serialize: (currentItemState, state) => {
-          const isActive = get(state, 'compare.active');
-          const initialDateString = util.toISOStringSeconds(initialDate);
-          const appNowMinusSevenDays = util.dateAdd(initialDateString, 'day', -7);
-          const appNowMinusSevenDaysString = util.toISOStringSeconds(
-            appNowMinusSevenDays,
-          );
-          if (!isActive) return undefined;
-          return appNowMinusSevenDaysString
-            === util.toISOStringSeconds(currentItemState)
-            ? undefined
-            : serializeDate(currentItemState || appNowMinusSevenDays);
-        },
-        parse: (str) => parsePermalinkDate(nowMinusSevenDays, str, parameters.l1, config),
       },
     },
     z: {
@@ -476,6 +433,30 @@ const getParameters = function(config, parameters) {
           }
           return coordinates;
         },
+      },
+    },
+    t: {
+      stateKey: 'date.selected',
+      initialState: new Date(initialDate),
+      type: 'date',
+      options: {
+        serializeNeedsGlobalState: true,
+        serializeNeedsPrev: true,
+        setAsEmptyItem: true,
+        serialize: serializeDateWrapper,
+        parse: (str) => parsePermalinkDate(now, str, parameters.l, config),
+      },
+    },
+    t1: {
+      stateKey: 'date.selectedB',
+      initialState: nowMinusSevenDays,
+      type: 'date',
+      options: {
+        serializeNeedsGlobalState: true,
+        serializeNeedsPrev: true,
+        setAsEmptyItem: true,
+        serialize: serializeDateBWrapper,
+        parse: (str) => parsePermalinkDate(nowMinusSevenDays, str, parameters.l1, config),
       },
     },
   };

--- a/web/js/modules/date/util.js
+++ b/web/js/modules/date/util.js
@@ -31,6 +31,63 @@ export function tryCatchDate(str, initialState) {
 }
 
 /**
+ * Serialize date A for location
+ *
+ * @method serializeDateWrapper
+ * @param  {Object} currentItemState
+ * @param  {Object} state
+ * @param  {Object} prev
+ * @returns {String | undefined} serialized time string OR undefined
+ */
+export function serializeDateWrapper(currentItemState, state, prev) {
+  const prevParams = Object.keys(prev).length > 0;
+  const initialDate = get(state, 'config.initialDate');
+  const initialDateString = util.toISOStringSeconds(initialDate);
+  const compareIsActive = get(state, 'compare.active');
+  const isCompareA = get(state, 'compare.isCompareA');
+
+  // exit compare mode with dateB selected, dateB now primary date 't='
+  const dateBSelected = !compareIsActive && !isCompareA;
+  if (dateBSelected) {
+    const dateB = get(state, 'date.selectedB');
+    const defaultDateB = util.toISOStringSeconds(dateB) === initialDateString;
+    return !prevParams && defaultDateB
+      ? undefined
+      : serializeDate(dateB);
+  }
+  // dateA 't=' serialization
+  const defaultDate = util.toISOStringSeconds(currentItemState) === initialDateString;
+  return !prevParams && defaultDate
+    ? undefined
+    : serializeDate(currentItemState);
+}
+
+/**
+ * Serialize date B for location
+ *
+ * @method serializeDateBWrapper
+ * @param  {Object} currentItemState
+ * @param  {Object} state
+ * @param  {Object} prev
+ * @returns {String | undefined} serialized time string OR undefined
+ */
+export function serializeDateBWrapper(currentItemState, state, prev) {
+  const prevParams = Object.keys(prev).length > 0;
+  const initialDate = get(state, 'config.initialDate');
+  const compareIsActive = get(state, 'compare.active');
+  if (!compareIsActive) return undefined;
+
+  const initialDateString = util.toISOStringSeconds(initialDate);
+  const appNowMinusSevenDays = util.dateAdd(initialDateString, 'day', -7);
+  const appNowMinusSevenDaysString = util.toISOStringSeconds(appNowMinusSevenDays);
+  // dateB 't1=' serialization
+  const defaultDate = util.toISOStringSeconds(currentItemState) === appNowMinusSevenDaysString;
+  return !prevParams && defaultDate
+    ? undefined
+    : serializeDate(currentItemState);
+}
+
+/**
  * Parse permalink date string and handle max dates if out of valid range or in future
  *
  * @method parsePermalinkDate

--- a/web/js/redux-location-state-customs.js
+++ b/web/js/redux-location-state-customs.js
@@ -52,10 +52,11 @@ export function stateToParams(initialState, currentState, location) {
     let isDefault = false;
     // check if the date is the same as the one in initial value
     if (type === 'date') {
+      const prevHasParams = Object.keys(prev).length > 0;
       if (initialValue && currentItemState) {
         const initialValueMS = initialValue.getTime();
         const currentItemStateMS = currentItemState.getTime();
-        isDefault = initialValueMS === currentItemStateMS;
+        isDefault = !prevHasParams && initialValueMS === currentItemStateMS;
       }
     } else {
       // if an empty object, make currentItemState undefined
@@ -80,6 +81,7 @@ export function stateToParams(initialState, currentState, location) {
       const itemState = options.serialize(
         currentItemState,
         options.serializeNeedsGlobalState ? currentState : undefined,
+        options.serializeNeedsPrev ? prev : undefined,
       );
       // short circuit if specialized serializer returns specifically undefined
       if (typeof itemState === 'undefined') {


### PR DESCRIPTION
## Description

Fixes #3242  .

- [x] Add time parameter to browser URL if other parameter is present to ensure shared URLs from copying the browser URL will include the desired date.
- [x] Move date serialize logic into its `util.js`

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
