### PR TITLE
Match partial shortname

### DIFF
--- a/web/js/modules/product-picker/search-config.js
+++ b/web/js/modules/product-picker/search-config.js
@@ -115,10 +115,11 @@ function filterSearch (layer, val, terms) {
   const conceptIdsArray = layer.conceptIds || [];
   const conceptIds = conceptIdsArray.map(({ value = '' }) => value.toLowerCase());
   const shortNames = conceptIdsArray.map(({ shortName = '' }) => shortName.toLowerCase());
-  const matchItems = [title, subtitle, tags, layerId, conceptIds, shortNames];
+  const matchItems = [title, subtitle, tags, layerId, conceptIds];
 
   lodashForEach(terms, (term) => {
-    isFilteredOut = matchItems.every((item) => !item.includes(term));
+    isFilteredOut = matchItems.every((item) => !item.includes(term))
+      && shortNames.every((name) => name.indexOf(term) < 0);
     if (isFilteredOut) return false;
   });
   return isFilteredOut;
@@ -185,7 +186,6 @@ export default function initSearch(state) {
   });
 
   return {
-    // debug: true,
     alwaysSearchOnInitialLoad: true,
     trackUrlState: false,
     initialState: {


### PR DESCRIPTION
## Description

Fixes #3630.

* Allows partial matching on `shortName` (but not other terms)

## How To Test

1. Search for a partial `shortName`
2. Confirm a match
3. Search for other items like "cloud"
4. Confirm results are what you expect

@nasa-gibs/worldview
