### PR TITLE
Disable ipify API GTM event

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line no-unused-vars
 import whatInput from 'what-input';
-import googleTagManager from 'googleTagManager';
 
 // Utils
 import { calculateResponsiveState } from 'redux-responsive';
@@ -137,11 +136,12 @@ class App extends React.Component {
       }
 
       if (Brand.release()) {
-        if (config.features.googleTagManager) {
-          if (window.location.href.includes(Brand.BRAND_URL)) {
-            googleTagManager.getIpAddress();
-          }
-        }
+        // Disabled GTM ipAddress - https://www.ipify.org/ API
+        // if (config.features.googleTagManager) {
+        //   if (window.location.href.includes(Brand.BRAND_URL)) {
+        //     googleTagManager.getIpAddress();
+        //   }
+        // }
         // Console build version notifications
         console.info(
           `${Brand.NAME

--- a/web/js/components/util/google-tag-manager.js
+++ b/web/js/components/util/google-tag-manager.js
@@ -24,14 +24,14 @@ export default {
   * @return {void}
   */
   // get user IP address for GTM/GA using https://www.ipify.org/ API
-  async getIpAddress() {
-    const response = await fetch('https://api.ipify.org?format=json');
-    const json = await response.json();
-    const ipAddress = json.ip;
+  // async getIpAddress() {
+  //   const response = await fetch('https://api.ipify.org?format=json');
+  //   const json = await response.json();
+  //   const ipAddress = json.ip;
 
-    this.pushEvent({
-      event: 'ipAddress',
-      ipAddress,
-    });
-  }
+  //   this.pushEvent({
+  //     event: 'ipAddress',
+  //     ipAddress,
+  //   });
+  // }
 };


### PR DESCRIPTION
## Description

Fixes WV-1969

- [x] Disable ipify API GTM event since metrics is not collecting this data at this time.

## How To Test

1. Confirm disabling

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
