### PR TITLE
Reset custom interval selector on tour step change without interval, or if delta is 1

### DIFF
--- a/web/js/components/timeline/timeline-controls/interval-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/interval-timescale-change.js
@@ -42,10 +42,7 @@ class TimeScaleIntervalChange extends PureComponent {
     } else if (customSelected && customDelta && timeScaleChangeUnit) {
       const didCustomDeltaChange = customDelta !== prevProps.customDelta;
       const didTimeScaleChangeUnitChange = timeScaleChangeUnit !== prevProps.timeScaleChangeUnit;
-      if (isCustomIntervalTextSet && defaultDelta) {
-        // setting custom to '1' will reset; ex: '1 day' won't be duplicated in interval list
-        this.resetCustomIntervalText();
-      } else if (didCustomDeltaChange || didTimeScaleChangeUnitChange) {
+      if (didCustomDeltaChange || didTimeScaleChangeUnitChange) {
         this.setCustomIntervalText();
       }
     }

--- a/web/js/components/timeline/timeline-controls/interval-timescale-change.js
+++ b/web/js/components/timeline/timeline-controls/interval-timescale-change.js
@@ -31,10 +31,21 @@ class TimeScaleIntervalChange extends PureComponent {
       timeScaleChangeUnit,
       customSelected,
     } = this.props;
-    if (customSelected && customDelta && timeScaleChangeUnit) {
+    const {
+      customIntervalText,
+    } = this.state;
+    const isCustomIntervalTextSet = customIntervalText !== 'Custom';
+    const defaultDelta = !customDelta || customDelta === 1;
+    if (!customSelected && isCustomIntervalTextSet && (defaultDelta || !timeScaleChangeUnit)) {
+      // reset from tour step change where previous step has custom interval and next step doesn't
+      this.resetCustomIntervalText();
+    } else if (customSelected && customDelta && timeScaleChangeUnit) {
       const didCustomDeltaChange = customDelta !== prevProps.customDelta;
       const didTimeScaleChangeUnitChange = timeScaleChangeUnit !== prevProps.timeScaleChangeUnit;
-      if (didCustomDeltaChange || didTimeScaleChangeUnitChange) {
+      if (isCustomIntervalTextSet && defaultDelta) {
+        // setting custom to '1' will reset; ex: '1 day' won't be duplicated in interval list
+        this.resetCustomIntervalText();
+      } else if (didCustomDeltaChange || didTimeScaleChangeUnitChange) {
         this.setCustomIntervalText();
       }
     }
@@ -75,6 +86,13 @@ class TimeScaleIntervalChange extends PureComponent {
     const { customDelta, customIntervalZoomLevel } = this.props;
     this.setState({
       customIntervalText: `${customDelta} ${customIntervalZoomLevel}`,
+    });
+  }
+
+  // reset custom text for custom interval
+  resetCustomIntervalText = () => {
+    this.setState({
+      customIntervalText: 'Custom',
     });
   }
 


### PR DESCRIPTION
## Description

Fixes #3389 .

- [X] Set update conditions to reset on tour step without interval, and reset if delta set to 1 (e.g. '1 day')

## Further comments

If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

## Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
