### PR TITLE
Display appropriate granule count

### DIFF
--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -133,7 +133,7 @@ export default function GranuleCount (props) {
         {!isLoading && (
           <>
             <span className="fade-in">
-              {granulesExist && selectedGranules >= 0 && `${selectedGranules} of `}
+              {currentExtent && granulesExist && selectedGranules >= 0 && `${selectedGranules} of `}
               {granulesExist ? totalGranules : 'NONE'}
             </span>
           </>


### PR DESCRIPTION
## Description

Fixes #3581

Only show the "x out of ..." message when the 'Set Area of Interest' checkbox is checked.