### PR TITLE
Smart Handoffs - Permalinks & Download size

### DIFF
--- a/e2e/features/smart-handoff/smart-handoff-test.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.js
@@ -11,7 +11,9 @@ const TIME_LIMIT = 10000;
 const layersTab = '#layers-sidebar-tab';
 const dataTabButton = '#download-sidebar-tab';
 const cloudRadiusRadioButton = '#C1443536017-LAADS-MODIS_Aqua_Cloud_Effective_Radius-collection-choice-label';
+const SSTRadioButton = '#C1664741463-PODAAC-GHRSST_L4_MUR_Sea_Surface_Temperature-collection-choice-label';
 const urlParams = '?l=Reference_Labels(hidden),Reference_Features(hidden),Coastlines&t=2019-12-01';
+const permalinkParams = '?l=GHRSST_L4_MUR_Sea_Surface_Temperature,MODIS_Aqua_Aerosol_Optical_Depth_3km&lg=true&sh=MODIS_Aqua_Aerosol_Optical_Depth_3km,C1443528505-LAADS&t=2020-02-06-T06%3A00%3A00Z';
 
 module.exports = {
 
@@ -55,13 +57,14 @@ module.exports = {
 
     // Verify granules and date are correct
     c.expect
-      .element('.granule-count > h1')
-      .to.have.text.equal('Available granules for 2019 Dec 01: 289');
+      .element('.granule-count-header')
+      .to.have.text.equal('Available granules for 2019 Dec 01:');
+    c.assert.containsText('.granule-count-info', '289');
   },
 
   'Enable area of interest': (c) => {
     c.click('#chk-crop-toggle');
-    c.assert.containsText('.granule-count > h1', 'of 289');
+    c.assert.containsText('.granule-count-info', 'of 289');
   },
 
   'Download via Earthdata Search': (c) => {
@@ -75,6 +78,21 @@ module.exports = {
     c.windowHandles((tabs) => {
       c.assert.equal(tabs.value.length, 2);
     });
+  },
+
+  'Arriving via permalink, data tab selected and granule count shows': (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    c.url(c.globals.url + permalinkParams);
+    c.expect.element(dataTabButton).to.be.visible;
+    c.expect
+      .element('.granule-count-info')
+      .to.not.have.text.equal('NONE');
+  },
+
+  'Changing collection updates URL': (c) => {
+    c.click(SSTRadioButton);
+    c.pause(200);
+    c.assert.urlContains('&sh=GHRSST_L4_MUR_Sea_Surface_Temperature,C1664741463-PODAAC');
   },
 
   after(c) {

--- a/web/css/smart-handoff.css
+++ b/web/css/smart-handoff.css
@@ -126,6 +126,7 @@ label[for='chk-crop-toggle'] span {
 .granule-count-info {
   margin: 0 30px;
   text-align: center;
+  height: 28px;
   span {
     color: #fff;
     font-size: 16px;

--- a/web/css/smart-handoff.css
+++ b/web/css/smart-handoff.css
@@ -120,13 +120,32 @@ label[for='chk-crop-toggle'] span {
     text-decoration: underline;
   }
 }
-
-.granule-count span {
-  color: #fff;
-  font-size: 16px;
-  font-weight: 900;
-  margin: 14px 0 10px;
+.granule-count-header {
+  text-align: center;
 }
+.granule-count-info {
+  margin: 0 30px;
+  text-align: center;
+  span {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 900;
+    margin: 14px 5px 5px;
+    display: inline-block;
+    text-align: center;
+    &.help-link {
+      text-align: left;
+      display: inline;
+    }
+    &.granule-size {
+      font-weight: 300;
+      font-size: 14px;
+      line-height: 14px;
+      vertical-align: bottom;
+    }
+  }
+}
+
 .loading-granule-count {
   font-size: 30px;
 }
@@ -135,11 +154,11 @@ label[for='chk-crop-toggle'] span {
   overflow: hidden;
   display: inline-block;
   vertical-align: bottom;
-  -moz-animation: ellipsis steps(4, end) 900ms infinite;
-  -o-animation: ellipsis steps(4, end) 900ms infinite;
-  -ms-animation: ellipsis steps(4, end) 900ms infinite;
-  -webkit-animation: ellipsis steps(4, end) 900ms infinite;
-  animation: ellipsis steps(4, end) 900ms infinite;
+  -moz-animation: ellipsis steps(4, end) 600ms infinite;
+  -o-animation: ellipsis steps(4, end) 600ms infinite;
+  -ms-animation: ellipsis steps(4, end) 600ms infinite;
+  -webkit-animation: ellipsis steps(4, end) 600ms infinite;
+  animation: ellipsis steps(4, end) 600ms infinite;
   content: '\2026'; /* ascii code for the ellipsis character */
   width: 0;
 }
@@ -160,11 +179,11 @@ label[for='chk-crop-toggle'] span {
 }
 
 .fade-in {
-  animation: fadein ease 1s;
-  -webkit-animation: fadein ease 1s;
-  -moz-animation: fadein ease 1s;
-  -o-animation: fadein ease 1s;
-  -ms-animation: fadein ease 1s;
+  animation: fadein ease 0.25s;
+  -webkit-animation: fadein ease 0.25s;
+  -moz-animation: fadein ease 0.25s;
+  -o-animation: fadein ease 0.25s;
+  -ms-animation: fadein ease 0.25s;
 }
 
 /* Overrides react image crop component  */

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -35,14 +35,16 @@ export default function GranuleCount (props) {
   };
 
   const getDownloadSize = (entries) => entries.reduce(
-    (prev, curr) => prev + parseInt(curr.granule_size, 10), 0,
+    (prev, curr) => (
+      curr.granule_size ? prev + parseInt(curr.granule_size, 10) : 0),
+    0,
   );
 
   /**
    * Fetch granule data for the specified selected layer/collection
    */
   const updateGranules = async () => {
-    const { southWest, northEast } = currentExtent || {};
+    const { southWest, northEast } = currentExtent;
     let newTotalGranules = 0;
     let newSelectedGranules;
     let newGranuleDownloadSize = 0;
@@ -59,7 +61,7 @@ export default function GranuleCount (props) {
 
     const granulesRequestUrl = granulesBaseUrl + util.toQueryString(params);
 
-    if (currentExtent) {
+    if (southWest && northEast) {
       const bboxRequestUrl = `${granulesRequestUrl}&bounding_box=${southWest},${northEast}`;
       const selectedEntries = await requestGranules(bboxRequestUrl);
       newSelectedGranules = selectedEntries.length;
@@ -96,7 +98,10 @@ export default function GranuleCount (props) {
   );
 
   const renderDownloadSize = () => {
-    const printSize = (s) => Number(s).toFixed(0).toLocaleString();
+    const printSize = (s) => {
+      const wholeNum = Number(s).toFixed(0);
+      return Number(wholeNum).toLocaleString();
+    };
     let sizeText;
     if (granuleDownloadSize > 1000) {
       sizeText = `${printSize(granuleDownloadSize / 1000)} GB`;

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -1,0 +1,104 @@
+import React, { useState, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { get as lodashGet } from 'lodash';
+import PropTypes from 'prop-types';
+import util from '../../util/util';
+
+export default function GranuleCount (props) {
+  const {
+    currentExtent,
+    displayDate,
+    showGranuleHelpModal,
+    selectedLayer,
+    selectedCollection,
+    selectedDate,
+    showBoundingBox,
+  } = props;
+
+  const [isLoading, setLoading] = useState(false);
+  const [selectedGranules, setSelectedGranules] = useState(0);
+  const [totalGranules, setTotalGranules] = useState(0);
+
+  const updateGranules = async () => {
+    const { southWest, northEast } = currentExtent;
+    if (!selectedLayer) return;
+
+    const { dateRanges } = selectedLayer;
+    const params = {
+      include_granule_counts: true,
+      concept_id: selectedCollection.value,
+    };
+
+    if (dateRanges) {
+      const startDate = `${selectedDate}T00:00:00.000Z`;
+      const endDate = `${selectedDate}T23:59:59.999Z`;
+      params.temporal = `${startDate},${endDate}`;
+    }
+
+    let granuleRequestUrl = `https://cmr.earthdata.nasa.gov/search/collections.json${util.toQueryString(params)}`;
+
+    if (!totalGranules) {
+      // Gets the total amount of granules that the layer has
+      const totalGranuleResponse = await fetch(granuleRequestUrl, { timeout: 5000 });
+      const totalResult = await totalGranuleResponse.json();
+      const newTotalGranules = lodashGet(totalResult, 'feed.entry[0].granule_count', 0);
+      setTotalGranules(newTotalGranules);
+    }
+
+    // Gets the total subset of granules that are within the defining bounding box
+    if (showBoundingBox && southWest && northEast) {
+      granuleRequestUrl += `&bounding_box=${southWest},${northEast}`;
+      const selectedGranulesResponse = await fetch(granuleRequestUrl, { timeout: 5000 });
+      const selectedResult = await selectedGranulesResponse.json();
+      const newSelectedGranules = lodashGet(selectedResult, 'feed.entry[0].granule_count', 0);
+      setSelectedGranules(newSelectedGranules);
+    }
+    setLoading(false);
+  };
+
+  /**
+   * Fetch granule data for the specified selected layer/collection
+   */
+  useEffect(() => {
+    setTotalGranules(0);
+    setLoading(true);
+    updateGranules();
+  }, [currentExtent, selectedCollection, displayDate]);
+
+  return !selectedCollection ? null : (
+    <div className="granule-count">
+      <h1>
+        Available granules for
+        {` ${displayDate}: `}
+
+        { !isLoading && totalGranules === 0 && (
+        <span className="fade-in constant-width">NONE</span>
+        )}
+
+        { !isLoading && totalGranules !== 0 && (
+        <span className="fade-in constant-width">
+          {showBoundingBox && `${selectedGranules} of `}
+          {totalGranules}
+        </span>
+        )}
+
+        { isLoading && (
+        <span className="loading-granule-count fade-in constant-width" />
+        )}
+        <span className="help-link" onClick={showGranuleHelpModal}>
+          <FontAwesomeIcon icon="question-circle" />
+        </span>
+      </h1>
+    </div>
+  );
+}
+
+GranuleCount.propTypes = {
+  currentExtent: PropTypes.object,
+  displayDate: PropTypes.string,
+  selectedLayer: PropTypes.object,
+  selectedDate: PropTypes.string,
+  selectedCollection: PropTypes.object,
+  showBoundingBox: PropTypes.bool,
+  showGranuleHelpModal: PropTypes.func,
+};

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -36,7 +36,7 @@ export default function GranuleCount (props) {
 
   const getDownloadSize = (entries) => entries.reduce(
     (prev, curr) => (
-      curr.granule_size ? prev + parseInt(curr.granule_size, 10) : 0),
+      curr.granule_size ? prev + parseFloat(curr.granule_size, 10) : 0),
     0,
   );
 
@@ -44,7 +44,7 @@ export default function GranuleCount (props) {
    * Fetch granule data for the specified selected layer/collection
    */
   const updateGranules = async () => {
-    const { southWest, northEast } = currentExtent;
+    const { southWest, northEast } = currentExtent || {};
     let newTotalGranules = 0;
     let newSelectedGranules;
     let newGranuleDownloadSize = 0;
@@ -86,7 +86,7 @@ export default function GranuleCount (props) {
     setState({
       isLoading: true,
       totalGranules: 0,
-      selectedGranules: 0,
+      selectedGranules: false,
     });
     updateGranules();
   }, [currentExtent, selectedCollection, selectedDate]);
@@ -99,7 +99,8 @@ export default function GranuleCount (props) {
 
   const renderDownloadSize = () => {
     const printSize = (s) => {
-      const wholeNum = Number(s).toFixed(0);
+      const precision = s > 9 ? 0 : 2;
+      const wholeNum = Number(s).toFixed(precision);
       return Number(wholeNum).toLocaleString();
     };
     let sizeText;
@@ -132,7 +133,7 @@ export default function GranuleCount (props) {
         {!isLoading && (
           <>
             <span className="fade-in">
-              {granulesExist && selectedGranules && `${selectedGranules} of `}
+              {granulesExist && selectedGranules >= 0 && `${selectedGranules} of `}
               {granulesExist ? totalGranules : 'NONE'}
             </span>
           </>

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -38,6 +38,9 @@ export default function GranuleCount (props) {
     (prev, curr) => prev + parseInt(curr.granule_size, 10), 0,
   );
 
+  /**
+   * Fetch granule data for the specified selected layer/collection
+   */
   const updateGranules = async () => {
     const { southWest, northEast } = currentExtent || {};
     let newTotalGranules = 0;
@@ -68,7 +71,6 @@ export default function GranuleCount (props) {
     if (newGranuleDownloadSize === 0) {
       newGranuleDownloadSize = getDownloadSize(totalEntries);
     }
-
     setState({
       isLoading: false,
       totalGranules: newTotalGranules,
@@ -77,9 +79,7 @@ export default function GranuleCount (props) {
     });
   };
 
-  /**
-   * Fetch granule data for the specified selected layer/collection
-   */
+  /** Trigger granule request when extent, collection, or date changes */
   useEffect(() => {
     setState({
       isLoading: true,

--- a/web/js/components/util/image-crop.js
+++ b/web/js/components/util/image-crop.js
@@ -54,6 +54,7 @@ export default class Crop extends React.Component {
     const {
       onClose,
       onChange,
+      onDragStop,
       maxWidth,
       maxHeight,
       showCoordinates,
@@ -78,6 +79,7 @@ export default class Crop extends React.Component {
           }}
           keepSelection={keepSelection}
           onComplete={(crop) => {
+            onDragStop(crop);
             if (!crop.width || !crop.height) {
               onClose();
             }
@@ -97,6 +99,7 @@ Crop.defaultProps = {
   height: 10,
   maxHeight: window.innerWidth,
   maxWidth: window.innerHeight,
+  onDragStop: () => {},
   keepSelection: false,
   width: 30,
   x: 20,
@@ -106,6 +109,7 @@ Crop.defaultProps = {
 Crop.propTypes = {
   onChange: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
+  onDragStop: PropTypes.func,
   bottomLeftStyle: PropTypes.object,
   coordinates: PropTypes.object,
   height: PropTypes.number,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -57,7 +57,7 @@ class SmartHandoff extends Component {
         y2: screenHeight / 2 + 100,
       },
       showBoundingBox: false,
-      currentExtent: {},
+      currentExtent: undefined,
       coordinates: {},
     };
 
@@ -66,7 +66,7 @@ class SmartHandoff extends Component {
     this.onCheckboxToggle = this.onCheckboxToggle.bind(this);
     this.onClickDownload = this.onClickDownload.bind(this);
     this.updateExtent = this.updateExtent.bind(this);
-    this.debouncedUpdateExtent = lodashDebounce(this.updateExtent, 250);
+    this.debouncedUpdateExtent = lodashDebounce(this.updateExtent, 500, { leading: true });
   }
 
   componentDidUpdate(prevProps) {
@@ -155,7 +155,7 @@ class SmartHandoff extends Component {
     };
 
     if (selectedCollection && extent) {
-      this.debouncedUpdateExtent(coordinates, boundaries, extent);
+      this.debouncedUpdateExtent(coordinates, newBoundaries, extent);
     }
   }
 
@@ -417,11 +417,10 @@ class SmartHandoff extends Component {
         {this.renderCropBox()}
         <GranuleCount
           displayDate={displayDate}
-          currentExtent={currentExtent}
+          currentExtent={showBoundingBox && currentExtent}
           selectedDate={selectedDate}
           selectedLayer={selectedLayer}
           selectedCollection={selectedCollection}
-          showBoundingBox={showBoundingBox}
           showGranuleHelpModal={showGranuleHelpModal}
         />
         <Button

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -414,7 +414,7 @@ class SmartHandoff extends Component {
         {this.renderCropBox()}
         <GranuleCount
           displayDate={displayDate}
-          currentExtent={showBoundingBox && currentExtent}
+          currentExtent={showBoundingBox ? currentExtent : undefined}
           selectedDate={selectedDate}
           selectedLayer={selectedLayer}
           selectedCollection={selectedCollection}

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -414,7 +414,7 @@ class SmartHandoff extends Component {
         {this.renderCropBox()}
         <GranuleCount
           displayDate={displayDate}
-          currentExtent={showBoundingBox ? currentExtent : {}}
+          currentExtent={showBoundingBox ? currentExtent : undefined}
           selectedDate={selectedDate}
           selectedLayer={selectedLayer}
           selectedCollection={selectedCollection}

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -50,7 +50,7 @@ class SmartHandoff extends Component {
         y2: screenHeight / 2 + 100,
       },
       showBoundingBox: false,
-      currentExtent: undefined,
+      currentExtent: {},
       coordinates: {},
     };
 
@@ -414,7 +414,7 @@ class SmartHandoff extends Component {
         {this.renderCropBox()}
         <GranuleCount
           displayDate={displayDate}
-          currentExtent={showBoundingBox ? currentExtent : undefined}
+          currentExtent={showBoundingBox ? currentExtent : {}}
           selectedDate={selectedDate}
           selectedLayer={selectedLayer}
           selectedCollection={selectedCollection}

--- a/web/js/location.js
+++ b/web/js/location.js
@@ -33,6 +33,10 @@ import { mapLocationToAnimationState } from './modules/animation/util';
 import { areCoordinatesWithinExtent, mapLocationToLocationSearchState } from './modules/location-search/util';
 import mapLocationToSidebarState from './modules/sidebar/util';
 import util from './util/util';
+import {
+  serializeSmartHandoff,
+  parseSmartHandoff,
+} from './modules/smart-handoff/util';
 
 /**
  * Override state with information from location.search when "REDUX-LOCATION-POP-ACTION"
@@ -406,26 +410,17 @@ const getParameters = function(config, parameters) {
         parse: (str) => str === 'on',
       },
     },
-    // download: {
-    //   stateKey: 'data.selectedProduct',
-    //   initialState: '',
-    //   type: 'string',
-    //   options: {
-    //     delimiter: ',',
-    //     serializeNeedsGlobalState: true,
-    //     parse: (id) => {
-    //       if (!config.products[id]) {
-    //         console.warn(`No such product: ${id}`);
-    //         return '';
-    //       }
-    //       return id;
-    //     },
-    //     serialize: (currentItemState, state) => {
-    //       if (state.sidebar.activeTab !== 'download') return undefined;
-    //       return encode(currentItemState);
-    //     },
-    //   },
-    // },
+    sh: {
+      stateKey: 'smartHandoffs',
+      initialState: '',
+      type: 'string',
+      options: {
+        setAsEmptyItem: true,
+        serializeNeedsGlobalState: true,
+        serialize: serializeSmartHandoff,
+        parse: parseSmartHandoff,
+      },
+    },
     s: {
       stateKey: 'locationSearch.coordinates',
       initialState: [],

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -1073,28 +1073,22 @@ export default function mapui(models, config, store, ui) {
   function createMousePosSel(map, proj) {
     const throttledOnMouseMove = lodashThrottle((e) => {
       const state = store.getState();
-      const { browser } = state;
+      const { browser, sidebar } = state;
       const isMobile = browser.lessThan.medium;
       if (self.mapIsbeingZoomed) return;
       if (compareMapUi && compareMapUi.dragging) return;
-      // if mobile return
       if (isMobile) return;
-      // if measure is active return
       if (state.measure.isActive) return;
 
       const pixels = map.getEventPixel(e);
       const coords = map.getCoordinateFromPixel(pixels);
       if (!coords) return;
 
-      // setting a limit on running-data retrieval
-      if (self.mapIsbeingDragged) {
-        return;
-      }
+      if (self.mapIsbeingDragged) return;
       // Don't add data runners if we're on the events or smart handoffs tabs, or if map is animating
       const isEventsTabActive = typeof state.events !== 'undefined' && state.events.active;
       const isMapAnimating = state.animation.isPlaying;
-      // TODO handle smart handoffs
-      if (isEventsTabActive || isMapAnimating) return;
+      if (isEventsTabActive || isMapAnimating || sidebar.activeTab === 'download') return;
 
       dataRunner.newPoint(pixels, map);
     }, 300);

--- a/web/js/modules/combine-reducers.js
+++ b/web/js/modules/combine-reducers.js
@@ -46,6 +46,7 @@ import { LOCATION_POP_ACTION } from '../redux-location-state-customs';
 
 import uiReducers from './ui/reducers';
 import { alertReducer } from './alerts/reducer';
+import { smartHandoffReducer } from './smart-handoff/reducer';
 
 function lastAction(state = null, action) {
   return action;
@@ -126,6 +127,7 @@ const reducers = {
   requestedEventCategories,
   modalAboutPage,
   shortLink,
+  smartHandoffs: smartHandoffReducer,
   notificationsRequest,
   lastAction,
   location: locationReducer,

--- a/web/js/modules/sidebar/util.js
+++ b/web/js/modules/sidebar/util.js
@@ -1,5 +1,4 @@
 import update from 'immutability-helper';
-import { assign as lodashAssign } from 'lodash';
 
 /**
  * Update sidebar state when location-pop action occurs
@@ -15,21 +14,21 @@ export default function mapLocationToSidebarState(
   state,
   config,
 ) {
+  let activeTab;
   if (parameters.e) {
-    const sidebarState = lodashAssign({}, state.sidebar, {
-      activeTab: 'events',
-    });
-    stateFromLocation = update(stateFromLocation, {
-      sidebar: { $set: sidebarState },
-    });
-    // TODO need to handle smart-handoffs param here?
+    activeTab = 'events';
+  } else if (parameters.sh) {
+    activeTab = 'download';
   } else {
-    const sidebarState = lodashAssign({}, state.sidebar, {
-      activeTab: 'layers',
-    });
-    stateFromLocation = update(stateFromLocation, {
-      sidebar: { $set: sidebarState },
-    });
+    activeTab = 'layers';
   }
+  stateFromLocation = update(stateFromLocation, {
+    sidebar: {
+      $set: {
+        ...state.sidebar,
+        activeTab,
+      },
+    },
+  });
   return stateFromLocation;
 }

--- a/web/js/modules/smart-handoff/actions.js
+++ b/web/js/modules/smart-handoff/actions.js
@@ -1,0 +1,11 @@
+import {
+  SELECT_COLLECTION,
+} from './constants';
+
+export default function selectCollection(conceptId, layerId) {
+  return {
+    type: SELECT_COLLECTION,
+    conceptId,
+    layerId,
+  };
+}

--- a/web/js/modules/smart-handoff/constants.js
+++ b/web/js/modules/smart-handoff/constants.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const SELECT_COLLECTION = 'SMART_HANDOFF/SELECT_COLLECTION';

--- a/web/js/modules/smart-handoff/reducer.js
+++ b/web/js/modules/smart-handoff/reducer.js
@@ -1,0 +1,21 @@
+import {
+  SELECT_COLLECTION,
+} from './constants';
+
+export const smartHadoffState = {
+  conceptId: null,
+  layerId: null,
+};
+
+export function smartHandoffReducer(state = smartHadoffState, action) {
+  switch (action.type) {
+    case SELECT_COLLECTION:
+      return {
+        ...state,
+        conceptId: action.conceptId,
+        layerId: action.layerId,
+      };
+    default:
+      return state;
+  }
+}

--- a/web/js/modules/smart-handoff/util.js
+++ b/web/js/modules/smart-handoff/util.js
@@ -1,0 +1,16 @@
+
+import { get } from 'lodash';
+
+export function parseSmartHandoff(state) {
+  const [layerId, conceptId] = state.split(',');
+  return {
+    layerId,
+    conceptId,
+  };
+}
+export function serializeSmartHandoff(currentItemState, state) {
+  const activeTab = get(state, 'sidebar.activeTab');
+  const { layerId, conceptId } = currentItemState;
+  const isActive = activeTab === 'download' && layerId && conceptId;
+  return isActive ? [layerId, conceptId].join(',') : undefined;
+}


### PR DESCRIPTION
## Description

Fixes #3233 #3376.

* Adds permalink support for smart handoffs
* Adds download size indication for granule selection

## How To Test

1. Open Worldview
2. Open layer picker
3. Add several layers with downloadable data (AOD and SST are good choices)
4. Move to the "Data" tab
5. Select a layer and confirm that the granule count and size displays
6. Check the "area of interest" box
7. Confirm that the granule count and size updates
8. Look at the URL, confirm that the `sh` param is set with the layer ID and concept ID (e.g `sh=MODIS_Aqua_Aerosol,C1443533683-LAADS`
9. Refresh the page
10. Confirm that the data tab is selected
11. Confirm that the same layer and collection are selected 
12. Confirm that the granule count and size are showing and match what you saw before page refresh
