### PR TITLE
Prevent non wv layers in map updateDate

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -714,7 +714,7 @@ export default function mapui(models, config, store, ui) {
       const visibleLayers = activeLayers.filter(
         ({ id }) => layers
           .filter((l) => l.getVisible())
-          .map(({ wv }) => wv.def.id)
+          .map(({ wv }) => lodashGet(wv, 'def.id'))
           .includes(id),
       );
 


### PR DESCRIPTION
## Description

Fixes [WV-1976](https://bugs.earthdata.nasa.gov/browse/WV-1976)

- [x] Prevents non `.wv` layers (event tracks in this case) from being processed in `updateDate` like map imagery layers

This fix will address the bug from breaking the app, but additional effort is needed to [WV-1979](https://bugs.earthdata.nasa.gov/browse/WV-1979)

## How To Test

1. http://localhost:3000/?v=-47.650390625,7.081835937499999,-28.349609375,20.3181640625&e=EONET_5943,2021-10-02&efs=true&efd=2021-06-07,2021-10-05&efc=dustHaze,manmade,seaLakeIce,severeStorms,snow,volcanoes,waterColor,wildfires&l=IMERG_Precipitation_Rate,VIIRS_SNPP_DayNightBand_ENCC(hidden),VIIRS_SNPP_DayNightBand_At_Sensor_Radiance(hidden),Reference_Labels_15m,Reference_Features_15m,Coastlines_15m(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2021-10-01-T00%3A00%3A00Z
2. Change selected date with date arrows
3. See no errors


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
