### PR TITLE
Location search compare fix and limit fly to coordinate on input search

### DIFF
--- a/web/js/components/location-search/location-search-modal.js
+++ b/web/js/components/location-search/location-search-modal.js
@@ -106,7 +106,7 @@ class LocationSearchModal extends Component {
     });
   }
 
-  // handle submitting search after inputing coordinates
+  // handle submitting search after inputting coordinates
   onCoordinateInputSelect = () => {
     const {
       clearSuggestions,
@@ -427,7 +427,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   setPlaceMarker: (coordinates, addressAttributes) => {
-    dispatch(setPlaceMarker(coordinates, addressAttributes));
+    dispatch(setPlaceMarker(coordinates, addressAttributes, true));
   },
   toggleReverseGeocodeActive: (isActive) => {
     dispatch(toggleReverseGeocodeActive(isActive));

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -768,7 +768,7 @@ export default function mapui(models, config, store, ui) {
     let layerGroup;
     if (compare && compare.active) {
       layerGroups = self.selected.getLayers().getArray();
-      if (layerGroups.length === 2) {
+      if (layerGroups.length > 1) {
         layerGroup = layerGroups[0].get('group') === compare.activeString
           ? layerGroups[0]
           : layerGroups[1].get('group') === compare.activeString

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -114,8 +114,9 @@ export default function mapui(models, config, store, ui) {
       }
       case CLEAR_MARKER:
         return removeCoordinatesMarker();
-      case SET_MARKER:
-        return addMarkerAndUpdateStore(null, true);
+      case SET_MARKER: {
+        return addMarkerAndUpdateStore(null, action.isInputSearch);
+      }
       case TOGGLE_DIALOG_VISIBLE: {
         if (action.value) {
           addCoordinatesTooltip();
@@ -349,8 +350,7 @@ export default function mapui(models, config, store, ui) {
    * @static
    *
    * @param {Object} geocodeResults
-   * @param {Boolean} shouldFlyToCoordinates
-   *
+   * @param {Boolean} shouldFlyToCoordinates - if location search via input
    * @returns {void}
    */
   const addMarkerAndUpdateStore = (geocodeResults, shouldFlyToCoordinates) => {

--- a/web/js/modules/location-search/actions.js
+++ b/web/js/modules/location-search/actions.js
@@ -57,8 +57,9 @@ export function toggleReverseGeocodeActive(isActive) {
  * Set coordinates and reverse geocode results for place
  * @param {Array} coordinates
  * @param {Object} reverseGeocodeResults
+ * @param {Boolean} isInputSearch
  */
-export function setPlaceMarker(coordinates, reverseGeocodeResults) {
+export function setPlaceMarker(coordinates, reverseGeocodeResults, isInputSearch) {
   return (dispatch, getState) => {
     const state = getState();
     const {
@@ -86,6 +87,7 @@ export function setPlaceMarker(coordinates, reverseGeocodeResults) {
       reverseGeocodeResults,
       coordinates,
       isCoordinatesDialogOpen: true,
+      isInputSearch,
     });
   };
 }

--- a/web/js/modules/vector-styles/selectors.js
+++ b/web/js/modules/vector-styles/selectors.js
@@ -93,7 +93,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state)
   if (olMap) {
     layerGroups = olMap.getLayers().getArray();
     if (compare && compare.active) {
-      if (layerGroups.length === 2) {
+      if (layerGroups.length > 1) {
         layerGroup = layerGroups[0].get('group') === compare.activeString
           ? layerGroups[0]
           : layerGroups[1].get('group') === compare.activeString


### PR DESCRIPTION
## Description

Fixes #3501  .
Fixes #3502  .

- [x] Fix layergroup length condition to accommodate vector layer used for location marker
- [x] Only fly to coordinates on input location search.

## How To Test

**Compare fix:**
1. Open `http://localhost:3000/?v=-72.937707421875,42.857130859375,-70.217492578125,44.513869140625&l1=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&ca=true&s=-71.5174,43.8257&t=2021-04-08-T20%3A43%3A46Z&t1=2021-03-27-T20%3A43%3A46Z`
2. Change A date, see date change/update
3. Change B date, see date change/update

**No animate to coordinate on map pin 'Add marker on map':**
1. Open default page, and use location search 'Add marker on map' to add marker - see no animate to coordinate
2. Input text place within projection and hit enter/select from results - see animate to coordinate

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
