### PR TITLE
Hide notifications when in distraction free mode

### DIFF
--- a/e2e/features/location-search/location-search-test.js
+++ b/e2e/features/location-search/location-search-test.js
@@ -3,7 +3,7 @@ const localSelectors = require('../../reuseables/selectors.js');
 
 // encoded id; originally coordinates-map-marker_38.8904,-77.032
 const testMarkerEncodedID = '.coordinates-map-marker_38__2E__8904__2C__-77__2E__032';
-const testMarkerNoDetailsEncodedID = '.coordinates-map-marker_5__2C__-51__2E__5';
+const testMarkerNoDetailsEncodedID = '.coordinates-map-marker_-75__2C__10';
 const TIME_LIMIT = 10000;
 
 const {
@@ -57,11 +57,11 @@ module.exports = {
     c.expect.element(tooltipCoordinatesContainer).to.not.be.present;
   },
   'Coordinate title for no suggested place results displays correct coordinates instead': (c) => {
-    c.url(`${c.globals.url}?v=-141.32806305066077,-56.35574752202643,18.000061949339212,60.01695346916299&s=-51.5,5`);
+    c.url(`${c.globals.url}?v=-39.980778604772254,-93.78047406661956,48.73858468999798,-50.229432449264905&s=10,-75`);
     c.waitForElementVisible(tooltipCoordinatesContainer, TIME_LIMIT);
     c.expect.element(testMarkerNoDetailsEncodedID).to.be.present;
-    c.assert.containsText(tooltipCoordinatesTitle, '5.0000°, -51.5000°');
-    c.assert.containsText(tooltipCoordinates, '5.0000°, -51.5000°');
+    c.assert.containsText(tooltipCoordinatesTitle, '-75.0000°, 10.0000°');
+    c.assert.containsText(tooltipCoordinates, '-75.0000°, 10.0000°');
   },
   'Clicking close tooltip removes the marker and coordinates dialog': (c) => {
     c.click(tooltipCoordinatesCloseButton);

--- a/web/js/containers/alerts.js
+++ b/web/js/containers/alerts.js
@@ -23,7 +23,28 @@ class DismissableAlerts extends React.Component {
       hasDismissedEvents: !!safeLocalStorage.getItem(DISMISSED_EVENT_VIS_ALERT),
       hasDismissedCompare: !!safeLocalStorage.getItem(DISMISSED_COMPARE_ALERT),
       hasDismissedDistractionFree: !!safeLocalStorage.getItem(DISMISSED_DISTRACTION_FREE_ALERT),
+      distractionFreeModeInitLoad: false,
     };
+  }
+
+  componentDidMount() {
+    const { isDistractionFreeModeActive } = this.props;
+    if (isDistractionFreeModeActive) {
+      this.toggleDistractionFreeModeInitLoad(true);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isDistractionFreeModeActive } = this.props;
+    const { distractionFreeModeInitLoad } = this.state;
+    const isDistractionFreeModeActiveChanged = prevProps.isDistractionFreeModeActive && !isDistractionFreeModeActive;
+    if (distractionFreeModeInitLoad && isDistractionFreeModeActiveChanged) {
+      this.toggleDistractionFreeModeInitLoad(false);
+    }
+  }
+
+  toggleDistractionFreeModeInitLoad(isActive) {
+    this.setState({ distractionFreeModeInitLoad: isActive });
   }
 
   /**
@@ -48,21 +69,28 @@ class DismissableAlerts extends React.Component {
       isVectorAlertPresent,
       openAlertModal,
     } = this.props;
-    const { hasDismissedEvents, hasDismissedCompare, hasDismissedDistractionFree } = this.state;
+    const {
+      hasDismissedEvents,
+      hasDismissedCompare,
+      hasDismissedDistractionFree,
+      distractionFreeModeInitLoad,
+    } = this.state;
     const { eventModalProps, compareModalProps, vectorModalProps } = MODAL_PROPERTIES;
+    if (distractionFreeModeInitLoad) return null;
     if (isSmall || !HAS_LOCAL_STORAGE) return null;
-    return (
-      <>
-        {!hasDismissedDistractionFree && isDistractionFreeModeActive && (
-          <AlertUtil
-            id="distraction-free-mode-active-alert"
-            isOpen
-            noPortal
-            onDismiss={() => this.dismissAlert(DISMISSED_DISTRACTION_FREE_ALERT, 'hasDismissedDistractionFree')}
-            message="You are now in distraction free mode. Click the eye button to exit."
-          />
-        )}
-        {!hasDismissedEvents && isEventsActive && (
+
+    return isDistractionFreeModeActive
+      ? !hasDismissedDistractionFree && (
+      <AlertUtil
+        id="distraction-free-mode-active-alert"
+        isOpen
+        noPortal
+        onDismiss={() => this.dismissAlert(DISMISSED_DISTRACTION_FREE_ALERT, 'hasDismissedDistractionFree')}
+        message="You are now in distraction free mode. Click the eye button to exit."
+      />
+      ) : (
+        <>
+          {!hasDismissedEvents && isEventsActive && (
           <AlertUtil
             id="event-alert"
             isOpen
@@ -71,8 +99,8 @@ class DismissableAlerts extends React.Component {
             onDismiss={() => this.dismissAlert(DISMISSED_EVENT_VIS_ALERT, 'hasDismissedEvents')}
             message="Events may not be visible at all times."
           />
-        )}
-        {!hasDismissedCompare && isCompareActive && (
+          )}
+          {!hasDismissedCompare && isCompareActive && (
           <AlertUtil
             isOpen
             noPortal
@@ -80,8 +108,8 @@ class DismissableAlerts extends React.Component {
             onDismiss={() => this.dismissAlert(DISMISSED_COMPARE_ALERT, 'hasDismissedCompare')}
             message="You are now in comparison mode."
           />
-        )}
-        {isVectorAlertPresent && (
+          )}
+          {isVectorAlertPresent && (
           <AlertUtil
             isOpen
             noPortal
@@ -89,9 +117,9 @@ class DismissableAlerts extends React.Component {
             onDismiss={dismissVectorAlert}
             message="Vector features may not be clickable at all zoom levels."
           />
-        )}
-      </>
-    );
+          )}
+        </>
+      );
   }
 }
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
## Description

Fixes #3462  .


- [x] Hide notifications when permalink includes distraction free mode. This is targeted at permalinks with `df=true` for page load to not show any notifications. However, a notification will be shown if a user 1) turns on distraction free mode from an off state after the page has initially loaded, and 2) hasn't previously dismissed the notification which localStorage would reflect.
- [x] Fix location search due to updated API results

[If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]

## How To Test
Make sure to remove dismissed localStorage:
```
localStorage.removeItem('dismissedDistractionFreeAlert')
localStorage.removeItem('dismissedCompareAlert')
```

1. Open `?df=true&l1=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&ca=true&t=2021-04-15-T14%3A22%3A53Z&t1=2021-04-08-T14%3A22%3A53Z
2. See no notifications
3. Exit distraction free mode by clicking to eye button in the upper right
4. See compare mode alert - don't dismiss
5. Enter distraction free mode by clicking in info menu
6. See distraction free mode alert


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
