### PR TITLE
Hide map coordinates element in smaller screens that were previously larger viewports

### DIFF
--- a/web/css/mobile.css
+++ b/web/css/mobile.css
@@ -12,7 +12,7 @@
   div.olControlScaleLineCustom {
     display: none !important;
   }
-  .wv-coords-map {
+  .wv-coords-map, .wv-coords-container {
     display: none !important;
   }
 


### PR DESCRIPTION
## Description

Fixes #3573  .

- [x] Hide map coordinates element in smaller screens that were larger viewports initially (e.g., large mobile devices that changed orientation, or shrunk desktop windows) so the element doesn't block clicking on event icons below its footprint.

## How To Test

Compare PR vs PROD:
1. Open normal desktop page, switch to simulated mobile device in browser
2. Select natural events tab
2. Try to click event icon under the footprint of where the map coordinates element is located
3. Verify you can click events in that location


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
