### PR TITLE
Prevent calling stop animation action when opening product picker if animation isn't playing

### DIFF
--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -40,12 +40,14 @@ class FooterContent extends React.Component {
       isCompareActive,
       compareMode,
       isMobile,
+      isPlaying,
       activeTab,
       changeCompareMode,
       addLayers,
       toggleCompare,
       compareFeature,
       showAll,
+      stopAnimation,
     } = this.props;
     const compareBtnText = !isCompareActive ? 'Start Comparison' : 'Exit Comparison';
     if (isCompareActive && isMobile) {
@@ -67,6 +69,9 @@ class FooterContent extends React.Component {
               text="+ Add Layers"
               onClick={(e) => {
                 e.stopPropagation();
+                if (isPlaying) {
+                  stopAnimation();
+                }
                 addLayers();
                 googleTagManager.pushEvent({
                   event: 'add_layers',
@@ -120,7 +125,6 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(toggleListAll());
   },
   addLayers: () => {
-    dispatch(stopAnimationAction());
     dispatch(
       openCustomContent('LAYER_PICKER_COMPONENT', {
         headerText: null,
@@ -131,18 +135,23 @@ const mapDispatchToProps = (dispatch) => ({
       }),
     );
   },
+  stopAnimation: () => {
+    dispatch(stopAnimationAction());
+  },
 });
 function mapStateToProps(state) {
   const {
-    requestedEvents, config, compare, browser,
+    animation, requestedEvents, config, compare, browser,
   } = state;
   const { showAll } = state.events;
   const events = lodashGet(requestedEvents, 'response');
+  const { isPlaying } = animation;
 
   return {
     showAll,
     events,
     isMobile: browser.lessThan.medium,
+    isPlaying,
     compareFeature: config.features.compare,
     isCompareActive: compare.active,
     compareMode: compare.mode,
@@ -162,7 +171,9 @@ FooterContent.propTypes = {
   compareMode: PropTypes.string,
   isCompareActive: PropTypes.bool,
   isMobile: PropTypes.bool,
+  isPlaying: PropTypes.bool,
   showAll: PropTypes.bool,
+  stopAnimation: PropTypes.func,
   toggleCompare: PropTypes.func,
   toggleListAll: PropTypes.func,
 };


### PR DESCRIPTION
## Description

- [x] Prevent calling stop animation action when opening product picker if animation isn't playing. If stop animation is called and vector layers are loaded all layers are re-requested

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
