### PR TITLE
Build categoryGroupOrder if missing during config

### DIFF
--- a/tasks/buildOptions.sh
+++ b/tasks/buildOptions.sh
@@ -124,7 +124,9 @@ fi
 
 # Throw error if no categoryGroupOrder.json file present
 if [ ! -e "$BUILD_DIR/config/wv.json/categoryGroupOrder.json" ] ; then
-    die "config/wv.json/categoryGroupOrder.json does not exist"
+    echo "categoryGroupOrder.json not found.  Generating..."
+    "$PYTHON_SCRIPTS_DIR/generateCategoryGroupOrder.py" "$SRC_DIR/common/config/wv.json/categories/" \
+        "$SRC_DIR/common/config/wv.json/"
 fi
 
 # Run mergeConfig.py on all directories in /config

--- a/tasks/buildOptions.sh
+++ b/tasks/buildOptions.sh
@@ -122,6 +122,11 @@ fi
 #         "$BUILD_DIR/config/wv.json/collections.json"
 # fi
 
+# Throw error if no categoryGroupOrder.json file present
+if [ ! -e "$BUILD_DIR/config/wv.json/categoryGroupOrder.json" ] ; then
+    die "config/wv.json/categoryGroupOrder.json does not exist"
+fi
+
 # Run mergeConfig.py on all directories in /config
 configs=$(ls "$BUILD_DIR/config")
 for config in $configs; do

--- a/tasks/python3/generateCategoryGroupOrder.py
+++ b/tasks/python3/generateCategoryGroupOrder.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from optparse import OptionParser
+import os
+import json
+import sys
+
+prog = os.path.basename(__file__)
+parser = OptionParser(usage="Usage: %s <input_dir> <output_dir>" % prog)
+(options, args) = parser.parse_args()
+
+category_directory = args[0]
+output_dir = args[1]
+
+category_dict = {}
+
+for root, dirs, files in os.walk(category_directory):
+    for file in files:
+      file_path = os.path.join(root, file)
+      with open(file_path) as category_config:
+        config = json.load(category_config)
+        try:
+          category = list(config['categories'])[0]
+          category_dict[category] = True
+        except Exception as e:
+          print("%s ERROR: Could not read category config. Check formatting of: %s" % (prog, file))
+          sys.exit(1)
+
+with open(output_dir + '/categoryGroupOrder.json', "w") as fp:
+  json.dump({ 'categoryGroupOrder': list(category_dict) }, fp, indent=2, sort_keys=True)
+  print("%s Successfully generated categoryGroupOrder.json with these categories: %s" % (prog, list(category_dict)))


### PR DESCRIPTION
## Description

Fixes #3282  .

- [x] Create `categoryGroupOrder.json` file from categories directories if missing during config build

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
