### PR TITLE
Prevent tooltip if zoom button is disabled

### DIFF
--- a/web/js/components/map/zoom.js
+++ b/web/js/components/map/zoom.js
@@ -8,38 +8,44 @@ import HoverTooltip from '../util/hover-tooltip';
 function Zoom({
   map, zoomLevel, numZoomLevels, isDistractionFreeModeActive, isMobile,
 }) {
+  const zoomInDisabled = zoomLevel === numZoomLevels;
+  const zoomOutDisabled = zoomLevel === 0;
   if (!map) return null;
 
   return !isDistractionFreeModeActive && (
     <div className="wv-zoom-buttons">
       <button
         type="button"
-        disabled={zoomLevel === numZoomLevels}
+        disabled={zoomInDisabled}
         className="wv-map-zoom wv-map-zoom-in"
         onClick={() => { mapUtilZoomAction(map, 1); }}
         onMouseMove={(e) => e.stopPropagation()}
       >
+        {!zoomInDisabled && (
         <HoverTooltip
           isMobile={isMobile}
           labelText="Zoom in view"
           placement="left"
           target=".wv-map-zoom-in"
         />
+        )}
         <FontAwesomeIcon icon="plus" />
       </button>
       <button
         type="button"
-        disabled={zoomLevel === 0}
+        disabled={zoomOutDisabled}
         className="wv-map-zoom wv-map-zoom-out"
         onClick={() => { mapUtilZoomAction(map, -1); }}
         onMouseMove={(e) => e.stopPropagation()}
       >
+        {!zoomOutDisabled && (
         <HoverTooltip
           isMobile={isMobile}
           labelText="Zoom out view"
           placement="left"
           target=".wv-map-zoom-out"
         />
+        )}
         <FontAwesomeIcon icon="minus" />
       </button>
     </div>


### PR DESCRIPTION
## Description

Fixes WV-1964

- [x] Prevent tooltip if zoom button is disabled. Relies on disabled button styling and `cursor: not-allowed;`.

## How To Test

1. Hover over zoom in button to see tooltip
2. Click zoom in button till it disabled
3. Verify tooltip is removed


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
