### PR TITLE
Google translate timeline break

### DIFF
--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1187,7 +1187,7 @@ class Timeline extends React.Component {
 
                     {!isTimelineHidden
                       && (
-                      <div id="timeline-footer">
+                      <div id="timeline-footer" className="notranslate">
                         {/* Axis */}
                         <TimelineAxis
                           axisWidth={axisWidth}


### PR DESCRIPTION
## Description
The app breaks when good translate is applied and someone interacts with the timeline
Fixes #3644

- [x] Disable translate of timeline footer


[If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]

## How To Test

[Provide whatever information a reviewer might need to know in order to verify that the changes made in this PR are working as expected. If there are special build steps that need to be taken in order to get these changes to run (building while on a separate branch, running `npm ci`, etc) include them here.]

- For bugfixes: What steps need to be taken in the UI to verify the bug is fixed?
- For enhancements and features: What is the expected functionality being added/modified? How can a reviewer verify this?

1. Open up the app
2. Switch to another language in chrome (e.g. Spanish)
3. drag timeline Luxor
4. see error


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview

## Additional Info
This fix only fixes the the timeline issue. There are numerous style issues applied when someone translates to another language. We may or may not want to address these style issues. If we do, let's open a new ticket.
