### PR TITLE
Fix end date used for matching coverage in layer panel, add back error css

### DIFF
--- a/web/css/alert.css
+++ b/web/css/alert.css
@@ -53,3 +53,15 @@
   min-height: inherit;
   font-size: 0;
 }
+
+/* ErrorBoundary */
+.error-icon {
+  margin-right: 10px;
+  vertical-align: middle;
+}
+.error-header {
+  margin-top: 5px;
+}
+.error-body {
+  margin-top: 10px;
+}

--- a/web/js/modules/date/util.js
+++ b/web/js/modules/date/util.js
@@ -157,9 +157,8 @@ export function getMaxActiveLayersDate(state) {
  * @returns {Array} Array of max layer end dates
  */
 export function getMaxLayerEndDates(layers, appNow) {
-  return layers.reduce((layerEndDates, layer) => {
-    const { endDate, futureTime } = layer;
-    const layerEndDate = futureTime ? new Date(endDate) : new Date(appNow);
+  return layers.reduce((layerEndDates, { endDate }) => {
+    const layerEndDate = new Date(endDate || appNow);
     return layerEndDates.concat(layerEndDate);
   }, []);
 }


### PR DESCRIPTION
## Description

Fixes #3360  .

- [x] Fix layer `endDate` logic for determining matching layer coverage
- [x] Add back css for ErrorBoundary and alert icon used in layer panel

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
