### PR TITLE
Fix running data issue

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -311,7 +311,7 @@ class PaletteLegend extends React.Component {
               let palletteClass = isActiveKey ? 'wv-active wv-palettes-class' : 'wv-palettes-class';
               const isSubLayer = !!parentLayer;
               const parentLayerId = isSubLayer ? `-${parentLayer.id}` : '';
-              const keyId = `${util.encodeId(legend.id)}-color${util.encodeId(parentLayerId)}-${compareState}${keyIndex}`;
+              const keyId = `${util.encodeId(legend.id)}-color${util.encodeId(parentLayerId)}-${util.encodeId(layer.id)}-${compareState}${keyIndex}`;
               const keyLabel = activeKeyObj ? activeKeyObj.label : '';
               const inActive = palette.disabled && palette.disabled.includes(keyIndex);
               const tooltipText = singleKey

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -357,6 +357,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     }
     return new OlLayerTile({
       preload: Infinity,
+      className: def.id,
       extent,
       source: new OlSourceWMTS(sourceOptions),
     });
@@ -445,6 +446,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
       extent: layerExtent,
       source: sourceOptions,
       renderMode: 'image',
+      className: def.id,
       vector: true,
       preload: 10,
       ...isMaxBreakPoint && { maxResolution: breakPointResolution },
@@ -551,6 +553,7 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     const resolutionBreakPoint = lodashGet(def, `breakPointLayer.projections.${proj.id}.resolutionBreakPoint`);
     const layer = new OlLayerTile({
       preload: Infinity,
+      className: def.id,
       extent,
       ...!!resolutionBreakPoint && { minResolution: resolutionBreakPoint },
       source: new OlSourceTileWMS(sourceOptions),


### PR DESCRIPTION
## Description

Fixes 2 runningdata errors
<img width="499" alt="Screen Shot 2021-02-24 at 2 53 13 PM" src="https://user-images.githubusercontent.com/3605988/109056649-121e4b00-76b7-11eb-9c8a-0a8e5c4948b7.png">
<img width="659" alt="Screen Shot 2021-02-24 at 2 52 21 PM" src="https://user-images.githubusercontent.com/3605988/109056654-15193b80-76b7-11eb-9d4a-0bc6050bff49.png">


- [x] classification tooltip error related to layer identifier (Applies running data value to wrong layer)
- [x] running data error related to `forEachLayerAtPixel` error with OL version (shows similar value for layers with same palette)


## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
