### PR TITLE
Fix tour step with custom palette issues

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -99,8 +99,11 @@ function LayerRow (props) {
     }
   };
 
+  // Request the layer palette only if it hasn't been loaded and is not currently being loaded
   useEffect(() => {
-    if (!isLoading && layer && hasPalette) requestPalette(layer.id);
+    if (!isLoading && layer && hasPalette && lodashIsEmpty(renderedPalette)) {
+      requestPalette(layer.id);
+    }
   }, [layer.id]);
 
   const getDisabledTitle = (layer) => {


### PR DESCRIPTION
## Description

Fixes #3392 

The individual requests for palettes were, for some reason, causing Redux actions to be mishandled by the map.  This prevents the request of a single palette when it is already loaded.  During each tour step change, the palettes for that step are loaded in bulk anyway.

This fixes the issue with the layer states in the map and the Redux store being out of sync, which caused both issues (changing date, map not zooming to correct location) that were noticed while investigating this issue.