### PR TITLE
Clear custom palettes if present on tour step

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -2,7 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import googleTagManager from 'googleTagManager';
-import { findIndex as lodashFindIndex, get as lodashGet, uniqBy } from 'lodash';
+import {
+  findIndex as lodashFindIndex,
+  get as lodashGet,
+  uniqBy,
+  isEmpty as lodashIsEmpty,
+} from 'lodash';
 import update from 'immutability-helper';
 
 import JoyrideWrapper from '../components/tour/joyride-wrapper';
@@ -16,6 +21,9 @@ import {
   preloadPalettes,
   hasCustomTypePalette,
 } from '../modules/palettes/util';
+import {
+  clearCustoms,
+} from '../modules/palettes/actions';
 import { BULK_PALETTE_RENDERING_SUCCESS } from '../modules/palettes/constants';
 import { stop as stopAnimation } from '../modules/animation/actions';
 import { onClose as closeModal } from '../modules/modal/actions';
@@ -468,6 +476,9 @@ const mapDispatchToProps = (dispatch) => ({
     });
     dispatch(stopAnimation());
     dispatch(closeModal());
+    if (!lodashIsEmpty(rendered)) {
+      dispatch(clearCustoms());
+    }
     if (
       (parameters.l && hasCustomTypePalette(parameters.l))
       || (parameters.l1 && hasCustomTypePalette(parameters.l1))


### PR DESCRIPTION
## Description

Fixes #3719  .

- [x] Clear custom palettes (if present) on tour `processStepLink`.

## How To Test

1. Progress through a tour that includes a step that has a custom palette for LAYER_X in one step and no custom palette for the same LAYER_X in the next step. See that the layer custom palette resets to its default min/max values as expected.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
