### PR TITLE
Allow instant serialize of extent query string

### DIFF
--- a/web/js/containers/map-interactions/map-interactions.js
+++ b/web/js/containers/map-interactions/map-interactions.js
@@ -52,7 +52,6 @@ function mapStateToProps(state) {
   const eventsEnabled = config.features.naturalEvents;
 
   return {
-    config,
     isShowingClick: map.isClickable,
     isDistractionFreeModeActive,
     isCoordinateSearchActive,

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -925,7 +925,7 @@ export default function mapui(models, config, store, ui) {
   const updateExtent = () => {
     const map = self.selected;
     const view = map.getView();
-    const extent = view.calculateExtent(map.getSize());
+    const extent = view.calculateExtent();
     store.dispatch({ type: UPDATE_MAP_EXTENT, extent });
     if (map.isRendered()) {
       store.dispatch({ type: dateConstants.CLEAR_PRELOAD });

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -40,7 +40,6 @@ export function getMapParameterSetup(
           return extent;
         },
         serialize: (currentItemState, currentState) => {
-          const rendered = lodashGet(currentState, 'map.rendered');
           const rotation = lodashGet(currentState, 'map.rotation');
 
           if (rotation) {
@@ -48,7 +47,6 @@ export function getMapParameterSetup(
             currentItemState = getRotatedExtent(map);
           }
 
-          if (!rendered) return undefined;
           const actualLeadingExtent = lodashGet(
             currentState,
             'map.leadingExtent',
@@ -157,7 +155,7 @@ export function getLeadingExtent(loadtime) {
  * the extent for prev, next & current day
  */
 function calculateExtent(layerExtent, map) {
-  const viewportExtent = map.getView().calculateExtent(map.getSize());
+  const viewportExtent = map.getView().calculateExtent();
   const visibleExtent = olExtent.getIntersection(viewportExtent, layerExtent);
 
   if (map.proj === 'geographic') {


### PR DESCRIPTION
## Description

Fixes WV-1956

- [x] Remove `map.rendered` condition to serialize in `v=` extent query string
- [x] Remove `map.getSize()` from `view.calculateExtent()` as it returned inconsistent extents on page refresh


## How To Test

1. Load page with `v=` and see faster query string population instead of delay to add extent to query string

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
