### PR TITLE
Allow future multidates in date range for active layer building without new requests

### DIFF
--- a/e2e/features/layers/layers-vector-test.js
+++ b/e2e/features/layers/layers-vector-test.js
@@ -1,7 +1,7 @@
 const skipTour = require('../../reuseables/skip-tour.js');
 
-const damsLayerQuerystring = '?v=-70.43215000968726,28.678203599725197,-59.81569241792232,31.62330063930118&l=GRanD_Dams,Reference_Labels(hidden),Reference_Features(hidden),Coastlines,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor';
-const damsLayerWMSZoomLevelQuerystring = '?v=-166.0537832499445,-8.893604135881553,79.78417648048394,59.303969410599414&l=GRanD_Dams,Reference_Labels(hidden),Reference_Features(hidden),Coastlines,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor';
+const damsLayerQuerystring = '?v=-70.43215000968726,28.678203599725197,-59.81569241792232,31.62330063930118&l=GRanD_Dams,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor';
+const damsLayerWMSZoomLevelQuerystring = '?v=-166.0537832499445,-8.893604135881553,79.78417648048394,59.303969410599414&l=GRanD_Dams,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor';
 
 const TIME_LIMIT = 10000;
 

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -178,6 +178,8 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
    */
   self.getRequestDates = function(def, options) {
     const state = store.getState();
+    const { date } = state;
+    const { appNow } = date;
     const stateCurrentDate = new Date(getSelectedDate(state));
     const previousLayer = options.previousLayer || {};
     let closestDate = options.date || stateCurrentDate;
@@ -194,7 +196,40 @@ export default function mapLayerBuilder(models, config, cache, ui, store) {
     ) {
       previousDateFromRange = previousLayerDate;
     } else {
-      const dateRange = datesinDateRanges(def, closestDate);
+      const { dateRanges, inactive, period } = def;
+      let dateRange;
+      if (inactive) {
+        dateRange = datesinDateRanges(def, closestDate);
+      } else {
+        let endDateLimit;
+        let startDateLimit;
+
+        let interval = 1;
+        if (dateRanges && dateRanges.length > 0) {
+          for (let i = 0; i < dateRanges.length; i += 1) {
+            const d = dateRanges[i];
+            const int = Number(d.dateInterval);
+            if (int > interval) {
+              interval = int;
+            }
+          }
+        }
+
+        if (period === 'daily') {
+          endDateLimit = util.dateAdd(closestDate, 'day', interval);
+          startDateLimit = util.dateAdd(closestDate, 'day', -interval);
+        } else if (period === 'monthly') {
+          endDateLimit = util.dateAdd(closestDate, 'month', interval);
+          startDateLimit = util.dateAdd(closestDate, 'month', -interval);
+        } else if (period === 'yearly') {
+          endDateLimit = util.dateAdd(closestDate, 'year', interval);
+          startDateLimit = util.dateAdd(closestDate, 'year', -interval);
+        } else {
+          endDateLimit = new Date(closestDate);
+          startDateLimit = new Date(closestDate);
+        }
+        dateRange = datesinDateRanges(def, closestDate, startDateLimit, endDateLimit, appNow);
+      }
       const { next, previous } = prevDateInDateRange(def, closestDate, dateRange);
       previousDateFromRange = previous;
       previousLayerDate = previous;

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -65,7 +65,7 @@ export function nearestInterval(def, date) {
    * @param  {object} def       A layer definition
    * @param  {object} date      A date to compare against the array of dates
    * @param  {array} dateArray  An array of dates
-   * @return {object}           The date object with normalized timeszone.
+   * @return {object}           The date object with normalized timezone.
    */
 export function prevDateInDateRange(def, date, dateArray) {
   const closestAvailableDates = [];


### PR DESCRIPTION
## Description

- [x] Use start/end date capability in `dateRange` for active layer building. This uses known max `dateInterval` of a layer from traversing its  `def.dateRanges`. This will allow single requests of active layer date intervals (4-day, 8-day, etc.) beyond what's known in the GC (e.g., 8-day layer beyond known GC will only request first day of range once instead of requesting every single day on date change within 8-day span of days).

## How To Test

1. Open in UAT (PROD is newly deployed, so won't have the necessary GC lag to demonstrate fix):
`?v=-108.42460335224303,-46.812755486230635,50.903521647756975,56.57227570998278&l=MODIS_Combined_L4_LAI_4Day&lg=false&t=2021-03-14-T18%3A00%3A00Z`
2. Open network panel to see requests, and use date arrows to change date by `1 day` into the future while staying within the `4 day` span (opening the layer coverage panel is helpful here)
3. Note **NEW** date requests on each day within the `4 day` span of days

PR Fix:
1. Open `http://localhost:3000/?v=-108.42460335224303,-46.812755486230635,50.903521647756975,56.57227570998278&l=MODIS_Combined_L4_LAI_4Day&lg=false&t=2021-03-14-T18%3A00%3A00Z`
2. Open network panel to see requests, and use date arrows to change date by `1 day` into the future while staying within the `4 day` span (opening the layer coverage panel is helpful here)
3. Note **NO NEW** daterequests on each day within the `4 day` span of days


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
