### PR TITLE
Skips two layers vectors e2e tests for firefox

### DIFF
--- a/e2e/features/layers/layers-vector-test.js
+++ b/e2e/features/layers/layers-vector-test.js
@@ -6,48 +6,54 @@ const damsLayerWMSZoomLevelQuerystring = '?v=-166.0537832499445,-8.8936041358815
 const TIME_LIMIT = 10000;
 
 module.exports = {
-  before: (client) => {
-    skipTour.loadAndSkipTour(client, TIME_LIMIT);
+  before: (c) => {
+    skipTour.loadAndSkipTour(c, TIME_LIMIT);
   },
-  'vector layer has pointer icon': (client) => {
-    client.url(client.globals.url + damsLayerQuerystring);
-    client.waitForElementVisible('#active-GRanD_Dams .fa-hand-pointer', TIME_LIMIT);
+  'vector layer has pointer icon': (c) => {
+    c.url(c.globals.url + damsLayerQuerystring);
+    c.waitForElementVisible('#active-GRanD_Dams .fa-hand-pointer', TIME_LIMIT);
   },
-  'vector layer click does not show alert when all vector layers are clickable': (client) => {
-    const globalSelectors = client.globals.selectors;
+  'vector layer click does not show alert when all vector layers are clickable': (c) => {
+    const globalSelectors = c.globals.selectors;
 
-    client.moveToElement('#wv-map-geographic', 400, 200)
+    c.moveToElement('#wv-map-geographic', 400, 200)
       .mouseButtonClick(0);
-    client.pause(200);
-    client.expect.element(globalSelectors.notifyMessage).to.not.be.present;
+    c.pause(200);
+    c.expect.element(globalSelectors.notifyMessage).to.not.be.present;
   },
-  'Vectors show alert when not clickable': (client) => {
-    const globalSelectors = client.globals.selectors;
+  'Vectors show alert when not clickable': (c) => {
+    if (c.options.desiredCapabilities.browserName === 'firefox') {
+      return;
+    }
+    const globalSelectors = c.globals.selectors;
 
-    client.url(client.globals.url + damsLayerWMSZoomLevelQuerystring);
-    client.waitForElementVisible('#active-GRanD_Dams .fa-hand-pointer', TIME_LIMIT, () => {
-      client.moveToElement('#wv-map-geographic', 400, 200)
+    c.url(c.globals.url + damsLayerWMSZoomLevelQuerystring);
+    c.waitForElementVisible('#active-GRanD_Dams .fa-hand-pointer', TIME_LIMIT, () => {
+      c.moveToElement('#wv-map-geographic', 400, 200)
         .mouseButtonClick(0);
-      client.pause(200);
-      client.expect.element(globalSelectors.notifyMessage).to.be.present;
-      client.assert.containsText(
+      c.pause(200);
+      c.expect.element(globalSelectors.notifyMessage).to.be.present;
+      c.assert.containsText(
         globalSelectors.notifyMessage,
         'Vector features may not be clickable at all zoom levels.',
       );
     });
   },
-  'clicking vector message shows modal': (client) => {
-    const globalSelectors = client.globals.selectors;
+  'clicking vector message shows modal': (c) => {
+    if (c.options.desiredCapabilities.browserName === 'firefox') {
+      return;
+    }
+    const globalSelectors = c.globals.selectors;
 
-    client.click(globalSelectors.notifyMessage);
-    client.waitForElementVisible('.modal-content', TIME_LIMIT, () => {
-      client.assert.containsText('.modal-content',
+    c.click(globalSelectors.notifyMessage);
+    c.waitForElementVisible('.modal-content', TIME_LIMIT, () => {
+      c.assert.containsText('.modal-content',
         'Vector features may not be clickable at all zoom levels.');
     });
   },
 
   // TODO tests for orbit tracks toggle on/off
-  after: (client) => {
-    client.end();
+  after: (c) => {
+    c.end();
   },
 };


### PR DESCRIPTION
## Description

Fixes #3470  .

- [x] These layers vector tests regularly fail on firefox headless but seem to work fine working through the tests manually. Chrome will cover these assertions.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
