### PR TITLE
Use opacity to hide map scales on hover

### DIFF
--- a/web/js/components/timeline/timeline-controls/axis-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/axis-timescale-change.js
@@ -46,20 +46,9 @@ class AxisTimeScaleChange extends PureComponent {
   disableMapScales = (disable) => {
     const imperialMapScale = document.getElementsByClassName('wv-map-scale-imperial');
     const metricMapScale = document.getElementsByClassName('wv-map-scale-metric');
-    if (disable) {
-      for (const el of imperialMapScale) {
-        el.style.display = 'none';
-      }
-      for (const el of metricMapScale) {
-        el.style.display = 'none';
-      }
-    } else {
-      for (const el of imperialMapScale) {
-        el.style.display = 'block';
-      }
-      for (const el of metricMapScale) {
-        el.style.display = 'block';
-      }
+    const opacity = disable ? '0' : '1';
+    for (const el of [...imperialMapScale, ...metricMapScale]) {
+      el.style.opacity = opacity;
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #3357  .

- [x] Use opacity to hide map scales on hover instead of changing display to fix distraction free trigger issue

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
