### PR TITLE
Limit splitting of orbit tracks image download processing to KMZ only

### DIFF
--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -31,19 +31,19 @@ export function getLatestIntervalTime(layerDefs, dateTime) {
 }
 
 /**
- * Process original orbit track layers to split into two separate layers and repeat
- * wrap and opacity values for original
+ * KMZ Only: Process original orbit track layers to split into two separate
+ * ayers and repeat wrap and opacity values for original
  * @param {Array} layersArray
  * @param {Array} layerWraps
  * @param {Array} opacities
  * @returns {Object} layersArray, layerWraps, opacities
  */
-const imageUtilProcessOrbitTracks = function(layersArray, layerWraps, opacities) {
+const imageUtilProcessKMZOrbitTracks = function(layersArray, layerWraps, opacities) {
   const processedLayersArray = [...layersArray];
   const processedLayerWraps = [...layerWraps];
   const processedOpacities = [...opacities];
-  let mod = 0;
 
+  let mod = 0;
   // check for OrbitTracks in layersArray
   for (let i = 0; i < layersArray.length; i += 1) {
     const layerId = layersArray[i];
@@ -74,6 +74,25 @@ const imageUtilProcessOrbitTracks = function(layersArray, layerWraps, opacities)
 };
 
 /**
+ * Wrap to handle image util processes with additional KMZ processing if applicable
+ * @param {String/Boolean} fileType (false for default 'image/jpeg')
+ * @param {Array} layersArray
+ * @param {Array} layerWraps
+ * @param {Array} opacities
+ * @returns {Object} layersArray, layerWraps, opacities
+ */
+const imageUtilProcessWrap = function(fileType, layersArray, layerWraps, opacities) {
+  if (fileType === 'application/vnd.google-earth.kmz') {
+    return imageUtilProcessKMZOrbitTracks(layersArray, layerWraps, opacities);
+  }
+  return {
+    layersArray,
+    layerWraps,
+    opacities,
+  };
+};
+
+/**
  * Get the snapshots URL to download an image
  * @param {String} url
  * @param {Object} proj
@@ -91,7 +110,8 @@ export function getDownloadUrl(url, proj, layerDefs, lonlats, dimensions, dateTi
     layersArray,
     layerWraps,
     opacities,
-  } = imageUtilProcessOrbitTracks(
+  } = imageUtilProcessWrap(
+    fileType,
     imageUtilGetLayers(layerDefs, proj.id),
     imageUtilGetLayerWrap(layerDefs),
     imageUtilGetLayerOpacities(layerDefs),


### PR DESCRIPTION
## Description

- [x] Limit splitting of orbit tracks into separate Lines and Points layers for image download processing to KMZ only in order to retain legacy orbit tracks names now available in WVS along with the Lines and Points orbit tracks layers.

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
