### PR TITLE
Prevent zero currentStep from triggering Joyride wrapper

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -415,7 +415,7 @@ class Tour extends React.Component {
     return (
       <ErrorBoundary>
         <div>
-          {currentStory && currentStory.steps && (
+          {currentStory && currentStory.steps && currentStep && (
             <JoyrideWrapper
               currentTourStep={currentStep}
               tourSteps={currentStory.steps}


### PR DESCRIPTION
## Description

Fixes #3278  .

- [x] Prevent zero `currentStep` from triggering Joyride wrapper

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
