### PR TITLE
Base Layers not updating when date changes and vector layers active

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -816,7 +816,9 @@ export default function mapui(models, config, store, ui) {
             }
           });
         }
-        setStyleFunction(def, vectorStyleId, vectorStyles, null, state);
+        setTimeout(() => {
+          setStyleFunction(def, vectorStyleId, vectorStyles, null, state);
+        }, 10);
       }
     });
     updateLayerVisibilities();


### PR DESCRIPTION
## Description

Fixes #3523

Base Layers not updating when date changes

## How To Test

Steps to reproduce the behavior:

* go to `?v=-69.94592971824508,-18.961055737707355,-30.571415587656446,-4.691609725265351&l=VIIRS_NOAA20_Thermal_Anomalies_375m_All,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor&lg=true&t=2021-05-08-T18%3A00%3A00Z`
* Click on forward arrow in the timeline for a few days
* Click on the back arrow the same number of days (or less)
* See no error - imagery updates.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
