### PR TITLE
Add now button to timeline controls

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -57,8 +57,7 @@ To run tests for both browsers in sequence: `npm run e2e`.
 
 ### Developing new End to End Tests
 
-* When creating new tests you will likely want to work locally with a `chrome` or `Firefox` driver to expedite the development process.
-
+* When creating new tests you will likely want to work locally with a `Chrome` or `Firefox` driver to expedite the development process.
 * If there is a specific test that you would like to run, you can change the `files` variable found in `./e2e/browserstack.conf.js` to point directly to your test.
 * If there is a specific browser that you would like to test, you can specify which in `./e2e/environments.json`
 
@@ -70,9 +69,7 @@ To run tests for both browsers in sequence: `npm run e2e`.
 | `mockFutureLayer` | String | *`VIIRS_NOAA20_CorrectedReflectance_TrueColor,5D`*| Pass layer `id` and `futureTime` to be parsed and added to that layer on page load |
 | `mockSources` | String | *`20170530`* | Use the static JSON file with sources feeds found at mock/sources\_data.json-X |
 | `mockAlerts` | string | *`alert`*, *`message`*, *`outage`*, *`no_types`*, or *`all_types`* | Use a static JSON file by passing the notification type. Local sources can be found at mock/notify_{string}.json |
-| `modalView` | string | *`categories`*, *`measurements`*, or *`layers`* | Forces the 'Add Layers' modal to display categories, measurements, or layers. By default Arctic/Antarctic shows measurements and Geographic shows categories. |
 | `now` | date | *`YYYY-MM-DDThh:mm:ssZ`* | Overrides the current date and time. This can be accessed on `config.initialDate` or `state.date.appNow`. |
 | `showError` | boolean | *`true` or `false`* | If any value is specified, an error dialog will be shown on startup. |
-| `showSubdaily` | boolean | *`true` or `false`* | If any value is specified, the hour input, minute input and "minutes" timeline zoom option will be shown. |
 | `notificationURL` | string | `https://testing.url.com` | Overrides the notification URL found in the features.json configuration file. |
 | `imageDownload` | string | `https://wvs.earthdata.nasa.gov/api/v1/snapshot` | Overrides the image download URL

--- a/e2e/features/compare/compare-test.js
+++ b/e2e/features/compare/compare-test.js
@@ -62,7 +62,10 @@ module.exports = {
     const disableMessage = 'You must exit comparison mode to download data';
     c.assert.cssClassPresent(dataDownloadTabButton, 'disabled');
     c.assert.attributeContains(dataDownloadTabButton, 'aria-label', disableMessage);
-    c.assert.attributeContains(dataDownloadTabButton, 'title', disableMessage);
+    c.moveToElement('#download-sidebar-tab', 10, 10);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT, (e) => {
+      c.assert.containsText(tooltipSelector, disableMessage);
+    });
 
     // Clicking does not switch tabs
     c.click(dataDownloadTabButton);
@@ -79,7 +82,10 @@ module.exports = {
     c.expect.element('#wv-eventscontent').to.not.be.present;
     c.assert.cssClassPresent(eventsSidebarTabButton, 'disabled');
     c.assert.attributeContains(eventsSidebarTabButton, 'aria-label', disableMessage);
-    c.assert.attributeContains(eventsSidebarTabButton, 'title', disableMessage);
+    c.moveToElement('#events-sidebar-tab', 10, 10);
+    c.waitForElementVisible(tooltipSelector, TIME_LIMIT, (e) => {
+      c.assert.containsText(tooltipSelector, disableMessage);
+    });
   },
 
   'Removing layer removes correct layer from correct layer group': (c) => {

--- a/e2e/features/share/share-test.js
+++ b/e2e/features/share/share-test.js
@@ -41,7 +41,8 @@ module.exports = {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
     c.waitForElementVisible(shareToolbarButton, TIME_LIMIT);
     c.click(shareToolbarButton);
-    let date = new Date();
+    const minutesOffset = 40 * 60000; // 40 minutes
+    let date = new Date(new Date().getTime() - minutesOffset);
     if (date.getUTCHours() < 3) {
       date = new Date(date.getTime() - 86400000);
     }

--- a/e2e/features/timeline/date-selector-test.js
+++ b/e2e/features/timeline/date-selector-test.js
@@ -55,20 +55,27 @@ module.exports = {
   },
 
   // verify default right arrow disabled since loaded on current day
-  'Right timeline arrow will be disabled by default - unless past 00:00 UTC but before 04:00': (c) => {
+  'Right timeline arrow will be disabled by defaul': (c) => {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
-    // accomodate for config.initialDate past 00:00 UTC but before 04:00
-    if (new Date().getUTCHours() < 3) {
-      c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
-    } else {
-      c.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
-    }
+    c.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
+  },
+
+  // verify default not button disabled
+  'Now button will be disabled by default': (c) => {
+    reuseables.loadAndSkipTour(c, TIME_LIMIT);
+    c.assert.cssClassPresent('#now-button-group', 'button-disabled');
   },
 
   // verify valid right arrow enabled since NOT loaded on current day
   'Right timeline arrow will not be disabled': (c) => {
     c.url(c.globals.url + knownDate);
     c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
+  },
+
+  // verify now button enabled since NOT loaded on current day
+  'Now button will not be disabled': (c) => {
+    c.url(c.globals.url + knownDate);
+    c.assert.not.cssClassPresent('#now-button-group', 'button-disabled');
   },
 
   // verify date selector is populated with date YYYY-MON-DD
@@ -146,7 +153,6 @@ module.exports = {
     c.click('#right-arrow-group');
     c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
     c.click('#right-arrow-group');
-    c.assert.not.cssClassPresent('#right-arrow-group', 'button-disabled');
   },
 
   after: (c) => {

--- a/e2e/features/timeline/date-selector-test.js
+++ b/e2e/features/timeline/date-selector-test.js
@@ -60,7 +60,7 @@ module.exports = {
     c.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
   },
 
-  // verify default not button disabled
+  // verify default now button disabled
   'Now button will be disabled by default': (c) => {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
     c.assert.cssClassPresent('#now-button-group', 'button-disabled');
@@ -73,7 +73,7 @@ module.exports = {
   },
 
   // verify now button enabled since NOT loaded on current day
-  'Now button will not be disabled': (c) => {
+  'Now button will not be disabled if date is not on now': (c) => {
     c.url(c.globals.url + knownDate);
     c.assert.not.cssClassPresent('#now-button-group', 'button-disabled');
   },

--- a/e2e/features/timeline/date-selector-test.js
+++ b/e2e/features/timeline/date-selector-test.js
@@ -55,7 +55,7 @@ module.exports = {
   },
 
   // verify default right arrow disabled since loaded on current day
-  'Right timeline arrow will be disabled by defaul': (c) => {
+  'Right timeline arrow will be disabled by default': (c) => {
     reuseables.loadAndSkipTour(c, TIME_LIMIT);
     c.assert.cssClassPresent('#right-arrow-group', 'button-disabled');
   },

--- a/e2e/features/timeline/timeline-mobile-test.js
+++ b/e2e/features/timeline/timeline-mobile-test.js
@@ -28,7 +28,7 @@ module.exports = {
       c.assert.containsText(mobileDatePickerSelectBtn, '2013 MAR 15');
     });
   },
-  'date.mob.init.3b:After 3:00 UTC: right button is  disabled': (c) => {
+  'date.mob.init.3b:After 3:00 UTC: right button is disabled': (c) => {
     c.expect.element(nextDayArrowContainer).to.be.present;
     c.expect.element(`${nextDayArrowContainer}.button-disabled`).to.be.present;
   },

--- a/e2e/reuseables/selectors.js
+++ b/e2e/reuseables/selectors.js
@@ -13,7 +13,7 @@ module.exports = {
   gifResults: '.gif-results-dialog-case img',
   animationWidget: '#wv-animation-widget',
   animationButtonCase: '#timeline-header .animate-button',
-  animationButton: '#animate-button',
+  animationButton: '.animate-button',
 
   // sidebar, layers
   sidebarContainer: '#productsHolder',

--- a/web/css/about.css
+++ b/web/css/about.css
@@ -1,3 +1,7 @@
+#about_modal {
+  max-width: 692px;
+}
+
 .about-page {
   background-color: #282828;
   padding: 5px;
@@ -16,7 +20,7 @@
 .about-page div,
 .about-page li,
 .about-page p {
-  font-size: 16px;
+  font-size: 14px;
   line-height: 22px;
 }
 
@@ -34,6 +38,10 @@
 
 .about-page p {
   margin: 1.12em 0;
+  &:first-of-type {
+    display: inline-block;
+    margin-bottom: 0;
+  }
 }
 
 .about-page hr {
@@ -64,7 +72,10 @@
 
 .about-page .right {
   float: right;
-  margin: 0 1em 1em;
+  margin: 0.4em 0.2em 0;
+  &:last-of-type {
+    margin: 1.4em 0.2em 0;
+  }
 }
 
 .about-page .caption {
@@ -101,7 +112,13 @@
 .about-page .keyboard-shortcuts-table {
   width: 100%;
   margin-top: 20px;
+  thead tr th {
+    padding-bottom: 8px;
+  }
   tr {
+    &:not(:last-of-type) {
+      border-bottom: 1px solid #404040;
+    }
     :first-child {
       text-align: left;
     }
@@ -110,7 +127,7 @@
     }
   }
   td {
-    padding: 7px 0;
+    padding: 11px 0;
   }
   code {
     color: #f60;

--- a/web/css/anim.widget.css
+++ b/web/css/anim.widget.css
@@ -3,7 +3,7 @@
   bottom: 88px;
   z-index: 100;
   &.minimized {
-    bottom: 120px;
+    bottom: 83px;
     left: 10px;
   }
 }

--- a/web/css/reset.css
+++ b/web/css/reset.css
@@ -144,6 +144,7 @@ body {
 }
 
 .wv-content {
+  min-width: 320px;
   position: fixed;
   width: 100%;
   height: 100%;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -179,19 +179,31 @@ button:focus {
     -ms-filter: 'FlipH';
   }
 
+  & #now-button-group {
+    width: 34px;
+    height: 34px;
+    top: 2px;
+    & svg {
+      top: 0;
+      left: 3px;
+      margin: 0;
+    }
+  }
+
   & > .button-action-group:hover .arrow,
-  & #zoom-buttons-group .button-action-group:hover .arrow {
+  & #zoom-buttons-group .button-action-group:hover .arrow,
+  & #zoom-buttons-group .button-action-group:hover .circle {
     fill: #1a1a1a;
     fill-opacity: 1;
     stroke: none;
   }
   & > .button-action-group.button-disabled .arrow,
   & #zoom-buttons-group .button-disabled .arrow {
-    fill: #333;
+    fill: #4d4d4d;
   }
   & > .button-action-group.button-disabled:hover .arrow,
   & #zoom-buttons-group .button-disabled:hover .arrow {
-    fill: #333;
+    fill: #4d4d4d;
   }
 
   & #animate-button {
@@ -201,11 +213,12 @@ button:focus {
 
   & .animate-button {
     position: absolute;
-    height: 40px;
-    width: 50px;
-    top: 11px;
-    right: 24px;
-    padding-left: 3px;
+    height: 34px;
+    width: 37px;
+    top: 20px;
+    right: 4px;
+    padding-left: 4px;
+    padding-top: 5px;
   }
   & .animate-button:hover svg.wv-animate path {
     fill: #1a1a1a;
@@ -217,17 +230,16 @@ button:focus {
   & .animate-button.wv-disabled-button:hover {
     background-color: transparent;
   }
-  & .animate-button.wv-disabled-button:hover .wv-animate {
-    opacity: 0.5;
-    color: #fff;
-  }
-  & .animate-button.wv-disabled-button .wv-animate {
-    opacity: 0.5;
+  & .animate-button.wv-disabled-button svg.wv-animate path {
+    fill: #4d4d4d;
     pointer-events: none;
   }
 
   & .button-action-group svg path {
     fill: #fff;
+  }
+  & .button-action-group:hover svg path {
+    fill: #000;
   }
 }
 
@@ -458,7 +470,7 @@ button:focus {
   position: absolute;
   bottom: 100%;
   border-bottom: 8px solid transparent;
-  width: 100px;
+  width: 80px;
   z-index: 10;
 }
 
@@ -484,7 +496,7 @@ button:focus {
 
 .zoom-btn-active,
 .interval-btn-active {
-  width: 100%;
+  width: 80px;
   color: #ccc;
   font-size: 12px;
   line-height: 14px;
@@ -732,4 +744,8 @@ button:focus {
 
 .datepicker-navbar-btn:hover {
   background: #fff;
+}
+
+#timeline-header .button-action-group .now-btn-1:hover svg path {
+  fill: #1a1a1a;
 }

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -178,11 +178,10 @@ button:focus {
     filter: FlipH;
     -ms-filter: 'FlipH';
   }
-
-  & #now-button-group {
+  & .now-button-group {
     width: 34px;
     height: 34px;
-    top: 2px;
+    top: -1px;
     & svg {
       top: 0;
       left: 3px;
@@ -215,7 +214,7 @@ button:focus {
     position: absolute;
     height: 34px;
     width: 37px;
-    top: 20px;
+    top: 16px;
     right: 4px;
     padding-left: 4px;
     padding-top: 5px;
@@ -551,22 +550,20 @@ button:focus {
   border-color: #000;
 }
 
-#timeline-hide:hover .wv-timeline-hide,
-#timeline-layer-coverage-panel-handle:hover .timeline-layer-coverage-panel-handle-chevron {
-  background-position: -206px -63px;
+#timeline-hide:hover .wv-timeline-hide {
+  background-position: -206px -68px;
 }
 
 .wv-timeline-hide {
   display: block;
-  top: 18px;
   right: -5px;
   color: #fff;
   cursor: pointer;
   user-select: none;
-  height: 30px;
+  height: 21px;
   width: 30px;
   position: absolute;
-  background: url('../images/icon-sprite.svg') -206px -3px no-repeat;
+  background: url('../images/icon-sprite.svg') -206px -8px no-repeat;
   border-radius: 0;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
@@ -574,10 +571,12 @@ button:focus {
 }
 
 .wv-timeline-hide-double-chevron-left {
+  top: 26px;
   transform: rotate(90deg);
 }
 
 .wv-timeline-hide-double-chevron-right {
+  top: 22px;
   transform: rotate(270deg);
 }
 
@@ -614,6 +613,10 @@ button:focus {
 .timeline-layer-coverage-panel-handle-chevron-closed {
   top: -4px;
   margin-left: -14px;
+}
+
+#timeline-layer-coverage-panel-handle:hover .timeline-layer-coverage-panel-handle-chevron {
+  background-position: -206px -63px;
 }
 
 .dragger-container {
@@ -708,7 +711,7 @@ button:focus {
 }
 
 /* Mobile date change arrows */
-.mobile-date-change-arrows-btn {
+#timeline-header .mobile-date-change-arrows-btn {
   position: absolute;
   left: 120px;
   bottom: 10px;
@@ -719,8 +722,18 @@ button:focus {
   height: 44px;
   & .button-action-group {
     height: 44px;
+  }
+  & #left-arrow-group, #now-button-group {
     border-top-right-radius: 5px;
     border-bottom-right-radius: 5px;
+  }
+  & #now-button-group {
+    height: 44px;
+    width: 40px;
+    top: 0;
+    svg {
+      left: 18px;
+    }
   }
 }
 

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -151,19 +151,17 @@ button:focus {
 
   & .date-arrows:hover,
   & > .button-action-group:hover,
-  & #zoom-buttons-group .button-action-group:hover {
+  & .button-action-group:hover {
     background-color: #fff;
     cursor: pointer;
   }
   & > .button-action-group .button-disabled:hover,
-  & #zoom-buttons-group .button-disabled:hover {
+  & .button-disabled:hover {
     background-color: transparent;
     cursor: default;
   }
   & .button-action-group svg {
     position: absolute;
-  }
-  & #zoom-buttons-group .button-action-group svg {
     top: 50%;
     margin-top: -15px;
     left: 50%;
@@ -178,20 +176,17 @@ button:focus {
     filter: FlipH;
     -ms-filter: 'FlipH';
   }
-  & .now-button-group {
+  & #now-button-group {
     width: 34px;
     height: 34px;
-    top: -1px;
-    & svg {
-      top: 0;
-      left: 3px;
-      margin: 0;
+    top: -2px;
+    svg {
+      left: 15px;
     }
   }
 
   & > .button-action-group:hover .arrow,
-  & #zoom-buttons-group .button-action-group:hover .arrow,
-  & #zoom-buttons-group .button-action-group:hover .circle {
+  & #zoom-buttons-group .button-action-group:hover .arrow {
     fill: #1a1a1a;
     fill-opacity: 1;
     stroke: none;
@@ -204,20 +199,17 @@ button:focus {
   & #zoom-buttons-group .button-disabled:hover .arrow {
     fill: #4d4d4d;
   }
-
-  & #animate-button {
-    width: 100%;
-    height: 100%;
-  }
-
   & .animate-button {
     position: absolute;
     height: 34px;
     width: 37px;
     top: 16px;
     right: 4px;
-    padding-left: 4px;
-    padding-top: 5px;
+    & svg {
+      top: 5px;
+      left: 4px;
+      margin: 0;
+    }
   }
   & .animate-button:hover svg.wv-animate path {
     fill: #1a1a1a;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -438,7 +438,6 @@ button:focus {
 
 #current-interval {
   white-space: nowrap;
-  padding: 2px 6px;
 }
 
 .timeline-interval,
@@ -461,7 +460,7 @@ button:focus {
   position: absolute;
   bottom: 100%;
   border-bottom: 8px solid transparent;
-  width: 80px;
+  min-width: 90px;
   z-index: 10;
 }
 
@@ -487,7 +486,7 @@ button:focus {
 
 .zoom-btn-active,
 .interval-btn-active {
-  width: 80px;
+  width: 90px;
   color: #ccc;
   font-size: 12px;
   line-height: 14px;

--- a/web/js/components/about/about-page.js
+++ b/web/js/components/about/about-page.js
@@ -6,6 +6,10 @@ export default function AboutPage() {
 
     <Scrollbar style={{ height: 'calc(var(--vh, 1vh) * 100 - 200px)' }}>
       <div className="about-page">
+        <h1>
+          Welcome to @NAME@
+        </h1>
+
         <div className="right">
           <div className="caption">
             Version @BUILD_VERSION@
@@ -14,10 +18,6 @@ export default function AboutPage() {
             )
           </div>
         </div>
-
-        <h1>
-          Welcome to @NAME@
-        </h1>
 
         <p>
           This app from NASA&apos;s

--- a/web/js/components/about/about-page.js
+++ b/web/js/components/about/about-page.js
@@ -91,6 +91,16 @@ export default function AboutPage() {
                   {' '}
                   +
                   {' '}
+                  <code>T</code>
+                </td>
+                <td>Jump to today/now on the timeline</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>Shift</code>
+                  {' '}
+                  +
+                  {' '}
                   <code>D</code>
                 </td>
                 <td>Toggle distraction free mode</td>

--- a/web/js/components/layer/product-picker/search/layer-metadata-detail.js
+++ b/web/js/components/layer/product-picker/search/layer-metadata-detail.js
@@ -92,7 +92,7 @@ class LayerMetadataDetail extends React.Component {
     if (endDate) {
       endDateId = `${id}-endDate`;
       layerEndDate = util.parseDate(endDate);
-      if (layerEndDate <= util.today() && !inactive) {
+      if (layerEndDate <= util.now() && !inactive) {
         layerEndDate = 'Present';
       } else {
         layerEndDate = util.coverageDateFormatter('END-DATE', endDate, period);

--- a/web/js/components/sidebar/events-filter.js
+++ b/web/js/components/sidebar/events-filter.js
@@ -78,7 +78,7 @@ function EventFilterModalBody (props) {
     return msg;
   };
   const minDate = new Date('2000-01-01');
-  const maxDate = new Date();
+  const maxDate = util.now();
 
   return (
     <div className="events-filter">

--- a/web/js/components/sidebar/nav/nav-case.js
+++ b/web/js/components/sidebar/nav/nav-case.js
@@ -31,7 +31,7 @@ function NavCase (props) {
     label={
       isCompareMode
         ? 'You must exit comparison mode to download data'
-        : 'Data download'
+        : 'Data Download'
     }
     className={
       activeTab === 'download'
@@ -89,13 +89,13 @@ function NavCase (props) {
       {renderDataDownload()}
       <div className="toggleIconHolder">
         <UncontrolledTooltip placement="right" target="accordion-toggler-button">
-          Hide Sidebar
+          Hide sidebar
         </UncontrolledTooltip>
         <a
           id="accordion-toggler-button"
           className="accordionToggler atcollapse arrow"
           onClick={toggleSidebar}
-          aria-label="Hide Sidebar"
+          aria-label="Hide sidebar"
         />
       </div>
     </Nav>

--- a/web/js/components/sidebar/nav/nav-item.js
+++ b/web/js/components/sidebar/nav/nav-item.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { NavItem, NavLink } from 'reactstrap';
+import HoverTooltip from '../../util/hover-tooltip';
 
 const CustomNavItem = (props) => {
   const {
@@ -26,13 +27,18 @@ const CustomNavItem = (props) => {
       <NavLink
         disabled={isDisabled}
         aria-label={label}
-        title={label}
         className={className}
         id={tabId}
         onClick={() => onTabClick(id)}
       >
         <i className={`productsIcon selected ${iconClassName}`} />
         {text}
+        <HoverTooltip
+          isMobile={isMobile}
+          labelText={label}
+          target={tabId}
+          placement="top"
+        />
       </NavLink>
     </NavItem>
   );

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -141,7 +141,6 @@ class TimelineAxis extends Component {
       timelineEndDateLimit,
     } = this.props;
     const { wheelZoom } = this.state;
-
     let draggerDate = draggerSelected === 'selected' ? draggerTimeState : draggerTimeStateB;
 
     // update timescale axis focus
@@ -220,12 +219,12 @@ class TimelineAxis extends Component {
   * @desc main function to update axis scale, time range, grids tiles/text, dragger A/B positions, animation start/end draggers
   * @param {String} inputDate
   * @param {String} updatedTimeScale
-  * @param {Number} leftOffsetFixedCoeff
+  * @param {Number} leftOffsetFixedCoefficient
   * @param {Boolean} hoverChange
   * @param {String} previousTimeScale - limited use for hover timeScale change
   * @returns {void}
   */
-  updateScale = (inputDate, timeScale, leftOffsetFixedCoeff, hoverChange, previousTimeScale) => {
+  updateScale = (inputDate, timeScale, leftOffsetFixedCoefficient, hoverChange, previousTimeScale) => {
     const {
       dateA,
       dateB,
@@ -246,8 +245,8 @@ class TimelineAxis extends Component {
     const options = timeScaleOptions[timeScale].timeAxis;
     const { gridWidth } = options;
     const timelineAxisWidth = axisWidth;
-    const hoverLeftOffset = leftOffsetFixedCoeff
-      ? timelineAxisWidth * leftOffsetFixedCoeff
+    const hoverLeftOffset = leftOffsetFixedCoefficient
+      ? timelineAxisWidth * leftOffsetFixedCoefficient
       : leftOffset === 0
         ? timelineAxisWidth * 0.8
         : leftOffset;
@@ -255,8 +254,8 @@ class TimelineAxis extends Component {
     // visible tiles based on timeline axis width (screen/browser size dependent)
     const numberOfVisibleTiles = Number((timelineAxisWidth / gridWidth).toFixed(8));
     // grid overflow/cushion coefficient
-    const gridOverflowCoeff = 2.5;
-    let gridNumber = Math.floor(numberOfVisibleTiles * gridOverflowCoeff);
+    const gridOverflowCoefficient = 2.5;
+    let gridNumber = Math.floor(numberOfVisibleTiles * gridOverflowCoefficient);
     const dragSentinelChangeNumber = gridWidth * (Math.floor(numberOfVisibleTiles * 0.25) + 1);
     if (timeScale === 'year') {
       const endLimitYear = new Date(timelineEndDateLimit).getUTCFullYear() + 1;
@@ -268,7 +267,7 @@ class TimelineAxis extends Component {
       gridNumber = monthTotal;
     }
 
-    // this is the middle on the axis based on number of tiles determined from width of axis and gridwidth
+    // this is the middle on the axis based on number of tiles determined from width of axis and grid width
     // this is used to determine position and also to "reset" position after an axis drag has stopped
     // eslint-disable-next-line no-mixed-operators
     const midPoint = numberOfVisibleTiles / 2 * gridWidth - gridWidth * gridNumber / 2;
@@ -329,9 +328,9 @@ class TimelineAxis extends Component {
     const pixelsToAdd = diffStartAndZeroed / diffFactor;
 
     // offset grids needed since each zoom in won't be centered
-    const gridOffsetCoeff = 2.5;
+    const gridOffsetCoefficient = 2.5;
     const offSetGrids = Math.floor(hoverLeftOffset / gridWidth);
-    const offSetHalved = Math.floor(Math.floor(numberOfVisibleTiles * gridOffsetCoeff) / 2);
+    const offSetHalved = Math.floor(Math.floor(numberOfVisibleTiles * gridOffsetCoefficient) / 2);
     const offSetGridsDiff = offSetGrids - Math.floor(numberOfVisibleTiles / 2);
     let gridsToSubtract = offSetHalved + offSetGridsDiff;
     let gridsToAdd = offSetHalved - offSetGridsDiff;
@@ -521,7 +520,7 @@ class TimelineAxis extends Component {
   * @param {Number} draggerPosition
   * @param {Number} draggerPositionB
   * @param {Number} overDrag
-  * @returns {Object} output - return new time range and dragger visibilty/updated position
+  * @returns {Object} output - return new time range and dragger visibility/updated position
   * @returns {Array} output.currentTimeRange
   * @returns {Number} output.transformX
   * @returns {Boolean} output.draggerVisible
@@ -545,25 +544,25 @@ class TimelineAxis extends Component {
       isCompareModeActive,
       draggerSelected,
     } = this.props;
-    // get updated visible tiles with overdrag
+    // get updated visible tiles with over drag
     const updatedNumberOfVisibleTiles = Math.floor(numberOfVisibleTiles * 0.25);
     const overDragGrids = Math.ceil(overDrag / gridWidth);
-    const numVisibleTilesWithOverdrag = updatedNumberOfVisibleTiles + 1 + overDragGrids;
+    const numVisibleTilesWithOverDrag = updatedNumberOfVisibleTiles + 1 + overDragGrids;
     const newCurrentTimeRange = currentTimeRange;
     let timeRangeAdd;
     let transform;
     if (deltaX > 0) { // dragging right - exposing past dates
       const firstDateInRange = newCurrentTimeRange[0].rawDate;
-      timeRangeAdd = this.getTimeRangeArray(numVisibleTilesWithOverdrag, -1, firstDateInRange);
-      removeBackMultipleInPlace(newCurrentTimeRange, numVisibleTilesWithOverdrag);
+      timeRangeAdd = this.getTimeRangeArray(numVisibleTilesWithOverDrag, -1, firstDateInRange);
+      removeBackMultipleInPlace(newCurrentTimeRange, numVisibleTilesWithOverDrag);
       newCurrentTimeRange.unshift(...timeRangeAdd);
-      transform = transformX - numVisibleTilesWithOverdrag * gridWidth;
+      transform = transformX - numVisibleTilesWithOverDrag * gridWidth;
     } else { // dragging left - exposing future dates
       const lastDateInRange = newCurrentTimeRange[newCurrentTimeRange.length - 1].rawDate;
-      timeRangeAdd = this.getTimeRangeArray(-1, numVisibleTilesWithOverdrag, lastDateInRange);
-      removeFrontMultipleInPlace(newCurrentTimeRange, numVisibleTilesWithOverdrag);
+      timeRangeAdd = this.getTimeRangeArray(-1, numVisibleTilesWithOverDrag, lastDateInRange);
+      removeFrontMultipleInPlace(newCurrentTimeRange, numVisibleTilesWithOverDrag);
       newCurrentTimeRange.push(...timeRangeAdd);
-      transform = transformX + numVisibleTilesWithOverdrag * gridWidth;
+      transform = transformX + numVisibleTilesWithOverDrag * gridWidth;
     }
 
     // check if dragger is in between range and visible
@@ -701,6 +700,7 @@ class TimelineAxis extends Component {
    */
   checkDraggerMoveOrUpdateScale = (previousDate, isDraggerB) => {
     const {
+      appNow,
       dateA,
       dateB,
       draggerPosition,
@@ -734,7 +734,10 @@ class TimelineAxis extends Component {
     const rightEdgeOfVisibleAxis = axisWidth - 80;
     const isDraggerPositionWithinAxis = selectedDraggerPosition <= rightEdgeOfVisibleAxis
       && selectedDraggerPosition >= leftEdgeOfVisibleAxis;
-    const newDraggerWithinRangeCheck = isDraggerPositionWithinAxis && isDateWithinRange;
+    let newDraggerWithinRangeCheck = isDraggerPositionWithinAxis && isDateWithinRange;
+    if (new Date(backDate) > appNow && selectedDraggerTimeState === getISODateFormatted(appNow)) {
+      newDraggerWithinRangeCheck = false;
+    }
 
     return {
       withinRange: newDraggerWithinRangeCheck,
@@ -751,10 +754,10 @@ class TimelineAxis extends Component {
   * @returns {void}
   */
   updateScaleWithOffset = (date, timeScale, newDateInThePast) => {
-    const leftOffsetFixedCoeff = newDateInThePast
+    const leftOffsetFixedCoefficient = newDateInThePast
       ? 0.25
       : 0.75;
-    this.updateScale(date, timeScale, leftOffsetFixedCoeff);
+    this.updateScale(date, timeScale, leftOffsetFixedCoefficient);
   }
 
   // #### Drag/mouse handlers ####
@@ -826,7 +829,7 @@ class TimelineAxis extends Component {
 
     // handle horizontal scroll on x axis wheel event
     this.handleStartDrag();
-    // mutli-touch drag left
+    // multi-touch drag left
     if (e.deltaX > 0) {
       const scrollX = position - deltaChangeCoefficient;
       // cancel drag if exceeds axis leftBound and hitLeftBound flag hit
@@ -985,10 +988,10 @@ class TimelineAxis extends Component {
       // calculate position of touch click relative to front date
       const positionRelativeToFront = clientX - parentOffset - position - transformX - 2;
 
-      // determine approximate new dragger date and coefficient based on gridwidth
-      const gridWidthCoef = positionRelativeToFront / gridWidth;
-      const gridWidthCoefRemainder = gridWidthCoef - Math.floor(gridWidthCoef);
-      const draggerDateAdded = moment.utc(frontDate).add(Math.floor(gridWidthCoef), timeScale);
+      // determine approximate new dragger date and coefficient based on grid width
+      const gridWidthCoefficient = positionRelativeToFront / gridWidth;
+      const gridWidthCoefficientRemainder = gridWidthCoefficient - Math.floor(gridWidthCoefficient);
+      const draggerDateAdded = moment.utc(frontDate).add(Math.floor(gridWidthCoefficient), timeScale);
 
       // get ms time value
       const draggerDateAddedValue = new Date(draggerDateAdded).getTime();
@@ -1001,10 +1004,10 @@ class TimelineAxis extends Component {
           daysCount = draggerDateAdded.daysInMonth();
         }
         // days times milliseconds in day times remainder
-        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefRemainder;
+        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefficientRemainder;
         newDraggerTime = Math.floor(draggerDateAddedValue + remainderMilliseconds);
       } else { // known scaleMs (e.g. 86400000 for day)
-        newDraggerTime = draggerDateAddedValue + (diffZeroValues * gridWidthCoefRemainder);
+        newDraggerTime = draggerDateAddedValue + (diffZeroValues * gridWidthCoefficientRemainder);
       }
 
       // check other dragger visibility on update
@@ -1274,16 +1277,16 @@ class TimelineAxis extends Component {
       if (!diffZeroValues) {
         // calculate based on frontDate due to varying number of days per month and per year (leap years)
         const hoverLinePositionRelativeToFrontDate = leftOffset - midPoint - newTransformX;
-        const gridWidthCoef = hoverLinePositionRelativeToFrontDate / gridWidth;
-        const hoverTimeAdded = moment.utc(frontDate).add(gridWidthCoef, timeScale);
+        const gridWidthCoefficient = hoverLinePositionRelativeToFrontDate / gridWidth;
+        const hoverTimeAdded = moment.utc(frontDate).add(gridWidthCoefficient, timeScale);
         let daysCount;
         if (timeScale === 'year') {
           daysCount = hoverTimeAdded.isLeapYear() ? 366 : 365;
         } else if (timeScale === 'month') {
           daysCount = hoverTimeAdded.daysInMonth();
         }
-        const gridWidthCoefRemainder = gridWidthCoef - Math.floor(gridWidthCoef);
-        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefRemainder;
+        const gridWidthCoefficientRemainder = gridWidthCoefficient - Math.floor(gridWidthCoefficient);
+        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefficientRemainder;
         hoverTimeDate = getISODateFormatted(hoverTimeAdded.add(remainderMilliseconds));
       } else {
         // calculate based on known diffZeroValues (days, hours, minutes)
@@ -1306,7 +1309,7 @@ class TimelineAxis extends Component {
         ? timelineStartDateLimit
         : hoverTimeDate;
 
-    // parent update positioning and hovertime
+    // parent update positioning and hover time
     updatePositioningOnAxisStopDrag(updatePositioningArguments, hoverTimeDate);
   }
 
@@ -1531,6 +1534,7 @@ TimelineAxis.propTypes = {
   animationStartLocation: PropTypes.number,
   animEndLocationDate: PropTypes.object,
   animStartLocationDate: PropTypes.object,
+  appNow: PropTypes.object,
   axisWidth: PropTypes.number,
   backDate: PropTypes.string,
   dateA: PropTypes.string,

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -68,6 +68,7 @@ class TimelineAxis extends Component {
       draggerSelected,
       timeScale,
       isCompareModeActive,
+      isAnimatingToEvent,
       hasFutureLayers,
       hasSubdailyLayers,
       matchingTimelineCoverage,
@@ -82,6 +83,7 @@ class TimelineAxis extends Component {
 
     const checkForPropsUpdates = nextProps.axisWidth === axisWidth
       && nextProps.position === position
+      && nextProps.isAnimatingToEvent === isAnimatingToEvent
       && nextProps.dateA === dateA
       && nextProps.dateB === dateB
       && nextProps.draggerSelected === draggerSelected
@@ -134,6 +136,7 @@ class TimelineAxis extends Component {
       hasFutureLayers,
       onDateChange,
       isAnimationPlaying,
+      isAnimatingToEvent,
       isCompareModeActive,
       isTimelineDragging,
       draggerTimeState,
@@ -157,6 +160,11 @@ class TimelineAxis extends Component {
         updatedTimeScale: true,
       });
       this.updateScale(draggerDate, timeScale, leftOffset, true, prevProps.timeScale);
+    }
+
+    // update axis on finish animate to event
+    if (prevProps.isAnimatingToEvent && !isAnimatingToEvent) {
+      this.updateScale(draggerDate, timeScale, 0.5);
     }
 
     // update axis on browser width change
@@ -1553,6 +1561,7 @@ TimelineAxis.propTypes = {
   hoverTime: PropTypes.string,
   isAnimationDraggerDragging: PropTypes.bool,
   isAnimationPlaying: PropTypes.bool,
+  isAnimatingToEvent: PropTypes.bool,
   isCompareModeActive: PropTypes.bool,
   isDraggerDragging: PropTypes.bool,
   isTimelineDragging: PropTypes.bool,

--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -21,7 +21,7 @@ class AnimationButton extends PureComponent {
           >
             {labelText}
           </UncontrolledTooltip>
-          <FontAwesomeIcon icon="video" className="wv-animate" size="3x" />
+          <FontAwesomeIcon icon="video" className="wv-animate" size="2x" />
         </div>
       </div>
     );

--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -11,10 +11,11 @@ class AnimationButton extends PureComponent {
     const labelText = label || 'Set up animation';
     return (
       <div
+        onClick={clickAnimationButton}
         className={disabled ? `wv-disabled-button ${className}` : className}
         aria-label={labelText}
       >
-        <div id={buttonId} onClick={clickAnimationButton}>
+        <div id={buttonId}>
           <UncontrolledTooltip
             placement="top"
             target={buttonId}

--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -144,7 +144,7 @@ class DateChangeArrows extends PureComponent {
         >
           <HoverTooltip
             isMobile={isMobile}
-            labelText="Now"
+            labelText="Latest available date"
             placement="top"
             target="now-button-group"
           />

--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -84,6 +84,7 @@ class DateChangeArrows extends PureComponent {
       isMobile,
       leftArrowDisabled,
       rightArrowDisabled,
+      handleSelectNowButton,
     } = this.props;
     return (
       <div>
@@ -94,6 +95,7 @@ class DateChangeArrows extends PureComponent {
           onMouseDown={this.leftArrowDown}
           onMouseUp={this.leftArrowUp}
           onMouseLeave={this.leftArrowUp}
+          aria-disabled={leftArrowDisabled}
         >
           <HoverTooltip
             isMobile={isMobile}
@@ -116,6 +118,7 @@ class DateChangeArrows extends PureComponent {
           onMouseDown={this.rightArrowDown}
           onMouseUp={this.rightArrowUp}
           onMouseLeave={this.rightArrowUp}
+          aria-disabled={rightArrowDisabled}
         >
           <HoverTooltip
             isMobile={isMobile}
@@ -130,12 +133,34 @@ class DateChangeArrows extends PureComponent {
             />
           </svg>
         </div>
+
+        {/* NOW BUTTON */}
+        <div
+          className={`button-action-group ${rightArrowDisabled ? 'button-disabled' : ''}`}
+          id="now-button-group"
+          onClick={handleSelectNowButton}
+          aria-disabled={rightArrowDisabled}
+        >
+          <HoverTooltip
+            isMobile={isMobile}
+            labelText="Now"
+            placement="top"
+            target="now-button-group"
+          />
+          <svg height="30" width="30" viewBox="0 0 40 28">
+            <path
+              d="M 10.240764,0 24,15 10.240764,30 0,30 13.759236,15 0,0 10.240764,0 z M 26,30 26,0 34,0 34,30 z"
+              className="arrow arrow-now"
+            />
+          </svg>
+        </div>
       </div>
     );
   }
 }
 
 DateChangeArrows.propTypes = {
+  handleSelectNowButton: PropTypes.func,
   leftArrowDisabled: PropTypes.bool,
   leftArrowDown: PropTypes.func,
   leftArrowUp: PropTypes.func,

--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -151,7 +151,7 @@ class DateChangeArrows extends PureComponent {
           <svg height="30" width="30" viewBox="0 0 40 28">
             <path
               d="M 10.240764,0 24,15 10.240764,30 0,30 13.759236,15 0,0 10.240764,0 z M 26,30 26,0 34,0 34,30 z"
-              className="arrow arrow-now"
+              className="arrow"
             />
           </svg>
         </div>

--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -81,16 +81,17 @@ class DateChangeArrows extends PureComponent {
 
   render() {
     const {
+      handleSelectNowButton,
       isMobile,
       leftArrowDisabled,
+      nowButtonDisabled,
       rightArrowDisabled,
-      handleSelectNowButton,
     } = this.props;
     return (
       <div>
         {/* LEFT ARROW */}
         <div
-          className={`button-action-group ${leftArrowDisabled ? 'button-disabled' : ''}`}
+          className={`button-action-group${leftArrowDisabled ? ' button-disabled' : ''}`}
           id="left-arrow-group"
           onMouseDown={this.leftArrowDown}
           onMouseUp={this.leftArrowUp}
@@ -113,7 +114,7 @@ class DateChangeArrows extends PureComponent {
 
         {/* RIGHT ARROW */}
         <div
-          className={`button-action-group ${rightArrowDisabled ? 'button-disabled' : ''}`}
+          className={`button-action-group${rightArrowDisabled ? ' button-disabled' : ''}`}
           id="right-arrow-group"
           onMouseDown={this.rightArrowDown}
           onMouseUp={this.rightArrowUp}
@@ -136,10 +137,10 @@ class DateChangeArrows extends PureComponent {
 
         {/* NOW BUTTON */}
         <div
-          className={`button-action-group ${rightArrowDisabled ? 'button-disabled' : ''}`}
+          className={`button-action-group now-button-group${nowButtonDisabled ? ' button-disabled' : ''}`}
           id="now-button-group"
           onClick={handleSelectNowButton}
-          aria-disabled={rightArrowDisabled}
+          aria-disabled={nowButtonDisabled}
         >
           <HoverTooltip
             isMobile={isMobile}
@@ -165,6 +166,7 @@ DateChangeArrows.propTypes = {
   leftArrowDown: PropTypes.func,
   leftArrowUp: PropTypes.func,
   isMobile: PropTypes.bool,
+  nowButtonDisabled: PropTypes.bool,
   rightArrowDisabled: PropTypes.bool,
   rightArrowDown: PropTypes.func,
   rightArrowUp: PropTypes.func,

--- a/web/js/components/timeline/timeline-coverage/timeline-coverage.js
+++ b/web/js/components/timeline/timeline-coverage/timeline-coverage.js
@@ -67,6 +67,7 @@ class TimelineLayerCoveragePanel extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const {
+      appNow,
       activeLayers,
       isProductPickerOpen,
       isTimelineLayerCoveragePanelOpen,
@@ -84,8 +85,8 @@ class TimelineLayerCoveragePanel extends Component {
     const layersChange = !lodashIsEqual(updatedActiveLayers, this.state.activeLayers);
     const projectionChange = prevProps.projection !== projection;
     const toggleHiddenChange = prevState.shouldIncludeHiddenLayers !== shouldIncludeHiddenLayers;
-
-    if (projectionChange || toggleHiddenChange || layersChange) {
+    const appNowUpdated = prevProps.appNow !== appNow;
+    if (projectionChange || toggleHiddenChange || layersChange || appNowUpdated) {
       // update coverage including layer added/removed and option changes (active/inactive)
       this.setActiveLayers(updatedActiveLayers);
       this.addMatchingCoverageToTimeline(shouldIncludeHiddenLayers, updatedActiveLayers);

--- a/web/js/components/timeline/timeline-draggers/dragger-container.js
+++ b/web/js/components/timeline/timeline-draggers/dragger-container.js
@@ -190,10 +190,10 @@ class DraggerContainer extends PureComponent {
       // only need to calculate difference in time unit for varying timescales - month and year
       const diffZeroValues = options.scaleMs;
       if (!diffZeroValues) {
-        // calculate based on frontDate due to varying number of days per month and per year (leapyears)
+        // calculate based on frontDate due to varying number of days per month and per year (leap years)
         const draggerPositionRelativeToFrontDate = draggerWidth - 2 + newDraggerPosition - position - transformX;
-        const gridWidthCoef = draggerPositionRelativeToFrontDate / gridWidth;
-        const draggerDateAdded = moment.utc(frontDate).add(Math.floor(gridWidthCoef), timeScale);
+        const gridWidthCoefficient = draggerPositionRelativeToFrontDate / gridWidth;
+        const draggerDateAdded = moment.utc(frontDate).add(Math.floor(gridWidthCoefficient), timeScale);
 
         let daysCount;
         if (timeScale === 'year') {
@@ -201,8 +201,8 @@ class DraggerContainer extends PureComponent {
         } else if (timeScale === 'month') {
           daysCount = draggerDateAdded.daysInMonth();
         }
-        const gridWidthCoefRemainder = gridWidthCoef - Math.floor(gridWidthCoef);
-        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefRemainder;
+        const gridWidthCoefficientRemainder = gridWidthCoefficient - Math.floor(gridWidthCoefficient);
+        const remainderMilliseconds = daysCount * 86400000 * gridWidthCoefficientRemainder;
         newDraggerTime = draggerDateAdded.add(remainderMilliseconds);
       } else {
         const diffFactor = diffZeroValues / gridWidth;
@@ -214,6 +214,16 @@ class DraggerContainer extends PureComponent {
       if (isBetweenValidTimeline) {
         newDraggerTime = getISODateFormatted(newDraggerTime);
       } else {
+        const timelineEndDateLimitTime = new Date(timelineEndDateLimit).getTime();
+        // prevent over drag and set endDatePosition and time to timelineEndDateLimit
+        if (newDraggerTime > timelineEndDateLimitTime) {
+          const frontDateObj = moment.utc(frontDate);
+          const endDateLimitPositionFromFront = Math.abs(frontDateObj.diff(timelineEndDateLimit, timeScale, true) * gridWidth);
+          const endDatePosition = endDateLimitPositionFromFront + position - draggerWidth + transformX + 2;
+
+          updateDraggerDatePosition(timelineEndDateLimit, draggerSelected, endDatePosition, null, null, true);
+          return;
+        }
         return false;
       }
 

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -16,7 +16,6 @@ import {
   deselectEvent as deselectEventActionCreator,
 } from '../../modules/natural-events/actions';
 import { collapseSidebar } from '../../modules/sidebar/actions';
-import { selectDate } from '../../modules/date/actions';
 import { getSelectedDate } from '../../modules/date/selectors';
 import { toggleCustomContent } from '../../modules/modal/actions';
 import util from '../../util/util';
@@ -138,9 +137,6 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(selectEventActionCreator(id, dateStr));
     if (shouldCollapse) {
       dispatch(collapseSidebar());
-    }
-    if (dateStr) {
-      dispatch(selectDate(new Date(dateStr)));
     }
   },
   deselectEvent: () => {

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -148,19 +148,19 @@ function LayerRow (props) {
   const renderControls = () => {
     const { title } = names;
     const removeLayerBtnId = `close-${compareState}${encodedLayerId}`;
-    const removeLayerBtnTitle = 'Remove Layer';
+    const removeLayerBtnTitle = 'Remove layer';
 
     const layerOptionsBtnId = `layer-options-btn-${encodedLayerId}`;
-    const layerOptionsBtnTitle = 'View Options';
+    const layerOptionsBtnTitle = 'View options';
 
     const layerInfoBtnId = `layer-info-btn-${encodedLayerId}`;
-    const layerInfoBtnTitle = 'View Description';
+    const layerInfoBtnTitle = 'View description';
 
     return (
       <>
         <a
           id={removeLayerBtnId}
-          arira-label={removeLayerBtnTitle}
+          aria-label={removeLayerBtnTitle}
           className="button wv-layers-close"
           onClick={() => onRemoveClick(layer.id)}
         >
@@ -247,10 +247,10 @@ function LayerRow (props) {
       ? `${visibilityButtonClasses} layer-hidden`
       : `${visibilityButtonClasses} layer-enabled layer-visible`;
   const visibilityTitle = !isVisible && !isDisabled
-    ? 'Show Layer'
+    ? 'Show layer'
     : isDisabled
       ? getDisabledTitle(layer)
-      : 'Hide Layer';
+      : 'Hide layer';
   const visibilityIconClass = isDisabled
     ? 'ban'
     : !isVisible

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -183,7 +183,7 @@ class Timeline extends React.Component {
     // appNow will not update if set in query string using 'now' parameter
     if (!nowOverride) {
       this.checkAndUpdateAppNow = this.checkAndUpdateAppNow.bind(this);
-      this.appNowUpdateInterval = setInterval(this.checkAndUpdateAppNow, 60000 * 15);
+      this.appNowUpdateInterval = setInterval(this.checkAndUpdateAppNow, 60000 * 10);
     }
     this.setInitialState();
   }
@@ -222,10 +222,8 @@ class Timeline extends React.Component {
       }
     }
 
-    // if user adds a subdaily layer (and none were active) adjust the time backwards if needed
-    // and change the time scale to hourly
+    // if user adds a subdaily layer (and none were active) change the time scale to hourly
     if (hasSubdailyLayers && !prevProps.hasSubdailyLayers) {
-      this.moveSelectedDateBackwards();
       this.changeTimeScale(4);
     }
 
@@ -865,21 +863,6 @@ class Timeline extends React.Component {
   }
 
   /**
-   * If a user adds a subdaily layer and the current selected time is too recent
-   * it is likely they will see no layer content. Here we are moving the selected time
-   * backwards for them to attempt to avoid this scenario
-   */
-  moveSelectedDateBackwards() {
-    const { selectedDate } = this.props;
-    const fortyMinutes = 40 * 60000;
-    const now = Date.now();
-    const isRecent = Math.abs(now - selectedDate.getTime()) < fortyMinutes;
-    if (isRecent) {
-      this.onDateChange(now - fortyMinutes);
-    }
-  }
-
-  /**
   * @desc update dragger time state
   * @param {String} date
   * @param {Boolean} is dragger B selected to update
@@ -927,7 +910,7 @@ class Timeline extends React.Component {
     };
 
     ensureCanUpdate().then(() => {
-      updateAppNow(new Date());
+      updateAppNow(util.now());
     });
   }
 
@@ -1765,6 +1748,7 @@ const getTimelineEndDateLimit = (state) => {
   }
 
   let timelineEndDateLimit;
+  console.log(layerDateRange && layerDateRange.end > appNow);
   if (layerDateRange && layerDateRange.end > appNow) {
     const layerDateRangeEndRoundedQuarterHour = util.roundTimeQuarterHour(layerDateRange.end);
     const appNowRoundedQuarterHour = util.roundTimeQuarterHour(appNow);

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1027,6 +1027,7 @@ class Timeline extends React.Component {
       hasSubdailyLayers,
       hideTimeline,
       isAnimationPlaying,
+      isAnimatingToEvent,
       isAnimationWidgetOpen,
       isCompareModeActive,
       isDataDownload,
@@ -1235,6 +1236,7 @@ class Timeline extends React.Component {
                           hasSubdailyLayers={hasSubdailyLayers}
                           isCompareModeActive={isCompareModeActive}
                           isAnimationPlaying={isAnimationPlaying}
+                          isAnimatingToEvent={isAnimatingToEvent}
                           isTourActive={isTourActive}
                           isAnimationDraggerDragging={isAnimationDraggerDragging}
                           isDraggerDragging={isDraggerDragging}
@@ -1384,6 +1386,7 @@ function mapStateToProps(state) {
     compare,
     config,
     date,
+    events,
     embed,
     layers,
     map,
@@ -1411,6 +1414,7 @@ function mapStateToProps(state) {
   const { isDistractionFreeModeActive } = ui;
   const { isEmbedModeActive } = embed;
   const isMobile = browser.lessThan.medium;
+  const { isAnimatingToEvent } = events;
 
   // handle active layer filtering and check for subdaily
   const activeLayers = getActiveLayers(state);
@@ -1489,6 +1493,7 @@ function mapStateToProps(state) {
     hasSubdailyLayers,
     customSelected,
     isCompareModeActive,
+    isAnimatingToEvent,
     hasFutureLayers,
     dateA: getISODateFormatted(selected),
     dateB: getISODateFormatted(selectedB),
@@ -1601,6 +1606,7 @@ Timeline.propTypes = {
   hasSubdailyLayers: PropTypes.bool,
   hideTimeline: PropTypes.bool,
   isAnimationPlaying: PropTypes.bool,
+  isAnimatingToEvent: PropTypes.bool,
   isAnimationWidgetOpen: PropTypes.bool,
   isCompareModeActive: PropTypes.bool,
   isDataDownload: PropTypes.bool,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -976,7 +976,7 @@ class Timeline extends React.Component {
       screenWidth,
     } = this.props;
 
-    const isScreenWidthLessThan450 = screenWidth < 450;
+    const isScreenWidthLessThan484 = screenWidth < 484;
 
     // default positioning
     let mobileLeft = 190;
@@ -989,12 +989,12 @@ class Timeline extends React.Component {
     // 1) subdaily (mobile date picker width);
     // 2) screen width; and
     // 3) compare mode
-    if (hasSubdailyLayers && screenWidth >= 450) {
+    if (hasSubdailyLayers && screenWidth >= 484) {
       mobileLeft = 287;
       if (isEmbedModeActive) {
         mobileLeft = 210;
       }
-    } else if (isScreenWidthLessThan450) {
+    } else if (isScreenWidthLessThan484) {
       mobileLeft = isCompareModeActive ? 112 : 10;
       mobileBottom = 65;
       if (isEmbedModeActive) {
@@ -1035,6 +1035,7 @@ class Timeline extends React.Component {
       isMobile,
       isTourActive,
       leftArrowDisabled,
+      nowButtonDisabled,
       parentOffset,
       rightArrowDisabled,
       timelineCustomModalOpen,
@@ -1122,13 +1123,14 @@ class Timeline extends React.Component {
                       <div id="zoom-buttons-group">
                         <DateChangeArrows
                           handleSelectNowButton={this.handleSelectNowButton}
+                          isMobile={isMobile}
+                          leftArrowDisabled={leftArrowDisabled}
                           leftArrowDown={this.throttleDecrementDate}
                           leftArrowUp={this.stopLeftArrow}
-                          leftArrowDisabled={leftArrowDisabled}
-                          isMobile={isMobile}
+                          nowButtonDisabled={nowButtonDisabled}
+                          rightArrowDisabled={rightArrowDisabled}
                           rightArrowDown={this.throttleIncrementDate}
                           rightArrowUp={this.stopRightArrow}
-                          rightArrowDisabled={rightArrowDisabled}
                         />
                       </div>
                     </div>
@@ -1166,13 +1168,14 @@ class Timeline extends React.Component {
                         />
                         <DateChangeArrows
                           handleSelectNowButton={this.handleSelectNowButton}
+                          isMobile={isMobile}
+                          leftArrowDisabled={leftArrowDisabled}
                           leftArrowDown={this.throttleDecrementDate}
                           leftArrowUp={this.stopLeftArrow}
-                          leftArrowDisabled={leftArrowDisabled}
-                          isMobile={isMobile}
+                          nowButtonDisabled={nowButtonDisabled}
+                          rightArrowDisabled={rightArrowDisabled}
                           rightArrowDown={this.throttleIncrementDate}
                           rightArrowUp={this.stopRightArrow}
-                          rightArrowDisabled={rightArrowDisabled}
                         />
                       </div>
                       <AnimationButton
@@ -1472,6 +1475,10 @@ function mapStateToProps(state) {
     timeScaleChangeUnit,
     timelineEndDateLimit,
   );
+  const nowButtonDisabled = checkNowButtonDisabled(
+    selectedDate,
+    timelineEndDateLimit,
+  );
   return {
     appNow,
     activeLayers: activeLayersFiltered,
@@ -1500,6 +1507,7 @@ function mapStateToProps(state) {
     timelineEndDateLimit,
     leftArrowDisabled,
     rightArrowDisabled,
+    nowButtonDisabled,
     hideTimeline:
       (modal.isOpen && modal.id === 'TOOLBAR_SNAPSHOT') || animation.gifActive,
     animationDisabled:
@@ -1521,8 +1529,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(updateAppNow(date));
   },
   // sets date to NOW based on state.date.appNow
-  triggerTodayButton: (date) => {
-    dispatch(triggerTodayButton(date));
+  triggerTodayButton: () => {
+    dispatch(triggerTodayButton());
   },
   // changes date of active dragger 'selected' or 'selectedB'
   changeDate: (val) => {
@@ -1602,6 +1610,7 @@ Timeline.propTypes = {
   isMobile: PropTypes.bool,
   isTourActive: PropTypes.bool,
   leftArrowDisabled: PropTypes.bool,
+  nowButtonDisabled: PropTypes.bool,
   onUpdateEndDate: PropTypes.func,
   onUpdateStartAndEndDate: PropTypes.func,
   onUpdateStartDate: PropTypes.func,
@@ -1702,12 +1711,19 @@ const checkRightArrowDisabled = (
 ) => {
   const nextIncMoment = moment.utc(date).add(delta, timeScaleChangeUnit);
   const nextIncrementDate = new Date(nextIncMoment.seconds(0).format());
-  const maxPlusDeltaMoment = moment.utc(timelineEndDateLimit).add(delta, timeScaleChangeUnit);
-  const maxPlusDeltaDate = new Date(maxPlusDeltaMoment.seconds(0).format());
 
   const nextIncrementDateTime = nextIncrementDate.getTime();
-  const maxPlusDeltaDateTime = maxPlusDeltaDate.getTime();
-  return nextIncrementDateTime >= maxPlusDeltaDateTime;
+  const maxPlusDeltaDateTime = new Date(timelineEndDateLimit).getTime();
+  return nextIncrementDateTime > maxPlusDeltaDateTime;
+};
+
+const checkNowButtonDisabled = (
+  date,
+  timelineEndDateLimit,
+) => {
+  const dateTimeMoment = new Date(moment.utc(date).seconds(0).format());
+  const maxDateMoment = new Date(moment.utc(timelineEndDateLimit).seconds(0).format());
+  return dateTimeMoment.getTime() === maxDateMoment.getTime();
 };
 
 // get timelineEndDateLimit based on potential future layers

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -44,6 +44,7 @@ import {
   changeCustomInterval,
   updateAppNow,
   toggleCustomModal,
+  triggerTodayButton,
 } from '../../modules/date/actions';
 import {
   filterProjLayersWithStartDate,
@@ -958,6 +959,11 @@ class Timeline extends React.Component {
     this.debounceDateUpdate(dateObj, draggerSelected);
   }
 
+  handleSelectNowButton = () => {
+    const { triggerTodayButton } = this.props;
+    triggerTodayButton();
+  }
+
   /**
   * @desc getMobileDateButtonStyle date change button style for smaller displays
   * @returns {Object} style { left, bottom }
@@ -1115,6 +1121,7 @@ class Timeline extends React.Component {
                     >
                       <div id="zoom-buttons-group">
                         <DateChangeArrows
+                          handleSelectNowButton={this.handleSelectNowButton}
                           leftArrowDown={this.throttleDecrementDate}
                           leftArrowUp={this.stopLeftArrow}
                           leftArrowDisabled={leftArrowDisabled}
@@ -1133,6 +1140,7 @@ class Timeline extends React.Component {
                     <div
                       id="timeline-header"
                       className={`timeline-header-desktop ${hasSubdailyLayers ? 'subdaily' : ''}`}
+                      style={{ marginRight: isTimelineHidden ? '20px' : '0' }}
                     >
                       {/* Date Selector, Interval, Arrow Controls */}
                       <div id="date-selector-main">
@@ -1157,6 +1165,7 @@ class Timeline extends React.Component {
                           hasSubdailyLayers={hasSubdailyLayers}
                         />
                         <DateChangeArrows
+                          handleSelectNowButton={this.handleSelectNowButton}
                           leftArrowDown={this.throttleDecrementDate}
                           leftArrowUp={this.stopLeftArrow}
                           leftArrowDisabled={leftArrowDisabled}
@@ -1184,6 +1193,7 @@ class Timeline extends React.Component {
                       <div id="timeline-footer" className="notranslate">
                         {/* Axis */}
                         <TimelineAxis
+                          appNow={appNow}
                           axisWidth={axisWidth}
                           parentOffset={parentOffset}
                           leftOffset={leftOffset}
@@ -1510,6 +1520,10 @@ const mapDispatchToProps = (dispatch) => ({
   updateAppNow: (date) => {
     dispatch(updateAppNow(date));
   },
+  // sets date to NOW based on state.date.appNow
+  triggerTodayButton: (date) => {
+    dispatch(triggerTodayButton(date));
+  },
   // changes date of active dragger 'selected' or 'selectedB'
   changeDate: (val) => {
     dispatch(selectDate(val));
@@ -1604,6 +1618,7 @@ Timeline.propTypes = {
   timeScaleChangeUnit: PropTypes.string,
   toggleActiveCompareState: PropTypes.func,
   toggleCustomModal: PropTypes.func,
+  triggerTodayButton: PropTypes.func,
   updateAppNow: PropTypes.func,
 };
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -897,10 +897,9 @@ class Timeline extends React.Component {
             isTimelineDragging,
             isDraggerDragging,
             isAnimationDraggerDragging,
-            isTimelineLayerCoveragePanelOpen,
           } = self.state;
           const { isAnimationPlaying } = self.props;
-          const userIsInteracting = isArrowDown || isTimelineDragging || isDraggerDragging || isAnimationDraggerDragging || isTimelineLayerCoveragePanelOpen;
+          const userIsInteracting = isArrowDown || isTimelineDragging || isDraggerDragging || isAnimationDraggerDragging;
           if (!userIsInteracting && !isAnimationPlaying) {
             return resolve();
           }

--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -6,6 +6,7 @@ import { getInitialState as getInitialDateState } from './modules/date/reducers'
 import { defaultState as initialAnimationState } from './modules/animation/reducers';
 import { defaultAlertState } from './modules/alerts/reducer';
 import { getInitialEventsState } from './modules/natural-events/reducers';
+import util from './util/util';
 
 const fixtures = {
   red: 'ff0000ff',
@@ -209,10 +210,11 @@ fixtures.map = () => ({
 });
 
 fixtures.config = function() {
+  const now = util.now();
   return {
-    pageLoadTime: new Date(),
-    initialDate: new Date(),
-    now: new Date(),
+    pageLoadTime: now,
+    initialDate: now,
+    now,
     defaults: {
       projection: 'geographic',
       startingLayers: [

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -139,8 +139,8 @@ window.onload = () => {
       config.initialIsMobile = crs.innerWidth <= 768;
 
       config.pageLoadTime = parameters.now
-        ? util.parseDateUTC(parameters.now) || new Date()
-        : new Date();
+        ? util.parseDateUTC(parameters.now) || util.now()
+        : util.now();
 
       const pageLoadTime = new Date(config.pageLoadTime);
 

--- a/web/js/map/natural-events/natural-events.js
+++ b/web/js/map/natural-events/natural-events.js
@@ -112,7 +112,7 @@ class NaturalEvents extends React.Component {
        * for today, this may not help.
        */
       if (event.categories[0].title === 'Wildfires' && !isInitialLoad) {
-        const today = dateFormat(new Date());
+        const today = dateFormat(util.now());
         const yesterday = dateFormat(util.yesterday());
         if (date !== today || date !== yesterday) {
           selectDate(util.dateAdd(util.parseDateUTC(date), 'day', 1));

--- a/web/js/modules/animation/actions.test.js
+++ b/web/js/modules/animation/actions.test.js
@@ -70,7 +70,7 @@ describe('Open, play, stop, close and toggle actions', () => {
   );
 });
 describe('Animation Datechange actions', () => {
-  const now = new Date();
+  const now = util.now();
   const then = util.dateAdd(now, 'day', -7);
   test(
     `changeStartDate action returns ${

--- a/web/js/modules/animation/reducer.test.js
+++ b/web/js/modules/animation/reducer.test.js
@@ -3,7 +3,7 @@ import { defaultState, animationReducer } from './reducers';
 import * as CONSTANTS from './constants';
 import util from '../../util/util';
 
-const now = new Date();
+const now = util.now();
 const then = util.dateAdd(now, 'day', -7);
 
 test('OPEN_ANIMATION action updates active state', () => {

--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -23,7 +23,7 @@ export function triggerTodayButton() {
 
     const selectedDateTime = selectedDate.getTime();
     const appNowTime = appNow.getTime();
-    if (selectedDateTime < appNowTime) {
+    if (selectedDateTime !== appNowTime) {
       dispatch({
         type: SELECT_DATE,
         activeString,

--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -7,7 +7,29 @@ import {
   TOGGLE_CUSTOM_MODAL,
   INIT_SECOND_DATE,
 } from './constants';
+import { getSelectedDate } from './selectors';
 import { getMaxActiveLayersDate } from './util';
+
+export function triggerTodayButton() {
+  return (dispatch, getState) => {
+    const state = getState();
+    const {
+      date,
+      compare,
+    } = state;
+    const activeString = compare.isCompareA ? 'selected' : 'selectedB';
+    const selectedDate = getSelectedDate(state, activeString);
+    const { appNow } = date;
+
+    if (selectedDate < appNow) {
+      dispatch({
+        type: SELECT_DATE,
+        activeString,
+        value: appNow,
+      });
+    }
+  };
+}
 
 export function changeTimeScale(num) {
   return {

--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -21,7 +21,9 @@ export function triggerTodayButton() {
     const selectedDate = getSelectedDate(state, activeString);
     const { appNow } = date;
 
-    if (selectedDate < appNow) {
+    const selectedDateTime = selectedDate.getTime();
+    const appNowTime = appNow.getTime();
+    if (selectedDateTime < appNowTime) {
       dispatch({
         type: SELECT_DATE,
         activeString,

--- a/web/js/modules/date/actions.test.js
+++ b/web/js/modules/date/actions.test.js
@@ -16,6 +16,7 @@ import {
 } from './constants';
 import fixtures from '../../fixtures';
 import { addLayer, getLayers } from '../layers/selectors';
+import util from '../../util/util';
 
 const config = fixtures.config();
 function getState(layers) {
@@ -50,7 +51,7 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 // test variables
-const mockDate = new Date();
+const mockDate = util.now();
 const customInterval = 3;
 const delta = 5;
 const interval = 3;

--- a/web/js/modules/date/reducers.test.js
+++ b/web/js/modules/date/reducers.test.js
@@ -9,9 +9,10 @@ import {
   SELECT_DATE,
   UPDATE_APP_NOW,
 } from './constants';
+import util from '../../util/util';
 
 // test variables
-const mockDate = new Date();
+const mockDate = util.now();
 const selectedZoom = 2;
 
 describe('dateReducer', () => {

--- a/web/js/modules/date/util.js
+++ b/web/js/modules/date/util.js
@@ -149,6 +149,28 @@ export function getMaxActiveLayersDate(state) {
 }
 
 /**
+ * Checks if future time layer is within included layers
+ *
+ * @method checkHasFutureLayers
+ * @param  {Object} state
+ * @returns {Boolean} hasFutureLayers
+ */
+export function checkHasFutureLayers(state) {
+  const { compare, proj, layers } = state;
+  let hasFutureLayers;
+  if (compare.active) {
+    const compareALayersFiltered = filterProjLayersWithStartDate(layers.active.layers, proj.id);
+    const compareBLayersFiltered = filterProjLayersWithStartDate(layers.activeB.layers, proj.id);
+    hasFutureLayers = [...compareALayersFiltered, ...compareBLayersFiltered].filter((layer) => layer.futureTime).length > 0;
+  } else {
+    const activeLayers = getActiveLayers(state);
+    const activeLayersFiltered = filterProjLayersWithStartDate(activeLayers, proj.id);
+    hasFutureLayers = activeLayersFiltered.filter((layer) => layer.futureTime).length > 0;
+  }
+  return hasFutureLayers;
+}
+
+/**
  * Checks the date provided against the active layers.
  *
  * @method getLayersActiveAtDate

--- a/web/js/modules/key-press/actions.js
+++ b/web/js/modules/key-press/actions.js
@@ -1,6 +1,7 @@
 import { KEY_PRESS_ACTION as ANIMATION_KEY_PRESS_ACTION } from '../animation/constants';
 import { TOUR_KEY_PRESS_CLOSE } from '../tour/constants';
 import { TOGGLE_DISTRACTION_FREE_MODE } from '../ui/constants';
+import { triggerTodayButton } from '../date/actions';
 import { CLOSE as CLOSE_MODAL } from '../modal/constants';
 
 /**
@@ -24,7 +25,7 @@ export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey, isInput) {
     } = modal;
     const { isDistractionFreeModeActive } = ui;
     const isProductPickerOpen = isOpen && id === 'LAYER_PICKER_COMPONENT';
-    if (tour.active && keyCode === 27) {
+    if (tour.active && keyCode === 27) { // ESC
       dispatch({
         type: TOUR_KEY_PRESS_CLOSE,
       });
@@ -36,12 +37,16 @@ export default function keyPress(keyCode, shiftKey, ctrlOrCmdKey, isInput) {
           keyCode,
         });
       }
-      if (!isInput && !ctrlOrCmdKey && shiftKey && keyCode === 68) {
-        dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
-        if (!isDistractionFreeModeActive && isOpen) {
-          dispatch({ type: CLOSE_MODAL });
+      if (!isInput && !ctrlOrCmdKey && shiftKey) {
+        if (keyCode === 68) { // SHIFT D
+          dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
+          if (!isDistractionFreeModeActive && isOpen) {
+            dispatch({ type: CLOSE_MODAL });
+          }
+        } else if (keyCode === 84) { // SHIFT T
+          dispatch(triggerTodayButton());
         }
-      } else if (keyCode === 27) {
+      } else if (keyCode === 27) { // ESC
         if (!isInput && isDistractionFreeModeActive) {
           dispatch({ type: TOGGLE_DISTRACTION_FREE_MODE });
         } else {

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -328,7 +328,7 @@ function forGroup(group, spec = {}, activeLayers, state) {
  */
 export function getFutureLayerEndDate(layer) {
   const { futureTime } = layer;
-  const max = new Date();
+  const max = util.now();
   const dateType = futureTime.slice(-1);
   const dateInterval = futureTime.slice(0, -1);
 

--- a/web/js/modules/layers/selectors.test.js
+++ b/web/js/modules/layers/selectors.test.js
@@ -194,7 +194,7 @@ test('all layers are visible', () => {
   expect(layerList).toEqual(['aqua-cr', 'terra-cr', 'aqua-aod', 'terra-aod']);
 });
 
-// NOTE: Not currently using getLayers to retrive layers that are
+// NOTE: Not currently using getLayers to retrieve layers that are
 // specifically either visible or not visible
 
 // test('only visible layers', () => {
@@ -383,9 +383,9 @@ test('no date range with static', () => {
 test('get future layer end date is 5 days after mock current date', () => {
   const testLayer = { futureTime: '5D' };
   // current date floored to quarter hour
-  const currentDate = util.roundTimeQuarterHour(new Date());
-  // test date to comopare is floored to quarter hour and added 5 days using util
-  const testDate = util.dateAdd(util.roundTimeQuarterHour(new Date()), 'day', 5);
+  const currentDate = util.roundTimeQuarterHour(util.now());
+  // test date to compare is floored to quarter hour and added 5 days using util
+  const testDate = util.dateAdd(util.roundTimeQuarterHour(util.now()), 'day', 5);
   const futureEndDate = getFutureLayerEndDate(testLayer);
 
   const testDateMinutes = testDate.getUTCMinutes();

--- a/web/js/modules/natural-events/util.js
+++ b/web/js/modules/natural-events/util.js
@@ -161,7 +161,7 @@ export function getDefaultEventDate(event) {
   let date = new Date(preDate).toISOString().split('T')[0];
   if (event.geometry.length < 2) return date;
   const category = event.categories.title || event.categories[0].title;
-  const today = new Date().toISOString().split('T')[0];
+  const today = util.now().toISOString().split('T')[0];
   // For storms that happened today, get previous date
   if (date === today && category === 'Severe Storms') {
     [date] = new Date(event.geometry[1].date).toISOString().split('T');
@@ -171,7 +171,7 @@ export function getDefaultEventDate(event) {
 
 /**
  * Validate whether an event and all it's points/polygons fall within
- * the provded projection's maxExtent
+ * the provided projection's maxExtent
  *
  * @param {*} event
  * @param {*} proj

--- a/web/js/modules/product-picker/util.js
+++ b/web/js/modules/product-picker/util.js
@@ -1,4 +1,5 @@
 import safeLocalStorage from '../../util/local-storage';
+import util from '../../util/util';
 
 const { RECENT_LAYERS } = safeLocalStorage.keys;
 const MAX_RECENT_LAYERS = 20;
@@ -74,7 +75,7 @@ export function updateRecentLayers(layer, allProjections) {
 
     if (existingEntry) {
       existingEntry.count += 1;
-      existingEntry.dateAdded = new Date().valueOf();
+      existingEntry.dateAdded = util.now().valueOf();
     } else {
       if (layers.length === MAX_RECENT_LAYERS) {
         const [lowestCountLayer] = layers.sort((a, b) => a.count - b.count);
@@ -89,7 +90,7 @@ export function updateRecentLayers(layer, allProjections) {
       recentLayers[proj].push({
         id: layerId,
         count: 1,
-        dateAdded: new Date().valueOf(),
+        dateAdded: util.now().valueOf(),
       });
     }
   });

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -669,35 +669,28 @@ export default (function(self) {
   };
 
   /**
-   * Gets the current time. Use this instead of the Date methods to allow
-   * debugging alternate "now" times.
+   * Gets the current time minus minutesOffset for geostationary layers.
+   * Use this instead of the Date methods to allow debugging alternate "now" times.
    *
    * @method now
    * @static
    * @return {Date} The current time or an overridden value.
    */
-  const now = function() {
-    return new Date();
+  const minutesOffset = 40 * 60000; // 40 minutes
+  self.now = function() {
+    return new Date(new Date().getTime() - minutesOffset);
   };
-
-  self.now = now;
 
   /**
-   * Gets the current day. Use this instead of the Date methods to allow
-   * debugging alternate "now" dates.
+   * Gets now minus one day, minus minutesOffset minutes for geostationary layers.
    *
-   * @method today
+   * @method yesterday
    * @static
    * @return {Date} The current time with the UTC hours, minutes, and seconds
-   * fields set to zero or an overridden value.
    */
-  self.today = function() {
-    return self.now();
-  };
-
   self.yesterday = function() {
-    const now = new Date();
-    return new Date(now.setDate(now.getDate() - 1));
+    const nowDate = self.now();
+    return new Date(nowDate.setDate(nowDate.getDate() - 1));
   };
 
   /**


### PR DESCRIPTION
## Description

Fixes #3315  .

Main:
- [x] Add now button to timeline controls that selects the current `appNow` date.
- [x] Add `SHIFT-T` Now shortcut and update about page with shortcut.
- [x] Disable right arrow if less than selected interval (e.g., 1 day) available to advance in the future.
- [x] Add timeline dragger max date to end of timeline date to allow dragging dragger to exact timeline end date limit - at some point since it was calculated based on position/pixels this value could be floored so the dragger wasn't at the exact timeline end date limit.
- [x] Resize animation button to fit and polish various related timeline styles.

Note: 
- [x] The default app now date is set to 40 minutes prior to the current time to account for the geostationary latency. This allows the now button to be used with geostationary layers and retrieve the most updated imagery as expected.
- [x] Future time layers will allow future layer coverage, but `appNow` will still adhere to now (i.e., new Date() minus 40 minutes), so the timeline dragger can be in the future beyond `appNow` and the now button can still be activated to "go back to" now.
- [x] Since `now=` test url parameter will override `appNow` and use the parameter date as `appNow`, `appNow` will be prevented from updating.

Other:
- [x] Update animation widget minimized default position to accommodate side height.
- [x] Add min-width for `wv-content` to affect page content.
- [x] Update About page to make wider, smaller text, and make shortcut keys more prominent before scrolling #3654 
- [x] Update timeline axis to reposition focus on finish animating to event date change.
- [x] Revise sidebar nav tabs to use new tooltips. Revise tooltip names to match other tooltip first letter only capitalization style.
- [x] Remove selectDate dispatch for natural events that resulted in a double firing of selectDate which is handled conditionally in `web\js\map\natural-events\natural-events.js`.
- [x] Remove unused `showSubdaily` and `modalView` deprecated test parameters from docs.


## How To Test

1. Change date and use NOW button and/or `SHIFT-T` shortcut to select `appNow` date

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
