### PR TITLE
Fix wrong variable for endDate check condition

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -115,7 +115,7 @@ function LayerRow (props) {
     }
     // end date
     let layerEndDate;
-    if (layerEndDate) {
+    if (endDate) {
       layerEndDate = util.coverageDateFormatter('END-DATE', endDate, period);
     }
 


### PR DESCRIPTION
## Description

Fixes #3299  .

- [x] Use `endDate` for conditional instead of temporary variable

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
