### PR TITLE
Query CMR with concept id on layer add to validate

### DIFF
--- a/e2e/features/smart-handoff/smart-handoff-test.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.js
@@ -52,9 +52,10 @@ module.exports = {
     c.click(dataTabButton);
 
     // Ensure layer is now showing as an option for download
-    c.expect.element(cloudRadiusRadioButton).to.be.present;
-
-    c.click(cloudRadiusRadioButton);
+    c.waitForElementVisible(cloudRadiusRadioButton, TIME_LIMIT, (e) => {
+      c.click(cloudRadiusRadioButton);
+      c.pause(500);
+    });
 
     // Verify granules and date are correct
     c.expect

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -93,7 +93,7 @@ class SmartHandoff extends Component {
   async validateConceptIds() {
     const { validatedConceptIds } = this.state;
     const { availableLayers } = this.props;
-    const baseUrl = 'http://cmr.earthdata.nasa.gov/search/collections.json?concept_id=';
+    const baseUrl = 'https://cmr.earthdata.nasa.gov/search/collections.json?concept_id=';
     const conceptIdRequest = async (url) => {
       const granulesResponse = await fetch(url, { timeout: 5000 });
       const result = await granulesResponse.json();


### PR DESCRIPTION
## Description

Fixes #3509 

Updates smart-handoffs to make a CMR request for each concept ID assigned to a layer to verify that it is still valid before displaying that option as an available downloadable product to the user.

## How To Test

1. Build the app as normal
2. Open in browser
3. Go to Data tab
4. Confirm "Corrected Reflectance (True Color) Suomi NPP / VIIRS" layer has one NRT data collection choice
5. Open `web/config/wv.json`
6. Search for `C1344298008-LANCEMODIS` and change this to an invalid value such as `C123456-LANCEARMSTRONG`
7. Restart webpack server
8. Confirm "Corrected Reflectance (True Color) Suomi NPP / VIIRS" layer no longer shows in data tab


