### PR TITLE
Fix mouseover feature check and sidebar layer row height for vector layers with features that don't have palette(s)

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -186,19 +186,25 @@ function LayerRow (props) {
   };
 
   const renderVectorIcon = () => {
-    const clasNames = hasClickableFeature
+    const classNames = hasClickableFeature
       ? 'layer-pointer-icon'
       : 'layer-pointer-icon disabled';
     const title = hasClickableFeature
-      ? 'You can click the features of this layer to see metadata associated with the feature.'
+      ? 'You can click the features of this layer to see associated metadata.'
       : 'Zoom in further to click features.';
+    const layerVectorBtnId = `layer-vector-hand-btn-${encodedLayerId}`;
     return (
-      <div title={title} className={runningObject ? `${clasNames} running` : clasNames} onClick={openVectorAlertModal}>
-        {' '}
-        <FontAwesomeIcon
-          icon="hand-pointer"
-          fixedWidth
-        />
+      <div
+        id={layerVectorBtnId}
+        aria-label={title}
+        className={runningObject ? `${classNames} running` : classNames}
+        onMouseDown={stopPropagation}
+        onClick={openVectorAlertModal}
+      >
+        <UncontrolledTooltip placement="top" target={layerVectorBtnId}>
+          {title}
+        </UncontrolledTooltip>
+        <FontAwesomeIcon icon="hand-pointer" fixedWidth />
       </div>
     );
   };
@@ -260,7 +266,7 @@ function LayerRow (props) {
       <Zot zot={zot} layer={layer.id} isMobile={isMobile} />
 
       <div className="layer-main">
-        <div className="layer-info">
+        <div className="layer-info" style={{ minHeight: isVectorLayer ? '60px' : '40px' }}>
           <div className="layer-buttons">
             {showButtons && renderControls()}
           </div>

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -52,13 +52,16 @@ export default function MapRunningData(models, compareUi, store) {
       const isWrapped = proj.id === 'geographic' && (def.wrapadjacentdays || def.wrapX);
       const isRenderedFeature = isWrapped ? lon > -250 || lon < 250 || lat > -90 || lat < 90 : true;
       if (!isRenderedFeature || !isFromActiveCompareRegion(pixels, layer.wv, state.compare, swipeOffset)) return;
-      let color;
+
+      const hasPalette = !lodashIsEmpty(def.palette);
+      if (!hasPalette) return;
       const identifier = def.palette.styleProperty;
       const layerId = def.id;
       const paletteLegends = getPalette(layerId, undefined, undefined, state);
       const { legend } = paletteLegends;
 
       if (!identifier && legend.colors.length > 1) return;
+      let color;
       if (identifier) {
         const properties = feature.getProperties();
         const value = properties[identifier] || def.palette.unclassified;


### PR DESCRIPTION
## Description

Fixes #3297  .

[Description of the bug or feature]

- [x] Break out of mouseover feature check if no `def.palette` that's used for running data
- [x] Add `min-height` condition for sidebar layer row if vector layer to handle showing the vector feature hand icon for vector feature interactivity 
- [x] Change vector feature hand icon to use updated tooltip

## Further comments

There are some related modal fixes made in #3247 that should be merged prior to testing this branch in mobile.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
