### PR TITLE
Reset settings to default settings for image download (graticule)

### DIFF
--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -405,6 +405,7 @@ class AnimationWidget extends React.Component {
       refreshStateAfterGif,
       hasNonDownloadableLayer,
       visibleLayersForProj,
+      proj,
     } = this.props;
     const gifDisabled = numberOfFrames >= maxFrames;
     const elemExists = document.querySelector('#create-gif-button');
@@ -428,7 +429,7 @@ class AnimationWidget extends React.Component {
 
       await this.getPromise(hasCustomPalettes, 'palette', clearCustoms, 'Notice');
       await this.getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
-      await this.getPromise(hasGraticule, 'graticule', clearGraticule, 'Remove Graticule?');
+      await this.getPromise(hasGraticule && proj.id === 'geographic', 'graticule', clearGraticule, 'Remove Graticule?');
       await this.getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
       await onUpdateStartAndEndDate(startDate, endDate);
       googleTagManager.pushEvent({
@@ -655,6 +656,7 @@ function mapStateToProps(state) {
     map,
     browser,
     ui,
+    proj,
   } = state;
   const {
     startDate, endDate, speed, loop, isPlaying, isActive, gifActive,
@@ -741,6 +743,7 @@ function mapStateToProps(state) {
     looping: loop,
     hasCustomPalettes,
     map,
+    proj,
     hasNonDownloadableLayer: hasNonDownloadableVisibleLayer(visibleLayersForProj),
     visibleLayersForProj,
     promiseImageryForTime: (date, layers) => promiseImageryForTime(date, layers, state),
@@ -886,6 +889,7 @@ AnimationWidget.propTypes = {
   onUpdateStartAndEndDate: PropTypes.func,
   onUpdateStartDate: PropTypes.func,
   promiseImageryForTime: PropTypes.func,
+  proj: PropTypes.object,
   refreshStateAfterGif: PropTypes.func,
   rotation: PropTypes.number,
   screenWidth: PropTypes.number,

--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -178,7 +178,6 @@ class ModalContainer extends Component {
             isOpen={isOpen}
             toggle={toggleFunction}
             backdrop={backdrop}
-            onExit={onClose}
             id={lowerCaseId}
             size={size}
             className={isTemplateModal ? 'template-modal' : modalClassName || 'default-modal'}

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -115,13 +115,14 @@ class toolbarContainer extends Component {
       toggleDialogVisible,
       hasNonDownloadableLayer,
       visibleLayersForProj,
+      proj,
     } = this.props;
     const nonDownloadableLayers = hasNonDownloadableLayer ? getNonDownloadableLayers(visibleLayersForProj) : null;
     const paletteStore = lodashCloneDeep(activePalettes);
     toggleDialogVisible(false);
     await this.getPromise(hasCustomPalette, 'palette', clearCustoms, 'Notice');
     await this.getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
-    await this.getPromise(hasGraticule, 'graticule', clearGraticule, 'Remove Graticule?');
+    await this.getPromise(hasGraticule && proj.id === 'geographic', 'graticule', clearGraticule, 'Remove Graticule?');
     await this.getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
     await openModal(
       'TOOLBAR_SNAPSHOT',
@@ -364,7 +365,7 @@ class toolbarContainer extends Component {
 
 const mapStateToProps = (state) => {
   const {
-    animation, browser, notifications, palettes, compare, map, measure, modal, ui, locationSearch, events,
+    animation, browser, notifications, palettes, compare, map, measure, modal, ui, locationSearch, events, proj,
   } = state;
   const { isDistractionFreeModeActive } = ui;
   const { number, type } = notifications;
@@ -382,6 +383,7 @@ const mapStateToProps = (state) => {
   const shouldBeCollapsed = snapshotModalOpen || measure.isActive || animation.gifActive;
   const visibleLayersForProj = lodashFilter(activeLayersForProj, 'visible');
   return {
+    proj,
     faSize,
     notificationType: type,
     notificationContentNumber: number,
@@ -489,6 +491,7 @@ toolbarContainer.propTypes = {
   hasNonDownloadableLayer: PropTypes.bool,
   visibleLayersForProj: PropTypes.array,
   config: PropTypes.object,
+  proj: PropTypes.object,
   faSize: PropTypes.string,
   hasCustomPalette: PropTypes.bool,
   hasGraticule: PropTypes.bool,


### PR DESCRIPTION
## Description

Fixes #3661 
Fixes #3655

Custom palettes, HLS grid, Graticule, and rotated imagery reset for image download had stopped working. This was probably caused by an update of the`react-bootrap` library. 
- [x] Fix reset error
- [x] Prevent reset dialog from showing for graticule in polar views

## How To Test

1. Open with these URL parameters : ?l=MODIS_Terra_Aerosol(palette=blue_1),Graticule,HLS_MGRS_Granule_Grid,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-08-12-T15%3A45%3A43Z
2. try to take an image snapshot
3. Verify expected result


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
