### PR TITLE
Revise dateline to allow click through of event icons, related dateline format update, compare fix, and and cleanup

### DIFF
--- a/web/css/sidebar.css
+++ b/web/css/sidebar.css
@@ -112,15 +112,20 @@
 }
 
 /* override bootstrap styles */
-.tab-content .ab-tabs-case .nav-item {
-  .active {
-    color: #495057;
+.tab-content .ab-tabs-case {
+  .nav-tabs {
+    flex-wrap: nowrap;
   }
-  .ab-tab {
-    overflow: hidden;
-    white-space: nowrap;
-    width: 141px;
-    padding-left: 5px;
+  .nav-item {
+    .active {
+      color: #495057;
+    }
+    .ab-tab {
+      overflow: hidden;
+      white-space: nowrap;
+      width: 140px;
+      padding-left: 5px;
+    }
   }
 }
 .nav-item .sidebar-tab.active {

--- a/web/js/components/dateline/dateline.js
+++ b/web/js/components/dateline/dateline.js
@@ -150,8 +150,7 @@ Line.defaultProps = {
   strokeWidth: '6',
   color: 'white',
   svgStyle: {
-    margin: '0 40px 0 40px',
-    transform: 'translateX(-43px)',
+    transform: 'translateX(-3px)',
   },
 };
 

--- a/web/js/components/dateline/text.js
+++ b/web/js/components/dateline/text.js
@@ -33,13 +33,19 @@ class LineText extends React.Component {
       util.getTextWidth(dateRight, '13px Open Sans') * 100,
     ) / 100 || textWidth;
     const svgStyle = {
-      transform: `translateX(${-(leftTextWidth + 20)}px)`,
+      position: 'absolute',
+      transform: `translateX(${-(leftTextWidth + 25)}px)`,
+      overflow: 'visible',
+      width: '100px',
+      userSelect: 'none',
+      pointerEvents: 'none',
+      left: '0',
     };
     return (
       <svg className="dateline-text" style={svgStyle}>
         <rect
           fill={fill}
-          width={leftTextWidth + 12}
+          width={leftTextWidth + 10}
           height={textHeight}
           x={0}
           rx={recRadius}
@@ -56,7 +62,7 @@ class LineText extends React.Component {
         </text>
         <rect
           fill={fill}
-          width={rightTextWidth + 12}
+          width={rightTextWidth + 10}
           height={textHeight}
           x={leftTextWidth + 40}
           rx={recRadius}
@@ -80,7 +86,7 @@ LineText.defaultProps = {
   width: '300',
   color: 'white',
   textY: 14,
-  fill: 'rgba(40,40,40,0.5)',
+  fill: 'rgba(40,40,40,0.75)',
   textWidth: 80,
   textHeight: 20,
   recRadius: 3,

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -67,7 +67,6 @@ export default function mapDateLineBuilder(store) {
     let dimensions;
     map = olMap;
     drawDatelines(map, date);
-    // [self.date] = date.toISOString().split('T');
     proj = store.getState().proj.id;
 
     events.on('map:moveend', () => {

--- a/web/js/map/datelinebuilder.js
+++ b/web/js/map/datelinebuilder.js
@@ -5,11 +5,15 @@ import OlOverlay from 'ol/Overlay';
 import util from '../util/util';
 import DateLine from '../components/dateline/dateline';
 import LineText from '../components/dateline/text';
-import { CHANGE_STATE as COMPARE_CHANGE_STATE } from '../modules/compare/constants';
+import {
+  CHANGE_STATE as COMPARE_CHANGE_STATE,
+  TOGGLE_ON_OFF as COMPARE_TOGGLE_ON_OFF,
+} from '../modules/compare/constants';
 import { SELECT_DATE } from '../modules/date/constants';
 import { CHANGE_PROJECTION } from '../modules/projection/constants';
 import { LOCATION_POP_ACTION } from '../redux-location-state-customs';
 import { getSelectedDate } from '../modules/date/selectors';
+import { memoizedDateMonthAbbrev } from '../modules/compare/selectors';
 
 const { events } = util;
 
@@ -24,39 +28,21 @@ let textLeft;
 let textRight;
 let proj;
 
-export default function mapDateLineBuilder(models, config, store, ui) {
+export default function mapDateLineBuilder(store) {
   const self = {};
-  // formatted YYYY-MM-DD (e.g., 2019-06-25) for checking daily change for dateline
-  self.date = {};
   /*
-   * Sets globals and event listeners
-   *
-   * @method init
-   * @static
-   *
-   * @param {object} Parent - Map class that we are listeing to
-          Note: this is an antipattern - should be adjusted
-   * @param {Object} olMap - OL map object
-   * @param {Object} date - JS date Object
-   *
-   * @returns {object} React Component
-   */
-  /**
-   * Suscribe to redux store and listen for
+   * Subscribe to redux store and listen for
    * specific action types
    */
   const subscribeToStore = function(action) {
     switch (action.type) {
       case SELECT_DATE:
       case LOCATION_POP_ACTION:
-      case COMPARE_CHANGE_STATE: {
+      case COMPARE_CHANGE_STATE:
+      case COMPARE_TOGGLE_ON_OFF: {
         const state = store.getState();
         const date = getSelectedDate(state);
-        const isNewDay = compareDateStrings(date);
-        if (isNewDay) {
-          return updateDate(date);
-        }
-        break;
+        return updateDate(date);
       }
       case CHANGE_PROJECTION:
         proj = action.id;
@@ -66,11 +52,22 @@ export default function mapDateLineBuilder(models, config, store, ui) {
     }
   };
 
-  self.init = function(Parent, olMap, date) {
+  /*
+   * Sets globals and event listeners
+   *
+   * @method init
+   * @static
+   *
+   * @param {Object} olMap - OL map object
+   * @param {Object} date - JS date Object
+   *
+   * @returns {object} React Component
+   */
+  self.init = function(olMap, date) {
     let dimensions;
     map = olMap;
     drawDatelines(map, date);
-    [self.date] = date.toISOString().split('T');
+    // [self.date] = date.toISOString().split('T');
     proj = store.getState().proj.id;
 
     events.on('map:moveend', () => {
@@ -104,7 +101,7 @@ export default function mapDateLineBuilder(models, config, store, ui) {
   };
 
   /*
-   * Add Props to React Compents that creates
+   * Add Props to React Components that creates
    *  a hoverable line SVG
    *
    * @method setLineDefaults
@@ -112,7 +109,7 @@ export default function mapDateLineBuilder(models, config, store, ui) {
    *
    * @param {object} Factory - React component Factory
    * @param {number} height - Length of line
-   * @param {number} lineX - x coord value
+   * @param {number} lineX - x coordinate value
    * @param {object} overlay - OL overlay
    * @param {object} reactCase - Dom El in which to render component
    * @param {object} tooltip - OL overlay that is associated with this widget
@@ -143,7 +140,7 @@ export default function mapDateLineBuilder(models, config, store, ui) {
   };
 
   /*
-   * Add Props to React Compents that creates an
+   * Add Props to React Components that creates an
    *  SVG text component
    *
    * @method setTextDefaults
@@ -173,20 +170,20 @@ export default function mapDateLineBuilder(models, config, store, ui) {
    * @returns {object} Object with tooltip state
    */
   const getTextState = function(date, isLeft) {
-    const isCompareActive = models.compare && models.compare.active;
-    const state = {
-      dateLeft: !isCompareActive
-        ? util.toISOStringDate(util.dateAdd(date, 'day', 1))
-        : isLeft
+    const state = store.getState();
+    if (state.compare.active) {
+      return {
+        dateLeft: isLeft
           ? '+ 1 day'
           : '',
-      dateRight: !isCompareActive
-        ? util.toISOStringDate(date)
-        : isLeft
+        dateRight: isLeft
           ? ''
           : '- 1 day',
-    };
-    return state;
+      };
+    }
+    const dateState = { selected: util.dateAdd(date, 'day', 1), selectedB: date };
+    const { dateA, dateB } = memoizedDateMonthAbbrev({ date: dateState })();
+    return { dateLeft: dateA, dateRight: dateB };
   };
 
   /*
@@ -220,6 +217,8 @@ export default function mapDateLineBuilder(models, config, store, ui) {
   const drawDatelines = function(map, date) {
     const leftLineCase = document.createElement('div');
     const rightLineCase = document.createElement('div');
+    leftLineCase.className = 'dateline-case';
+    rightLineCase.className = 'dateline-case';
     const leftTextCase = document.createElement('div');
     const rightTextCase = document.createElement('div');
     const height = 0;
@@ -382,7 +381,7 @@ export default function mapDateLineBuilder(models, config, store, ui) {
    * @method drawOverlay
    * @private
    *
-   * @param {Array} coodinate
+   * @param {Array} coordinate
    * @param {Object} el - DOM object to be append to overlay
    *
    * @returns {void}
@@ -394,27 +393,6 @@ export default function mapDateLineBuilder(models, config, store, ui) {
     });
     overlay.setPosition(coordinate);
     return overlay;
-  };
-
-  /*
-   * Check if YYYY-MM-DD changed or a subdaily drag occurred
-   *  to determine if new date lines are needed
-   *
-   * @method compareDateStrings
-   * @private
-   *
-   * @param {object} date
-   *
-   * @sets {string} self.date - if new date
-   * @returns {boolean}
-   */
-  const compareDateStrings = (date) => {
-    const dateString = date.toISOString().split('T')[0];
-    if (dateString !== self.date) {
-      self.date = dateString;
-      return true;
-    }
-    return false;
   };
 
   return self;

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -73,7 +73,7 @@ export default function mapui(models, config, store, ui) {
   const animationDuration = 250;
   const self = {};
   let cache;
-  const dateline = mapDateLineBuilder(models, config, store, ui);
+  const dateline = mapDateLineBuilder(store);
   const precache = mapPrecacheTile(models, config, cache, self);
   const compareMapUi = mapCompare(store);
   const dataRunner = self.runningdata = new MapRunningData(
@@ -998,7 +998,7 @@ export default function mapui(models, config, store, ui) {
       map.addInteraction(rotateInteraction);
       map.addInteraction(mobileRotation);
     } else if (proj.id === 'geographic') {
-      dateline.init(self, map, dateSelected);
+      dateline.init(map, dateSelected);
     }
 
     const onRotate = () => {


### PR DESCRIPTION
## Description

Fixes #3609  .

- [x] Reduce dateline svg el footprint, allow click through to event icons
- [x] Prevent sidebar A/B tabs from overflowing to new line (need to zoom browser pretty far ~25% to see)
- [x] Update dateline format to YYYY-MMM-DD
- [x] Cleanup dateline to remove unused models, fix compare conditional to use `+/- 1 day` for compare mode


## How To Test

Easier to test in `develop` with historical events available, but can reproduce in PROD as well. Compare against current SIT.

1. http://localhost:3000/?v=-218.64087006716454,-46.96523722501313,-143.97901446764405,4.072876212918366&e=true&efs=true&efd=2015-03-16,2021-07-14&efc=severeStorms&t=2021-06-29-T15%3A20%3A31Z
2. Hover over dateline and line up dateline text over an event icon on map
3. Try to click event icon


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
