### PR TITLE
Add `pipenv run` to `build:options` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "pipenv run run-s clean getcapabilities build:config build:dev",
     "build:ci": "pipenv run run-s getcapabilities build:config build:prod",
     "build:dev": "cross-env NODE_ENV=development webpack",
-    "build:options": "bash -c 'tasks/buildOptions.sh'",
+    "build:options": "bash -c 'pipenv run tasks/buildOptions.sh'",
     "build:config": "pipenv run run-s build:options && node ./tasks/config.js",
     "build:prod": "cross-env NODE_ENV=production webpack",
     "clean": "node ./tasks/clean.js",


### PR DESCRIPTION
## Description

Fixes #3496 

[Description of the bug or feature]

Adding `pipenv run` will ensure that `#!/usr/bin/env python` shebang resolves to the python used for the created pipenv

## How To Test

Follow the steps listed in #3496 and notice that no error is encountered.
Would also recommend running your normal ci pipeline to ensure it didn't break anything for you.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
