### PR TITLE
Add height for events sidebar top tabs, add pause for ff fail test

### DIFF
--- a/e2e/features/notifications/notify-test.js
+++ b/e2e/features/notifications/notify-test.js
@@ -89,6 +89,7 @@ module.exports = {
   'Verify that warning shows in the product picker category/measurement rows': function(c) {
     c.click(addLayers);
     c.waitForElementVisible(categoriesNav, TIME_LIMIT);
+    c.pause(500);
     c.click('#layer-category-item-air-quality-corrected-reflectance');
     c.moveToElement('#checkbox-case-MODIS_Aqua_CorrectedReflectance_TrueColor', 2, 2);
     c.waitForElementVisible(tooltipSelector, TIME_LIMIT);

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -255,7 +255,7 @@ class Sidebar extends React.Component {
     const maxHeight = isCollapsed
       ? '0'
       : isEmbedModeActive
-        ? '70vh'
+        ? '95vh'
         : `${screenHeight}px`;
     return (
       <ErrorBoundary>


### PR DESCRIPTION
## Description

Fixes #3637  .

- [x] Add height for events sidebar to accommodate events tabs from being cut off 
- [x] Add pause for firefox failing e2e test

[If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]

## How To Test

[Provide whatever information a reviewer might need to know in order to verify that the changes made in this PR are working as expected. If there are special build steps that need to be taken in order to get these changes to run (building while on a separate branch, running `npm ci`, etc) include them here.]

- For bugfixes: What steps need to be taken in the UI to verify the bug is fixed?
- For enhancements and features: What is the expected functionality being added/modified? How can a reviewer verify this?

1. Open with these URL parameters
2. ...
3. Verify expected result


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
