### PR TITLE
Throw error when measurement names dont match

### DIFF
--- a/web/js/components/layer/product-picker/browse/category-cell.js
+++ b/web/js/components/layer/product-picker/browse/category-cell.js
@@ -17,6 +17,13 @@ const CategoryCell = (props) => {
     }
     : {};
 
+  const checkForSources = (measurement) => {
+    if (measurementConfig[measurement]) {
+      return hasMeasurementSource(measurementConfig[measurement]);
+    }
+    throw new Error(`No measurement config entry for "${measurement}".`);
+  };
+
   return (
     <div
       key={category.id}
@@ -36,7 +43,7 @@ const CategoryCell = (props) => {
           </h3>
           <ul>
             {category.measurements
-              .filter((measurement) => hasMeasurementSource(measurementConfig[measurement]))
+              .filter(checkForSources)
               .slice(0, 7)
               .map((measurement, index) => {
                 const current = measurementConfig[measurement];

--- a/web/js/modules/product-picker/format-config.js
+++ b/web/js/modules/product-picker/format-config.js
@@ -1,6 +1,7 @@
 import {
   forEach as lodashForEach,
   map as lodashMap,
+  get as lodashGet,
 } from 'lodash';
 import moment from 'moment';
 import { available } from '../layers/selectors';
@@ -51,7 +52,10 @@ function setCategoryFacetProps (layers, measurements, categories) {
         return;
       }
       (subCategoryObj.measurements || []).forEach((measureKey) => {
-        const { sources } = measurements[measureKey];
+        const sources = lodashGet(measurements, `[${measureKey}].sources`);
+        if (!sources) {
+          throw new Error(`No measurement config entry for "${measureKey}".`);
+        }
         lodashForEach(sources, ({ settings = [] }) => {
           settings.forEach((id) => {
             setLayerProp(layers[id], 'categories', subCategoryKey);


### PR DESCRIPTION
## Description

Fixes #2141

A measurement name that doesn't match up will throw a descriptive error when opening the Product Picker.

## To test

1. Change "Dust" on line 3 of `config/default/common/config/wv.json/measurements/Dust.json` to "Dust score"
2. `npm run build:config`
3. Load the app
4. Open the product picker
5. See descriptive error
6. Revert changes to configs
7. Change "Dust" on line 12 of `config/default/common/config/wv.json/categories/hazards_and_disasters/Dust Storms.json` to "Dust Score"
8. `npm run build:config`
9. Load the app
10. Open the product picker
11. See descriptive error

