### PR TITLE
Add dnb data download

### DIFF
--- a/config/default/common/config/wv.json/conceptIds.json
+++ b/config/default/common/config/wv.json/conceptIds.json
@@ -4196,7 +4196,7 @@
     },
     "VIIRS_SNPP_DayNightBand_At_Sensor_Radiance": {
       "conceptId": [
-        "C1897815356-LAADS"
+        "C1989175258-LANCEMODIS"
       ]
     },
     "VIIRS_SNPP_Clear_Sky_Confidence_Day": {

--- a/config/default/common/config/wv.json/conceptIds.json
+++ b/config/default/common/config/wv.json/conceptIds.json
@@ -4194,6 +4194,11 @@
         "C1607549631-ASIPS"
       ]
     },
+    "VIIRS_SNPP_DayNightBand_At_Sensor_Radiance": {
+      "conceptId": [
+        "C1897815356-LAADS"
+      ]
+    },
     "VIIRS_SNPP_Clear_Sky_Confidence_Day": {
       "conceptId": [
         "C1607563719-ASIPS"

--- a/config/default/common/config/wv.json/layers/viirs/VIIRS_SNPP_DayNightBand_At_Sensor_Radiance.json
+++ b/config/default/common/config/wv.json/layers/viirs/VIIRS_SNPP_DayNightBand_At_Sensor_Radiance.json
@@ -11,9 +11,6 @@
       "group": "overlays",
       "tracks": [
         "OrbitTracks_Suomi_NPP_Descending"
-      ],
-      "daynight": [
-        "night"
       ]
     }
   }


### PR DESCRIPTION
## Description

Fixes #3269  .

Added conceptID for NRT data download and removed daynight property so it will display granules in Earthdata Search.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
