### PR TITLE
Move tour modal on short windows

### DIFF
--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -714,7 +714,6 @@
   }
 }
 
-
 @media (min-height: 450px) {
   .tour {
     display: block;

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -223,7 +223,7 @@
     border-radius: 8px 0 0;
     background-color: rgb(0, 69, 123);
     padding: 8px 20px 8px 16px;
-    border-bottom: 2px solid #fff;
+    border-bottom: 1px solid #fff;
     .close {
       position: absolute;
       padding: 0;
@@ -237,7 +237,6 @@
     color: #fff;
     padding: 0;
     overflow-y: auto;
-    border-bottom: 2px solid #fff;
     -ms-flex: 1 1 25px;
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -681,31 +681,19 @@
 
 @media (max-height: 776px) {
   .tour-in-progress .modal {
-    bottom: 278px;
+    bottom: 290px;
   }
   .tour-in-progress .modal-content {
     height: 300px;
   }
 }
 
-@media (max-height: 712px) {
+@media (max-height: 720px) {
   .tour-in-progress .modal {
-    bottom: 232px;
-  }
-  .tour-in-progress .modal-content {
-    height: 250px;
-  }
-}
-
-@media (max-height: 665px) {
-
-  .tour-in-progress .modal {
-    bottom: 365px;
     right: 55px;
     .modal-dialog {
       box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.45);
       .modal-content {
-        height: 400px;
         border-radius: 8px;
       }
       .modal-header {
@@ -719,6 +707,13 @@
     }
   }
 }
+
+@media (max-height: 550px) {
+  .tour-in-progress .modal {
+    bottom: calc(var(--vh, 1vh) * 100 - 265px);
+  }
+}
+
 
 @media (min-height: 450px) {
   .tour {

--- a/web/css/tour.css
+++ b/web/css/tour.css
@@ -239,6 +239,8 @@
     overflow-y: auto;
     border-bottom: 2px solid #fff;
     -ms-flex: 1 1 25px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
     p {
       font-size: 13px;
       line-height: 20px;
@@ -697,12 +699,25 @@
 }
 
 @media (max-height: 665px) {
-  .tour-in-progress .modal {
-    bottom: 178px;
-  }
 
-  .tour-in-progress .modal-content {
-    height: 200px;
+  .tour-in-progress .modal {
+    bottom: 365px;
+    right: 55px;
+    .modal-dialog {
+      box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.45);
+      .modal-content {
+        height: 400px;
+        border-radius: 8px;
+      }
+      .modal-header {
+        border-top-right-radius: 8px;
+        border-top-left-radius: 8px;
+      }
+      .modal-footer {
+        border-bottom-right-radius: 8px;
+        border-bottom-left-radius: 8px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #3340

On iPad height:
* moves the tour modal left and makes it taller
* makes all corners equally rounded
* reduces shadow a bit since the default looked heavy over the zoom/rotate buttons
