### PR TITLE
Fix animation widget interactions on touch devices

### DIFF
--- a/web/css/anim.widget.css
+++ b/web/css/anim.widget.css
@@ -14,17 +14,18 @@
   background: #212121;
   color: #fff;
   padding: 1px 0;
-  cursor: move;
   &.minimized {
     height: 52px;
     width: 80px;
     background: rgba(40, 40, 40, 0.85);
+    cursor: move;
   }
   & .wv-animation-widget-header {
     display: block;
     margin: 7px 45px 10px 5px;
     text-align: center;
     text-transform: capitalize;
+    cursor: move;
     & .interval-btn-container,
     & .interval-btn.interval-btn-active {
       color: #ce4c21;

--- a/web/js/components/animation-widget/loop-button.js
+++ b/web/js/components/animation-widget/loop-button.js
@@ -17,8 +17,8 @@ const LoopButton = ({ looping, onLoop }) => {
       aria-label={labelText}
       className={
             looping
-              ? 'wv-loop-icon-case wv-icon-case active'
-              : 'wv-loop-icon-case wv-icon-case'
+              ? 'wv-loop-icon-case wv-icon-case no-drag active'
+              : 'wv-loop-icon-case wv-icon-case no-drag'
           }
       onClick={onLoop}
     >

--- a/web/js/components/animation-widget/play-button.js
+++ b/web/js/components/animation-widget/play-button.js
@@ -15,7 +15,7 @@ const PlayButton = (props) => {
     <a
       id={buttonId}
       aria-label={labelText}
-      className="wv-anim-play-case wv-icon-case"
+      className="wv-anim-play-case wv-icon-case no-drag"
       onClick={playing ? pause : play}
     >
       <UncontrolledTooltip

--- a/web/js/components/timeline/custom-interval-selector/delta-input.js
+++ b/web/js/components/timeline/custom-interval-selector/delta-input.js
@@ -82,7 +82,7 @@ class DeltaInput extends PureComponent {
     } = this.state;
     return (
       <input
-        className="custom-interval-delta-input"
+        className="custom-interval-delta-input no-drag"
         type="text"
         style={valid ? {} : { borderColor: '#ff0000' }}
         min="1"

--- a/web/js/components/timeline/custom-interval-selector/interval-select.js
+++ b/web/js/components/timeline/custom-interval-selector/interval-select.js
@@ -25,22 +25,22 @@ class TimeScaleSelect extends PureComponent {
     } = this.props;
     return (
       <form
-        className="custom-interval-timescale-select-form-container"
+        className="custom-interval-timescale-select-form-container no-drag"
         onSubmit={this.handleSubmit}
       >
         <select
-          className="custom-interval-timescale-select"
+          className="custom-interval-timescale-select no-drag"
           value={zoomLevel}
           onChange={this.handleChangeZoomLevel}
         >
-          <option className="custom-interval-timescale-select-option" value="year">year</option>
-          <option className="custom-interval-timescale-select-option" value="month">month</option>
-          <option className="custom-interval-timescale-select-option" value="day">day</option>
+          <option className="custom-interval-timescale-select-option no-drag" value="year">year</option>
+          <option className="custom-interval-timescale-select-option no-drag" value="month">month</option>
+          <option className="custom-interval-timescale-select-option no-drag" value="day">day</option>
           {hasSubdailyLayers
             ? (
               <>
-                <option className="custom-interval-timescale-select-option" value="hour">hour</option>
-                <option className="custom-interval-timescale-select-option" value="minute">minute</option>
+                <option className="custom-interval-timescale-select-option no-drag" value="hour">hour</option>
+                <option className="custom-interval-timescale-select-option no-drag" value="minute">minute</option>
               </>
             )
             : null}

--- a/web/js/components/timeline/timeline-controls/interval-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/interval-timescale-change.js
@@ -54,6 +54,13 @@ class TimeScaleIntervalChange extends PureComponent {
     });
   }
 
+  onClick = () => {
+    const { toolTipHovered } = this.state;
+    this.setState({
+      toolTipHovered: !toolTipHovered,
+    });
+  }
+
   // handle click of timescale intervals
   handleClickInterval = (timescale, openModal = false) => {
     const { setTimeScaleIntervalChangeUnit } = this.props;
@@ -61,35 +68,6 @@ class TimeScaleIntervalChange extends PureComponent {
     this.setState({
       toolTipHovered: false,
     }, setTimeScaleIntervalChangeUnit(timescale, openModal));
-  }
-
-  // individual linking timescale handlers
-  handleClickIntervalYear = () => {
-    this.handleClickInterval('year');
-  }
-
-  handleClickIntervalMonth = () => {
-    this.handleClickInterval('month');
-  }
-
-  handleClickIntervalDay= () => {
-    this.handleClickInterval('day');
-  }
-
-  handleClickIntervalHour = () => {
-    this.handleClickInterval('hour');
-  }
-
-  handleClickIntervalMinute = () => {
-    this.handleClickInterval('minute');
-  }
-
-  handleClickIntervalCustom = () => {
-    this.handleClickInterval('custom');
-  }
-
-  handleClickIntervalCustomStatic = () => {
-    this.handleClickInterval('custom', true);
   }
 
   // set custom text for custom interval
@@ -114,14 +92,15 @@ class TimeScaleIntervalChange extends PureComponent {
       <>
         <div
           id="timeline-interval-btn-container"
-          className="interval-btn-container noselect"
+          className="interval-btn-container noselect no-drag"
           onMouseEnter={this.toolTipHoverOn}
           onMouseLeave={this.toolTipHoverOff}
+          onClick={this.onClick}
         >
           {/* timeScale display */}
           <span
             id="current-interval"
-            className={`interval-btn interval-btn-active${customSelected ? ' custom-interval-text' : ''}`}
+            className={`no-drag interval-btn interval-btn-active${customSelected ? ' custom-interval-text' : ''}`}
           >
             {customSelected ? customIntervalText : `${1} ${timeScaleChangeUnit}`}
           </span>
@@ -135,21 +114,21 @@ class TimeScaleIntervalChange extends PureComponent {
               <span
                 id="interval-years"
                 className="interval-btn interval-years"
-                onClick={this.handleClickIntervalYear}
+                onClick={() => this.handleClickInterval('year')}
               >
                 Year
               </span>
               <span
                 id="interval-months"
                 className="interval-btn interval-months"
-                onClick={this.handleClickIntervalMonth}
+                onClick={() => this.handleClickInterval('month')}
               >
                 Month
               </span>
               <span
                 id="interval-days"
                 className="interval-btn interval-days"
-                onClick={this.handleClickIntervalDay}
+                onClick={() => this.handleClickInterval('day')}
               >
                 Day
               </span>
@@ -158,14 +137,14 @@ class TimeScaleIntervalChange extends PureComponent {
                   <span
                     id="interval-hours"
                     className="interval-btn interval-hours"
-                    onClick={this.handleClickIntervalHour}
+                    onClick={() => this.handleClickInterval('hour')}
                   >
                     Hour
                   </span>
                   <span
                     id="interval-minutes"
                     className="interval-btn interval-minutes"
-                    onClick={this.handleClickIntervalMinute}
+                    onClick={() => this.handleClickInterval('minute')}
                   >
                     Minute
                   </span>
@@ -175,14 +154,14 @@ class TimeScaleIntervalChange extends PureComponent {
                 id="interval-custom"
                 className="interval-btn interval-custom custom-interval-text"
                 style={{ display: customIntervalText === 'Custom' ? 'none' : 'block' }}
-                onClick={this.handleClickIntervalCustom}
+                onClick={() => this.handleClickInterval('custom')}
               >
                 {customIntervalText}
               </span>
               <span
                 id="interval-custom-static"
                 className="interval-btn interval-custom custom-interval-text"
-                onClick={this.handleClickIntervalCustomStatic}
+                onClick={() => this.handleClickInterval('custom', true)}
               >
                 Custom
               </span>

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -342,9 +342,11 @@ class AnimationWidget extends React.Component {
       hasSubdailyLayers,
     } = this.props;
     const { collapsedWidgetPosition } = this.state;
+    const cancelSelector = '.no-drag, svg';
     return (
       <Draggable
         bounds="body"
+        cancel={cancelSelector}
         onStart={this.handleDragStart}
         position={collapsedWidgetPosition}
         onDrag={this.onCollapsedDrag}
@@ -417,7 +419,7 @@ class AnimationWidget extends React.Component {
       <a
         id="create-gif-button"
         aria-label={labelText}
-        className={gifDisabled ? 'wv-icon-case disabled' : 'wv-icon-case'}
+        className={gifDisabled ? 'wv-icon-case no-drag disabled' : 'wv-icon-case no-drag'}
         onClick={openGif}
       >
         <FontAwesomeIcon
@@ -457,10 +459,13 @@ class AnimationWidget extends React.Component {
       hasSubdailyLayers,
     } = this.props;
     const { speed, widgetPosition } = this.state;
+    const cancelSelector = '.no-drag, .interval-btn-container, .date-arrows';
 
     return (
       <Draggable
         bounds="body"
+        cancel={cancelSelector}
+        handle=".wv-animation-widget-header"
         position={widgetPosition}
         onDrag={this.onExpandedDrag}
         onStart={this.handleDragStart}

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -459,7 +459,7 @@ class AnimationWidget extends React.Component {
       hasSubdailyLayers,
     } = this.props;
     const { speed, widgetPosition } = this.state;
-    const cancelSelector = '.no-drag, .interval-btn-container, .date-arrows';
+    const cancelSelector = '.no-drag, .date-arrows';
 
     return (
       <Draggable


### PR DESCRIPTION
## Description

Fixes #3337.

The `react-draggable` component was causing all the child elements in this widget to be drag targets of touch events which prevented the primary touch interaction with them.

## To test

1. Load the app in Chrome, set device to iPad
2. Confirm all buttons in the animation widget respond as expected to touch events both in collapsed and expanded mode
