### PR TITLE
Reposition animation widget init y position, fix layer coverage panel button click style issue

### DIFF
--- a/web/css/tooltip.css
+++ b/web/css/tooltip.css
@@ -79,6 +79,7 @@
   position: relative;
   z-index: 101;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 150ms ease;
 }
 

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -112,7 +112,7 @@ class AnimationWidget extends React.Component {
       speed: props.speed,
       widgetPosition: {
         x: (props.screenWidth / 2) - halfWidgetWidth,
-        y: -10,
+        y: -25,
       },
       collapsed: false,
       collapsedWidgetPosition: { x: 0, y: 0 },


### PR DESCRIPTION
## Description

Fixes #3482  .

- [x] Change init y position for animation widget so it clears the date tooltip on the timeline.
- [x] CSS fix for tooltip covering up/preventing click on layer coverage panel button.

## How To Test

Visual test on animation widget.
Test the layer coverage panel button by comparing UAT to this and change the date to cover button up and try to click. Kind of edge casey. 


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
