### PR TITLE
Add alert if snapshot selection area crosses dateline

### DIFF
--- a/e2e/features/image-download/crosses-dateline-test.js
+++ b/e2e/features/image-download/crosses-dateline-test.js
@@ -5,8 +5,8 @@ const {
 
 const TIME_LIMIT = 10000;
 
-const datelineAlertIcon = '.snapshot-date-alert-icon';
-const datelineAlertIconTooltipText = '.snapshot-date-warning-tooltip-inner';
+const datelineAlert = '#snapshot-dateline-alert';
+const datelineAlertMessage = '#snapshot-dateline-alert .wv-alert-message';
 
 const withinMapURLParams = '?v=-67.80916012733559,-56.052180562072095,-30.50743102883792,-30.873513420586164&t=2021-08-08-T0';
 const crossesPrevDayURLParams = '?v=161.16767164758798,-54.46571918482002,198.46940074608565,-29.287052043334096&t=2021-08-08-T0';
@@ -23,7 +23,7 @@ module.exports = {
     openImageDownloadPanel(c);
     c.pause(500);
 
-    c.expect.element(datelineAlertIcon).to.not.be.present;
+    c.expect.element(datelineAlert).to.not.be.present;
   },
 
   'Dateline alert icon with previous day message if crosses previous day dateline': (c) => {
@@ -32,10 +32,9 @@ module.exports = {
     openImageDownloadPanel(c);
     c.pause(500);
 
-    c.expect.element(datelineAlertIcon).to.be.present;
-    c.moveToElement(datelineAlertIcon, 0, 0);
-    c.waitForElementVisible(datelineAlertIconTooltipText, TIME_LIMIT, (e) => {
-      c.assert.containsText(datelineAlertIconTooltipText, 'The selected snapshot area crosses the dateline and uses imagery from the previous day 2021 AUG 07.');
+    c.expect.element(datelineAlert).to.be.present;
+    c.waitForElementVisible(datelineAlertMessage, TIME_LIMIT, (e) => {
+      c.assert.containsText(datelineAlertMessage, 'The selected snapshot area crosses the dateline and uses imagery from the previous day 2021 AUG 07.');
     });
   },
 
@@ -45,10 +44,9 @@ module.exports = {
     openImageDownloadPanel(c);
     c.pause(500);
 
-    c.expect.element(datelineAlertIcon).to.be.present;
-    c.moveToElement(datelineAlertIcon, 0, 0);
-    c.waitForElementVisible(datelineAlertIconTooltipText, TIME_LIMIT, (e) => {
-      c.assert.containsText(datelineAlertIconTooltipText, 'The selected snapshot area crosses the dateline and uses imagery from the next day 2021 AUG 09.');
+    c.expect.element(datelineAlert).to.be.present;
+    c.waitForElementVisible(datelineAlertMessage, TIME_LIMIT, (e) => {
+      c.assert.containsText(datelineAlertMessage, 'The selected snapshot area crosses the dateline and uses imagery from the next day 2021 AUG 09.');
     });
   },
 

--- a/e2e/features/image-download/crosses-dateline-test.js
+++ b/e2e/features/image-download/crosses-dateline-test.js
@@ -17,7 +17,7 @@ module.exports = {
     client.end();
   },
 
-  'No dateline alert icon with message if not crossing dateline(s)': (c) => {
+  'No dateline alert notification with message if not crossing dateline(s)': (c) => {
     normalizeViewport(c, 1024, 768);
     c.url(c.globals.url + withinMapURLParams);
     openImageDownloadPanel(c);
@@ -26,7 +26,7 @@ module.exports = {
     c.expect.element(datelineAlert).to.not.be.present;
   },
 
-  'Dateline alert icon with previous day message if crosses previous day dateline': (c) => {
+  'Dateline alert notification with previous day message if crosses previous day dateline': (c) => {
     normalizeViewport(c, 1024, 768);
     c.url(c.globals.url + crossesPrevDayURLParams);
     openImageDownloadPanel(c);
@@ -38,7 +38,7 @@ module.exports = {
     });
   },
 
-  'Dateline alert icon with next day message if crosses next day dateline': (c) => {
+  'Dateline alert notification with next day message if crosses next day dateline': (c) => {
     normalizeViewport(c, 1024, 768);
     c.url(c.globals.url + crossesNextDayURLParams);
     openImageDownloadPanel(c);

--- a/e2e/features/image-download/crosses-dateline-test.js
+++ b/e2e/features/image-download/crosses-dateline-test.js
@@ -1,0 +1,55 @@
+const { normalizeViewport } = require('../../reuseables/normalize-viewport');
+const {
+  openImageDownloadPanel,
+} = require('../../reuseables/image-download');
+
+const TIME_LIMIT = 10000;
+
+const datelineAlertIcon = '.snapshot-date-alert-icon';
+const datelineAlertIconTooltipText = '.snapshot-date-warning-tooltip-inner';
+
+const withinMapURLParams = '?v=-67.80916012733559,-56.052180562072095,-30.50743102883792,-30.873513420586164&t=2021-08-08-T0';
+const crossesPrevDayURLParams = '?v=161.16767164758798,-54.46571918482002,198.46940074608565,-29.287052043334096&t=2021-08-08-T0';
+const crossesNextDayURLParams = '?v=-198.76946733086245,-59.504883811673906,-161.46773823236478,-34.326216670187975&t=2021-08-08-T0';
+
+module.exports = {
+  after(client) {
+    client.end();
+  },
+
+  'No dateline alert icon with message if not crossing dateline(s)': (c) => {
+    normalizeViewport(c, 1024, 768);
+    c.url(c.globals.url + withinMapURLParams);
+    openImageDownloadPanel(c);
+    c.pause(500);
+
+    c.expect.element(datelineAlertIcon).to.not.be.present;
+  },
+
+  'Dateline alert icon with previous day message if crosses previous day dateline': (c) => {
+    normalizeViewport(c, 1024, 768);
+    c.url(c.globals.url + crossesPrevDayURLParams);
+    openImageDownloadPanel(c);
+    c.pause(500);
+
+    c.expect.element(datelineAlertIcon).to.be.present;
+    c.moveToElement(datelineAlertIcon, 0, 0);
+    c.waitForElementVisible(datelineAlertIconTooltipText, TIME_LIMIT, (e) => {
+      c.assert.containsText(datelineAlertIconTooltipText, 'The selected snapshot area crosses the dateline and uses imagery from the previous day 2021 AUG 07.');
+    });
+  },
+
+  'Dateline alert icon with next day message if crosses next day dateline': (c) => {
+    normalizeViewport(c, 1024, 768);
+    c.url(c.globals.url + crossesNextDayURLParams);
+    openImageDownloadPanel(c);
+    c.pause(500);
+
+    c.expect.element(datelineAlertIcon).to.be.present;
+    c.moveToElement(datelineAlertIcon, 0, 0);
+    c.waitForElementVisible(datelineAlertIconTooltipText, TIME_LIMIT, (e) => {
+      c.assert.containsText(datelineAlertIconTooltipText, 'The selected snapshot area crosses the dateline and uses imagery from the next day 2021 AUG 09.');
+    });
+  },
+
+};

--- a/e2e/features/image-download/resolutions3413-test.js
+++ b/e2e/features/image-download/resolutions3413-test.js
@@ -31,12 +31,12 @@ module.exports = {
   },
 
   'Next two zooms are 1km': function(c) {
-    zoomIn(c, 'arctic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="4"]')
       .to.be.selected;
     closeImageDownloadPanel(c);
-    zoomIn(c, 'arctic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="4"]')
       .to.be.selected;
@@ -44,7 +44,7 @@ module.exports = {
   },
 
   'Next zoom is 500m': function(c) {
-    zoomIn(c, 'arctic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="2"]')
       .to.be.selected;
@@ -52,12 +52,12 @@ module.exports = {
   },
 
   'Next zoom is 250m': function(c) {
-    zoomIn(c, 'arctic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="1"]')
       .to.be.selected;
     closeImageDownloadPanel(c);
-    zoomIn(c, 'arctic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="1"]')
       .to.be.selected;
@@ -67,7 +67,7 @@ module.exports = {
   'Last zoom level is 250m': function(c) {
     // mash the zoom button a bunch of times and see if it changes
     for (let i = 0; i < 5; i += 1) {
-      zoomIn(c, 'arctic');
+      zoomIn(c);
     }
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="1"]')

--- a/e2e/features/image-download/resolutions4326-test.js
+++ b/e2e/features/image-download/resolutions4326-test.js
@@ -26,7 +26,7 @@ module.exports = {
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="40"]').to.be.selected;
     closeImageDownloadPanel(c);
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
 
     c.expect.element('#wv-image-resolution option[value="40"]').to.be.selected;
@@ -34,50 +34,50 @@ module.exports = {
   },
 
   'Next zoom is 5km': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="20"]').to.be.selected;
     closeImageDownloadPanel(c);
   },
 
   'Next two zooms are 1km': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="4"]').to.be.selected;
     closeImageDownloadPanel(c);
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="4"]').to.be.selected;
     closeImageDownloadPanel(c);
   },
 
   'Next zoom is 500m': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="2"]').to.be.selected;
     closeImageDownloadPanel(c);
   },
 
   'Next two zooms are 250m': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="1"]').to.be.selected;
     closeImageDownloadPanel(c);
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="1"]').to.be.selected;
     closeImageDownloadPanel(c);
   },
 
   'Next zoom is 125m': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="0.5"]').to.be.selected;
     closeImageDownloadPanel(c);
   },
 
   'Next zoom is 60m': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="0.25"]').to.be
       .selected;
@@ -85,7 +85,7 @@ module.exports = {
   },
 
   'Next zoom is 30m': function(c) {
-    zoomIn(c, 'geographic');
+    zoomIn(c);
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="0.125"]').to.be
       .selected;
@@ -95,7 +95,7 @@ module.exports = {
   'Last zoom level is 30m': function(c) {
     // mash the zoom button a bunch of times and see if it changes
     for (let i = 0; i < 5; i += 1) {
-      zoomIn(c, 'geographic');
+      zoomIn(c);
     }
     openImageDownloadPanel(c);
     c.expect.element('#wv-image-resolution option[value="0.125"]').to.be

--- a/e2e/reuseables/zoom.js
+++ b/e2e/reuseables/zoom.js
@@ -1,5 +1,5 @@
 module.exports = {
-  zoomIn(c, proj) {
+  zoomIn(c) {
     c.click('button.wv-map-zoom-in');
     c.pause(300);
   },

--- a/web/css/image.css
+++ b/web/css/image.css
@@ -93,23 +93,3 @@
 .wv-image-top {
   text-align: right;
 }
-
-.snapshots-date-header {
-  display: flex;
-  & .date-text {
-    font: 400 12px 'Arial';
-  }
-}
-
-.snapshot-date-alert-icon {
-  font-size: 10px;
-  position: absolute;
-  bottom: 8px;
-  right: 5px;
-  color: #f60;
-  cursor: pointer;
-}
-
-.snapshot-date-warning-tooltip-inner {
-  line-height: 16px;
-}

--- a/web/css/image.css
+++ b/web/css/image.css
@@ -93,3 +93,23 @@
 .wv-image-top {
   text-align: right;
 }
+
+.snapshots-date-header {
+  display: flex;
+  & .date-text {
+    font: 400 12px 'Arial';
+  }
+}
+
+.snapshot-date-alert-icon {
+  font-size: 10px;
+  position: absolute;
+  bottom: 8px;
+  right: 5px;
+  color: #f60;
+  cursor: pointer;
+}
+
+.snapshot-date-warning-tooltip-inner {
+  line-height: 16px;
+}

--- a/web/css/toolbar.css
+++ b/web/css/toolbar.css
@@ -100,7 +100,8 @@
 
 /* Snapshot modal */
 .toolbar-snapshot-modal {
-  right: 70px;
+  top: 85px;
+  right: 10px;
 }
 
 .toolbar-snapshot-modal .modal-body {
@@ -145,7 +146,7 @@
 }
 
 @media (min-width: 576px) {
-  .toolbar-modal {
+  .toolbar-modal:not(.toolbar-snapshot-modal) {
     top: 33px;
   }
 

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -7,7 +7,6 @@ import {
   getDimensions,
   getDownloadUrl,
 } from '../../modules/image-download/util';
-import util from '../../util/util';
 import SelectionList from '../util/selector';
 import ResTable from './grid';
 import HoverTooltip from '../util/hover-tooltip';
@@ -148,7 +147,7 @@ export default class ImageResSelection extends React.Component {
     }
   }
 
-  getDatelineMessage() {
+  getDatelineAlertIcon() {
     const { datelineMessage } = this.props;
     return datelineMessage && (
       <div
@@ -174,7 +173,7 @@ export default class ImageResSelection extends React.Component {
 
   render() {
     const {
-      date, getLayers, hasSubdailyLayers, projection, lonlats, resolutions, maxImageSize, firstLabel,
+      getLayers, projection, lonlats, resolutions, maxImageSize, firstLabel,
     } = this.props;
     const { resolution, debugUrl } = this.state;
     const dimensions = getDimensions(projection.id, lonlats, resolution);
@@ -183,7 +182,6 @@ export default class ImageResSelection extends React.Component {
     const filetypeSelect = this._renderFileTypeSelect();
     const worldfileSelect = this._renderWorldfileSelect();
     const layerList = getLayers();
-    const displayDate = util.toISOStringDateMonthAbbrev(date, hasSubdailyLayers);
 
     return (
       <div className="wv-re-pick-wrapper wv-image">
@@ -192,12 +190,6 @@ export default class ImageResSelection extends React.Component {
           style={{ display: 'none' }}
           url={debugUrl}
         />
-        <div className="wv-image-header snapshots-date-header">
-          <div className="date-text">
-            Date:&nbsp;
-            {displayDate}
-          </div>
-        </div>
         <div className="wv-image-header">
           <SelectionList
             id="wv-image-resolution"
@@ -219,7 +211,7 @@ export default class ImageResSelection extends React.Component {
           validLayers={layerList.length > 0}
           onClick={this.onDownload}
         />
-        {this.getDatelineMessage()}
+        {this.getDatelineAlertIcon()}
       </div>
     );
   }
@@ -243,7 +235,6 @@ ImageResSelection.propTypes = {
   fileTypes: PropTypes.object,
   firstLabel: PropTypes.string,
   getLayers: PropTypes.func,
-  hasSubdailyLayers: PropTypes.bool,
   isWorldfile: PropTypes.bool,
   lonlats: PropTypes.array,
   maxImageSize: PropTypes.string,

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import googleTagManager from 'googleTagManager';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   imageSizeValid,
   getDimensions,
   getDownloadUrl,
 } from '../../modules/image-download/util';
-
+import util from '../../util/util';
 import SelectionList from '../util/selector';
 import ResTable from './grid';
+import HoverTooltip from '../util/hover-tooltip';
 
 const MAX_DIMENSION_SIZE = 8200;
 const RESOLUTION_KEY = {
@@ -146,9 +148,33 @@ export default class ImageResSelection extends React.Component {
     }
   }
 
+  getDatelineMessage() {
+    const { datelineMessage } = this.props;
+    return datelineMessage && (
+      <div
+        className="snapshot-date-alert-icon"
+      >
+        <FontAwesomeIcon
+          icon="exclamation-triangle"
+          id="snapshot-date-warning-tooltip"
+          size="2x"
+        />
+        <HoverTooltip
+          isMobile={false}
+          labelText={datelineMessage}
+          target="snapshot-date-warning-tooltip"
+          delay={{ show: 0, hide: 200 }}
+          fade={false}
+          placement="left-start"
+          innerClassName="snapshot-date-warning-tooltip-inner"
+        />
+      </div>
+    );
+  }
+
   render() {
     const {
-      getLayers, projection, lonlats, resolutions, maxImageSize, firstLabel,
+      date, getLayers, hasSubdailyLayers, projection, lonlats, resolutions, maxImageSize, firstLabel,
     } = this.props;
     const { resolution, debugUrl } = this.state;
     const dimensions = getDimensions(projection.id, lonlats, resolution);
@@ -157,6 +183,8 @@ export default class ImageResSelection extends React.Component {
     const filetypeSelect = this._renderFileTypeSelect();
     const worldfileSelect = this._renderWorldfileSelect();
     const layerList = getLayers();
+    const displayDate = util.toISOStringDateMonthAbbrev(date, hasSubdailyLayers);
+
     return (
       <div className="wv-re-pick-wrapper wv-image">
         <div
@@ -164,6 +192,12 @@ export default class ImageResSelection extends React.Component {
           style={{ display: 'none' }}
           url={debugUrl}
         />
+        <div className="wv-image-header snapshots-date-header">
+          <div className="date-text">
+            Date:&nbsp;
+            {displayDate}
+          </div>
+        </div>
         <div className="wv-image-header">
           <SelectionList
             id="wv-image-resolution"
@@ -185,6 +219,7 @@ export default class ImageResSelection extends React.Component {
           validLayers={layerList.length > 0}
           onClick={this.onDownload}
         />
+        {this.getDatelineMessage()}
       </div>
     );
   }
@@ -202,11 +237,13 @@ ImageResSelection.defaultProps = {
 };
 ImageResSelection.propTypes = {
   date: PropTypes.object,
+  datelineMessage: PropTypes.string,
   fileType: PropTypes.string,
   fileTypeOptions: PropTypes.bool,
   fileTypes: PropTypes.object,
   firstLabel: PropTypes.string,
   getLayers: PropTypes.func,
+  hasSubdailyLayers: PropTypes.bool,
   isWorldfile: PropTypes.bool,
   lonlats: PropTypes.array,
   maxImageSize: PropTypes.string,

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import googleTagManager from 'googleTagManager';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   imageSizeValid,
   getDimensions,
@@ -9,7 +8,7 @@ import {
 } from '../../modules/image-download/util';
 import SelectionList from '../util/selector';
 import ResTable from './grid';
-import HoverTooltip from '../util/hover-tooltip';
+import AlertUtil from '../util/alert';
 
 const MAX_DIMENSION_SIZE = 8200;
 const RESOLUTION_KEY = {
@@ -147,27 +146,15 @@ export default class ImageResSelection extends React.Component {
     }
   }
 
-  getDatelineAlertIcon() {
+  crossesDatelineAlert() {
     const { datelineMessage } = this.props;
     return datelineMessage && (
-      <div
-        className="snapshot-date-alert-icon"
-      >
-        <FontAwesomeIcon
-          icon="exclamation-triangle"
-          id="snapshot-date-warning-tooltip"
-          size="2x"
-        />
-        <HoverTooltip
-          isMobile={false}
-          labelText={datelineMessage}
-          target="snapshot-date-warning-tooltip"
-          delay={{ show: 0, hide: 200 }}
-          fade={false}
-          placement="left-start"
-          innerClassName="snapshot-date-warning-tooltip-inner"
-        />
-      </div>
+      <AlertUtil
+        id="snapshot-dateline-alert"
+        isOpen
+        title="Crosses Dateline Alert"
+        message={datelineMessage}
+      />
     );
   }
 
@@ -184,35 +171,37 @@ export default class ImageResSelection extends React.Component {
     const layerList = getLayers();
 
     return (
-      <div className="wv-re-pick-wrapper wv-image">
-        <div
-          id="wv-image-download-url"
-          style={{ display: 'none' }}
-          url={debugUrl}
-        />
-        <div className="wv-image-header">
-          <SelectionList
-            id="wv-image-resolution"
-            optionArray={resolutions}
-            value={resolution}
-            optionName="resolution"
-            onChange={this.handleChange}
+      <>
+        {this.crossesDatelineAlert()}
+        <div className="wv-re-pick-wrapper wv-image">
+          <div
+            id="wv-image-download-url"
+            style={{ display: 'none' }}
+            url={debugUrl}
           />
-          {firstLabel}
+          <div className="wv-image-header">
+            <SelectionList
+              id="wv-image-resolution"
+              optionArray={resolutions}
+              value={resolution}
+              optionName="resolution"
+              onChange={this.handleChange}
+            />
+            {firstLabel}
+          </div>
+          {filetypeSelect}
+          {worldfileSelect}
+          <ResTable
+            width={width}
+            height={height}
+            fileSize={((width * height * 24) / 8388608).toFixed(2)}
+            maxImageSize={maxImageSize}
+            validSize={imageSizeValid(height, width, MAX_DIMENSION_SIZE)}
+            validLayers={layerList.length > 0}
+            onClick={this.onDownload}
+          />
         </div>
-        {filetypeSelect}
-        {worldfileSelect}
-        <ResTable
-          width={width}
-          height={height}
-          fileSize={((width * height * 24) / 8388608).toFixed(2)}
-          maxImageSize={maxImageSize}
-          validSize={imageSizeValid(height, width, MAX_DIMENSION_SIZE)}
-          validLayers={layerList.length > 0}
-          onClick={this.onDownload}
-        />
-        {this.getDatelineAlertIcon()}
-      </div>
+      </>
     );
   }
 }

--- a/web/js/components/timeline/date-util.js
+++ b/web/js/components/timeline/date-util.js
@@ -22,11 +22,7 @@ export const getISODateFormatted = (date) => `${new Date(date).toISOString().spl
 
 // display date as '2000 OCT 28' for default or '2000 OCT 28 20:28Z' for subdaily
 export const getDisplayDate = (date, isSubdaily) => {
-  let displayDate = util.toISOStringDateMonthAbbrev(new Date(date));
-  if (isSubdaily) {
-    const subdailyHHSSZ = `${getISODateFormatted(date).split('T')[1].split(':', 2).join(':')}Z`;
-    displayDate += ` ${subdailyHHSSZ}`;
-  }
+  const displayDate = util.toISOStringDateMonthAbbrev(new Date(date), isSubdaily);
   return displayDate;
 };
 

--- a/web/js/components/util/hover-tooltip.js
+++ b/web/js/components/util/hover-tooltip.js
@@ -11,7 +11,7 @@ import {
  */
 const HoverTooltip = (props) => {
   const {
-    isMobile, labelText, placement, target,
+    delay, fade, innerClassName, isMobile, labelText, placement, target,
   } = props;
 
   return !isMobile && (
@@ -20,6 +20,9 @@ const HoverTooltip = (props) => {
       target={target}
       boundariesElement="window"
       placement={placement}
+      delay={delay}
+      fade={fade}
+      innerClassName={innerClassName}
     >
       {labelText}
     </UncontrolledTooltip>
@@ -28,9 +31,15 @@ const HoverTooltip = (props) => {
 
 HoverTooltip.defaultProps = {
   placement: 'bottom',
+  delay: { show: 50, hide: 300 },
+  fade: true,
+  innerClassName: '',
 };
 
 HoverTooltip.propTypes = {
+  delay: PropTypes.object,
+  fade: PropTypes.bool,
+  innerClassName: PropTypes.string,
   isMobile: PropTypes.bool,
   labelText: PropTypes.string,
   placement: PropTypes.string,

--- a/web/js/containers/image-download.js
+++ b/web/js/containers/image-download.js
@@ -8,6 +8,7 @@ import Crop from '../components/util/image-crop';
 import { onToggle } from '../modules/modal/actions';
 import ErrorBoundary from './error-boundary';
 import {
+  getAlertMessageIfCrossesDateline,
   imageUtilCalculateResolution,
   imageUtilGetCoordsFromPixelValues,
 } from '../modules/image-download/util';
@@ -92,7 +93,7 @@ class ImageDownloadContainer extends Component {
       boundaries,
       map.ui.selected,
     );
-    const { crs, maxExtent } = proj.selected;
+    const { crs } = proj.selected;
     const geolonlat1 = olProj.transform(lonlats[0], crs, 'EPSG:4326');
     const geolonlat2 = olProj.transform(lonlats[1], crs, 'EPSG:4326');
 
@@ -104,22 +105,6 @@ class ImageDownloadContainer extends Component {
       );
     const boxTopLongitude = Math.abs(geolonlat1[0]) > 180 ? util.normalizeWrappedLongitude(geolonlat1[0]) : geolonlat1[0];
     const boxBottomLongitude = Math.abs(geolonlat2[0]) > 180 ? util.normalizeWrappedLongitude(geolonlat2[0]) : geolonlat2[0];
-
-    let datelineMessage = '';
-    if (isGeoProjection) {
-      // min longitude less than maxExtent min longitude (-180 geographic)
-      if (geolonlat1[0] < maxExtent[0]) {
-        const nextDay = util.toISOStringDateMonthAbbrev(util.dateAdd(util.clearTimeUTC(date), 'day', 1));
-        datelineMessage = `Part of the selected snapshot crossed the dateline and uses imagery from the next day ${nextDay}.`;
-      }
-
-      // max longitude greater than maxExtent max longitude (180 geographic)
-      if (geolonlat2[0] > maxExtent[2]) {
-        const prevDay = util.toISOStringDateMonthAbbrev(util.dateAdd(util.clearTimeUTC(date), 'day', -1));
-        datelineMessage = `Part of the selected snapshot crossed the dateline and uses imagery from the previous day ${prevDay}.`;
-      }
-    }
-
     return (
       <ErrorBoundary>
         <Panel
@@ -133,7 +118,7 @@ class ImageDownloadContainer extends Component {
           hasSubdailyLayers={hasSubdailyLayers}
           markerCoordinates={markerCoordinates}
           date={date}
-          datelineMessage={datelineMessage}
+          datelineMessage={getAlertMessageIfCrossesDateline(date, geolonlat1, geolonlat2, proj)}
           url={url}
           crs={crs}
           getLayers={getLayers}

--- a/web/js/util/util.js
+++ b/web/js/util/util.js
@@ -304,9 +304,10 @@ export default (function(self) {
    * @method toISOStringDateMonthAbbrev
    * @static
    * @param date {Date} the date to convert
-   * @return {string} ISO string in the form of ``YYYY-MMM-DD``.
+   * @param hasSubdaily {Boolean} has subdaily date
+   * @return {string} ISO string in the form of `YYYY MMM DD` -or- `YYYY MMM DD HH:SSZ` for subdaily.
    */
-  self.toISOStringDateMonthAbbrev = function(date) {
+  self.toISOStringDateMonthAbbrev = function(date, hasSubdaily) {
     const stringDate = self.toISOStringDate(date).split('-');
     const year = stringDate[0];
     const month = stringDate[1];
@@ -314,6 +315,9 @@ export default (function(self) {
 
     const monthAbbrev = self.monthStringArray[Number(month) - 1];
 
+    if (hasSubdaily) {
+      return `${year} ${monthAbbrev} ${day} ${self.toHourMinutes(date)}Z`;
+    }
     return `${year} ${monthAbbrev} ${day}`;
   };
 


### PR DESCRIPTION
## Description

Fixes #2549  .

- [x] Add dateline alert notification when snapshot image selection area crosses the dateline(s). Warns user based on dateline crossed previous day, next day, or both. Minor style changes - dialog more right and lower to fit alert.


## How To Test

1. Open snapshot image tool and select area within the map area (no alert).
2. Extend over the dateline and see alert notification.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
