### PR TITLE
Revise distraction free sidebar styling for event listeners

### DIFF
--- a/e2e/features/ui/distraction-free-mode-test.js
+++ b/e2e/features/ui/distraction-free-mode-test.js
@@ -32,11 +32,13 @@ const distractionFreeModeValidElsRemoved = (c, proj, isActive) => {
     measureBtn,
     projToolbarButton,
     shareToolbarButton,
-    sidebarContainer,
     snapshotToolbarButton,
     timelineHeader,
     zoomInButton,
     zoomOutButton,
+  ];
+  const visibleEls = [
+    sidebarContainer,
   ];
 
   // add rotate buttons for polar projections
@@ -52,9 +54,11 @@ const distractionFreeModeValidElsRemoved = (c, proj, isActive) => {
   if (isActive) {
     // distraction free mode is active and els should be removed/hidden
     presentEls.forEach((el) => c.waitForElementNotPresent(el, TIME_LIMIT));
+    visibleEls.forEach((el) => c.waitForElementNotVisible(el, TIME_LIMIT));
   } else {
     // els should be added/visible
     presentEls.forEach((el) => c.waitForElementPresent(el, TIME_LIMIT));
+    visibleEls.forEach((el) => c.waitForElementVisible(el, TIME_LIMIT));
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6656,9 +6656,9 @@
       }
     },
     "chromedriver": {
-      "version": "88.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-88.0.0.tgz",
-      "integrity": "sha512-EE8rXh7mikxk3VWKjUsz0KCUX8d3HkQ4HgMNJhWrWjzju12dKPPVHO9MY+YaAI5ryXrXGNf0Y4HcNKgW36P/CA==",
+      "version": "90.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-90.0.0.tgz",
+      "integrity": "sha512-k+GMmNb7cmuCCctQvUIeNxDGSq8DJauO+UKQS2qLT8aA36CPEcv8rpFepf6lRkNaIlfwdCUt/0B5bZDw3wY2yw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -6671,15 +6671,6 @@
         "tcp-port-used": "^1.0.1"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "dev": true,
-          "requires": {
-            "debug": "4"
-          }
-        },
         "array-union": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -6703,9 +6694,9 @@
           }
         },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+          "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -6739,9 +6730,9 @@
           "dev": true
         },
         "is-path-inside": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-          "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
           "dev": true
         },
         "mkdirp": {
@@ -10484,18 +10475,18 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
+          "version": "0.0.8",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "mkdirp": {
-          "version": "0.5.5",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -10742,18 +10733,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.13",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "browserstack-capabilities": "^0.7.0",
     "browserstack-local": "^1.4.4",
     "cheerio": "^1.0.0-rc.2",
-    "chromedriver": "^88.0.0",
+    "chromedriver": "^90.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "cross-env": "^7.0.2",
     "css-hot-loader": "^1.4.1",

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -133,14 +133,14 @@ class App extends React.Component {
       if (config.scripts) {
         util.loadScripts(config.scripts);
       }
-      if (config.features.googleTagManager) {
-        if (!/localhost/.test(window.location.href)) {
-          googleTagManager.getIpAddress();
-        }
-      }
 
-      // Console notifications
       if (Brand.release()) {
+        if (config.features.googleTagManager) {
+          if (window.location.href.includes(Brand.BRAND_URL)) {
+            googleTagManager.getIpAddress();
+          }
+        }
+        // Console build version notifications
         console.info(
           `${Brand.NAME
           } - Version ${

--- a/web/js/brand.js
+++ b/web/js/brand.js
@@ -47,6 +47,13 @@ export default (function() {
   self.BUILD_NONCE = '@BUILD_NONCE@';
 
   /**
+   * @attribute BRAND_URL
+   * @type String
+   * @static
+   */
+  self.BRAND_URL = '@URL@';
+
+  /**
    * Determines if this is a release build.
    *
    * @method release

--- a/web/js/components/util/detect-outer-click.js
+++ b/web/js/components/util/detect-outer-click.js
@@ -14,10 +14,12 @@ export default class OutsideAlerter extends Component {
   }
 
   componentDidMount() {
+    document.addEventListener('touchstart', this.handleClickOutside);
     document.addEventListener('mousedown', this.handleClickOutside);
   }
 
   componentWillUnmount() {
+    document.addEventListener('touchstart', this.handleClickOutside);
     document.removeEventListener('mousedown', this.handleClickOutside);
   }
 

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -222,73 +222,70 @@ class Sidebar extends React.Component {
             ref={(iconElement) => { this.iconElement = iconElement; }}
             onWheel={wheelCallBack}
           />
-          {isDistractionFreeModeActive
-            ? null
-            : (
-              <>
-                {isCollapsed && (
-                <CollapsedButton
-                  isMobile={isMobile}
-                  onclick={this.toggleSidebar}
-                  numberOfLayers={numberOfLayers}
-                />
-                )}
-                <div
-                  id="productsHolder"
-                  className="products-holder-case"
-                  ref={(el) => {
-                    this.sideBarCase = el;
-                  }}
-                  style={{
-                    maxHeight: isCollapsed ? '0' : `${screenHeight}px`,
-                  }}
-                  onWheel={wheelCallBack}
-                >
-                  {!isCollapsed && (
-                    <>
-                      <NavCase
-                        activeTab={activeTab}
-                        onTabClick={onTabClick}
-                        tabTypes={tabTypes}
-                        isMobile={isMobile}
-                        toggleSidebar={this.toggleSidebar}
-                        isCompareMode={isCompareMode}
-                        isDataDisabled={isDataDisabled}
-                      />
-                      <TabContent activeTab={activeTab}>
-                        <TabPane tabId="layers">
-                          {this.getProductsToRender(activeTab, isCompareMode)}
-                        </TabPane>
-                        <TabPane tabId="events">
-                          {naturalEvents && activeTab === 'events' && (
-                          <Events
-                            height={subComponentHeight}
-                            isLoading={isLoadingEvents}
-                            hasRequestError={hasEventRequestError}
-                            eventsData={eventsData}
-                            sources={eventsSources}
-                          />
-                          )}
-                        </TabPane>
-                        <TabPane tabId="download">
-                          {smartHandoffs && (
-                          <SmartHandoff
-                            isActive={activeTab === 'download'}
-                            tabTypes={tabTypes}
-                          />
-                          )}
-                        </TabPane>
-                        <footer
-                          ref={(footerElement) => { this.footerElement = footerElement; }}
-                        >
-                          <FooterContent tabTypes={tabTypes} activeTab={activeTab} />
-                        </footer>
-                      </TabContent>
-                    </>
-                  )}
-                </div>
-              </>
+          <>
+            {!isDistractionFreeModeActive && isCollapsed && (
+            <CollapsedButton
+              isMobile={isMobile}
+              onclick={this.toggleSidebar}
+              numberOfLayers={numberOfLayers}
+            />
             )}
+            <div
+              id="productsHolder"
+              className="products-holder-case"
+              ref={(el) => {
+                this.sideBarCase = el;
+              }}
+              style={{
+                maxHeight: isCollapsed ? '0' : `${screenHeight}px`,
+                display: isDistractionFreeModeActive ? 'none' : 'block',
+              }}
+              onWheel={wheelCallBack}
+            >
+              {!isCollapsed && (
+                <>
+                  <NavCase
+                    activeTab={activeTab}
+                    onTabClick={onTabClick}
+                    tabTypes={tabTypes}
+                    isMobile={isMobile}
+                    toggleSidebar={this.toggleSidebar}
+                    isCompareMode={isCompareMode}
+                    isDataDisabled={isDataDisabled}
+                  />
+                  <TabContent activeTab={activeTab}>
+                    <TabPane tabId="layers">
+                      {this.getProductsToRender(activeTab, isCompareMode)}
+                    </TabPane>
+                    <TabPane tabId="events">
+                      {naturalEvents && activeTab === 'events' && (
+                      <Events
+                        height={subComponentHeight}
+                        isLoading={isLoadingEvents}
+                        hasRequestError={hasEventRequestError}
+                        eventsData={eventsData}
+                        sources={eventsSources}
+                      />
+                      )}
+                    </TabPane>
+                    <TabPane tabId="download">
+                      {smartHandoffs && (
+                      <SmartHandoff
+                        isActive={activeTab === 'download'}
+                        tabTypes={tabTypes}
+                      />
+                      )}
+                    </TabPane>
+                    <footer
+                      ref={(footerElement) => { this.footerElement = footerElement; }}
+                    >
+                      <FooterContent tabTypes={tabTypes} activeTab={activeTab} />
+                    </footer>
+                  </TabContent>
+                </>
+              )}
+            </div>
+          </>
         </section>
       </ErrorBoundary>
     );


### PR DESCRIPTION
## Description

Fixes #3469  .

- [x] Revise distraction free sidebar display for component event listeners
- [x] Add detect outer click `touch` listener for Browserstack log error issue encountered
- [x] Limit GTM/IP check to brand url only (PROD) to cut down on SIT/UAT log errors
- [x] Update `chromedriver` to `v90` for failing tests

## How To Test

1. Test issue locally or with `tab-df-sb` UAT


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
