### PR TITLE
Remove no results location search e2e test with Antarctica support

### DIFF
--- a/e2e/features/location-search/location-search-test.js
+++ b/e2e/features/location-search/location-search-test.js
@@ -3,7 +3,6 @@ const localSelectors = require('../../reuseables/selectors.js');
 
 // encoded id; originally coordinates-map-marker_38.8904,-77.032
 const testMarkerEncodedID = '.coordinates-map-marker_38__2E__8904__2C__-77__2E__032';
-const testMarkerNoDetailsEncodedID = '.coordinates-map-marker_-75__2C__10';
 const TIME_LIMIT = 10000;
 
 const {
@@ -56,14 +55,9 @@ module.exports = {
     c.pause(500);
     c.expect.element(tooltipCoordinatesContainer).to.not.be.present;
   },
-  'Coordinate title for no suggested place results displays correct coordinates instead': (c) => {
+  'Clicking close tooltip removes the marker and coordinates dialog': (c) => {
     c.url(`${c.globals.url}?v=-39.980778604772254,-93.78047406661956,48.73858468999798,-50.229432449264905&s=10,-75`);
     c.waitForElementVisible(tooltipCoordinatesContainer, TIME_LIMIT);
-    c.expect.element(testMarkerNoDetailsEncodedID).to.be.present;
-    c.assert.containsText(tooltipCoordinatesTitle, '-75.0000°, 10.0000°');
-    c.assert.containsText(tooltipCoordinates, '-75.0000°, 10.0000°');
-  },
-  'Clicking close tooltip removes the marker and coordinates dialog': (c) => {
     c.click(tooltipCoordinatesCloseButton);
     c.pause(500);
     c.expect.element(coordinatesMapMarker).to.not.be.present;


### PR DESCRIPTION
## Description

Fixes WV-1965

- [x] Remove no results location search e2e test with Antarctica reverseGeocode support. Refactor next test step that relied on removed step.

## How To Test

Confirm no location-search E2E tests are failing.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
