### PR TITLE
3471 Fix event selection carry over on projection switch

### DIFF
--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get as lodashGet } from 'lodash';
@@ -26,13 +26,11 @@ function Events(props) {
     eventsData,
     eventCategories,
     sources,
-    isPlaying,
     isLoading,
     selectEvent,
     selected,
     selectCategory,
     selectedCategory,
-    visibleWithinMapExtent,
     visibleEvents,
     height,
     deselectEvent,
@@ -40,8 +38,6 @@ function Events(props) {
     isMobile,
     showAlert,
     selectedDate,
-    updateEventSelect,
-    isAnimatingToEvent,
   } = props;
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -50,23 +46,6 @@ function Events(props) {
   const dropdownHeight = 34;
   const scrollbarMaxHeight = height - dropdownHeight;
   let showInactiveEventAlert = selected.id && !selected.date;
-
-  // Deselect event if it's not visible in the map extent
-  useEffect(() => {
-    if (selected.id && selected.date && !visibleWithinMapExtent[selected.id] && eventsData && eventsData.length) {
-      deselectEvent();
-    }
-  });
-
-  // If the date was changed to one that this event has, re-select it to move the marker
-  useEffect(() => {
-    if (isPlaying || isAnimatingToEvent) return;
-    const geometry = selected.eventObject && selected.eventObject.geometry;
-    const geometryForDate = (geometry || []).find((g) => g.date.split('T')[0] === selectedDate);
-    if (geometryForDate) {
-      updateEventSelect(selected.id, selectedDate);
-    }
-  }, [selectedDate]);
 
   const errorOrLoadingText = isLoading
     ? 'Loading...'
@@ -190,7 +169,6 @@ const mapStateToProps = (state, ownProps) => {
     selected, showAll, category,
   } = events;
   let visibleEvents = {};
-
   const mapExtent = lodashGet(state, 'map.extent');
   let visibleWithinMapExtent = {};
 
@@ -236,10 +214,8 @@ Events.propTypes = {
   eventsData: PropTypes.array,
   hasRequestError: PropTypes.bool,
   height: PropTypes.number,
-  isPlaying: PropTypes.bool,
   isLoading: PropTypes.bool,
   isMobile: PropTypes.bool,
-  isAnimatingToEvent: PropTypes.bool,
   selected: PropTypes.object,
   selectedDate: PropTypes.string,
   selectEvent: PropTypes.func,
@@ -247,7 +223,5 @@ Events.propTypes = {
   selectedCategory: PropTypes.string,
   showAlert: PropTypes.bool,
   sources: PropTypes.array,
-  updateEventSelect: PropTypes.func,
   visibleEvents: PropTypes.object,
-  visibleWithinMapExtent: PropTypes.object,
 };

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -21,22 +21,22 @@ export function getDefaultEventDate(event) {
 
 /**
  *
- * @param {*} loadedEvents
+ * @param {*} events
  * @param {*} selected
  * @param {*} extent
  * @param {*} selectedProj
  * @param {*} showAll
  */
 export function getEventsWithinExtent(
-  loadedEvents,
+  events,
   selected,
-  extent,
+  currentExtent,
   selectedProj,
 ) {
   const { maxExtent, crs } = selectedProj;
   const visibleListEvents = {};
 
-  loadedEvents.forEach((naturalEvent) => {
+  events.forEach((naturalEvent) => {
     const isSelectedEvent = selected.id === naturalEvent.id;
     let date = getDefaultEventDate(naturalEvent);
     if (selected && selected.date) {
@@ -64,11 +64,10 @@ export function getEventsWithinExtent(
       coordinates = getCenter(geomExtent);
     }
 
-    // limit to maxExtent while allowing zoom and filter 'out of extent' events
-    const coordsInProjExtent = containsCoordinate(maxExtent, coordinates);
-    const isVisible = containsCoordinate(extent, coordinates) && coordsInProjExtent;
+    const visibleInProj = containsCoordinate(maxExtent, coordinates);
+    const visibleInExtent = containsCoordinate(currentExtent, coordinates) && visibleInProj;
 
-    if (isVisible || (isSelectedEvent && coordsInProjExtent)) {
+    if (visibleInExtent || (isSelectedEvent && visibleInProj)) {
       visibleListEvents[naturalEvent.id] = true;
     }
   });

--- a/web/js/modules/natural-events/actions.js
+++ b/web/js/modules/natural-events/actions.js
@@ -30,16 +30,10 @@ export function requestSources(location) {
 }
 
 export function selectEvent(id, eventDate) {
-  return (dispatch, getState) => {
-    const { requestedEvents } = getState();
-    const eventObject = requestedEvents.response.find((e) => e.id === id);
-
-    dispatch({
-      type: SELECT_EVENT,
-      id,
-      date: eventDate,
-      eventObject,
-    });
+  return {
+    type: SELECT_EVENT,
+    id,
+    date: eventDate,
   };
 }
 

--- a/web/js/modules/natural-events/reducers.js
+++ b/web/js/modules/natural-events/reducers.js
@@ -64,14 +64,13 @@ export function eventsReducer(state = eventsReducerState, action) {
   switch (action.type) {
     case SELECT_EVENT: {
       const {
-        id, date, eventObject,
+        id, date,
       } = action;
       return {
         ...state,
         selected: {
           id,
           date,
-          eventObject,
         },
         isAnimatingToEvent: true,
       };


### PR DESCRIPTION
## Description

Fixes #3471

- don't deselect event when it's not visible in current projection
- remove code that tried to select track points on date change for selected event


## How To Test

Follow the steps for `event.focus` in the test suite.


