### PR TITLE
Don't show notifications in info menu if there are none available

### DIFF
--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -44,7 +44,7 @@ module.exports = {
     c.assert.containsText(infoMenu, 'Notifications');
     c.expect.element(notificationsListItem).to.be.present;
   },
-  'Verify that layer notices don\'t show up in the nofication list or contribute to the count': function(c) {
+  'Verify that layer notices don\'t show up in the notification list or contribute to the count': function(c) {
     c.waitForElementVisible('#notifications_info_item', TIME_LIMIT);
     c.expect.element('span.badge').to.be.present;
     c.assert.containsText('span.badge', '3');
@@ -65,7 +65,7 @@ module.exports = {
       'This is a message test',
     );
   },
-  'Verify that the user is only alerted if he has not already stored all items in localStorage': function(c) {
+  'Verify that the user is only alerted if they have not already stored all items in localStorage': function(c) {
     c.click('#notification_list_modal .close')
       .pause(500);
     c.waitForElementVisible(infoButtonIcon, TIME_LIMIT);

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -35,7 +35,7 @@ function InfoList (props) {
   } = props;
 
   function getNotificationListItem() {
-    const { number, type, object } = notifications;
+    const { numberUnseen, type, object } = notifications;
     return {
       text: 'Notifications',
       iconClass: 'ui-icon',
@@ -45,10 +45,10 @@ function InfoList (props) {
           ? 'exclamation-circle'
           : ['fas', 'bolt'],
       id: 'notifications_info_item',
-      badge: number,
+      badge: numberUnseen,
       className: type ? `${type}-notification` : '',
       onClick: () => {
-        notificationClick(object, number);
+        notificationClick(object, numberUnseen);
       },
     };
   }
@@ -135,7 +135,7 @@ function InfoList (props) {
         arr.splice(1, 0, getExploreWorldviewObj());
       }
     }
-    if (notifications.isActive) {
+    if (notifications.isActive && notifications.number > 0) {
       arr.splice(4, 0, getNotificationListItem());
     }
     arr.push(getDistractionFreeObj());
@@ -171,13 +171,13 @@ const mapDispatchToProps = (dispatch) => ({
       dispatch(initFeedback());
     }
   },
-  notificationClick: (obj, num) => {
+  notificationClick: (obj, numberUnseen) => {
     dispatch(
       openCustomContent('NOTIFICATION_LIST_MODAL', {
         headerText: 'Notifications',
         bodyComponent: Notifications,
         onClose: () => {
-          if (num > 0) {
+          if (numberUnseen > 0) {
             dispatch(notificationsSeen());
             addToLocalStorage(obj);
           }

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -22,9 +22,6 @@ import {
   requestNotifications,
   setNotifications,
 } from '../modules/notifications/actions';
-import {
-  REQUEST_NOTIFICATIONS,
-} from '../modules/notifications/constants';
 import { clearCustoms, refreshPalettes } from '../modules/palettes/actions';
 import { clearRotate, refreshRotation } from '../modules/map/actions';
 import {
@@ -471,7 +468,7 @@ const mapDispatchToProps = (dispatch) => ({
   }),
   requestNotifications: (location) => {
     const promise = dispatch(
-      requestNotifications(location, REQUEST_NOTIFICATIONS, 'json'),
+      requestNotifications(location),
     );
     promise.then((data) => {
       const obj = JSON.parse(data);

--- a/web/js/modules/notifications/actions.js
+++ b/web/js/modules/notifications/actions.js
@@ -5,7 +5,7 @@ import {
   NOTIFICATIONS_SEEN,
 } from './constants';
 
-export function requestNotifications(location, type) {
+export function requestNotifications(location) {
   return (dispatch) => requestAction(dispatch, REQUEST_NOTIFICATIONS, location);
 }
 export function setNotifications(array) {

--- a/web/js/modules/notifications/actions.test.js
+++ b/web/js/modules/notifications/actions.test.js
@@ -30,7 +30,7 @@ describe('Notification fetch action', () => {
     ];
     const store = mockStore({ notifications: {} });
     return store
-      .dispatch(actions.requestNotifications(loc, 'application/json'))
+      .dispatch(actions.requestNotifications(loc))
       .then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -49,7 +49,7 @@ describe('Notification fetch action', () => {
     ];
     const store = mockStore({ shortLink: {} });
     return store
-      .dispatch(actions.requestNotifications(loc, 'application/json'))
+      .dispatch(actions.requestNotifications(loc))
       .catch(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
@@ -57,7 +57,7 @@ describe('Notification fetch action', () => {
 });
 describe('Notification post-request actions', () => {
   test(
-    `setNotication action returns ${
+    `setNotification action returns ${
       constants.SET_NOTIFICATIONS
     } action type with array`,
     () => {

--- a/web/js/modules/notifications/reducers.js
+++ b/web/js/modules/notifications/reducers.js
@@ -12,6 +12,7 @@ import {
 
 export const notificationReducerState = {
   number: null,
+  numberUnseen: null,
   type: '',
   isActive: false,
   object: {},
@@ -30,6 +31,7 @@ export function notificationsReducer(state = notificationReducerState, action) {
         return {
           ...state,
           number: getCount(notificationsByType),
+          numberUnseen: getCount(notificationsByType, true),
           type: getPriority(notificationsByType),
           isActive: true,
           object: notificationsByType,
@@ -40,7 +42,7 @@ export function notificationsReducer(state = notificationReducerState, action) {
     case NOTIFICATIONS_SEEN:
       return {
         ...state,
-        number: null,
+        numberUnseen: null,
         type: '',
         isActive: true,
       };

--- a/web/js/modules/notifications/reducers.test.js
+++ b/web/js/modules/notifications/reducers.test.js
@@ -53,6 +53,7 @@ describe('notificationsReducer', () => {
         }),
       ).toEqual({
         number: 1,
+        numberUnseen: 1,
         type: 'outage',
         isActive: true,
         object: constants.MOCK_SORTED_NOTIFICATIONS,
@@ -69,6 +70,7 @@ describe('notificationsReducer', () => {
         }),
       ).toEqual({
         number: null,
+        numberUnseen: null,
         type: '',
         isActive: true,
         object: {},

--- a/web/js/modules/notifications/util.js
+++ b/web/js/modules/notifications/util.js
@@ -80,20 +80,25 @@ export function getPriority(sortedNotifications) {
 }
 
 /**
- * Gets a total count of the unseen notifications
- * @function getCounts
+ * Gets a total count of the notifications - excluding layerNotices
+ * @function getCount
  * @private
+ * @param {boolean} unseenOnly - count only unseen notifications
  * @returns {Number}
  */
-export function getCount(notifications) {
+export function getCount(notifications, unseenOnly) {
   const {
     messages, outages, alerts,
   } = notifications;
-  const messageCount = getNumberOfTypeNotSeen(NOTIFICATION_MSG, messages);
-  const alertCount = getNumberOfTypeNotSeen(NOTIFICATION_ALERT, alerts);
-  const outageCount = getNumberOfTypeNotSeen(NOTIFICATION_OUTAGE, outages);
 
-  return messageCount + outageCount + alertCount;
+  if (unseenOnly) {
+    const messageCount = getNumberOfTypeNotSeen(NOTIFICATION_MSG, messages);
+    const alertCount = getNumberOfTypeNotSeen(NOTIFICATION_ALERT, alerts);
+    const outageCount = getNumberOfTypeNotSeen(NOTIFICATION_OUTAGE, outages);
+
+    return messageCount + outageCount + alertCount;
+  }
+  return messages.length + alerts.length + outages.length;
 }
 
 export function addToLocalStorage({ messages, outages, alerts }) {


### PR DESCRIPTION
## Description

Fixes #3604  .

- [X] Notifications don't appear in the info menu if there aren't any notifications
- [X] Differentiate state `number` for total available notifications and `numberUnseen` for badge

## How To Test

1. See no notifications in info menu
2. http://localhost:3000/?mockAlerts=all_types  to confirm notifications show (may need to clear localstorage)

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
