### PR TITLE
Add map:contextmenu event trigger

### DIFF
--- a/web/js/combine-ui.js
+++ b/web/js/combine-ui.js
@@ -68,7 +68,7 @@ function registerMapMouseHandlers(maps) {
       events.trigger('map:singleclick', event, map, crs);
     });
     map.on('contextmenu', (event) => {
-      events.trigger('contextmenu', event, map, crs);
+      events.trigger('map:contextmenu', event, map, crs);
     });
     element.addEventListener('click', (event) => {
       events.trigger('map:click', event, map, crs);


### PR DESCRIPTION
## Description

Fixes #3318  .

- [x] Add `map:contextmenu` event trigger to handle right click cancel for Geosearch reverse geocode

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
