### PR TITLE
Lower default hovertooltip delay hide ms, add tooltips to share icons

### DIFF
--- a/web/css/embed.css
+++ b/web/css/embed.css
@@ -125,6 +125,7 @@
   .mobile-date-change-arrows-btn {
     left: 168px;
     transform: scale(0.75);
+    transform-origin: bottom left;
   }
 
   /* COMPARE */
@@ -196,7 +197,8 @@
   }
   @media only screen and (max-width: 450px) {
     .wv-animation-widget-wrapper.minimized {
-      left: 93px;
+      bottom: 90px;
+      left: 10px;
     }
   }
 }

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -199,6 +199,10 @@ button:focus {
   & #zoom-buttons-group .button-disabled:hover .arrow {
     fill: #4d4d4d;
   }
+  & #animate-button {
+    width: 100%;
+    height: 100%;
+  }
   & .animate-button {
     position: absolute;
     height: 34px;

--- a/web/js/components/toolbar/share/links.js
+++ b/web/js/components/toolbar/share/links.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import HoverTooltip from '../../util/hover-tooltip';
 
 class ShareLinks extends React.Component {
   onClick(event, type) {
@@ -10,38 +11,63 @@ class ShareLinks extends React.Component {
   }
 
   render() {
+    const { isMobile } = this.props;
     return (
       <div id="social-share" className="social-share">
         <a
           id="fb-share"
           className="icon-link social-icon-container-facebook"
           onClick={(e) => this.onClick(e, 'facebook')}
-          title="Share via Facebook!"
         >
+          <HoverTooltip
+            isMobile={isMobile}
+            labelText="Share on Facebook!"
+            placement="left-end"
+            target="fb-share"
+            fade={false}
+          />
           <FontAwesomeIcon icon={['fab', 'facebook-f']} />
         </a>
         <a
           id="tw-share"
           className="icon-link social-icon-container-twitter"
           onClick={(e) => this.onClick(e, 'twitter')}
-          title="Share via Twitter!"
         >
+          <HoverTooltip
+            isMobile={isMobile}
+            labelText="Share on Twitter!"
+            placement="left-end"
+            target="tw-share"
+            fade={false}
+          />
           <FontAwesomeIcon icon={['fab', 'twitter']} />
         </a>
         <a
           id="rd-share"
           className="icon-link social-icon-container-reddit-alien"
           onClick={(e) => this.onClick(e, 'reddit')}
-          title="Share via Reddit!"
         >
+          <HoverTooltip
+            isMobile={isMobile}
+            labelText="Share on Reddit!"
+            placement="left-end"
+            target="rd-share"
+            fade={false}
+          />
           <FontAwesomeIcon icon={['fab', 'reddit-alien']} />
         </a>
         <a
           id="email-share"
           className="icon-link social-icon-container-email"
           onClick={(e) => this.onClick(e, 'email')}
-          title="Share via Email!"
         >
+          <HoverTooltip
+            isMobile={isMobile}
+            labelText="Share via Email!"
+            placement="left-end"
+            target="email-share"
+            fade={false}
+          />
           <FontAwesomeIcon icon="envelope" />
         </a>
       </div>
@@ -50,6 +76,7 @@ class ShareLinks extends React.Component {
 }
 
 ShareLinks.propTypes = {
+  isMobile: PropTypes.bool,
   onClick: PropTypes.func,
 };
 

--- a/web/js/components/util/hover-tooltip.js
+++ b/web/js/components/util/hover-tooltip.js
@@ -31,7 +31,7 @@ const HoverTooltip = (props) => {
 
 HoverTooltip.defaultProps = {
   placement: 'bottom',
-  delay: { show: 50, hide: 300 },
+  delay: { show: 50, hide: 0 },
   fade: true,
   innerClassName: '',
 };

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -282,6 +282,7 @@ class ShareLinkContainer extends Component {
   }
 
   renderSocialTab = () => {
+    const { isMobile } = this.props;
     const {
       activeTab,
     } = this.state;
@@ -290,7 +291,10 @@ class ShareLinkContainer extends Component {
       <TabPane tabId="social" className="share-tab-social">
         {activeTab === 'social' && (
           <>
-            <ShareLinks onClick={this.onLinkClick} />
+            <ShareLinks
+              isMobile={isMobile}
+              onClick={this.onLinkClick}
+            />
             <p>
               Share Worldview on social media.
             </p>

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -911,8 +911,8 @@ class Timeline extends React.Component {
     let mobileLeft = 190;
     let mobileBottom = 10;
     if (isEmbedModeActive) {
-      mobileLeft = 135;
-      mobileBottom = 4;
+      mobileLeft = 145;
+      mobileBottom = 10;
     }
     // positioning will change depending on a combination of:
     // 1) subdaily (mobile date picker width);
@@ -927,8 +927,8 @@ class Timeline extends React.Component {
       mobileLeft = isCompareModeActive ? 112 : 10;
       mobileBottom = 65;
       if (isEmbedModeActive) {
-        mobileLeft = isCompareModeActive ? 80 : 0;
-        mobileBottom = 45;
+        mobileLeft = isCompareModeActive ? 80 : 10;
+        mobileBottom = 50;
       }
     }
 

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -15,7 +15,7 @@ import toggleDistractionFreeMode from '../modules/ui/actions';
 import ImageDownload from './image-download';
 import Projection from './projection';
 import InfoList from './info';
-import ShareLinks from './share';
+import Share from './share';
 import HoverTooltip from '../components/util/hover-tooltip';
 import ErrorBoundary from './error-boundary';
 import {
@@ -55,7 +55,7 @@ const CUSTOM_MODAL_PROPS = {
     modalClassName: 'toolbar-share-modal toolbar-modal toolbar-medium-modal',
     clickableBehindModal: true,
     wrapClassName: 'toolbar_modal_outer',
-    bodyComponent: ShareLinks,
+    bodyComponent: Share,
   },
   TOOLBAR_INFO: {
     headerText: null,


### PR DESCRIPTION
## Description

Fixes #3715 .

- [x] Set lower default hide delay timing for tooltips
- [x] Refactor share icon links to use new tooltips
- [x] Add style dimensions for `#animate-button` container element for better tooltip hovering and tour story targeting
- [x] Fix styling on embed mode timeline controls and animate button from NOW button addition 

## How To Test

**TOOLTIPS**
1. In SIT - hover over left/right date arrow buttons and notice how the tooltips hang
2. Compare faster tooltip hiding in this branch

SHARE ICONS
1. You can test the share icon links by looking at the Facebook, Twitter, etc. icons and hover over them.

ANIMATE BUTTON
1. The animate button style fix can be best seen in the WV Intro tour story where currently the step that focuses on the animate button isn't fully outlined prior to this fix.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
