### PR TITLE
dont require escaping underscores mid-word

### DIFF
--- a/tasks/config.js
+++ b/tasks/config.js
@@ -7,7 +7,11 @@ const showdown = require('showdown');
 const shell = require('shelljs');
 
 console.log('Converting markdown to html');
-const converter = new showdown.Converter({ openLinksInNewWindow: true });
+const converter = new showdown.Converter({
+  openLinksInNewWindow: true,
+  // don't require escaping underscores in the middle of a word
+  literalMidWordUnderscores: true,
+});
 
 const configFiles = glob.sync('build/options/config/metadata/**/*.md');
 for (const configFile of configFiles) {


### PR DESCRIPTION
## Description

* No longer require escaping underscores in markdown if they are in the middle of a word `like_this`
* Existing escaped underscores are unaffected and don't need to be changed
