### PR TITLE
Add filter to hide layers from data download if outside layer date range

### DIFF
--- a/e2e/features/smart-handoff/smart-handoff-test.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.js
@@ -14,7 +14,7 @@ const cloudRadiusRadioButton = '#C1443536017-LAADS-MODIS_Aqua_Cloud_Effective_Ra
 const SSTRadioButton = '#C1664741463-PODAAC-GHRSST_L4_MUR_Sea_Surface_Temperature-collection-choice-label';
 const urlParams = '?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m&t=2019-12-01';
 const permalinkParams = '?l=GHRSST_L4_MUR_Sea_Surface_Temperature,MODIS_Aqua_Aerosol_Optical_Depth_3km&lg=true&sh=MODIS_Aqua_Aerosol_Optical_Depth_3km,C1443528505-LAADS&t=2020-02-06-T06%3A00%3A00Z';
-
+const permalinkParams1980 = '?l=GHRSST_L4_MUR_Sea_Surface_Temperature,MODIS_Aqua_Aerosol_Optical_Depth_3km&lg=true&sh=MODIS_Aqua_Aerosol_Optical_Depth_3km,C1443528505-LAADS&t=1980-02-06-T06%3A00%3A00Z';
 
 module.exports = {
 
@@ -95,6 +95,14 @@ module.exports = {
     c.click(SSTRadioButton);
     c.pause(200);
     c.assert.urlContains('&sh=GHRSST_L4_MUR_Sea_Surface_Temperature,C1664741463-PODAAC');
+  },
+
+  'Layers outside of their coverage date range are hidden from layers available for download': (c) => {
+    c.url(c.globals.url + permalinkParams1980);
+    c.expect.element(dataTabButton).to.be.visible;
+    c.expect
+      .element('.smart-handoff-side-panel > h1')
+      .to.have.text.equal('None of your current layers are available for download.');
   },
 
   after(c) {

--- a/web/js/components/smart-handoffs/smart-handoff-not-available-modal.js
+++ b/web/js/components/smart-handoffs/smart-handoff-not-available-modal.js
@@ -5,7 +5,11 @@ export default function SmartHandoffNotAvailableModal() {
     <div className="basic-modal">
       <h1>Why are some layers not available for download?</h1>
       <p>
-        Some layers in Worldview do not have corresponding source data products available for download.
+        Data will not be available on dates outside of each layers respective coverage date range.
+        These layers will be hidden from the layers available to download.
+      </p>
+      <p>
+        In addition, some layers in Worldview do not have corresponding source data products available for download.
         These include Geostationary, Reference, Orbit Tracks, Earth at Night, and MODIS Corrected Reflectance products.
       </p>
       <p>

--- a/web/js/components/smart-handoffs/smart-handoff-not-available-modal.js
+++ b/web/js/components/smart-handoffs/smart-handoff-not-available-modal.js
@@ -5,7 +5,7 @@ export default function SmartHandoffNotAvailableModal() {
     <div className="basic-modal">
       <h1>Why are some layers not available for download?</h1>
       <p>
-        Data will not be available on dates outside of each layers respective coverage date range.
+        Data will not be available on dates outside of each layer's respective coverage date range.
         These layers will be hidden from the layers available to download.
       </p>
       <p>

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -18,7 +18,7 @@ import GranuleAlertModalBody from '../../components/smart-handoffs/smart-handoff
 import GranuleCount from '../../components/smart-handoffs/granule-count';
 import { imageUtilGetCoordsFromPixelValues } from '../../modules/image-download/util';
 import { onClose, openCustomContent } from '../../modules/modal/actions';
-import { getActiveLayers } from '../../modules/layers/selectors';
+import { memoizedAvailable as availableSelector, getActiveLayers } from '../../modules/layers/selectors';
 import { getSelectedDate } from '../../modules/date/selectors';
 import safeLocalStorage from '../../util/local-storage';
 import openEarthDataSearch from '../../components/smart-handoffs/util';
@@ -518,9 +518,12 @@ const mapStateToProps = (state) => {
   const selectedDateFormatted = moment.utc(selectedDate).format('YYYY-MM-DD'); // 2020-01-01
   const displayDate = moment.utc(selectedDate).format('YYYY MMM DD'); // 2020 JAN 01
   const filterForSmartHandoff = (layer) => {
-    const { projections, disableSmartHandoff, conceptIds } = layer;
+    const {
+      id, projections, disableSmartHandoff, conceptIds,
+    } = layer;
+    const isAvailable = availableSelector(state)(id);
     const filteredConceptIds = (conceptIds || []).filter(({ type, value, version }) => type && value && version);
-    return projections[proj.id] && !disableSmartHandoff && !!filteredConceptIds.length;
+    return isAvailable && projections[proj.id] && !disableSmartHandoff && !!filteredConceptIds.length;
   };
   const availableLayers = getActiveLayers(state).filter(filterForSmartHandoff);
 


### PR DESCRIPTION
## Description

Fixes #3552  .

- [x] Add filter to hide layers from data download available layers based on available date range coverage, add E2E.
- [x] Expand no coverage modal text to reflect this change.


## How To Test

1. Open [localhost 1980 - no available layers](http://localhost:3000/?z=1&l=GHRSST_L4_MUR_Sea_Surface_Temperature,MODIS_Aqua_Aerosol_Optical_Depth_3km&lg=true&sh=MODIS_Aqua_Aerosol_Optical_Depth_3km,C1443528505-LAADS&t=1980-02-06-T06%3A00%3A00Z)
2. See no available layers message
3. Open [localhost 2018 - available layers](http://localhost:3000/?z=1&l=GHRSST_L4_MUR_Sea_Surface_Temperature,MODIS_Aqua_Aerosol_Optical_Depth_3km&lg=true&sh=MODIS_Aqua_Aerosol_Optical_Depth_3km,C1443528505-LAADS&t=2018-02-06-T06%3A00%3A00Z)
4. See available layers


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
