### PR TITLE
Add imageDownload param config override for GIF

### DIFF
--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -26,6 +26,7 @@ import getImageArray from '../modules/animation/selectors';
 import { getStampProps, svgToPng } from '../modules/animation/util';
 import { changeCropBounds } from '../modules/animation/actions';
 
+const DEFAULT_URL = 'http://localhost:3002/api/v1/snapshot';
 const gifStream = new GifStream();
 
 class GIF extends Component {
@@ -386,11 +387,15 @@ function mapStateToProps(state) {
   const increment = customSelected
     ? `${customDelta} ${timeScaleFromNumberKey[customInterval]}`
     : `1 ${timeScaleFromNumberKey[interval]}`;
-  let url = 'http://localhost:3002/api/v1/snapshot';
+  let url = DEFAULT_URL;
   if (config.features.imageDownload && config.features.imageDownload.url) {
     url = config.features.imageDownload.url;
+  }
+  if ('imageDownload' in config.parameters) {
+    url = config.parameters.imageDownload;
     util.warn(`Redirecting GIF download to: ${url}`);
   }
+
   return {
     screenWidth,
     screenHeight,


### PR DESCRIPTION
## Description

Fixes #3657  .

- [x] Add imageDownload param config override for GIF

## How To Test

WVS_UAT_URL
1. http://localhost:3000/?imageDownload=WVS_UAT_URL/api/v1/snapshot
2. Create GIF, console shows override


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
