### PR TITLE
Handle undefined conceptids

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -9,7 +9,7 @@
         "feedback": true,
         "previewSnapshots": true,
         "vismetadata": {
-            "url": "https://uat.gibs.earthdata.nasa.gov/layer-metadata/v1.0/"
+            "url": "https://gibs.earthdata.nasa.gov/layer-metadata/v1.0/"
         },
         "googleTagManager": true,
         "notification": {

--- a/e2e/features/smart-handoff/smart-handoff-test.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.js
@@ -59,7 +59,7 @@ module.exports = {
       .to.have.text.equal('Available granules for 2019 Dec 01: 289');
   },
 
-  'Enable target area selection': (c) => {
+  'Enable area of interest': (c) => {
     c.click('#chk-crop-toggle');
     c.assert.containsText('.granule-count > h1', 'of 289');
   },

--- a/web/js/components/smart-handoffs/smart-handoff-granule-alert.js
+++ b/web/js/components/smart-handoffs/smart-handoff-granule-alert.js
@@ -25,11 +25,11 @@ const GranuleAlertModalBody = () => (
     <p>You may also see NONE or “0 out of n” granules when:</p>
     <ol>
       <li>
-        The target area selection does not encompass any of the imagery displayed on the map.
+        The area of interest does not encompass any of the imagery displayed on the map.
       </li>
       <li>
-        The target area selection is encompassing imagery but the collection&apos;s metadata record does not contain the appropriate spatial
-        information for this feature to work. Unchecking the &quot;Target Area Selection&quot; box should address this.
+        The area of interest is encompassing imagery but the collection&apos;s metadata record does not contain the appropriate spatial
+        information for this feature to work. Unchecking the &quot;Set Area of Interest&quot; box should address this.
       </li>
     </ol>
 


### PR DESCRIPTION
## Description

Fixes #3373 

This branch is based off Minnie's AMSRE layers branch since those layers were the example for which this issue was noticed.

These changes will filter out any layers from smart handoffs for which we did not receive data from CMR during the build process.   Ideally, in the future we might want to be making requests to CMR in the UI while the user is looking at layers to have the most updated possible info on whether or not the collection exists in CMR.  However, that felt like too invasive of an approach this close to the release which would risk introducing other bugs.

If concept ids get updated/added/removed in CMR after we release, a simple rebuild and deploy should address the issue.  An entire release would not be needed.