### PR TITLE
Handle splitting orbit track id into two separate layer ids for image download requests

### DIFF
--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -36,11 +36,12 @@ export function getLatestIntervalTime(layerDefs, dateTime) {
  * @param {Array} layersArray
  * @param {Array} layerWraps
  * @param {Array} opacities
+ * @returns {Object} layersArray, layerWraps, opacities
  */
-const addOrbitTrackRevisions = function(layersArray, layerWraps, opacities) {
-  const revisedLayersArray = [...layersArray];
-  const revisedLayerWraps = [...layerWraps];
-  const revisedOpacities = [...opacities];
+const imageUtilProcessOrbitTracks = function(layersArray, layerWraps, opacities) {
+  const processedLayersArray = [...layersArray];
+  const processedLayerWraps = [...layerWraps];
+  const processedOpacities = [...opacities];
   let mod = 0;
 
   // check for OrbitTracks in layersArray
@@ -52,13 +53,13 @@ const addOrbitTrackRevisions = function(layersArray, layerWraps, opacities) {
       // revise OrbitTracks layerId requested to indiviudal 'Lines' and 'Points' layers
       // ex: 'OrbitTracks_Aqua_Ascending' is revised in the request as:
       // 'OrbitTracks_Aqua_Ascending_Points' and 'OrbitTracks_Aqua_Ascending_Lines'
-      revisedLayersArray.splice(idx, 1, `${layerId}_Lines`, `${layerId}_Points`);
+      processedLayersArray.splice(idx, 1, `${layerId}_Lines`, `${layerId}_Points`);
       // repeat wrap and opacity values for revised 'Lines' and 'Points' layers
-      const wrap = revisedLayerWraps[idx];
-      revisedLayerWraps.splice(idx, 0, wrap);
+      const wrap = processedLayerWraps[idx];
+      processedLayerWraps.splice(idx, 0, wrap);
       if (opacities.length > 0) {
-        const opacity = revisedOpacities[idx];
-        revisedOpacities.splice(idx, 0, opacity);
+        const opacity = processedOpacities[idx];
+        processedOpacities.splice(idx, 0, opacity);
       }
 
       mod += 1;
@@ -66,9 +67,9 @@ const addOrbitTrackRevisions = function(layersArray, layerWraps, opacities) {
   }
 
   return {
-    revisedLayersArray,
-    revisedLayerWraps,
-    revisedOpacities,
+    layersArray: processedLayersArray,
+    layerWraps: processedLayerWraps,
+    opacities: processedOpacities,
   };
 };
 
@@ -76,31 +77,25 @@ const addOrbitTrackRevisions = function(layersArray, layerWraps, opacities) {
  * Get the snapshots URL to download an image
  * @param {String} url
  * @param {Object} proj
- * @param {Array} layers
- * @param {Object} lonlats
+ * @param {Array} layer(s) objects
+ * @param {Array} lonlats
  * @param {Object} dimensions
  * @param {Date} dateTime
+ * @param {String/Boolean} fileType (false for default 'image/jpeg')
  * @param {Boolean} isWorldfile
  * @param {Array} markerCoordinates
  */
 export function getDownloadUrl(url, proj, layerDefs, lonlats, dimensions, dateTime, fileType, isWorldfile, markerCoordinates) {
   const { crs } = proj.selected;
-  let layersArray = imageUtilGetLayers(layerDefs, proj.id);
-  let layerWraps = imageUtilGetLayerWrap(layerDefs);
-  let opacities = imageUtilGetLayerOpacities(layerDefs);
-
-  // check for orbit tracks, split to individual 'Lines' and 'Points' layers for request while retaining order
-  if (layersArray.some((id) => id.includes('OrbitTracks'))) {
-    const {
-      revisedLayersArray,
-      revisedLayerWraps,
-      revisedOpacities,
-    } = addOrbitTrackRevisions(layersArray, layerWraps, opacities);
-
-    layersArray = revisedLayersArray;
-    layerWraps = revisedLayerWraps;
-    opacities = revisedOpacities;
-  }
+  const {
+    layersArray,
+    layerWraps,
+    opacities,
+  } = imageUtilProcessOrbitTracks(
+    imageUtilGetLayers(layerDefs, proj.id),
+    imageUtilGetLayerWrap(layerDefs),
+    imageUtilGetLayerOpacities(layerDefs),
+  );
 
   const imgFormat = fileType || 'image/jpeg';
   const { height, width } = dimensions;


### PR DESCRIPTION
## Description

Changes in GC and related WVS MapServer Mapfile configurations built from it now split each Orbit Tracks layer into individual 'Lines' and 'Points' layers. To request an image from WVS for a snapshot or GIF, the Orbit Tracks layer id needs to be replaced into its two separate layer ids as follows:

`OrbitTracks_Aqua_Ascending` in WV is revised in order in its image request to WVS as:
`OrbitTracks_Aqua_Ascending_Points` and `OrbitTracks_Aqua_Ascending_Lines`

In addition, any wrap and opacity values within the query string request are repeated in order.

## Further comments

This is intended to be tested against the current WVS SIT v1.4.5.

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
