### PR TITLE
Revert animation daterange condition that limited closestdate from being used at end of range

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -178,11 +178,6 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
    */
   self.getRequestDates = function(def, options) {
     const state = store.getState();
-    const { animation, date } = state;
-    const { endDate, startDate, isPlaying } = animation;
-    const {
-      appNow,
-    } = date;
     const stateCurrentDate = new Date(getSelectedDate(state));
     const previousLayer = options.previousLayer || {};
     let closestDate = options.date || stateCurrentDate;
@@ -199,10 +194,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     ) {
       previousDateFromRange = previousLayerDate;
     } else {
-      // limit range animation requests
-      const dateRange = isPlaying
-        ? datesinDateRanges(def, closestDate, startDate, endDate, appNow)
-        : datesinDateRanges(def, closestDate);
+      const dateRange = datesinDateRanges(def, closestDate);
       const { next, previous } = prevDateInDateRange(def, closestDate, dateRange);
       previousDateFromRange = previous;
       previousLayerDate = previous;


### PR DESCRIPTION

## Description

Fixes #3323  .

- [x] Revert animation daterange condition that limited closestdate from being used at end of range

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
