### PR TITLE
Add GTM to index html, use deployment environment variable for ID

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -8,9 +8,7 @@
         "tour": true,
         "feedback": true,
         "previewSnapshots": true,
-        "googleTagManager": {
-            "id": "GTM-WNP7MLF"
-        },
+        "googleTagManager": true,
         "notification": {
             "url": "https://status.earthdata.nasa.gov/api/v1/notifications",
             "releases": "https://github.com/nasa-gibs/worldview/releases"

--- a/doc/features.md
+++ b/doc/features.md
@@ -48,3 +48,14 @@ This feature uses
 ```
 
 > Caution: Do not commit this file to a public repo, and make sure the `build/options` directory is not publicly accessible on your web server to protect the privacy of your API key.
+
+## Google Tag Manager
+
+Worldview uses the analytics framework [Google Tag Manager](https://developers.google.com/tag-manager) to collect user interface interaction metrics. To use this feature, obtain a Google Tag Manager ID formatted as "GTM-XXXXXX", and add the ID as environment variable `GTM_ID` that can be accessed during the build process to inject your ID into the necessary code. This feature is turned on by default:
+
+```json
+"googleTagManager": true
+```
+
+to disable this feature, set:
+`"googleTagManager": false`

--- a/tasks/dist.js
+++ b/tasks/dist.js
@@ -12,7 +12,7 @@ shell.mkdir('-p', 'build/worldview');
 shell.cp('-rf', 'web/*', 'build/worldview');
 
 // Remove preview images, if that feature is disabled, for smaller dist file size
-const { CONFIG_ENV } = process.env;
+const { CONFIG_ENV, GTM_ID } = process.env;
 const featuresConfigPath = CONFIG_ENV
   ? `config/active/${CONFIG_ENV}/features.json`
   : 'config/default/common/features.json';
@@ -52,6 +52,10 @@ shell.sed('-i', /@MAIL@/g, email, applyTo);
 shell.sed('-i', /@BUILD_NONCE/g, buildNonce, applyTo);
 shell.sed('-i', /@BUILD_TIMESTAMP@/g, buildTimestamp, applyTo);
 shell.sed('-i', /@BUILD_VERSION@/g, pkg.version, applyTo);
+
+// replace google tag manager id
+const googleTagManagerID = GTM_ID || '';
+shell.sed('-i', /@GTM_ID@/g, googleTagManagerID, applyTo);
 
 const dist = 'dist/worldview.tar.gz';
 console.log(`Creating distribution: ${dist}`);

--- a/web/index.html
+++ b/web/index.html
@@ -4,12 +4,11 @@ NASA Worldview (https://github.com/nasa-gibs/worldview)
 
 This code was originally developed at NASA/Goddard Space Flight Center for the Earth Science Data and Information System (ESDIS) project.
 
-Copyright (C) 2013 - 2019 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+Copyright (C) 2013 - 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
 
 Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.gsfc.nasa.gov/nosa.php)
 -->
 <html lang="en" prefix="og: https://ogp.me/ns#">
-
 <head>
     <!-- Google Tag Manager -->
     <script async>(function (w, d, s, l, i) {
@@ -19,13 +18,14 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
       }); var f = d.getElementsByTagName(s)[0],
         j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
           'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', 'GTM-WNP7MLF');
+      })(window, document, 'script', 'dataLayer', '@GTM_ID@');
 
-      window.dataLayer = window.dataLayer || [];
+      if ('@GTM_ID@') {
+        window.dataLayer = window.dataLayer || [];
+      }
     </script>
   <!-- End Google Tag Manager -->
   <title>@OFFICIAL_NAME@</title>
-  <meta name="google-site-verification" content="cX2U525Pb71Qs92wY4LTYsP_Eu1Y9dMaLgE2XQU9-Pw" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <script type="text/javascript">
@@ -66,7 +66,7 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
 
 <body>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNP7MLF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=@GTM_ID@" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <div data-role="page" id="app">
   </div>

--- a/web/index.html
+++ b/web/index.html
@@ -11,7 +11,21 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
 <html lang="en" prefix="og: https://ogp.me/ns#">
 
 <head>
+    <!-- Google Tag Manager -->
+    <script async>(function (w, d, s, l, i) {
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-WNP7MLF');
+
+      window.dataLayer = window.dataLayer || [];
+    </script>
+  <!-- End Google Tag Manager -->
   <title>@OFFICIAL_NAME@</title>
+  <meta name="google-site-verification" content="cX2U525Pb71Qs92wY4LTYsP_Eu1Y9dMaLgE2XQU9-Pw" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <script type="text/javascript">
@@ -21,9 +35,8 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
     }
   </script>
 
-  <!-- Favicon -->
+  <!-- favicon -->
   <link rel="shortcut icon" type="image/x-icon" href="brand/images/favicon.ico">
-  <!-- favicon  -->
 
   <!-- meta defines -->
   <meta http-equiv="Content-Type" content="text/html" charset="UTF-8">
@@ -52,6 +65,9 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
 </head>
 
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WNP7MLF" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
   <div data-role="page" id="app">
   </div>
   <div id="wv-vector-metadata" class="wv-vector-metadata"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -10,8 +10,10 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
 -->
 <html lang="en" prefix="og: https://ogp.me/ns#">
 <head>
-    <!-- Google Tag Manager -->
-    <script async>(function (w, d, s, l, i) {
+  <!-- Google Tag Manager -->
+  <script async>
+  if (!/localhost/.test(window.location.href) && '@GTM_ID@') {
+    (function (w, d, s, l, i) {
       w[l] = w[l] || []; w[l].push({
         'gtm.start':
           new Date().getTime(), event: 'gtm.js'
@@ -20,10 +22,9 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
           'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
       })(window, document, 'script', 'dataLayer', '@GTM_ID@');
 
-      if ('@GTM_ID@') {
-        window.dataLayer = window.dataLayer || [];
-      }
-    </script>
+      window.dataLayer = window.dataLayer || [];
+    }
+  </script>
   <!-- End Google Tag Manager -->
   <title>@OFFICIAL_NAME@</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-unused-vars
 import whatInput from 'what-input';
-// import googleTagManager from 'googleTagManager';
+import googleTagManager from 'googleTagManager';
 
 // Utils
 import { calculateResponsiveState } from 'redux-responsive';
@@ -127,29 +127,16 @@ class App extends React.Component {
     const { config } = self.props;
     config.parameters = state;
 
-    // get user IP address for GTM/GA using https://www.ipify.org/ API
-    // const getIpAddress = async() => {
-    //   const response = await fetch('https://api.ipify.org?format=json');
-    //   const json = await response.json();
-    //   const ipAddress = json.ip;
-
-    //   googleTagManager.pushEvent({
-    //     event: 'ipAddress',
-    //     ipAddress,
-    //   });
-    // };
-
     const main = function() {
       // Load any additional scripts as needed
       if (config.scripts) {
         util.loadScipts(config.scripts);
       }
-      // if (config.features.googleTagManager) {
-      //   googleTagManager.init(config.features.googleTagManager.id); // Insert google tag manager
-      //   if (!/localhost/.test(window.location.href)) {
-      //     getIpAddress();
-      //   }
-      // }
+      if (config.features.googleTagManager) {
+        if (!/localhost/.test(window.location.href)) {
+          googleTagManager.getIpAddress();
+        }
+      }
 
       // Console notifications
       if (Brand.release()) {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-unused-vars
 import whatInput from 'what-input';
-import googleTagManager from 'googleTagManager';
+// import googleTagManager from 'googleTagManager';
 
 // Utils
 import { calculateResponsiveState } from 'redux-responsive';
@@ -128,28 +128,28 @@ class App extends React.Component {
     config.parameters = state;
 
     // get user IP address for GTM/GA using https://www.ipify.org/ API
-    const getIpAddress = async() => {
-      const response = await fetch('https://api.ipify.org?format=json');
-      const json = await response.json();
-      const ipAddress = json.ip;
+    // const getIpAddress = async() => {
+    //   const response = await fetch('https://api.ipify.org?format=json');
+    //   const json = await response.json();
+    //   const ipAddress = json.ip;
 
-      googleTagManager.pushEvent({
-        event: 'ipAddress',
-        ipAddress,
-      });
-    };
+    //   googleTagManager.pushEvent({
+    //     event: 'ipAddress',
+    //     ipAddress,
+    //   });
+    // };
 
     const main = function() {
       // Load any additional scripts as needed
       if (config.scripts) {
         util.loadScipts(config.scripts);
       }
-      if (config.features.googleTagManager) {
-        googleTagManager.init(config.features.googleTagManager.id); // Insert google tag manager
-        if (!/localhost/.test(window.location.href)) {
-          getIpAddress();
-        }
-      }
+      // if (config.features.googleTagManager) {
+      //   googleTagManager.init(config.features.googleTagManager.id); // Insert google tag manager
+      //   if (!/localhost/.test(window.location.href)) {
+      //     getIpAddress();
+      //   }
+      // }
 
       // Console notifications
       if (Brand.release()) {

--- a/web/js/components/about/about-page.js
+++ b/web/js/components/about/about-page.js
@@ -297,7 +297,7 @@ export default function AboutPage() {
         <hr />
         <h2>License</h2>
         <p>
-          Copyright &copy; 2013 - 2020 United States Government as represented by the Administrator of the National Aeronautics and
+          Copyright &copy; 2013 - 2021 United States Government as represented by the Administrator of the National Aeronautics and
           Space Administration. All Rights Reserved. This software is licensed under the
           {' '}
           <a href="https://ti.arc.nasa.gov/opensource/nosa/" target="_blank" rel="noopener noreferrer">NASA Open Source Software Agreement, Version 1.3</a>

--- a/web/js/components/about/about-page.js
+++ b/web/js/components/about/about-page.js
@@ -297,7 +297,11 @@ export default function AboutPage() {
         <hr />
         <h2>License</h2>
         <p>
-          Copyright &copy; 2013 - 2021 United States Government as represented by the Administrator of the National Aeronautics and
+          Copyright &copy; 2013 -
+          {'  '}
+          {new Date().getFullYear()}
+          {' '}
+          United States Government as represented by the Administrator of the National Aeronautics and
           Space Administration. All Rights Reserved. This software is licensed under the
           {' '}
           <a href="https://ti.arc.nasa.gov/opensource/nosa/" target="_blank" rel="noopener noreferrer">NASA Open Source Software Agreement, Version 1.3</a>

--- a/web/js/components/util/google-tag-manager.js
+++ b/web/js/components/util/google-tag-manager.js
@@ -2,35 +2,6 @@
 
 export default {
   /*
-  * Initialize GTM tracking if tracking
-  * code is present - will add to head in document
-  * noscript will not be handled
-  *
-  * @func init
-  * @static
-  *
-  * @param Category {id} GTM tracking code
-  *
-  * @return {void}
-  */
-  init(id) {
-    if(id) {
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer',id);
-
-        // create inline SCRIPT tag with dataLayer array and push to HEAD after TITLE tag
-        let dataLayerScript = document.createElement('script');
-        dataLayerScript.type = 'text/javascript';
-        let inlineScript = document.createTextNode('window.dataLayer = window.dataLayer || [];');
-        dataLayerScript.appendChild(inlineScript);
-        document.head.insertBefore(dataLayerScript, document.head.firstElementChild.nextSibling);
-    }
-  },
-
-  /*
   * @func dataLayerPush object to GoogleTagManager
   * can add custom javascript object that can be retrieved as custom data layer variables
   * @static
@@ -43,5 +14,24 @@ export default {
     if (typeof (dataLayer) !== 'undefined') {
       window.dataLayer.push(eventObject);
     }
+  },
+
+  /*
+  * @func getIpAddress
+  * get user IP address for GTM/GA using https://www.ipify.org/ API
+  * @static
+  *
+  * @return {void}
+  */
+  // get user IP address for GTM/GA using https://www.ipify.org/ API
+  async getIpAddress() {
+    const response = await fetch('https://api.ipify.org?format=json');
+    const json = await response.json();
+    const ipAddress = json.ip;
+
+    pushEvent({
+      event: 'ipAddress',
+      ipAddress,
+    });
   }
 };

--- a/web/js/components/util/google-tag-manager.js
+++ b/web/js/components/util/google-tag-manager.js
@@ -29,7 +29,7 @@ export default {
     const json = await response.json();
     const ipAddress = json.ip;
 
-    pushEvent({
+    this.pushEvent({
       event: 'ipAddress',
       ipAddress,
     });


### PR DESCRIPTION
## Description

Our current injection of GTM using JavaScript causes Google parsing issues in using the Search Console tool since the page `index.html` is being parsed. This change will include tag manager template code in the `head` by default and use the environment variable `GTM_ID` to fill in the GTM ID and make it active.

- [x] Move GTM ID out of `features.json` and into bamboo as an environment variable `GTM_ID`
- [x] Eliminate dynamic JavaScript GTM code injection into and hard code into `index.html` `head` by default - this code will be inactive if no `GTM_ID` is included during the build
- [x] Update year to 2021

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
