### PR TITLE
Improve day of year tooltip visibility

### DIFF
--- a/e2e/features/timeline/timeline-test.js
+++ b/e2e/features/timeline/timeline-test.js
@@ -2,7 +2,7 @@ const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 const localQueryStrings = require('../../reuseables/querystrings.js');
 
-const draggerA = '.timeline-dragger.draggerA ';
+const draggerA = '.timeline-dragger.draggerA';
 const dateSelectorDayInput = '#date-selector-main .input-wrapper-day input';
 const TIME_LIMIT = 20000;
 
@@ -134,21 +134,15 @@ module.exports = {
     c.assert.containsText('#current-zoom', 'HOUR');
   },
 
-  // blue hover line and valid date tooltip date are present on hovering over timeline axis
-  'Blue hover line is present on hovering over timeline axis': (c) => {
+  // valid date tooltip date present on clicking on dragger on timeline axis
+  'Date tooltip date present on clicking on dragger on timeline axis': (c) => {
     c.url(`${c.globals.url}?t=2019-02-22`);
     c.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
     c.useCss()
       .moveToElement(draggerA, 15, 15)
       .mouseButtonDown(0)
       .waitForElementVisible('.date-tooltip', TIME_LIMIT)
-      .assert.containsText('.date-tooltip', '2019-02-22 (53)')
-      .mouseButtonUp(0)
-      .moveTo(null, -200, 0);
-
-    c.waitForElementVisible('.axis-hover-line-container', TIME_LIMIT);
-    c.expect.element('.axis-hover-line-container').to.be.visible;
-    c.expect.element('.date-tooltip').to.be.visible;
+      .assert.containsText('.date-tooltip', '2019-02-22 (DOY 53)');
   },
 
   // subdaily valid date tooltip date is present on hovering over timeline axis
@@ -159,7 +153,7 @@ module.exports = {
       .moveToElement(draggerA, 15, 15)
       .mouseButtonDown(0)
       .waitForElementVisible('.date-tooltip', TIME_LIMIT)
-      .assert.containsText('.date-tooltip', '2019-10-04 09:46Z (277)');
+      .assert.containsText('.date-tooltip', '2019-10-04 09:46Z (DOY 277)');
   },
 
   after: (c) => {

--- a/e2e/features/timeline/timeline-test.js
+++ b/e2e/features/timeline/timeline-test.js
@@ -2,7 +2,6 @@ const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 const localQueryStrings = require('../../reuseables/querystrings.js');
 
-const draggerA = '.timeline-dragger.draggerA';
 const dateSelectorDayInput = '#date-selector-main .input-wrapper-day input';
 const TIME_LIMIT = 20000;
 
@@ -65,8 +64,7 @@ module.exports = {
   // verify interval state restored from permalink
   'Interval state of HOUR restored from permalink': (c) => {
     c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
-    c.useCss()
-      .moveToElement('#timeline-interval-btn-container', 0, 0)
+    c.moveToElement('#timeline-interval-btn-container', 0, 0)
       .waitForElementVisible('#current-interval', TIME_LIMIT);
     c.assert.containsText('#current-interval', '1 HOUR');
   },
@@ -83,8 +81,7 @@ module.exports = {
 
   // verify custom interval widget panel opens
   'Custom interval widget opens on selecting custom': (c) => {
-    c.useCss()
-      .click('#interval-custom-static')
+    c.click('#interval-custom-static')
       .waitForElementVisible('.custom-interval-widget', TIME_LIMIT);
     c.expect.element('.custom-interval-widget').to.be.visible;
   },
@@ -93,8 +90,7 @@ module.exports = {
   'Select custom interval changes current interval and changes date by current interval': (c) => {
     c.url(c.globals.url + localQueryStrings.knownDate);
     c.assert.attributeContains(dateSelectorDayInput, 'value', '22');
-    c.useCss()
-      .moveToElement('#timeline-interval-btn-container', 0, 0)
+    c.moveToElement('#timeline-interval-btn-container', 0, 0)
       .pause(100)
       .click('#interval-custom-static')
       .pause(100)
@@ -116,8 +112,7 @@ module.exports = {
   // verify subdaily default year, month, day, hour, minute, and custom intervals
   'Timescale zoom subdaily default year, month, day, hour, minute, and custom intervals': (c) => {
     c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
-    c.useCss()
-      .moveToElement('#current-zoom', 0, 0)
+    c.moveToElement('#current-zoom', 0, 0)
       .waitForElementVisible('#zoom-years', TIME_LIMIT);
 
     c.expect.element('#zoom-years').to.be.visible;
@@ -129,30 +124,21 @@ module.exports = {
 
   // verify timescale zoom state restored from permalink
   'Timescale zoom HOUR restored from permalink': (c) => {
-    c.useCss()
-      .waitForElementVisible('#current-zoom', TIME_LIMIT);
+    c.waitForElementVisible('#current-zoom', TIME_LIMIT);
     c.assert.containsText('#current-zoom', 'HOUR');
   },
 
-  // valid date tooltip date present on clicking on dragger on timeline axis
-  'Date tooltip date present on clicking on dragger on timeline axis': (c) => {
+  // date tooltip date present on load
+  'Date tooltip date present load': (c) => {
     c.url(`${c.globals.url}?t=2019-02-22`);
-    c.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
-    c.useCss()
-      .moveToElement(draggerA, 15, 15)
-      .mouseButtonDown(0)
-      .waitForElementVisible('.date-tooltip', TIME_LIMIT)
-      .assert.containsText('.date-tooltip', '2019-02-22 (DOY 53)');
+    c.waitForElementVisible('.date-tooltip', TIME_LIMIT)
+      .assert.containsText('.date-tooltip', '2019-02-22 (DOY 053)');
   },
 
-  // subdaily valid date tooltip date is present on hovering over timeline axis
-  'Subdaily date tooltip date is present on hovering over timeline axis': (c) => {
+  // date subdaily tooltip date present on load
+  'Date subdaily tooltip date present load': (c) => {
     c.url(c.globals.url + localQueryStrings.subdailyLayerIntervalTimescale);
-    c.waitForElementVisible(localSelectors.dragger, TIME_LIMIT);
-    c.useCss()
-      .moveToElement(draggerA, 15, 15)
-      .mouseButtonDown(0)
-      .waitForElementVisible('.date-tooltip', TIME_LIMIT)
+    c.waitForElementVisible('.date-tooltip', TIME_LIMIT)
       .assert.containsText('.date-tooltip', '2019-10-04 09:46Z (DOY 277)');
   },
 

--- a/web/css/tooltip.css
+++ b/web/css/tooltip.css
@@ -88,7 +88,7 @@
 
 .date-tooltip-day {
   position: relative;
-  bottom: 2px;
+  bottom: 1px;
   font-size: 14px;
   font-family: "Lucida Console", monospace;
   font-weight: 300;

--- a/web/css/tooltip.css
+++ b/web/css/tooltip.css
@@ -78,6 +78,12 @@
   padding-left: 8px;
   position: relative;
   z-index: 101;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.date-tooltip-fade {
+  opacity: 1;
 }
 
 .date-tooltip-day {

--- a/web/css/tooltip.css
+++ b/web/css/tooltip.css
@@ -72,7 +72,7 @@
   font-family: 'Roboto Mono', monospace;
   border-radius: 5px;
   height: 25px;
-  line-height: 25px;
+  line-height: 23px;
   white-space: nowrap;
   user-select: none;
   padding-left: 8px;

--- a/web/js/components/range-selection/range-selection.js
+++ b/web/js/components/range-selection/range-selection.js
@@ -363,7 +363,6 @@ TimelineRangeSelector.propTypes = {
   timeScale: PropTypes.string,
   transformX: PropTypes.number,
   updateAnimationDateAndLocation: PropTypes.func,
-  width: PropTypes.number,
 };
 
 export default TimelineRangeSelector;

--- a/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/axis-hover-line.js
@@ -12,9 +12,7 @@ class AxisHoverLine extends PureComponent {
     const {
       activeLayers,
       axisWidth,
-      draggerSelected,
-      draggerPosition,
-      draggerPositionB,
+      selectedDraggerPosition,
       isTimelineLayerCoveragePanelOpen,
       isDraggerDragging,
       isTimelineDragging,
@@ -38,7 +36,6 @@ class AxisHoverLine extends PureComponent {
       ? layer.startDate
       : layer.startDate && layer.visible));
 
-    // min 1 layer for error message display
     const layerLengthCoef = Math.max(layers.length, 1);
     // handle active layer count dependent tooltip height
     if (isTimelineLayerCoveragePanelOpen) {
@@ -50,11 +47,8 @@ class AxisHoverLine extends PureComponent {
 
     // hoverline positioning based on dragger position
     if (panelDraggerHoverLine) {
-      const selectedDraggerPosition = draggerSelected === 'selected'
-        ? draggerPosition
-        : draggerPositionB;
       linePosition = selectedDraggerPosition + 47;
-      // lineheight for dragger
+      // lineHeight for dragger
       const minusY1Height = Math.min(layerLengthCoef, 5) * 40.5;
       lineHeightInner = 47 + minusY1Height;
     }
@@ -86,14 +80,12 @@ class AxisHoverLine extends PureComponent {
 AxisHoverLine.propTypes = {
   activeLayers: PropTypes.array,
   axisWidth: PropTypes.number,
-  draggerPosition: PropTypes.number,
-  draggerPositionB: PropTypes.number,
-  draggerSelected: PropTypes.string,
   hoverLinePosition: PropTypes.number,
   isAnimationDraggerDragging: PropTypes.bool,
   isTimelineLayerCoveragePanelOpen: PropTypes.bool,
   isDraggerDragging: PropTypes.bool,
   isTimelineDragging: PropTypes.bool,
+  selectedDraggerPosition: PropTypes.number,
   shouldIncludeHiddenLayers: PropTypes.bool,
   showHoverLine: PropTypes.bool,
 };

--- a/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
+++ b/web/js/components/timeline/timeline-axis/date-tooltip/date-tooltip.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getDaysInYear } from '../../date-util';
+import util from '../../../../util/util';
 
 /*
  * Date tooltip for hover and draggers
@@ -61,22 +62,18 @@ class DateTooltip extends Component {
 
   /**
   * @param {String} time
-  * @returns {String} formatted yearMonthDay -OR- yearMonthDayHourMin (subdaily)
+  * @returns {String} formatted YYYY-MM-DD -OR- YYYY-MM-DD hh:mmZ (subdaily)
   */
   getTooltipTime = (time) => {
     const { hasSubdailyLayers } = this.props;
-    const timeSplit = time.split('T');
-    const yearMonthDay = timeSplit[0];
+    const date = new Date(time);
 
-    // if no subdaily, return YEAR-MON-DAY / 2020-02-15
-    if (!hasSubdailyLayers) {
-      return yearMonthDay;
+    // if subdaily, return YYYY-MM-DD hh:mmZ / 2020-02-15 18:00Z
+    if (hasSubdailyLayers) {
+      return util.toISOStringMinutes(date).replace('T', ' ');
     }
-    const hourMinSecZ = timeSplit[1].split(':');
-    const hourMinZ = `${[hourMinSecZ[0], hourMinSecZ[1]].join(':')}Z`;
-    const yearMonthDayHourMin = `${yearMonthDay} ${hourMinZ}`;
-    // if subdaily, return YEAR-MON-DAY HOUR-MIN-Z / 2020-02-15 18:00Z
-    return yearMonthDayHourMin;
+    // if no subdaily, return YYYY-MM-DD / 2020-02-15
+    return util.toISOStringDate(date);
   };
 
   /**

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -168,8 +168,8 @@ class TimelineAxis extends Component {
     // update scale if end time limit has changed (e.g. time has elapsed since the app was started)
     const hasFutureLayersUpdated = prevProps.hasFutureLayers !== hasFutureLayers;
     const isTimelineInteracting = isDraggerDragging || isTimelineDragging;
-    const didtTimelineEndDateLimitUpdate = timelineEndDateLimit !== prevProps.timelineEndDateLimit;
-    if (didtTimelineEndDateLimitUpdate && (!isAnimationPlaying || hasFutureLayersUpdated) && !isTimelineInteracting) {
+    const didTimelineEndDateLimitUpdate = timelineEndDateLimit !== prevProps.timelineEndDateLimit;
+    if (didTimelineEndDateLimitUpdate && (!isAnimationPlaying || hasFutureLayersUpdated) && !isTimelineInteracting) {
       const updatedDraggerDate = hasFutureLayersUpdated
         ? new Date(draggerDate) > new Date(timelineEndDateLimit)
           ? timelineEndDateLimit
@@ -459,6 +459,7 @@ class TimelineAxis extends Component {
       wheelZoom: false,
       hitLeftBound: false,
       hitRightBound: false,
+      updatedTimeScale: true,
     }, updatePositioning(updatePositioningArguments, isYearOrMonth ? hoverTime : hoverTimeString));
   }
 
@@ -627,7 +628,7 @@ class TimelineAxis extends Component {
     * @param {String} sharedDraggerVisibilityParams.backDate
     * @param {Number} sharedDraggerVisibilityParams.position
     * @param {Number} sharedDraggerVisibilityParams.transform
-  * @returns {Object} output - return params used for dragger visibilty/updating dragger position
+  * @returns {Object} output - return params used for dragger visibility/updating dragger position
     * @returns {Boolean} output.newDraggerPosition
     * @returns {Boolean} output.isVisible - dragger within visible range
   */
@@ -694,7 +695,7 @@ class TimelineAxis extends Component {
    * @desc check if selectedDate will be within acceptable visible axis width
    * @param {String} previousDate
    * @param {Boolean} isDraggerB - draggerB being checked?
-   * @returns {Object} output - return params used for dragger visibilty/updating axis
+   * @returns {Object} output - return params used for dragger visibility/updating axis
    * @returns {Boolean} output.withinRange - within visible range
    * @returns {Boolean} output.newDateInThePast - new date older than previous date
    */
@@ -758,7 +759,7 @@ class TimelineAxis extends Component {
 
   // #### Drag/mouse handlers ####
   /**
-  * @desc show hover line - additional parent conditons required
+  * @desc show hover line - additional parent conditions required
   * @param {Event} mouse event
   * @returns {void}
   */
@@ -992,7 +993,7 @@ class TimelineAxis extends Component {
       // get ms time value
       const draggerDateAddedValue = new Date(draggerDateAdded).getTime();
       let newDraggerTime;
-      if (!diffZeroValues) { // unknown scaleMs due to varying number of days per month and year (leapyears)
+      if (!diffZeroValues) { // unknown scaleMs due to varying number of days per month and year (leap years)
         let daysCount;
         if (timeScale === 'year') {
           daysCount = draggerDateAdded.isLeapYear() ? 366 : 365;
@@ -1006,7 +1007,7 @@ class TimelineAxis extends Component {
         newDraggerTime = draggerDateAddedValue + (diffZeroValues * gridWidthCoefRemainder);
       }
 
-      // check other dragger visibilty on update
+      // check other dragger visibility on update
       let otherDraggerVisible;
       if (draggerSelected === 'selected') {
         // check Dragger B visibility and then update Dragger A
@@ -1263,7 +1264,7 @@ class TimelineAxis extends Component {
       wheelZoom: !!wheelZoom,
     });
 
-    // hoverTime conditional calculation necessary for touchpad horizontal scroll gesture
+    // hoverTime conditional calculation necessary for touch-pad horizontal scroll gesture
     let hoverTimeDate;
     if (hasMoved) {
       const options = timeScaleOptions[timeScale].timeAxis;
@@ -1271,7 +1272,7 @@ class TimelineAxis extends Component {
       const diffZeroValues = options.scaleMs;
       const newHoverTimeValue = new Date(frontDate).getTime();
       if (!diffZeroValues) {
-        // calculate based on frontDate due to varying number of days per month and per year (leapyears)
+        // calculate based on frontDate due to varying number of days per month and per year (leap years)
         const hoverLinePositionRelativeToFrontDate = leftOffset - midPoint - newTransformX;
         const gridWidthCoef = hoverLinePositionRelativeToFrontDate / gridWidth;
         const hoverTimeAdded = moment.utc(frontDate).add(gridWidthCoef, timeScale);
@@ -1328,7 +1329,7 @@ class TimelineAxis extends Component {
       endDate,
     } = matchingTimelineCoverage;
 
-    const postionTransformX = position + transformX;
+    const positionTransformX = position + transformX;
     const { gridWidth } = timeScaleOptions[timeScale].timeAxis;
     const axisFrontDate = new Date(frontDate).getTime();
     const axisBackDate = new Date(backDate).getTime();
@@ -1353,14 +1354,14 @@ class TimelineAxis extends Component {
         // positive diff means layerStart more recent than axisFrontDate
         const diff = moment.utc(layerStart).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
-        leftOffset = gridDiff + postionTransformX;
+        leftOffset = gridDiff + positionTransformX;
       }
 
       if (layerEndBeforeAxisBack) {
         // positive diff means layerEnd earlier than back date
         const diff = moment.utc(layerEnd).diff(axisFrontDate, timeScale, true);
         const gridDiff = gridWidth * diff;
-        width = Math.max(gridDiff + postionTransformX - leftOffset, 0);
+        width = Math.max(gridDiff + positionTransformX - leftOffset, 0);
       }
     }
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -18,7 +18,7 @@ import TimelineLayerCoveragePanel from '../../components/timeline/timeline-cover
 import TimeScaleIntervalChange from '../../components/timeline/timeline-controls/interval-timescale-change';
 import DraggerContainer from '../../components/timeline/timeline-draggers/dragger-container';
 import AxisHoverLine from '../../components/timeline/timeline-axis/date-tooltip/axis-hover-line';
-import DateToolTip from '../../components/timeline/timeline-axis/date-tooltip/date-tooltip';
+import DateTooltip from '../../components/timeline/timeline-axis/date-tooltip/date-tooltip';
 import CustomIntervalSelectorWidget from '../../components/timeline/custom-interval-selector/interval-selector-widget';
 
 import DateSelector from '../../components/date-selector/date-selector';
@@ -467,10 +467,10 @@ class Timeline extends React.Component {
 
   /**
   * @desc handle left/right arrow decrement/increment date
-  * @param {Number} signconstant - used to determine if decrement (-1) or increment (1)
+  * @param {Number} signConstant - used to determine if decrement (-1) or increment (1)
   * @returns {void}
   */
-  handleArrowDateChange(signconstant) {
+  handleArrowDateChange(signConstant) {
     const {
       customSelected,
       deltaChangeAmt,
@@ -486,8 +486,8 @@ class Timeline extends React.Component {
     if (!timeScaleChangeUnit) { // undefined custom will not allow arrow change
       return;
     }
-    delta = Number(delta * signconstant); // determine if negative or positive change
-    const disabled = signconstant > 0 ? rightArrowDisabled : leftArrowDisabled;
+    delta = Number(delta * signConstant); // determine if negative or positive change
+    const disabled = signConstant > 0 ? rightArrowDisabled : leftArrowDisabled;
     if (!disabled) {
       const minDate = new Date(timelineStartDateLimit);
       const maxDate = new Date(timelineEndDateLimit);
@@ -1068,7 +1068,12 @@ class Timeline extends React.Component {
       timelineHidden,
       transformX,
     } = this.state;
-    const selectedDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
+    const selectedDate = draggerSelected === 'selected'
+      ? draggerTimeState
+      : draggerTimeStateB;
+    const selectedDraggerPosition = draggerSelected === 'selected'
+      ? draggerPosition
+      : draggerPositionB;
     // timeline open/closed styling
     const isTimelineHidden = timelineHidden || hideTimeline;
     const chevronDirection = isTimelineHidden ? 'left' : 'right';
@@ -1230,9 +1235,7 @@ class Timeline extends React.Component {
                           isTimelineDragging={isTimelineDragging}
                           isAnimationDraggerDragging={isAnimationDraggerDragging}
                           isDraggerDragging={isDraggerDragging}
-                          draggerSelected={draggerSelected}
-                          draggerPosition={draggerPosition}
-                          draggerPositionB={draggerPositionB}
+                          selectedDraggerPosition={selectedDraggerPosition}
                           isTimelineLayerCoveragePanelOpen={isTimelineLayerCoveragePanelOpen}
                         />
 
@@ -1301,17 +1304,14 @@ class Timeline extends React.Component {
 
                         {!isTimelineDragging
                           && (
-                          <DateToolTip
+                          <DateTooltip
                             activeLayers={activeLayers}
                             shouldIncludeHiddenLayers={shouldIncludeHiddenLayers}
                             axisWidth={axisWidth}
                             leftOffset={leftOffset}
                             hoverTime={hoverTime}
-                            draggerSelected={draggerSelected}
-                            draggerTimeState={draggerTimeState}
-                            draggerTimeStateB={draggerTimeStateB}
-                            draggerPosition={draggerPosition}
-                            draggerPositionB={draggerPositionB}
+                            selectedDate={selectedDate}
+                            selectedDraggerPosition={selectedDraggerPosition}
                             hasSubdailyLayers={hasSubdailyLayers}
                             showDraggerTime={showDraggerTime}
                             showHoverLine={showHoverLine}


### PR DESCRIPTION
## Description

Fixes #3419 .

- [x] Update day of year (DOY) in date tooltip to make more visible with text, and display conditions to now show on init render and date change and A/B toggle
- [x] Minor props cleanup/spellcheck fixes

## How To Test

1. Date tooltip with DOY should display on page load (note tour can obscure it if not disabled)
2. The following should result in the date tooltip showing for 1 second:

- Init page render
- Date change via clicking on the timeline axis
- Date change via changes within the date selector
- A/B toggle (when compare mode is active)

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/master/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
