### PR TITLE
create PR with layer template when layers modified

### DIFF
--- a/.github/LAYER_PULL_REQUEST_TEMPLATE.md
+++ b/.github/LAYER_PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+Fixes #
+
+[Ids of the layers being added]
+
+- [ ] Included layer(s) were added to the `layer-order.json`
+- [ ] Included layer(s) have an appropriate `layergroup` defined
+- [ ] Included layer(s) were added the appropriate measurements
+- [ ] Included layer(s) have a corresponding preview image
+- [ ] Included layer(s) have the necessary visualization metadata configs in GIBS
+- [ ] The corresponding concept ids in the visualization metadata configs are valid and return a collection when requested from CMR (e.g. `https://cmr.earthdata.nasa.gov/search/concepts/<concept-id>.html`)
+
+## How To Test
+
+- Do the dates show properly in the layer details both when viewed from the sidebar and in the layer description when browsing?
+- Do the dates in the description match with what appears available when adjusting the timeline?
+- Do the layers properly group with other layers in the same `layergroup`?
+- Do the layers show in the right category/measurement when browsing?
+- Do the preview images for the layers look right when searching in the product picker?
+- Does data download work properly (if concept id present)?
+
+## PR Submission Checklist
+
+This is simply a reminder of what we are going to look for before merging your code.
+
+- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
+- I have added necessary documentation (if applicable)
+- I have added tests that prove my fix is effective or that my feature works (if applicable)
+- Any dependent changes have been merged and published in downstream modules (if applicable)
+
+@nasa-gibs/worldview

--- a/.github/workflows/layer-pr-template.yml
+++ b/.github/workflows/layer-pr-template.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         destination_branch: "develop"
         pr_title: "Add/modify layers ${{ github.ref }}"
-        pr_label: "layers"
+        pr_label: "layer"
         pr_template: ".github/LAYER_PULL_REQUEST_TEMPLATE.md"
         pr_draft: true
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/layer-pr-template.yml
+++ b/.github/workflows/layer-pr-template.yml
@@ -1,0 +1,22 @@
+# Template for layer PRs
+
+on:
+  push:
+    paths:
+      - 'config/default/common/config/wv.json/layers/*'
+
+jobs:
+  layer-pr-template:
+    name: 'Create PR with Layers Template'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "develop"
+        pr_title: "Add/modify layers ${{ github.ref }}"
+        pr_label: "layers"
+        pr_template: ".github/LAYER_PULL_REQUEST_TEMPLATE.md"
+        pr_draft: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

When merged, these changes should cause a draft PR to be automatically opened anytime someone pushes code that modifies a file in the layers directory.  The PR will use a custom template that has a checklist for layer PR specific things and some helpful testing notes on things to look for when testing layer PRs.  It will also automatically label the pr with the "layer" label which will help group the layer changes in the changelog properly when generating release notes.

To test this, I think we will have to merge it then try pushing some code to see what happens.
