### PR TITLE
Allow distraction free mode with animation widget

### DIFF
--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -572,6 +572,7 @@ class AnimationWidget extends React.Component {
       isActive,
       layers,
       hasCustomPalettes,
+      isDistractionFreeModeActive,
       promiseImageryForTime,
       selectDate,
       currentDate,
@@ -626,9 +627,11 @@ class AnimationWidget extends React.Component {
             onClose={onPushPause}
           />
         )}
-
-        {collapsed ? this.renderCollapsedWidget() : this.renderExpandedWidget()}
-
+        {!isDistractionFreeModeActive && (
+          <>
+            {collapsed ? this.renderCollapsedWidget() : this.renderExpandedWidget()}
+          </>
+        )}
       </ErrorBoundary>
     );
   }
@@ -645,6 +648,7 @@ function mapStateToProps(state) {
     config,
     map,
     browser,
+    ui,
   } = state;
   const {
     startDate, endDate, speed, loop, isPlaying, isActive, gifActive,
@@ -678,6 +682,7 @@ function mapStateToProps(state) {
     maxDate = appNow;
   }
 
+  const { isDistractionFreeModeActive } = ui;
   const animationIsActive = isActive
     && browser.greaterThan.small
     && lodashGet(map, 'ui.selected.frameState_')
@@ -713,6 +718,7 @@ function mapStateToProps(state) {
     minDate,
     maxDate,
     isActive: animationIsActive,
+    isDistractionFreeModeActive,
     hasFutureLayers,
     hasSubdailyLayers,
     subDailyMode,
@@ -851,6 +857,7 @@ AnimationWidget.propTypes = {
   hasSubdailyLayers: PropTypes.bool,
   interval: PropTypes.string,
   isActive: PropTypes.bool,
+  isDistractionFreeModeActive: PropTypes.bool,
   isGifActive: PropTypes.bool,
   isPlaying: PropTypes.bool,
   isRotated: PropTypes.bool,

--- a/web/js/modules/key-press/actions.js
+++ b/web/js/modules/key-press/actions.js
@@ -34,7 +34,8 @@ export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey, isInput) {
           type: ANIMATION_KEY_PRESS_ACTION,
           keyCode,
         });
-      } else if (!isInput && !ctrlOrCmdKey && shiftKey && keyCode === 68) {
+      }
+      if (!isInput && !ctrlOrCmdKey && shiftKey && keyCode === 68) {
         dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
         if (!isDistractionFreeModeActive && isOpen) {
           dispatch({ type: CLOSE_MODAL });


### PR DESCRIPTION
## Description

Fixes #3491  .

- [x] Allow distraction free mode to activate within animation widget. This implementation allows distraction free mode to activate while animation widget is active, so a user can now play an animation and enter distraction free mode.

## How To Test

1. Open animation widget
2. Use shortcut key `SHIFT D` to enter distraction free


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
