### PR TITLE
CMR details missing in data download panel

### DIFF
--- a/web/js/components/smart-handoffs/smart-handoff-modal.js
+++ b/web/js/components/smart-handoffs/smart-handoff-modal.js
@@ -89,10 +89,10 @@ function SmartHandoffModal({
 
         <h1> Collection: </h1>
         <div className="handoff-modal-link">
-          {`${STD_NRT_MAP[type]} - v${version}`}
+          {STD_NRT_MAP[type] + (version ? ` - v${version}` : '')}
           <br />
           <a href={cmrSearchDetailURL} target="_blank" rel="noopener noreferrer">
-            {`${title}`}
+            {`${title || 'Details'}`}
           </a>
         </div>
 

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -264,7 +264,7 @@ class SmartHandoff extends Component {
                       onChange={() => selectCollection(collection.value, layer.id)}
                     />
                     <label id={labelId} htmlFor={inputId}>
-                      {`${STD_NRT_MAP[type]} - v${version}`}
+                      {STD_NRT_MAP[type] + (version ? ` - v${version}` : '')}
                       <FontAwesomeIcon id={`${util.encodeId(value)}-tooltip`} icon="info-circle" />
                     </label>
 


### PR DESCRIPTION
## Description

Fixes #3487

![Screen Shot 2021-05-04 at 12 54 07 PM](https://user-images.githubusercontent.com/1480000/117040880-5beb6900-acd8-11eb-8f03-ef45e6db1ea0.png)


## How To Test

1. Open `web/config/wv.json`
2. Find the entry for the `OMPS_SO2_Upper_Troposphere_and_Stratosphere` layer
3. Remove the `title` and `version` attributes from one or both `conceptId` entries
4. Restart webpack server
5. Load with these parameters `?v=-144,-108,144,108&l=OMPS_SO2_Upper_Troposphere_and_Stratosphere&lg=false&sh=OMPS_SO2_Upper_Troposphere_and_Stratosphere,C1439293808-OMINRT&t=2021-05-02-T13%3A55%3A10Z`
6.  You should not see `undefined` in either the sidebar or the modal that shows when transitioning to Earthdata Search (see screenshot)

