### PR TITLE
Fix failing firefox e2e tests

### DIFF
--- a/e2e/features/geosearch/geosearch-test.js
+++ b/e2e/features/geosearch/geosearch-test.js
@@ -57,7 +57,7 @@ module.exports = {
     c.expect.element(tooltipCoordinatesContainer).to.not.be.present;
   },
   'Coordinate title for no suggested place results displays correct coordinates instead': (c) => {
-    c.url(`${c.globals.url}?gm=-51.5,5`);
+    c.url(`${c.globals.url}?v=-141.32806305066077,-56.35574752202643,18.000061949339212,60.01695346916299&gm=-51.5,5`);
     c.waitForElementVisible(tooltipCoordinatesContainer, TIME_LIMIT);
     c.expect.element(testMarkerNoDetailsEncodedID).to.be.present;
     c.assert.containsText(tooltipCoordinatesTitle, '5.0000°, -51.5000°');
@@ -67,12 +67,12 @@ module.exports = {
     c.click(tooltipCoordinatesCloseButton);
     c.pause(500);
     c.expect.element(coordinatesMapMarker).to.not.be.present;
-    c.assert.not.urlContains('marker');
+    c.assert.not.urlContains('gm');
   },
   'Invalid marker query string parameter prevents state update': (c) => {
     c.url(`${c.globals.url}?gm=-51.5,invalidtext`);
     c.expect.element(coordinatesMapMarker).to.not.be.present;
-    c.assert.not.urlContains('marker');
+    c.assert.not.urlContains('gm');
   },
   after(c) {
     c.end();

--- a/e2e/features/layers/layer-picker-mobile-test.js
+++ b/e2e/features/layers/layer-picker-mobile-test.js
@@ -94,7 +94,7 @@ module.exports = {
     c.waitForElementVisible(sourceMetadataExpanded, TIME_LIMIT, (e) => {
       c.assert.containsText(aquaTerraModisHeader, 'MODIS (Terra and Aqua) Combined Value-Added Aerosol Optical Depth');
       c.assert.containsText(maiacHeader, 'MAIAC Aerosol Optical Depth');
-      c.expect.elements('.source-metadata > p').count.to.equal(7);
+      c.expect.elements('.source-metadata > p').count.to.equal(10);
       c.expect.element('.ellipsis.up').to.be.present;
     });
   },


### PR DESCRIPTION

## Description

**Fix the following recently failing Firefox E2E tests in Travis CI:**

- [x] Add explicit view coordinates for Geosearch test to prevent sidebar from obscuring marker, use revised `gm` query string:
![image](https://user-images.githubusercontent.com/24417194/106639448-f6f66a80-6552-11eb-85d0-da9faa7e4a64.png)
- [x] update layer count:
![image](https://user-images.githubusercontent.com/24417194/106639541-0d9cc180-6553-11eb-8eac-59caeb13084e.png)

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
