### PR TITLE
Location search select zoom based on minimum best zoom of active layers

### DIFF
--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -557,15 +557,18 @@ function getZoomLevel(layer, zoom, proj, sources) {
 
 export function getMaxZoomLevelLayerCollection(layers, zoom, proj, sources) {
   const zoomOffset = proj === 'arctic' || proj === 'antarctic' ? 1 : 0;
-  let maxZoom = zoom;
+  let maxZoom;
 
   lodashEach(layers, (layer) => {
     const { matrixSet } = layer.projections[proj];
     if (matrixSet !== undefined && layer.type !== 'vector') {
       const { source } = layer.projections[proj];
       const zoomLimit = sources[source].matrixSets[matrixSet].resolutions.length - 1 + zoomOffset;
-      maxZoom = Math.max(maxZoom, zoomLimit);
+      if (!maxZoom) {
+        maxZoom = zoomLimit;
+      }
+      maxZoom = Math.min(maxZoom, zoomLimit);
     }
   });
-  return maxZoom;
+  return maxZoom || zoom;
 }


### PR DESCRIPTION
## Description

Fixes #3474  .

- [x] Uses minimum best zoom of active layer sources vs previously using maximum and zooming in too far.

## How To Test

1. Open default page, search for New York, NY and compare zoom level of PROD vs PR

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
