### PR TITLE
Remove anim event condition that prevent vector style update

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -760,8 +760,7 @@ export default function mapui(models, config, store, ui) {
    */
   const updateDate = self.updateDate = function() {
     const state = store.getState();
-    const { embed, events, compare } = state;
-    const { isAnimatingToEvent } = events;
+    const { embed, compare } = state;
     let activeLayers = getAllActiveLayers(state);
     let layerGroups;
     let layerGroup;
@@ -806,7 +805,7 @@ export default function mapui(models, config, store, ui) {
           .getLayers()
           .setAt(index, createLayer(def, { previousLayer: layerValue ? layerValue.wv : null }));
       }
-      if (!isAnimatingToEvent && config.vectorStyles && def.vectorStyle && def.vectorStyle.id) {
+      if (config.vectorStyles && def.vectorStyle && def.vectorStyle.id) {
         const { vectorStyles } = config;
         let vectorStyleId;
 


### PR DESCRIPTION
## Description

Fixes #3625  .

- [X] Remove anim event condition that prevent vector style update

Could not reproduce original issue that prompted adding the anim event condition, so appears safe to revert.

## How To Test

1. Pick fire event, select another fire event within same view and note no style issue with vector points

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
