### PR TITLE
Don't show layer info for layers that aren't available in current projection

### DIFF
--- a/web/js/components/layer/product-picker/browse/measurement-metadata-detail.js
+++ b/web/js/components/layer/product-picker/browse/measurement-metadata-detail.js
@@ -42,10 +42,12 @@ function MeasurementMetadataDetail (props) {
     return () => (controller ? controller.abort() : null);
   }, [source]);
 
-  const renderMetadataForLayers = () => layers.map((l) => (
-    <div className="layer-description" key={l.id}>
-      <h3>{l.title}</h3>
-      {showPreviewImage && (
+  const renderMetadataForLayers = () => layers
+    .filter(({ projections }) => !!projections[selectedProjection])
+    .map((l) => (
+      <div className="layer-description" key={l.id}>
+        <h3>{l.title}</h3>
+        {showPreviewImage && (
         <div className="text-center">
           <a
             href={`images/layers/previews/${selectedProjection}/${l.id}.jpg`}
@@ -58,10 +60,10 @@ function MeasurementMetadataDetail (props) {
             />
           </a>
         </div>
-      )}
-      <LayerInfo key={l.id} layer={l} />
-    </div>
-  ));
+        )}
+        <LayerInfo key={l.id} layer={l} />
+      </div>
+    ));
 
   const renderMobile = () => {
     const sourceTextLong = metadataForSource && metadataForSource.length >= 1000;


### PR DESCRIPTION
## Description

Fixes [WV-1960](https://bugs.earthdata.nasa.gov/browse/WV-1960)

* Filter out layers by projection

## How To Test
1. Open app
2. Go to arctic projection
3. Open product picker
4. Browser "Cloud Fraction" layers
5. Confirm "Total Cloud Fraction L2 Day" layer info is not visible in details on right side

