### PR TITLE
Support comparison mode in mobile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -80,7 +80,7 @@
         */
 
         // Base rule overrides
-        "no-nested-ternary": "warn", // 58 errors
+        "no-nested-ternary": "off", // 58 errors
         "no-shadow": "warn", // 136 errors
         "max-len": "off",
         "consistent-return": "off", // 73 errors

--- a/e2e/features/animation/animation-test.js
+++ b/e2e/features/animation/animation-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 10000;
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
     });
   },
   'Opening custom interval widget': (client) => {
-    client.url(client.globals.url + localQuerystrings.activeAnimationWidget);
+    client.url(client.globals.url + localQueryStrings.activeAnimationWidget);
     client.waitForElementVisible(
       localSelectors.animationButton,
       TIME_LIMIT,
@@ -42,7 +42,7 @@ module.exports = {
    * in the animation widget date selector
    */
   'Changing date range of animation': (client) => {
-    client.url(client.globals.url + localQuerystrings.activeAnimationWidget);
+    client.url(client.globals.url + localQueryStrings.activeAnimationWidget);
     // Test Permalink opens widget
     client.waitForElementVisible(
       '#day-animation-widget-start',

--- a/e2e/features/animation/gif-test.js
+++ b/e2e/features/animation/gif-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 30000; // Sometimes takes a while to generate GIFs
 const askDialog = '.modal-body .notify';
@@ -15,7 +15,7 @@ module.exports = {
   'Downloading GIF when custom colormap is activated': function(client) {
     if (client.options.desiredCapabilities.browserName !== 'ie') {
       // Custom colormaps down exist in IE
-      client.url(client.globals.url + localQuerystrings.activeCustomColormap);
+      client.url(client.globals.url + localQueryStrings.activeCustomColormap);
       client.waitForElementVisible(
         localSelectors.animationWidget,
         TIME_LIMIT,
@@ -46,7 +46,7 @@ module.exports = {
   },
   'Downloading GIF when polar projection is rotated': function(client) {
     client.url(
-      client.globals.url + localQuerystrings.animationProjectionRotated,
+      client.globals.url + localQueryStrings.animationProjectionRotated,
     );
     client.waitForElementVisible(
       localSelectors.animationWidget,
@@ -65,7 +65,7 @@ module.exports = {
   'GIF selection preview is Accurate and selections that are too high disable GIF download': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.activeAnimationWidget);
+    client.url(client.globals.url + localQueryStrings.activeAnimationWidget);
     client.waitForElementVisible(
       localSelectors.animationWidget,
       TIME_LIMIT,
@@ -112,7 +112,7 @@ module.exports = {
   'GIF download is disabled when too many frames would be requested with standard interval': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.animationTooManyFrames);
+    client.url(client.globals.url + localQueryStrings.animationTooManyFrames);
     client.waitForElementVisible(
       localSelectors.animationWidget,
       TIME_LIMIT,
@@ -124,7 +124,7 @@ module.exports = {
   'GIF download is disabled when too many frames would be requested with custom interval': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.animationTooManyFramesCustomInterval);
+    client.url(client.globals.url + localQueryStrings.animationTooManyFramesCustomInterval);
     client.waitForElementVisible(
       localSelectors.animationWidget,
       TIME_LIMIT,

--- a/e2e/features/compare/compare-mobile-test.js
+++ b/e2e/features/compare/compare-mobile-test.js
@@ -1,0 +1,96 @@
+const reuseables = require('../../reuseables/skip-tour.js');
+const localSelectors = require('../../reuseables/selectors.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
+
+const {
+  aTab,
+  bTab,
+  compareButton,
+  compareButtonText,
+  compareMobileSelectToggle,
+  collapsedLayerButton,
+  layerContainer,
+  mobileDatePickerSelectButton,
+  swipeDragger,
+} = localSelectors;
+
+const aMobileCompareButton = `${compareMobileSelectToggle} > div:nth-child(1)`;
+const bMobileCompareButton = `${compareMobileSelectToggle} > div:nth-child(2)`;
+
+const TIME_LIMIT = 10000;
+module.exports = {
+  before: (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    c.resizeWindow(375, 667); // iPhone 6/7/8 dimensions
+  },
+
+  // load SWIPE and verify that it is active
+  'Mobile SWIPE is loaded': (c) => {
+    c.url(c.globals.url + localQueryStrings.swipeAndAIsActive);
+    c.waitForElementVisible(swipeDragger, TIME_LIMIT);
+  },
+
+  // load SWIPE and verify mobile compare A|B toggle buttons are visible
+  'Mobile comparison A|B toggle buttons are visible and only A is selected by default': (c) => {
+    c.waitForElementVisible(compareMobileSelectToggle, TIME_LIMIT);
+    c.assert.cssClassPresent(aMobileCompareButton, 'compare-btn-selected');
+    c.assert.cssClassNotPresent(bMobileCompareButton, 'compare-btn-selected');
+  },
+
+  // toggle select B change compare mode date to B
+  'Toggling to B compare side changes mobile date picker date': (c) => {
+    // confirm initial A mobile date picker date
+    c.waitForElementVisible(mobileDatePickerSelectButton, TIME_LIMIT, (e) => {
+      c.assert.containsText(mobileDatePickerSelectButton, '2018-08-17');
+    });
+    // click B compare toggle button and confirm B mobile date picker date
+    c.click(bMobileCompareButton);
+    c.waitForElementVisible(mobileDatePickerSelectButton, TIME_LIMIT, (e) => {
+      c.assert.containsText(mobileDatePickerSelectButton, '2018-08-16');
+    });
+  },
+
+  'Expand mobile layer list and confirm comparison mode button is present and toggles compare mode': (c) => {
+    c.click(collapsedLayerButton);
+    c.waitForElementVisible(layerContainer, TIME_LIMIT, (e) => {
+      c.assert.elementPresent(compareButton);
+      c.assert.elementPresent(aTab);
+      c.assert.elementPresent(bTab);
+      c.assert.containsText(compareButtonText, 'Exit Comparison Mode');
+    });
+
+    c.click(compareButton);
+    c.waitForElementVisible(compareButtonText, TIME_LIMIT, (e) => {
+      c.assert.elementNotPresent(aTab);
+      c.assert.elementNotPresent(bTab);
+      c.assert.elementPresent(compareButton);
+      c.assert.containsText(compareButtonText, 'Start Comparison Mode');
+    });
+  },
+
+  // B compare button toggle is selected on B permalink load and A is not selected
+  'B compare button toggle is only selected on B permalink load': (c) => {
+    c.url(c.globals.url + localQueryStrings.spyAndBIsActive);
+    c.waitForElementVisible(swipeDragger, TIME_LIMIT);
+    c.assert.cssClassNotPresent(aMobileCompareButton, 'compare-btn-selected');
+    c.assert.cssClassPresent(bMobileCompareButton, 'compare-btn-selected');
+  },
+
+  // load comparison SPY mode and verify that it reverts to SWIPE mode
+  'Mobile SPY mode reverts to SWIPE mode': (c) => {
+    c.url(c.globals.url + localQueryStrings.spyAndBIsActive);
+    c.waitForElementVisible(swipeDragger, TIME_LIMIT);
+    c.pause(500);
+  },
+
+  // load comparison OPACITY mode and verify that it reverts to SWIPE mode
+  'Mobile OPACITY mode reverts to SWIPE mode': (c) => {
+    c.url(c.globals.url + localQueryStrings.opacityAndBIsActive);
+    c.waitForElementVisible(swipeDragger, TIME_LIMIT);
+    c.pause(500);
+  },
+
+  after(c) {
+    c.end();
+  },
+};

--- a/e2e/features/compare/compare-test.js
+++ b/e2e/features/compare/compare-test.js
@@ -1,13 +1,18 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
-const animationButtonCase = '#timeline-header .animate-button';
-const ImageDownloadButton = '#wv-image-button';
-const eventsTabButton = '#events-sidebar-tab';
-const dataDownloadTabButton = '#download-sidebar-tab';
-const ModisTruecolorLayerA = '#active-MODIS_Terra_CorrectedReflectance_TrueColor';
-const ModisTruecolorLayerB = '#activeB-MODIS_Terra_CorrectedReflectance_TrueColor';
+const {
+  animationButtonCase,
+  animationWidget,
+  dataDownloadTabButton,
+  eventsSidebarTabButton,
+  snapshotToolbarButton,
+  swipeDragger,
+} = localSelectors;
+
+const ModisTrueColorLayerA = '#active-MODIS_Terra_CorrectedReflectance_TrueColor';
+const ModisTrueColorLayerB = '#activeB-MODIS_Terra_CorrectedReflectance_TrueColor';
 const toggleButton = '.toggleIconHolder .accordionToggler';
 const collapsedToggleButton = '#productsHoldertoggleButtonHolder .accordionToggler';
 const tooltipSelector = '.tooltip-inner';
@@ -19,8 +24,8 @@ module.exports = {
   },
   // load A|B and verify that it is active
   'A|B is loaded': (c) => {
-    c.url(c.globals.url + localQuerystrings.swipeAndAIsActive);
-    c.waitForElementVisible(localSelectors.swipeDragger, TIME_LIMIT);
+    c.url(c.globals.url + localQueryStrings.swipeAndAIsActive);
+    c.waitForElementVisible(swipeDragger, TIME_LIMIT);
     c.pause(1000);
   },
 
@@ -35,20 +40,20 @@ module.exports = {
 
     // Clicking does not activate animation
     c.click(animationButtonCase);
-    c.expect.element('#wv-animation-widget').to.not.be.present;
+    c.expect.element(animationWidget).to.not.be.present;
   },
 
   'Image download is disabled when compare mode active': (c) => {
     const disableMessage = 'You must exit comparison mode to use the snapshot feature';
-    c.assert.cssClassPresent(ImageDownloadButton, 'disabled');
-    c.assert.attributeContains(ImageDownloadButton, 'aria-label', disableMessage);
+    c.assert.cssClassPresent(snapshotToolbarButton, 'disabled');
+    c.assert.attributeContains(snapshotToolbarButton, 'aria-label', disableMessage);
     c.moveToElement('#snapshot-btn-wrapper svg', 10, 10);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT, (e) => {
       c.assert.containsText(tooltipSelector, disableMessage);
     });
 
     // Clicking does not activate image download
-    c.click(ImageDownloadButton);
+    c.click(snapshotToolbarButton);
     c.pause(100);
     c.expect.element('#wv-image-resolution').to.not.be.present;
   },
@@ -68,31 +73,31 @@ module.exports = {
   'Events disabled when compare mode active': (c) => {
     const disableMessage = 'You must exit comparison mode to use the natural events feature';
 
-    c.moveToElement(eventsTabButton, 1, 1);
-    c.click(eventsTabButton);
+    c.moveToElement(eventsSidebarTabButton, 1, 1);
+    c.click(eventsSidebarTabButton);
     c.pause(100);
     c.expect.element('#wv-eventscontent').to.not.be.present;
-    c.assert.cssClassPresent(eventsTabButton, 'disabled');
-    c.assert.attributeContains(eventsTabButton, 'aria-label', disableMessage);
-    c.assert.attributeContains(eventsTabButton, 'title', disableMessage);
+    c.assert.cssClassPresent(eventsSidebarTabButton, 'disabled');
+    c.assert.attributeContains(eventsSidebarTabButton, 'aria-label', disableMessage);
+    c.assert.attributeContains(eventsSidebarTabButton, 'title', disableMessage);
   },
 
   'Removing layer removes correct layer from correct layer group': (c) => {
-    c.expect.element(ModisTruecolorLayerA).to.be.visible;
-    c.moveToElement(ModisTruecolorLayerA, 1, 1).pause(200);
+    c.expect.element(ModisTrueColorLayerA).to.be.visible;
+    c.moveToElement(ModisTrueColorLayerA, 1, 1).pause(200);
     c.click('#close-activeMODIS_Terra_CorrectedReflectance_TrueColor');
     c.pause(100);
-    c.expect.element(ModisTruecolorLayerA).to.not.be.present;
-    c.expect.element(ModisTruecolorLayerB).to.not.be.present;
+    c.expect.element(ModisTrueColorLayerA).to.not.be.present;
+    c.expect.element(ModisTrueColorLayerB).to.not.be.present;
     c.click(localSelectors.bTab);
-    c.waitForElementVisible(ModisTruecolorLayerB, TIME_LIMIT);
+    c.waitForElementVisible(ModisTrueColorLayerB, TIME_LIMIT);
   },
 
   /**
    * B state can layer list collapse
    */
   'Collapse layer list with B state and test label shows correct number of layers': (c) => {
-    c.url(c.globals.url + localQuerystrings.spyAndBIsActive);
+    c.url(c.globals.url + localQueryStrings.spyAndBIsActive);
 
     c.waitForElementVisible(toggleButton, TIME_LIMIT, () => {
       c.expect.element(collapsedToggleButton).to.not.be.present;

--- a/e2e/features/compare/layer-dialog-test.js
+++ b/e2e/features/compare/layer-dialog-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 20000;
 const aerosolLayer = '#active-MODIS_Terra_Aerosol';
@@ -17,7 +17,7 @@ module.exports = {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
   },
   'Layer option features work in A|B mode': (c) => {
-    c.url(c.globals.url + localQuerystrings.swipeAOD);
+    c.url(c.globals.url + localQueryStrings.swipeAOD);
     c.waitForElementVisible(aerosolLayer, TIME_LIMIT);
     c.expect.element(AodOptionsPanelBody).to.not.be.present;
     c.moveToElement(aerosolLayer, 0, 0).pause(200);

--- a/e2e/features/compare/layer-sidebar-test.js
+++ b/e2e/features/compare/layer-sidebar-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const selectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const aodCombinedValueId = 'MODIS_Combined_Value_Added_AOD';
 const aodMAIACId = 'MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth';
@@ -13,7 +13,7 @@ module.exports = {
     reuseables.loadAndSkipTour(client, client.globals.timeout);
   },
   'Add AOD Layer to Layer Group A': (client) => {
-    client.url(client.globals.url + localQuerystrings.swipeAndAIsActive);
+    client.url(client.globals.url + localQueryStrings.swipeAndAIsActive);
     client.waitForElementVisible(selectors.swipeDragger, client.globals.timeout, () => {
       client.click(selectors.addLayers);
       client.waitForElementVisible(selectors.aerosolOpticalDepth, client.globals.timeout, () => {

--- a/e2e/features/compare/permalinks-test.js
+++ b/e2e/features/compare/permalinks-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 20000;
 module.exports = {
@@ -14,7 +14,7 @@ module.exports = {
   'Swipe mode and A|B state A are active and date is correct': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.swipeAndAIsActive);
+    client.url(client.globals.url + localQueryStrings.swipeAndAIsActive);
     client.waitForElementVisible(
       localSelectors.swipeDragger,
       TIME_LIMIT,
@@ -30,7 +30,7 @@ module.exports = {
   'Opacity mode and A|B state B are active and date is correct': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.opacityAndBIsActive);
+    client.url(client.globals.url + localQueryStrings.opacityAndBIsActive);
     client.waitForElementVisible('#ab-slider-case', TIME_LIMIT, () => {
       client.expect.element(localSelectors.opacityButton).to.not.be.enabled;
       client.assert.cssClassPresent(localSelectors.bTab, 'active');
@@ -38,7 +38,7 @@ module.exports = {
     });
   },
   'Spy mode is active in B state': function(client) {
-    client.url(client.globals.url + localQuerystrings.spyAndBIsActive);
+    client.url(client.globals.url + localQueryStrings.spyAndBIsActive);
     client.waitForElementPresent('.ab-spy-span', TIME_LIMIT, () => {
       client.expect.element(localSelectors.spyButton).to.not.be.enabled;
       client.assert.cssClassPresent(localSelectors.bTab, 'active');
@@ -51,7 +51,7 @@ module.exports = {
   'A|B loaded with one only layer in A section -- Corrected Reflectance (True Color)': function(
     client,
   ) {
-    client.url(client.globals.url + localQuerystrings.swipeAndAIsActive);
+    client.url(client.globals.url + localQueryStrings.swipeAndAIsActive);
     client.waitForElementPresent(localSelectors.aTab, TIME_LIMIT, () => {
       client.expect.element(
         '.ab-tabs-case .tab-pane.active ul#overlays .item',

--- a/e2e/features/compare/timeline-test.js
+++ b/e2e/features/compare/timeline-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const draggerA = '.timeline-dragger.draggerA ';
 const draggerB = '.timeline-dragger.draggerB ';
@@ -14,7 +14,7 @@ module.exports = {
   },
   // load A|B and verify that it is active
   'A|B is loaded': function(client) {
-    client.url(client.globals.url + localQuerystrings.swipeAndAIsActive);
+    client.url(client.globals.url + localQueryStrings.swipeAndAIsActive);
     client.waitForElementVisible(localSelectors.swipeDragger, TIME_LIMIT);
   },
   'Verify that A|B draggers are visible': function(client) {

--- a/e2e/features/events/events-test.js
+++ b/e2e/features/events/events-test.js
@@ -1,5 +1,5 @@
 const reuseables = require('../../reuseables/skip-tour.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 10000;
 /**
@@ -24,13 +24,13 @@ module.exports = {
     const inactiveAlertMsgContainer = `${inactiveEventAlert} .wv-alert-message`;
     const inactiveEventMsg = 'The event with an id of EONET_5133 is no longer active.';
 
-    c.url(c.globals.url + localQuerystrings.closedEvent);
+    c.url(c.globals.url + localQueryStrings.closedEvent);
     c.waitForElementVisible(inactiveEventAlert, TIME_LIMIT);
     c.expect.element(inactiveEventAlert).to.be.present;
     c.assert.containsText(inactiveAlertMsgContainer, inactiveEventMsg);
   },
   'Make sure that 4 fire layers are not present in layer list: use mock': (c) => {
-    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.url(c.globals.url + localQueryStrings.mockEvents);
     c.waitForElementVisible(
       '#sidebar-event-EONET_3931',
       TIME_LIMIT,
@@ -65,13 +65,13 @@ module.exports = {
     );
   },
   'Use Mock to make sure appropriate number of event markers are appended to map': (c) => {
-    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.url(c.globals.url + localQueryStrings.mockEvents);
     c.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
       c.expect.elements(eventIcons).count.to.equal(9);
     });
   },
   'On events tab click events list is loaded': (c) => {
-    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.url(c.globals.url + localQueryStrings.mockEvents);
     c.waitForElementVisible(listOfEvents, TIME_LIMIT);
   },
   'Use Mock to ensure number of event track points is correct and event markers and tabs are not visible when layer tab is clicked': (c) => {
@@ -88,7 +88,7 @@ module.exports = {
     });
   },
   'Click Events tab and select an Event from the List': (c) => {
-    c.url(c.globals.url + localQuerystrings.mockEvents);
+    c.url(c.globals.url + localQueryStrings.mockEvents);
     c.waitForElementVisible(listOfEvents, TIME_LIMIT, () => {
       c.click(firstEvent);
       c.waitForElementVisible(selectedMarker, TIME_LIMIT, () => {

--- a/e2e/features/events/list-all-test.js
+++ b/e2e/features/events/list-all-test.js
@@ -1,5 +1,5 @@
 const reuseables = require('../../reuseables/skip-tour.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const TIME_LIMIT = 10000;
 const layersTab = '#layers-sidebar-tab';
@@ -8,7 +8,7 @@ const eventsTab = '#events-sidebar-tab';
 module.exports = {
   before(client) {
     reuseables.loadAndSkipTour(client, TIME_LIMIT);
-    client.url(client.globals.url + localQuerystrings.mockEvents);
+    client.url(client.globals.url + localQueryStrings.mockEvents);
   },
   'Seleting a category filters events': function(client) {
     client.click('#event-category-dropdown');

--- a/e2e/features/layers/running-data-test.js.wip
+++ b/e2e/features/layers/running-data-test.js.wip
@@ -1,5 +1,5 @@
 const loadAndSkipTour = require('../../reuseables/skip-tour.js').loadAndSkipTour;
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 const TIME_LIMIT = 10000;
 /**
  * selectors
@@ -11,7 +11,7 @@ module.exports = {
     loadAndSkipTour(client, TIME_LIMIT);
   },
   'Load Layer with continuous palette': function(client) {
-    client.url(client.globals.url + localQuerystrings.continuousDataLayers);
+    client.url(client.globals.url + localQueryStrings.continuousDataLayers);
     client.waitForElementVisible('.wv-palettes-colorbar', TIME_LIMIT);
   },
   'Veryify running data label is correct when mouse hovers data': function(client) {

--- a/e2e/features/timeline/date-selector-test.js
+++ b/e2e/features/timeline/date-selector-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const {
   dayUp,
@@ -11,7 +11,7 @@ const {
 const {
   knownDate,
   subdailyLayerIntervalTimescale,
-} = localQuerystrings;
+} = localQueryStrings;
 
 const dateSelectorMinuteInput = '#date-selector-main .input-wrapper-minute input';
 const dateSelectorHourInput = '#date-selector-main .input-wrapper-hour input';

--- a/e2e/features/timeline/layer-coverage-panel.js
+++ b/e2e/features/timeline/layer-coverage-panel.js
@@ -1,5 +1,5 @@
 const reuseables = require('../../reuseables/skip-tour.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const layerCoverageContainer = '.timeline-layer-coverage-container';
 const layerCoverageHandle = '#timeline-layer-coverage-panel-handle';
@@ -18,7 +18,7 @@ module.exports = {
 
   // verify no layer coverage is visible on the timeline axis with just reference layers loaded
   'No layer coverage is shown by default': (client) => {
-    client.url(client.globals.url + localQuerystrings.referenceLayersOnly);
+    client.url(client.globals.url + localQueryStrings.referenceLayersOnly);
     client.waitForElementVisible(layerCoverageHandle, TIME_LIMIT);
     client.expect.element(matchingLayerCoverageAxisLine).to.not.be.present;
   },

--- a/e2e/features/timeline/timeline-mobile-test.js
+++ b/e2e/features/timeline/timeline-mobile-test.js
@@ -1,6 +1,6 @@
 const skipTour = require('../../reuseables/skip-tour.js');
 
-const mobileDatePickerSelectBtn = '#date-selector-main .mobile-date-picker-select-btn';
+const mobileDatePickerSelectBtn = '.mobile-date-picker-select-btn';
 const nextDayArrowContainer = '#right-arrow-group';
 const datepickerHeader = '.datepicker .datepicker-header';
 const TIME_LIMIT = 10000;

--- a/e2e/features/timeline/timeline-test.js
+++ b/e2e/features/timeline/timeline-test.js
@@ -1,6 +1,6 @@
 const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
-const localQuerystrings = require('../../reuseables/querystrings.js');
+const localQueryStrings = require('../../reuseables/querystrings.js');
 
 const draggerA = '.timeline-dragger.draggerA ';
 const dateSelectorDayInput = '#date-selector-main .input-wrapper-day input';
@@ -63,7 +63,7 @@ module.exports = {
 
   // verify interval state restored from permalink
   'Interval state of HOUR restored from permalink': (c) => {
-    c.url(c.globals.url + localQuerystrings.subdailyLayerIntervalTimescale);
+    c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
     c.useCss()
       .moveToElement('#timeline-interval-btn-container', 0, 0)
       .waitForElementVisible('#current-interval', TIME_LIMIT);
@@ -90,7 +90,7 @@ module.exports = {
 
   // verify changing custom interval changes current interval and how many time units change with date arrows
   'Select custom interval changes current interval and changes date by current interval': (c) => {
-    c.url(c.globals.url + localQuerystrings.knownDate);
+    c.url(c.globals.url + localQueryStrings.knownDate);
     c.assert.attributeContains(dateSelectorDayInput, 'value', '22');
     c.useCss()
       .moveToElement('#timeline-interval-btn-container', 0, 0)
@@ -114,7 +114,7 @@ module.exports = {
 
   // verify subdaily default year, month, day, hour, minute, and custom intervals
   'Timescale zoom subdaily default year, month, day, hour, minute, and custom intervals': (c) => {
-    c.url(c.globals.url + localQuerystrings.subdailyLayerIntervalTimescale);
+    c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
     c.useCss()
       .moveToElement('#current-zoom', 0, 0)
       .waitForElementVisible('#zoom-years', TIME_LIMIT);
@@ -152,7 +152,7 @@ module.exports = {
 
   // subdaily valid date tooltip date is present on hovering over timeline axis
   'Subdaily date tooltip date is present on hovering over timeline axis': (c) => {
-    c.url(c.globals.url + localQuerystrings.subdailyLayerIntervalTimescale);
+    c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
     c.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
     c.useCss()
       .moveToElement(draggerA, 15, 15)

--- a/e2e/features/timeline/timeline-test.js
+++ b/e2e/features/timeline/timeline-test.js
@@ -22,8 +22,9 @@ module.exports = {
     c.expect.element('#timeline-footer').to.be.visible;
     // hide timeline
     c.click('#timeline-hide')
-      .waitForElementNotVisible('#timeline-footer', TIME_LIMIT);
-    c.expect.element('#timeline-footer').to.not.be.visible;
+      .waitForElementNotPresent('#timeline-footer', TIME_LIMIT);
+    c.expect.element('#timeline-footer').to.not.be.present;
+
     // expand timeline
     c.click('#timeline-hide')
       .waitForElementVisible('#timeline-footer', TIME_LIMIT);

--- a/e2e/reuseables/selectors.js
+++ b/e2e/reuseables/selectors.js
@@ -12,6 +12,7 @@ module.exports = {
   gifDownloadButton: '.animation-gif-dialog-wrapper .wv-button',
   gifResults: '.gif-results-dialog-case img',
   animationWidget: '#wv-animation-widget',
+  animationButtonCase: '#timeline-header .animate-button',
   animationButton: '#animate-button',
 
   // sidebar, layers
@@ -21,6 +22,8 @@ module.exports = {
   infoDialog: '.layer-info-settings-modal',
   optionsDialog: '.layer-info-settings-modal',
   addLayers: '#layers-add',
+  dataDownloadTabButton: '#download-sidebar-tab',
+  eventsSidebarTabButton: '#events-sidebar-tab',
   groupCheckbox: '#group-overlays-checkbox',
   viirsFiresCheckbox: '#VIIRS_NOAA20_Thermal_Anomalies_375m_All-checkbox',
   firesGroup: '#active-Fires_and_Thermal_Anomalies',
@@ -48,6 +51,8 @@ module.exports = {
   bTab: '.ab-tabs-case .ab-tab.second-tab',
   swipeDragger: '.ab-swipe-line .ab-swipe-dragger',
   compareButton: '#compare-toggle-button',
+  compareButtonText: '#compare-toggle-button > span',
+  compareMobileSelectToggle: '.comparison-mobile-select-toggle',
 
   // measure
   measureBtn: '#wv-measure-button',
@@ -64,6 +69,7 @@ module.exports = {
 
   // timeline
   timelineContainer: '.timeline-container',
+  mobileDatePickerSelectButton: '.mobile-date-picker-select-btn',
   dragger: '.timeline-dragger',
   dayDown: '.input-wrapper-day > div.date-arrows.date-arrow-down',
   dayUp: '.input-wrapper-day > div.date-arrows.date-arrow-up',

--- a/web/css/compare.css
+++ b/web/css/compare.css
@@ -122,3 +122,42 @@
   display: block;
   max-width: 100%;
 }
+
+/* Mobile */
+.comparison-mobile-select-toggle {
+  border-radius: 5px;
+  height: 44px;
+  border: thin solid #333;
+  background-color: rgba(40, 40, 40, 0.85);
+  position: absolute;
+  bottom: 65px;
+  left: 10px;
+  display: flex;
+  overflow: hidden;
+}
+
+.compare-toggle-selected-btn {
+  cursor: pointer;
+  user-select: none;
+  font-size: 25px;
+  padding: 13.5px;
+  color: #fff;
+  border: thin solid transparent;
+  &:first-child {
+    border-bottom-left-radius: 5px;
+    border-top-left-radius: 5px;
+  }
+  &:last-child {
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+  }
+  &:hover:not(.compare-btn-selected) {
+    border-color: #fff;
+  }
+}
+
+.compare-btn-selected {
+  color: #495057;
+  background-color: #fff;
+  border-color: #fff;
+}

--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -118,7 +118,8 @@
     display: none !important;
   }
 
-  button#layers-add {
+  button#layers-add,
+  button#compare-toggle-button {
     width: 100%;
     position: relative;
     left: 0;

--- a/web/css/sidebar.css
+++ b/web/css/sidebar.css
@@ -275,6 +275,10 @@ footer .compare-toggle-button {
       display: inline;
     }
   }
+
+  #productsHolder footer .product-buttons {
+    height: 110px;
+  }
 }
 
 .group-overlays-checkbox {

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -677,6 +677,7 @@ button:focus {
 }
 
 .mobile-date-picker-select-btn {
+  user-select: none;
   position: absolute;
   left: 10px;
   bottom: 10px;

--- a/web/js/components/compare/mobile-toggle.js
+++ b/web/js/components/compare/mobile-toggle.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { toggleActiveCompareState as toggleActiveCompareStateAction } from '../../modules/compare/actions';
+
+function MobileComparisonToggle (props) {
+  const {
+    active,
+    isCompareA,
+    toggleActiveCompareState,
+  } = props;
+  if (!active) {
+    return null;
+  }
+
+  const [isCompareASelected, toggleCompareASelected] = useState(isCompareA);
+  useEffect(() => {
+    if (isCompareASelected !== isCompareA) {
+      toggleCompareASelected(isCompareA);
+    }
+  }, [isCompareA]);
+  useEffect(() => {
+    if (isCompareASelected !== isCompareA) {
+      toggleActiveCompareState();
+    }
+  }, [isCompareASelected]);
+
+  const classA = isCompareASelected ? 'compare-btn-selected' : '';
+  const classB = !isCompareASelected ? 'compare-btn-selected' : '';
+
+  return (
+    <>
+      <div className="comparison-mobile-select-toggle">
+        <div
+          className={`compare-toggle-selected-btn ${classA}`}
+          onClick={() => toggleCompareASelected(true)}
+        >
+          A
+        </div>
+        <div
+          className={`compare-toggle-selected-btn ${classB}`}
+          onClick={() => toggleCompareASelected(false)}
+        >
+          B
+        </div>
+      </div>
+    </>
+  );
+}
+
+const mapStateToProps = (state) => {
+  const { compare } = state;
+  const { active, isCompareA } = compare;
+  return {
+    active,
+    isCompareA,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => ({
+  toggleActiveCompareState: () => {
+    dispatch(toggleActiveCompareStateAction());
+  },
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(MobileComparisonToggle);
+
+MobileComparisonToggle.propTypes = {
+  active: PropTypes.bool.isRequired,
+  isCompareA: PropTypes.bool.isRequired,
+  toggleActiveCompareState: PropTypes.func.isRequired,
+};

--- a/web/js/components/location-search/coordinates-dialog.js
+++ b/web/js/components/location-search/coordinates-dialog.js
@@ -25,7 +25,7 @@ class CoordinatesDialog extends Component {
         isCopyToClipboardTooltipVisible: true,
       });
 
-      // Prevnet keyboard overlay in iOS
+      // Prevent keyboard overlay in iOS
       setTimeout(() => {
         document.getElementById('location-search-autocomplete').blur();
       }, 50);

--- a/web/js/components/location-search/location-search-input.js
+++ b/web/js/components/location-search/location-search-input.js
@@ -1,4 +1,3 @@
-/* eslint no-nested-ternary: 0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Autocomplete from 'react-autocomplete';

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -21,7 +21,6 @@ function Event (props) {
   if (eventDate.getUTCFullYear() !== util.today().getUTCFullYear()) {
     dateString += `, ${eventDate.getUTCFullYear()}`;
   }
-  // eslint-disable-next-line no-nested-ternary
   const itemClass = isSelected
     ? 'item-selected selectorItem item item-visible'
     : isVisible

--- a/web/js/components/sidebar/mode-selection.js
+++ b/web/js/components/sidebar/mode-selection.js
@@ -18,12 +18,14 @@ class ModeSelection extends React.Component {
   }
 
   render() {
-    const { isActive, selected, onclick } = this.props;
+    const {
+      isActive, isMobile, selected, onclick,
+    } = this.props;
     return (
       <div
         id="wv-ab-mode-selection-case"
         className="wv-ab-mode-selection-case"
-        style={{ display: isActive ? 'block' : 'none' }}
+        style={{ display: isActive && !isMobile ? 'block' : 'none' }}
       >
         <h3>COMPARE MODE:</h3>
         <ButtonGroup size="sm">
@@ -58,6 +60,7 @@ class ModeSelection extends React.Component {
 }
 ModeSelection.propTypes = {
   isActive: PropTypes.bool,
+  isMobile: PropTypes.bool,
   onclick: PropTypes.func,
   selected: PropTypes.string,
 };

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -102,7 +102,6 @@ class DateToolTip extends PureComponent {
       toolTipHeightOffset = Math.max(toolTipHeightOffset, -357);
     }
 
-    // eslint-disable-next-line no-nested-ternary
     const toolTipWidth = hasSubdailyLayers
       ? toolTipDayOfYear >= 100
         ? '239px'

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1,4 +1,3 @@
-/* eslint no-nested-ternary: 0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Draggable from 'react-draggable';

--- a/web/js/components/timeline/timeline-coverage/coverage-item-list.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-list.js
@@ -1,4 +1,3 @@
-/* eslint no-nested-ternary: 0 */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -39,7 +39,6 @@ function InfoList (props) {
     return {
       text: 'Notifications',
       iconClass: 'ui-icon',
-      // eslint-disable-next-line no-nested-ternary
       iconName: type === 'message'
         ? 'gift'
         : type === 'outage'

--- a/web/js/containers/sidebar/compare.js
+++ b/web/js/containers/sidebar/compare.js
@@ -82,7 +82,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const { compare, date } = state;
 
   return {

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -49,15 +49,15 @@ class FooterContent extends React.Component {
       showAll,
       stopAnimation,
     } = this.props;
-    const compareBtnText = !isCompareActive ? 'Start Comparison' : 'Exit Comparison';
-    if (isCompareActive && isMobile) {
-      toggleCompare();
-    }
+    const compareBtnText = !isCompareActive
+      ? `Start Comparison${isMobile ? ' Mode' : ''}`
+      : `Exit Comparison${isMobile ? ' Mode' : ''}`;
     if (activeTab === 'layers') {
       return (
         <>
           <ModeSelection
             isActive={isCompareActive}
+            isMobile={isMobile}
             selected={compareMode}
             onclick={changeCompareMode}
           />
@@ -82,7 +82,7 @@ class FooterContent extends React.Component {
               id="compare-toggle-button"
               aria-label={compareBtnText}
               className="compare-toggle-button"
-              style={isMobile || !compareFeature ? { display: 'none' } : null}
+              style={!compareFeature ? { display: 'none' } : null}
               onClick={(e) => {
                 e.stopPropagation();
                 toggleCompare();

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-danger */
-/* eslint-disable no-nested-ternary */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Draggable } from 'react-beautiful-dnd';

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -105,7 +105,10 @@ function LayersContainer (props) {
     </DragDropContext>
   );
 
-  const maxHeight = isCompareActive && isMobile ? height - 94 : height;
+  const mobileHeightCoeff = isCompareActive ? -30 : 20;
+  const maxHeight = isMobile
+    ? height + mobileHeightCoeff
+    : height;
   const scrollContainerStyles = {
     maxHeight: `${maxHeight}px`,
     overflowY: 'auto',

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -18,16 +18,18 @@ import util from '../../util/util';
 function LayersContainer (props) {
   const {
     activeLayersMap,
+    baselayers,
+    compareState,
+    groupOverlays,
+    height,
+    isActive,
+    isCompareActive,
+    isMobile,
     overlayGroups,
     overlays,
-    baselayers,
-    groupOverlays,
-    isActive,
-    compareState,
-    height,
     reorderOverlayGroups,
-    toggleOverlayGroups,
     toggleCollapse,
+    toggleOverlayGroups,
   } = props;
 
   const [overlaysCollapsed, toggleOverlaysCollapsed] = useState(false);
@@ -103,8 +105,9 @@ function LayersContainer (props) {
     </DragDropContext>
   );
 
+  const maxHeight = isCompareActive && isMobile ? height - 94 : height;
   const scrollContainerStyles = {
-    maxHeight: `${height}px`,
+    maxHeight: `${maxHeight}px`,
     overflowY: 'auto',
     paddingBottom: '4px',
     minHeight: '100px',
@@ -154,12 +157,16 @@ function LayersContainer (props) {
 
 const mapStateToProps = (state, ownProps) => {
   const { compareState } = ownProps;
-  const { layers } = state;
+  const { browser, compare, layers } = state;
+  const isCompareActive = compare.active;
+  const isMobile = browser.lessThan.medium;
   const { groupOverlays } = layers[compareState];
   const { baselayers, overlays } = getAllActiveOverlaysBaselayers(state);
   const overlayGroups = groupOverlays ? getActiveOverlayGroups(state) : [];
 
   return {
+    isCompareActive,
+    isMobile,
     baselayers,
     overlays,
     overlayGroups,
@@ -190,13 +197,15 @@ export default connect(
 LayersContainer.propTypes = {
   activeLayersMap: PropTypes.object,
   baselayers: PropTypes.array,
+  compareState: PropTypes.string,
+  groupOverlays: PropTypes.bool,
   height: PropTypes.number,
   isActive: PropTypes.bool,
-  compareState: PropTypes.string,
+  isCompareActive: PropTypes.bool,
+  isMobile: PropTypes.bool,
   overlayGroups: PropTypes.array,
   overlays: PropTypes.array,
   reorderOverlayGroups: PropTypes.func,
-  groupOverlays: PropTypes.bool,
-  toggleOverlayGroups: PropTypes.func,
   toggleCollapse: PropTypes.func,
+  toggleOverlayGroups: PropTypes.func,
 };

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -64,7 +64,7 @@ class Sidebar extends React.Component {
       loadedCustomPalettes(customs);
     });
     this.updateDimensions();
-    // prevent browserzooming in safari
+    // prevent browser zooming in safari
     if (util.browser.safari) {
       const onGestureCallback = (e) => {
         e.preventDefault();

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -66,6 +66,8 @@ import {
 } from '../../modules/date/constants';
 import util from '../../util/util';
 
+import MobileComparisonToggle from '../../components/compare/mobile-toggle';
+
 const ANIMATION_DELAY = 500;
 const preventDefaultFunc = (e) => {
   e.preventDefault();
@@ -965,95 +967,116 @@ class Timeline extends React.Component {
     this.debounceDateUpdate(dateObj, draggerSelected);
   }
 
+  /**
+  * @desc hoverOverDistractionFreeTimeUI to determine if timeline should open
+  * @param {Boolean} isHover
+  * @returns {void}
+  */
   hoverOverDistractionFreeTimeUI = (isHover) => {
     this.setState({
       isHoverOverDistractionFreeTimeUI: isHover,
     });
   }
 
-  render() {
+  /**
+  * @desc getMobileDateButtonStyle date change button style for smaller displays
+  * @returns {Object} style { left, bottom }
+  */
+  getMobileDateButtonStyle = () => {
     const {
-      appNow,
-      activeLayers,
-      dateA,
-      dateB,
-      hasFutureLayers,
       hasSubdailyLayers,
-      draggerSelected,
-      leftArrowDisabled,
-      rightArrowDisabled,
-      customSelected,
-      customIntervalValue,
-      customIntervalZoomLevel,
-      isAnimationPlaying,
-      isDistractionFreeModeActive,
       isCompareModeActive,
-      axisWidth,
-      timelineEndDateLimit,
-      timelineStartDateLimit,
-      timeScaleChangeUnit,
-      animStartLocationDate,
-      animEndLocationDate,
-      isAnimationWidgetOpen,
-      animationDisabled,
-      hideTimeline,
-      timeScale,
-      isSmallScreen,
       isScreenWidthLessThan350,
       isScreenWidthLessThan450,
-      toggleActiveCompareState,
-      parentOffset,
-      isTourActive,
+    } = this.props;
+    // eslint-disable-next-line no-nested-ternary
+    const mobileLeft = hasSubdailyLayers
+      // eslint-disable-next-line no-nested-ternary
+      ? isScreenWidthLessThan450
+        ? isCompareModeActive ? '112px' : '10px'
+        : '277px'
+      // eslint-disable-next-line no-nested-ternary
+      : isScreenWidthLessThan350
+        ? isCompareModeActive ? '112px' : '10px'
+        : '180px';
+    const mobileBottom = (hasSubdailyLayers && isScreenWidthLessThan450) || isScreenWidthLessThan350
+      ? '65px'
+      : '10px';
+    return {
+      left: mobileLeft,
+      bottom: mobileBottom,
+    };
+  }
+
+  render() {
+    const {
+      activeLayers,
+      animationDisabled,
+      animEndLocationDate,
+      animStartLocationDate,
+      appNow,
+      axisWidth,
+      customIntervalValue,
+      customIntervalZoomLevel,
+      customSelected,
+      dateA,
+      dateB,
+      draggerSelected,
+      hasFutureLayers,
+      hasSubdailyLayers,
+      hideTimeline,
+      isAnimationPlaying,
+      isAnimationWidgetOpen,
+      isCompareModeActive,
       isDataDownload,
+      isDistractionFreeModeActive,
+      isSmallScreen,
+      isTourActive,
+      leftArrowDisabled,
+      parentOffset,
+      rightArrowDisabled,
       timelineCustomModalOpen,
+      timelineEndDateLimit,
+      timelineStartDateLimit,
+      timeScale,
+      timeScaleChangeUnit,
+      toggleActiveCompareState,
     } = this.props;
     const {
-      initialLoadComplete,
-      timelineHidden,
-      draggerTimeState,
-      draggerTimeStateB,
-      draggerPosition,
-      draggerPositionB,
-      draggerVisible,
-      draggerVisibleB,
-      animationStartLocationDate,
+      animationEndLocation,
       animationEndLocationDate,
       animationStartLocation,
-      animationEndLocation,
-      rangeSelectorMax,
-      transformX,
-      position,
-      leftOffset,
-      hoverTime,
-      frontDate,
+      animationStartLocationDate,
       backDate,
-      isTimelineDragging,
-      isDraggerDragging,
-      isAnimationDraggerDragging,
-      isTimelineLayerCoveragePanelOpen,
-      matchingTimelineCoverage,
-      isHoverOverDistractionFreeTimeUI,
-      showHoverLine,
-      showDraggerTime,
+      draggerPosition,
+      draggerPositionB,
+      draggerTimeState,
+      draggerTimeStateB,
+      draggerVisible,
+      draggerVisibleB,
+      frontDate,
       hoverLinePosition,
+      hoverTime,
+      initialLoadComplete,
+      isAnimationDraggerDragging,
+      isDraggerDragging,
+      isHoverOverDistractionFreeTimeUI,
+      isTimelineDragging,
+      isTimelineLayerCoveragePanelOpen,
+      leftOffset,
+      matchingTimelineCoverage,
+      position,
+      rangeSelectorMax,
       shouldIncludeHiddenLayers,
+      showDraggerTime,
+      showHoverLine,
+      timelineHidden,
+      transformX,
     } = this.state;
     const selectedDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
     // timeline open/closed styling
     const isTimelineHidden = timelineHidden || hideTimeline;
     const chevronDirection = isTimelineHidden ? 'left' : 'right';
-    // handle mobile size styling
-    // eslint-disable-next-line no-nested-ternary
-    const mobileLeft = hasSubdailyLayers
-      ? isScreenWidthLessThan450
-        ? '10px'
-        : '277px'
-      : isScreenWidthLessThan350
-        ? '10px'
-        : '180px';
-    const mobileBottom = (hasSubdailyLayers && isScreenWidthLessThan450) || isScreenWidthLessThan350
-      ? '65px'
-      : '10px';
     const isAnimationWidgetReady = isAnimationWidgetOpen
       && !animationDisabled
       && animationStartLocation
@@ -1089,21 +1112,17 @@ class Timeline extends React.Component {
               /* Mobile Timeline Size */
                 ? (
                   <div id="timeline-header" className="timeline-header-mobile">
-                    <div id="date-selector-main">
-                      <MobileDatePicker
-                        date={selectedDate}
-                        startDateLimit={timelineStartDateLimit}
-                        endDateLimit={timelineEndDateLimit}
-                        onDateChange={this.onDateChange}
-                        hasSubdailyLayers={hasSubdailyLayers}
-                      />
-                    </div>
+                    <MobileDatePicker
+                      date={selectedDate}
+                      startDateLimit={timelineStartDateLimit}
+                      endDateLimit={timelineEndDateLimit}
+                      onDateChange={this.onDateChange}
+                      hasSubdailyLayers={hasSubdailyLayers}
+                    />
+                    <MobileComparisonToggle />
                     <div
                       className="mobile-date-change-arrows-btn"
-                      style={{
-                        left: mobileLeft,
-                        bottom: mobileBottom,
-                      }}
+                      style={this.getMobileDateButtonStyle()}
                     >
                       <div id="zoom-buttons-group">
                         <DateChangeArrows
@@ -1173,8 +1192,7 @@ class Timeline extends React.Component {
                     <div
                       id="timeline-footer"
                       style={{
-                        display:
-                        isTimelineHidden ? 'none' : 'block',
+                        display: isTimelineHidden ? 'none' : 'block',
                       }}
                     >
                       {/* Axis */}
@@ -1300,7 +1318,7 @@ class Timeline extends React.Component {
                         isDraggerDragging={isDraggerDragging}
                         isAnimationPlaying={isAnimationPlaying}
                       />
-                      ) }
+                      )}
 
                       {!isTimelineDragging
                       && (

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -986,22 +986,32 @@ class Timeline extends React.Component {
     const {
       hasSubdailyLayers,
       isCompareModeActive,
-      isScreenWidthLessThan350,
-      isScreenWidthLessThan450,
+      screenWidth,
     } = this.props;
-    // eslint-disable-next-line no-nested-ternary
-    const mobileLeft = hasSubdailyLayers
-      // eslint-disable-next-line no-nested-ternary
-      ? isScreenWidthLessThan450
-        ? isCompareModeActive ? '112px' : '10px'
-        : '277px'
-      // eslint-disable-next-line no-nested-ternary
-      : isScreenWidthLessThan350
-        ? isCompareModeActive ? '112px' : '10px'
-        : '180px';
-    const mobileBottom = (hasSubdailyLayers && isScreenWidthLessThan450) || isScreenWidthLessThan350
-      ? '65px'
-      : '10px';
+
+    const isScreenWidthLessThan350 = screenWidth < 350;
+    const isScreenWidthLessThan450 = screenWidth < 450;
+
+    // default positioning
+    let mobileLeft = '180px';
+    let mobileBottom = '10px';
+
+    // positioning will change depending on a combination of:
+    // 1) subdaily (mobile date picker width);
+    // 2) screen width; and
+    // 3) compare mode
+    if (hasSubdailyLayers) {
+      if (isScreenWidthLessThan450) {
+        mobileLeft = isCompareModeActive ? '112px' : '10px';
+        mobileBottom = '65px';
+      } else {
+        mobileLeft = '277px';
+      }
+    } else if (isScreenWidthLessThan350) {
+      mobileLeft = isCompareModeActive ? '112px' : '10px';
+      mobileBottom = '65px';
+    }
+
     return {
       left: mobileLeft,
       bottom: mobileBottom,
@@ -1179,7 +1189,6 @@ class Timeline extends React.Component {
                         clickAnimationButton={this.clickAnimationButton}
                         disabled={animationDisabled}
                         label={
-                        // eslint-disable-next-line no-nested-ternary
                         isCompareModeActive
                           ? 'Animation feature is deactivated when Compare feature is active'
                           : isDataDownload
@@ -1189,158 +1198,155 @@ class Timeline extends React.Component {
                       />
                     </div>
 
-                    <div
-                      id="timeline-footer"
-                      style={{
-                        display: isTimelineHidden ? 'none' : 'block',
-                      }}
-                    >
-                      {/* Axis */}
-                      <TimelineAxis
-                        axisWidth={axisWidth}
-                        parentOffset={parentOffset}
-                        leftOffset={leftOffset}
-                        position={position}
-                        transformX={transformX}
-                        timeScale={timeScale}
-                        timelineStartDateLimit={timelineStartDateLimit}
-                        timelineEndDateLimit={timelineEndDateLimit}
-                        frontDate={frontDate}
-                        backDate={backDate}
-                        dateA={dateA}
-                        dateB={dateB}
-                        hoverTime={hoverTime}
-                        draggerSelected={draggerSelected}
-                        draggerTimeState={draggerTimeState}
-                        draggerTimeStateB={draggerTimeStateB}
-                        draggerPosition={draggerPosition}
-                        draggerPositionB={draggerPositionB}
-                        draggerVisible={draggerVisible}
-                        draggerVisibleB={draggerVisibleB}
-                        animationStartLocation={animationStartLocation}
-                        animationEndLocation={animationEndLocation}
-                        animStartLocationDate={animStartLocationDate}
-                        animEndLocationDate={animEndLocationDate}
-                        debounceChangeTimeScaleWheel={this.debounceChangeTimeScaleWheel}
-                        onDateChange={this.onDateChange}
-                        updatePositioning={this.updatePositioning}
-                        updateTimelineMoveAndDrag={this.updateTimelineMoveAndDrag}
-                        updatePositioningOnSimpleDrag={this.updatePositioningOnSimpleDrag}
-                        updatePositioningOnAxisStopDrag={this.updatePositioningOnAxisStopDrag}
-                        updateDraggerDatePosition={this.updateDraggerDatePosition}
-                        showHoverOn={this.showHoverOn}
-                        showHoverOff={this.showHoverOff}
-                        showHover={this.showHover}
-                        hasFutureLayers={hasFutureLayers}
-                        hasSubdailyLayers={hasSubdailyLayers}
-                        isCompareModeActive={isCompareModeActive}
-                        isAnimationPlaying={isAnimationPlaying}
-                        isTourActive={isTourActive}
-                        isAnimationDraggerDragging={isAnimationDraggerDragging}
-                        isDraggerDragging={isDraggerDragging}
-                        isTimelineDragging={isTimelineDragging}
-                        matchingTimelineCoverage={matchingTimelineCoverage}
-                      />
-
-                      <AxisHoverLine
-                        activeLayers={activeLayers}
-                        shouldIncludeHiddenLayers={shouldIncludeHiddenLayers}
-                        axisWidth={axisWidth}
-                        hoverLinePosition={hoverLinePosition}
-                        showHoverLine={showHoverLine}
-                        isTimelineDragging={isTimelineDragging}
-                        isAnimationDraggerDragging={isAnimationDraggerDragging}
-                        isDraggerDragging={isDraggerDragging}
-                        draggerSelected={draggerSelected}
-                        draggerPosition={draggerPosition}
-                        draggerPositionB={draggerPositionB}
-                        isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
-                      />
-
-                      {/* Timeline Layer Coverage Panel */}
-                      <TimelineLayerCoveragePanel
-                        appNow={appNow}
-                        axisWidth={axisWidth}
-                        backDate={backDate}
-                        frontDate={frontDate}
-                        isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
-                        matchingTimelineCoverage={matchingTimelineCoverage}
-                        parentOffset={parentOffset}
-                        positionTransformX={position + transformX}
-                        setMatchingTimelineCoverage={this.setMatchingTimelineCoverage}
-                        timelineStartDateLimit={timelineStartDateLimit}
-                        timeScale={timeScale}
-                        toggleLayerCoveragePanel={this.toggleLayerCoveragePanel}
-                      />
-
-                      {isAnimationWidgetReady
+                    {!isTimelineHidden
                       && (
-                      <TimelineRangeSelector
-                        axisWidth={axisWidth}
-                        position={position}
-                        transformX={transformX}
-                        timeScale={timeScale}
-                        timelineStartDateLimit={timelineStartDateLimit}
-                        timelineEndDateLimit={timelineEndDateLimit}
-                        frontDate={frontDate}
-                        startLocation={animationStartLocation}
-                        endLocation={animationEndLocation}
-                        startLocationDate={animationStartLocationDate}
-                        endLocationDate={animationEndLocationDate}
-                        updateAnimationDateAndLocation={this.updateAnimationDateAndLocation}
-                        max={rangeSelectorMax}
-                      />
-                      )}
+                      <div id="timeline-footer">
+                        {/* Axis */}
+                        <TimelineAxis
+                          axisWidth={axisWidth}
+                          parentOffset={parentOffset}
+                          leftOffset={leftOffset}
+                          position={position}
+                          transformX={transformX}
+                          timeScale={timeScale}
+                          timelineStartDateLimit={timelineStartDateLimit}
+                          timelineEndDateLimit={timelineEndDateLimit}
+                          frontDate={frontDate}
+                          backDate={backDate}
+                          dateA={dateA}
+                          dateB={dateB}
+                          hoverTime={hoverTime}
+                          draggerSelected={draggerSelected}
+                          draggerTimeState={draggerTimeState}
+                          draggerTimeStateB={draggerTimeStateB}
+                          draggerPosition={draggerPosition}
+                          draggerPositionB={draggerPositionB}
+                          draggerVisible={draggerVisible}
+                          draggerVisibleB={draggerVisibleB}
+                          animationStartLocation={animationStartLocation}
+                          animationEndLocation={animationEndLocation}
+                          animStartLocationDate={animStartLocationDate}
+                          animEndLocationDate={animEndLocationDate}
+                          debounceChangeTimeScaleWheel={this.debounceChangeTimeScaleWheel}
+                          onDateChange={this.onDateChange}
+                          updatePositioning={this.updatePositioning}
+                          updateTimelineMoveAndDrag={this.updateTimelineMoveAndDrag}
+                          updatePositioningOnSimpleDrag={this.updatePositioningOnSimpleDrag}
+                          updatePositioningOnAxisStopDrag={this.updatePositioningOnAxisStopDrag}
+                          updateDraggerDatePosition={this.updateDraggerDatePosition}
+                          showHoverOn={this.showHoverOn}
+                          showHoverOff={this.showHoverOff}
+                          showHover={this.showHover}
+                          hasFutureLayers={hasFutureLayers}
+                          hasSubdailyLayers={hasSubdailyLayers}
+                          isCompareModeActive={isCompareModeActive}
+                          isAnimationPlaying={isAnimationPlaying}
+                          isTourActive={isTourActive}
+                          isAnimationDraggerDragging={isAnimationDraggerDragging}
+                          isDraggerDragging={isDraggerDragging}
+                          isTimelineDragging={isTimelineDragging}
+                          matchingTimelineCoverage={matchingTimelineCoverage}
+                        />
 
-                      {frontDate
-                      && (
-                      <DraggerContainer
-                        axisWidth={axisWidth}
-                        position={position}
-                        transformX={transformX}
-                        timeScale={timeScale}
-                        timelineStartDateLimit={timelineStartDateLimit}
-                        timelineEndDateLimit={timelineEndDateLimit}
-                        frontDate={frontDate}
-                        backDate={backDate}
-                        draggerSelected={draggerSelected}
-                        draggerTimeState={draggerTimeState}
-                        draggerTimeStateB={draggerTimeStateB}
-                        draggerPosition={draggerPosition}
-                        draggerPositionB={draggerPositionB}
-                        draggerVisible={draggerVisible}
-                        draggerVisibleB={draggerVisibleB}
-                        setDraggerVisibility={this.setDraggerVisibility}
-                        toggleShowDraggerTime={this.toggleShowDraggerTime}
-                        onChangeSelectedDragger={toggleActiveCompareState}
-                        updateDraggerDatePosition={this.updateDraggerDatePosition}
-                        isCompareModeActive={isCompareModeActive}
-                        isDraggerDragging={isDraggerDragging}
-                        isAnimationPlaying={isAnimationPlaying}
-                      />
-                      )}
+                        <AxisHoverLine
+                          activeLayers={activeLayers}
+                          shouldIncludeHiddenLayers={shouldIncludeHiddenLayers}
+                          axisWidth={axisWidth}
+                          hoverLinePosition={hoverLinePosition}
+                          showHoverLine={showHoverLine}
+                          isTimelineDragging={isTimelineDragging}
+                          isAnimationDraggerDragging={isAnimationDraggerDragging}
+                          isDraggerDragging={isDraggerDragging}
+                          draggerSelected={draggerSelected}
+                          draggerPosition={draggerPosition}
+                          draggerPositionB={draggerPositionB}
+                          isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
+                        />
 
-                      {!isTimelineDragging
-                      && (
-                      <DateToolTip
-                        activeLayers={activeLayers}
-                        shouldIncludeHiddenLayers={shouldIncludeHiddenLayers}
-                        axisWidth={axisWidth}
-                        leftOffset={leftOffset}
-                        hoverTime={hoverTime}
-                        draggerSelected={draggerSelected}
-                        draggerTimeState={draggerTimeState}
-                        draggerTimeStateB={draggerTimeStateB}
-                        draggerPosition={draggerPosition}
-                        draggerPositionB={draggerPositionB}
-                        hasSubdailyLayers={hasSubdailyLayers}
-                        showDraggerTime={showDraggerTime}
-                        showHoverLine={showHoverLine}
-                        isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
-                      />
-                      )}
-                    </div>
+                        {/* Timeline Layer Coverage Panel */}
+                        <TimelineLayerCoveragePanel
+                          appNow={appNow}
+                          axisWidth={axisWidth}
+                          backDate={backDate}
+                          frontDate={frontDate}
+                          isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
+                          matchingTimelineCoverage={matchingTimelineCoverage}
+                          parentOffset={parentOffset}
+                          positionTransformX={position + transformX}
+                          setMatchingTimelineCoverage={this.setMatchingTimelineCoverage}
+                          timelineStartDateLimit={timelineStartDateLimit}
+                          timeScale={timeScale}
+                          toggleLayerCoveragePanel={this.toggleLayerCoveragePanel}
+                        />
 
+                        {isAnimationWidgetReady
+                          && (
+                          <TimelineRangeSelector
+                            axisWidth={axisWidth}
+                            position={position}
+                            transformX={transformX}
+                            timeScale={timeScale}
+                            timelineStartDateLimit={timelineStartDateLimit}
+                            timelineEndDateLimit={timelineEndDateLimit}
+                            frontDate={frontDate}
+                            startLocation={animationStartLocation}
+                            endLocation={animationEndLocation}
+                            startLocationDate={animationStartLocationDate}
+                            endLocationDate={animationEndLocationDate}
+                            updateAnimationDateAndLocation={this.updateAnimationDateAndLocation}
+                            max={rangeSelectorMax}
+                          />
+                          )}
+
+                        {frontDate
+                          && (
+                          <DraggerContainer
+                            axisWidth={axisWidth}
+                            position={position}
+                            transformX={transformX}
+                            timeScale={timeScale}
+                            timelineStartDateLimit={timelineStartDateLimit}
+                            timelineEndDateLimit={timelineEndDateLimit}
+                            frontDate={frontDate}
+                            backDate={backDate}
+                            draggerSelected={draggerSelected}
+                            draggerTimeState={draggerTimeState}
+                            draggerTimeStateB={draggerTimeStateB}
+                            draggerPosition={draggerPosition}
+                            draggerPositionB={draggerPositionB}
+                            draggerVisible={draggerVisible}
+                            draggerVisibleB={draggerVisibleB}
+                            setDraggerVisibility={this.setDraggerVisibility}
+                            toggleShowDraggerTime={this.toggleShowDraggerTime}
+                            onChangeSelectedDragger={toggleActiveCompareState}
+                            updateDraggerDatePosition={this.updateDraggerDatePosition}
+                            isCompareModeActive={isCompareModeActive}
+                            isDraggerDragging={isDraggerDragging}
+                            isAnimationPlaying={isAnimationPlaying}
+                          />
+                          )}
+
+                        {!isTimelineDragging
+                          && (
+                          <DateToolTip
+                            activeLayers={activeLayers}
+                            shouldIncludeHiddenLayers={shouldIncludeHiddenLayers}
+                            axisWidth={axisWidth}
+                            leftOffset={leftOffset}
+                            hoverTime={hoverTime}
+                            draggerSelected={draggerSelected}
+                            draggerTimeState={draggerTimeState}
+                            draggerTimeStateB={draggerTimeStateB}
+                            draggerPosition={draggerPosition}
+                            draggerPositionB={draggerPositionB}
+                            hasSubdailyLayers={hasSubdailyLayers}
+                            showDraggerTime={showDraggerTime}
+                            showHoverLine={showHoverLine}
+                            isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
+                          />
+                          )}
+                      </div>
+                      )}
                     {/* Custom Interval Selector Widget */}
                     <CustomIntervalSelectorWidget
                       customDelta={customIntervalValue}
@@ -1415,8 +1421,6 @@ function mapStateToProps(state) {
   const isCompareModeActive = compare.active;
   const { isDistractionFreeModeActive } = ui;
   const isSmallScreen = lessThan.medium;
-  const isScreenWidthLessThan350 = screenWidth < 350;
-  const isScreenWidthLessThan450 = screenWidth < 450;
 
   // handle active layer filtering and check for subdaily
   const activeLayers = getActiveLayers(state);
@@ -1486,8 +1490,7 @@ function mapStateToProps(state) {
     activeLayers: activeLayersFiltered,
     isTourActive: tour.active,
     isSmallScreen,
-    isScreenWidthLessThan350,
-    isScreenWidthLessThan450,
+    screenWidth,
     draggerSelected: isCompareA ? 'selected' : 'selectedB',
     hasSubdailyLayers,
     customSelected,
@@ -1603,8 +1606,6 @@ Timeline.propTypes = {
   isDataDownload: PropTypes.bool,
   isDistractionFreeModeActive: PropTypes.bool,
   isGifActive: PropTypes.bool,
-  isScreenWidthLessThan350: PropTypes.bool,
-  isScreenWidthLessThan450: PropTypes.bool,
   isSmallScreen: PropTypes.bool,
   isTourActive: PropTypes.bool,
   leftArrowDisabled: PropTypes.bool,
@@ -1614,6 +1615,7 @@ Timeline.propTypes = {
   openAnimation: PropTypes.func,
   parentOffset: PropTypes.number,
   rightArrowDisabled: PropTypes.bool,
+  screenWidth: PropTypes.number,
   selectedDate: PropTypes.object,
   selectInterval: PropTypes.func,
   timelineCustomModalOpen: PropTypes.bool,

--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';

--- a/web/js/location.js
+++ b/web/js/location.js
@@ -358,11 +358,17 @@ const getParameters = function(config, parameters) {
     cm: {
       stateKey: 'compare.mode',
       initialState: 'swipe',
+      options: {
+        parse: (param) => (config.initialIsMobile ? 'swipe' : param),
+      },
     },
     cv: {
       stateKey: 'compare.value',
       initialState: 50,
       type: 'number',
+      options: {
+        parse: (param) => (config.initialIsMobile ? 50 : param),
+      },
     },
     tr: {
       stateKey: 'tour.selected',

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -14,7 +14,7 @@ import {
   compose as defaultCompose,
 } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { responsiveStoreEnhancer } from 'redux-responsive';
+import { calculateResponsiveState, responsiveStoreEnhancer } from 'redux-responsive';
 import {
   createReduxLocationActions,
   listenForHistoryChange,
@@ -143,6 +143,9 @@ window.onload = () => {
         parameters = util.fromQueryString(hasTour.steps[0].stepLink);
         parameters.mockTour = isMockTour;
       }
+
+      const crs = calculateResponsiveState(window);
+      config.initialIsMobile = crs.innerWidth <= 768;
 
       config.pageLoadTime = parameters.now
         ? util.parseDateUTC(parameters.now) || new Date()

--- a/web/js/map/compare/compare.js
+++ b/web/js/map/compare/compare.js
@@ -18,7 +18,7 @@ const MOUSE_EVENT = {
   move: 'mousemove',
   end: 'mouseup',
 };
-export default function mapCompare(config, store) {
+export default function mapCompare(store) {
   const self = {};
   let comparison = null;
   let mode = 'swipe';

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -75,7 +75,7 @@ export default function mapui(models, config, store, ui) {
   let cache;
   const dateline = mapDateLineBuilder(models, config, store, ui);
   const precache = mapPrecacheTile(models, config, cache, self);
-  const compareMapUi = mapCompare(config, store);
+  const compareMapUi = mapCompare(store);
   const dataRunner = self.runningdata = new MapRunningData(
     models,
     compareMapUi,
@@ -103,7 +103,7 @@ export default function mapui(models, config, store, ui) {
   self.activeMarker = null;
   self.coordinatesDialogDOMEl = null;
   /**
-   * Suscribe to redux store and listen for
+   * Subscribe to redux store and listen for
    * specific action types
    */
   const subscribeToStore = function(action) {
@@ -319,7 +319,7 @@ export default function mapui(models, config, store, ui) {
     const geocodeProperties = { latitude, longitude, reverseGeocodeResults: results };
     const coordinatesMetadata = getCoordinatesMetadata(geocodeProperties);
 
-    // handle clearing cooridnates using created marker
+    // handle clearing coordinates using created marker
     const clearMarker = () => {
       store.dispatch({ type: CLEAR_MARKER });
     };
@@ -490,7 +490,7 @@ export default function mapui(models, config, store, ui) {
   }
 
   /*
-   * When page is resised set for mobile or desktop
+   * When page is resized set for mobile or desktop
    *
    * @method onResize
    * @static
@@ -839,7 +839,7 @@ export default function mapui(models, config, store, ui) {
   /*
    * Get a layer object from id
    *
-   * @method findlayer
+   * @method findLayer
    * @static
    *
    * @param {object} def - Layer Specs
@@ -1086,7 +1086,7 @@ export default function mapui(models, config, store, ui) {
       const coords = map.getCoordinateFromPixel(pixels);
       if (!coords) return;
 
-      // setting a limit on running-data retrievel
+      // setting a limit on running-data retrieval
       if (self.mapIsbeingDragged) {
         return;
       }

--- a/web/js/modules/compare/actions.js
+++ b/web/js/modules/compare/actions.js
@@ -7,7 +7,7 @@ import {
   CHANGE_MODE,
 } from './constants';
 
-export function toggleActiveCompareState(str) {
+export function toggleActiveCompareState() {
   return {
     type: CHANGE_STATE,
   };

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -583,7 +583,6 @@ const getSubdailyDateRange = ({
   }
   let minMinuteDate;
   if (rangeLimitsProvided) {
-  // eslint-disable-next-line no-nested-ternary
     minMinuteDate = hourBeforeStartDateLimit < minDate
       ? hourBeforeStartDateLimit
       : hourBeforeStartDateLimit > minMinuteDateMinusIntervalOffset

--- a/web/js/modules/natural-events/reducers.js
+++ b/web/js/modules/natural-events/reducers.js
@@ -142,7 +142,6 @@ export function eventsRequestReducer(actionName, state, action) {
         response: null,
       });
     case SUCCESS: {
-      // eslint-disable-next-line no-nested-ternary
       const key = actionName === REQUEST_EVENTS
         ? 'events'
         : actionName === REQUEST_CATEGORIES

--- a/web/js/modules/sidebar/actions.js
+++ b/web/js/modules/sidebar/actions.js
@@ -18,7 +18,7 @@ export function changeTab(str) {
     }
   };
 }
-export function toggleSidebarCollapse(str) {
+export function toggleSidebarCollapse() {
   return (dispatch, getState) => {
     const isMobile = getState().browser.lessThan.medium;
     if (isMobile) {
@@ -29,7 +29,7 @@ export function toggleSidebarCollapse(str) {
   };
 }
 
-export function collapseSidebar(str) {
+export function collapseSidebar() {
   return (dispatch, getState) => {
     const isMobile = getState().browser.lessThan.medium;
     if (isMobile) {
@@ -40,7 +40,7 @@ export function collapseSidebar(str) {
   };
 }
 
-export function expandSidebar(str) {
+export function expandSidebar() {
   return (dispatch, getState) => {
     const isMobile = getState().browser.lessThan.medium;
     if (isMobile) {


### PR DESCRIPTION
## Description

Fixes #3188  .

- [x] Allow "official support" to comparison mode in mobile. Comparison mode will be limited to `swipe` in mobile and will use the same sidebar A/B tabs along with a new A/B toggle button.
- [x] Add initial mobile screen size check to config on load as `config.initialIsMobile` to help determine location state changes for compare permalinks opened in mobile
- [x] Add e2e mobile-compare tests and minor update on a few others.
- [x] Minor cleanup removing unnecessary dom depth, remove unused function params, and random spell fixes from adding a new extension to VS Code `Code Spell Checker`

## How To Test

1. Activate compare mode in mobile, verify activate/deactivate, verify desktop permalinks with compare mode open in mobile including a desktop `spy` compare permalink should open as a `swipe` when opened on a mobile device


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
