### PR TITLE
Fix window width updating for window resize when compare mode is active

### DIFF
--- a/web/js/components/map/zoom.js
+++ b/web/js/components/map/zoom.js
@@ -31,7 +31,6 @@ function Zoom({
         type="button"
         disabled={zoomLevel === 0}
         className="wv-map-zoom wv-map-zoom-out"
-        title="Zoom out view."
         onClick={() => { mapUtilZoomAction(map, -1); }}
         onMouseMove={(e) => e.stopPropagation()}
       >

--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -153,7 +153,7 @@ const addLineOverlay = function(map, dateA, dateB) {
   const draggerCircleEl = document.createElement('div');
   const firstLabel = document.createElement('span');
   const secondLabel = document.createElement('span');
-  const windowWidth = util.browser.dimensions[0];
+  const windowWidth = window.innerWidth;
   mapCase = map.getTargetElement();
   draggerCircleEl.className = 'swipe-dragger-circle';
   firstLabel.className = 'ab-swipe-span left-label';
@@ -223,7 +223,7 @@ const dragLine = function(listenerObj, lineCaseEl, map) {
       dragging = true;
       events.trigger('compare:movestart');
     }
-    const windowWidth = util.browser.dimensions[0];
+    const windowWidth = window.innerWidth;
     if (listenerObj.type === 'default') evt.preventDefault();
     evt.stopPropagation();
 

--- a/web/js/util/browser.js
+++ b/web/js/util/browser.js
@@ -4,7 +4,6 @@ export default (function() {
 
   const init = function() {
     self.mobileAndTabletDevice = self.tests.mobileAndTabletDevice();
-    self.dimensions = self.tests.getWindowDimensions();
   };
 
   self.tests = {};
@@ -24,10 +23,6 @@ export default (function() {
       }
     }(navigator.userAgent || navigator.vendor || window.opera));
     return check;
-  };
-
-  self.tests.getWindowDimensions = function() {
-    return [window.innerWidth, window.innerHeight];
   };
 
   init();


### PR DESCRIPTION
## Description

Fixes WV-1961
- [x] Use `window.innerWidth` for updated dimensions on resize
- [x] Remove unused util browser function
- [x] Remove legacy title from zoom button with new tooltip

## How To Test

1. Open compare mode in desktop, make sure swiper can move across full screen
2. Resize browser, make sure swiper is repositioning based on it's previous percent within the viewport

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
