### PR TITLE
WV-1978 - Automatically add/remove subdaily intervals when subdaily layer added/removed

### DIFF
--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -25,6 +25,7 @@ class CustomIntervalSelector extends PureComponent {
     const {
       changeCustomInterval,
       customInterval,
+      customSelected,
       hasSubdailyLayers,
       interval,
       selectInterval,
@@ -35,13 +36,16 @@ class CustomIntervalSelector extends PureComponent {
       this.customIntervalWidget.focus();
     }
 
+    const subdailyAdded = hasSubdailyLayers && !prevProps.hasSubdailyLayers;
+    const subdailyRemoved = !hasSubdailyLayers && prevProps.hasSubdailyLayers;
     const subdailyInterval = customInterval > 3 || interval > 3;
-    if (!hasSubdailyLayers && prevProps.hasSubdailyLayers && subdailyInterval) {
+
+    if (subdailyRemoved && subdailyInterval) {
       changeCustomInterval();
       selectInterval(1, timeScaleToNumberKey.day, false);
     }
 
-    if (hasSubdailyLayers && !prevProps.hasSubdailyLayers) {
+    if (subdailyAdded && !customSelected) {
       changeCustomInterval(10, timeScaleToNumberKey.minute);
     }
   }
@@ -115,11 +119,12 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state) => {
   const { date } = state;
   const {
-    interval, customInterval, customDelta,
+    interval, customInterval, customDelta, customSelected,
   } = date;
   return {
     customDelta: customDelta || 1,
     customInterval: customInterval || interval,
+    customSelected,
     interval,
   };
 };
@@ -134,6 +139,7 @@ CustomIntervalSelector.propTypes = {
   closeModal: PropTypes.func,
   customDelta: PropTypes.number,
   customInterval: PropTypes.number,
+  customSelected: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
   interval: PropTypes.number,
   selectInterval: PropTypes.func,

--- a/web/js/components/timeline/custom-interval-selector/interval-select.js
+++ b/web/js/components/timeline/custom-interval-selector/interval-select.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
  *
  * @class TimeScaleSelect
  */
-class TimeScaleSelect extends PureComponent {
+class IntervalSelect extends PureComponent {
   handleChangeZoomLevel = (e) => {
     const { changeZoomLevel } = this.props;
     const zoomLevel = e.target.value;
@@ -50,10 +50,10 @@ class TimeScaleSelect extends PureComponent {
   }
 }
 
-TimeScaleSelect.propTypes = {
+IntervalSelect.propTypes = {
   changeZoomLevel: PropTypes.func,
   hasSubdailyLayers: PropTypes.bool,
   zoomLevel: PropTypes.string,
 };
 
-export default TimeScaleSelect;
+export default IntervalSelect;

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -17,8 +17,8 @@ import ErrorBoundary from './error-boundary';
 import DateRangeSelector from '../components/date-selector/date-range-selector';
 import LoopButton from '../components/animation-widget/loop-button';
 import PlayButton from '../components/animation-widget/play-button';
-import TimeScaleIntervalChange from '../components/timeline/timeline-controls/interval-timescale-change';
-import CustomIntervalSelectorWidget from '../components/timeline/custom-interval-selector/interval-selector-widget';
+import TimeScaleIntervalChange from '../components/timeline/timeline-controls/timescale-interval-change';
+import CustomIntervalSelector from '../components/timeline/custom-interval-selector/custom-interval-selector';
 import PlayQueue from '../components/animation-widget/play-queue';
 import Notify from '../components/image-download/notify';
 import { promiseImageryForTime } from '../modules/map/util';
@@ -26,7 +26,6 @@ import GifContainer from './gif';
 import {
   selectDate,
   selectInterval,
-  changeCustomInterval,
   toggleCustomModal,
 } from '../modules/date/actions';
 import {
@@ -344,17 +343,6 @@ class AnimationWidget extends React.Component {
     toggleCustomModal(isOpen, customModalType.ANIMATION);
   };
 
-  /**
-  * @desc handle SET of custom time scale panel
-  * @param {Number} delta
-  * @param {Number} timeScale
-  * @returns {void}
-  */
-  changeCustomInterval = (delta, timeScale) => {
-    const { changeCustomInterval } = this.props;
-    changeCustomInterval(delta, timeScale);
-  };
-
   renderCollapsedWidget() {
     const {
       onClose,
@@ -479,9 +467,6 @@ class AnimationWidget extends React.Component {
       onPushPause,
       subDailyMode,
       interval,
-      customSelected,
-      customDelta,
-      customInterval,
       animationCustomModalOpen,
       hasSubdailyLayers,
     } = this.props;
@@ -505,15 +490,18 @@ class AnimationWidget extends React.Component {
             <div className="wv-animation-widget-header">
               {'Animate Map in '}
               <TimeScaleIntervalChange
-                setTimeScaleIntervalChangeUnit={this.onIntervalSelect}
-                customIntervalZoomLevel={timeScaleFromNumberKey[customInterval]}
-                customSelected={customSelected}
-                customDelta={customDelta}
                 timeScaleChangeUnit={interval}
                 hasSubdailyLayers={hasSubdailyLayers}
+                modalType={customModalType.ANIMATION}
               />
               {' Increments'}
             </div>
+
+            {/* Custom time interval selection */}
+            <CustomIntervalSelector
+              modalOpen={animationCustomModalOpen}
+              hasSubdailyLayers={hasSubdailyLayers}
+            />
 
             <PlayButton
               playing={isPlaying}
@@ -554,14 +542,6 @@ class AnimationWidget extends React.Component {
             <FontAwesomeIcon icon="chevron-down" className="wv-minimize" onClick={this.toggleCollapse} />
             <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} />
 
-            {/* Custom time interval selection */}
-            <CustomIntervalSelectorWidget
-              customDelta={customDelta}
-              customIntervalZoomLevel={customInterval}
-              customIntervalModalOpen={animationCustomModalOpen}
-              changeCustomInterval={this.changeCustomInterval}
-              hasSubdailyLayers={hasSubdailyLayers}
-            />
           </div>
         </div>
       </Draggable>
@@ -822,9 +802,6 @@ const mapDispatchToProps = (dispatch) => ({
   onIntervalSelect: (delta, timeScale, customSelected) => {
     dispatch(selectInterval(delta, timeScale, customSelected));
   },
-  changeCustomInterval: (delta, timeScale) => {
-    dispatch(changeCustomInterval(delta, timeScale));
-  },
   onUpdateStartDate(date) {
     dispatch(changeStartDate(date));
   },
@@ -851,11 +828,9 @@ AnimationWidget.propTypes = {
   activePalettes: PropTypes.object,
   animationCustomModalOpen: PropTypes.bool,
   visibleLayersForProj: PropTypes.array,
-  changeCustomInterval: PropTypes.func,
   currentDate: PropTypes.object,
   customDelta: PropTypes.number,
   customInterval: PropTypes.number,
-  customSelected: PropTypes.bool,
   delta: PropTypes.number,
   endDate: PropTypes.object,
   hasCustomPalettes: PropTypes.bool,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -15,11 +15,11 @@ import MobileDatePicker from '../../components/timeline/mobile-date-picker';
 
 import TimelineAxis from '../../components/timeline/timeline-axis/timeline-axis';
 import TimelineLayerCoveragePanel from '../../components/timeline/timeline-coverage/timeline-coverage';
-import TimeScaleIntervalChange from '../../components/timeline/timeline-controls/interval-timescale-change';
+import TimeScaleIntervalChange from '../../components/timeline/timeline-controls/timescale-interval-change';
 import DraggerContainer from '../../components/timeline/timeline-draggers/dragger-container';
 import AxisHoverLine from '../../components/timeline/timeline-axis/date-tooltip/axis-hover-line';
 import DateTooltip from '../../components/timeline/timeline-axis/date-tooltip/date-tooltip';
-import CustomIntervalSelectorWidget from '../../components/timeline/custom-interval-selector/interval-selector-widget';
+import CustomIntervalSelector from '../../components/timeline/custom-interval-selector/custom-interval-selector';
 
 import DateSelector from '../../components/date-selector/date-selector';
 import DateChangeArrows from '../../components/timeline/timeline-controls/date-change-arrows';
@@ -560,44 +560,6 @@ class Timeline extends React.Component {
   }
 
   /**
-  * @desc handle SET of custom time scale panel
-  * @param {Number} delta
-  * @param {Number} timeScale
-  * @returns {void}
-  */
-  changeCustomInterval = (delta, timeScale) => {
-    const { changeCustomInterval } = this.props;
-    changeCustomInterval(delta, timeScale);
-  };
-
-  /**
-  * @desc handle SELECT of LEFT/RIGHT interval selection
-  * @param {String} timeScale
-  * @param {Boolean} modalOpen - is custom interval modal open
-  * @returns {void}
-  */
-  setTimeScaleIntervalChangeUnit = (timeScale, openModal) => {
-    const { customIntervalZoomLevel, customIntervalValue, selectInterval } = this.props;
-    const customSelected = timeScale === 'custom';
-    let delta;
-    let newTimeScale = timeScale;
-
-    if (openModal) {
-      this.toggleCustomIntervalModal(openModal);
-      return;
-    }
-
-    if (customSelected && customIntervalZoomLevel && customIntervalValue) {
-      newTimeScale = customIntervalZoomLevel;
-      delta = customIntervalValue;
-    } else {
-      newTimeScale = Number(timeScaleToNumberKey[newTimeScale]);
-      delta = 1;
-    }
-    selectInterval(delta, newTimeScale, customSelected);
-  };
-
-  /**
   * @desc open animation widget
   * @returns {void}
   */
@@ -990,9 +952,6 @@ class Timeline extends React.Component {
       animStartLocationDate,
       appNow,
       axisWidth,
-      customIntervalValue,
-      customIntervalZoomLevel,
-      customSelected,
       dateA,
       dateB,
       draggerSelected,
@@ -1098,14 +1057,13 @@ class Timeline extends React.Component {
                         />
                       </div>
                       <div id="zoom-buttons-group">
+
                         <TimeScaleIntervalChange
-                          setTimeScaleIntervalChangeUnit={this.setTimeScaleIntervalChangeUnit}
-                          customIntervalZoomLevel={timeScaleFromNumberKey[customIntervalZoomLevel]}
-                          customSelected={customSelected}
-                          customDelta={customIntervalValue}
                           timeScaleChangeUnit={timeScaleChangeUnit}
                           hasSubdailyLayers={hasSubdailyLayers}
+                          modalType={customModalType.TIMELINE}
                         />
+
                         {this.renderDateChangeArrows()}
                       </div>
                       <AnimationButton
@@ -1267,12 +1225,10 @@ class Timeline extends React.Component {
                           )}
                       </div>
                       )}
+
                     {/* Custom Interval Selector Widget */}
-                    <CustomIntervalSelectorWidget
-                      customDelta={customIntervalValue}
-                      customIntervalZoomLevel={customIntervalZoomLevel}
-                      changeCustomInterval={this.changeCustomInterval}
-                      customIntervalModalOpen={timelineCustomModalOpen}
+                    <CustomIntervalSelector
+                      modalOpen={timelineCustomModalOpen}
                       hasSubdailyLayers={hasSubdailyLayers}
                     />
 
@@ -1511,11 +1467,8 @@ Timeline.propTypes = {
   animEndLocationDate: PropTypes.object,
   animStartLocationDate: PropTypes.object,
   axisWidth: PropTypes.number,
-  changeCustomInterval: PropTypes.func,
   changeTimeScale: PropTypes.func,
   closeAnimation: PropTypes.func,
-  customIntervalValue: PropTypes.number,
-  customIntervalZoomLevel: PropTypes.number,
   customSelected: PropTypes.bool,
   dateA: PropTypes.string,
   dateB: PropTypes.string,
@@ -1546,7 +1499,6 @@ Timeline.propTypes = {
   screenWidth: PropTypes.number,
   selectDate: PropTypes.func,
   selectedDate: PropTypes.object,
-  selectInterval: PropTypes.func,
   timelineCustomModalOpen: PropTypes.bool,
   timelineEndDateLimit: PropTypes.string,
   timelineStartDateLimit: PropTypes.string,

--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -86,7 +86,7 @@ export function changeCustomInterval(delta, customInterval) {
     dispatch(clearPreload());
     dispatch({
       type: CHANGE_CUSTOM_INTERVAL,
-      value: customInterval,
+      interval: customInterval,
       delta,
     });
   };
@@ -96,7 +96,7 @@ export function selectInterval(delta, interval, customSelected) {
     dispatch(clearPreload());
     dispatch({
       type: CHANGE_INTERVAL,
-      value: interval,
+      interval,
       delta,
       customSelected,
     });

--- a/web/js/modules/date/actions.test.js
+++ b/web/js/modules/date/actions.test.js
@@ -111,7 +111,7 @@ describe('Date timescale changes', () => {
       expect(store.getActions()[1]).toEqual(expectedSecond);
     });
 
-  test(`selectDate action returns ${SELECT_DATE}as type and selectedB as activeString and ${mockDate} as value`,
+  test(`selectDate action returns ${SELECT_DATE} as type and selectedB as activeString and ${mockDate} as value`,
     () => {
       const expectedFirst = {
         type: CLEAR_PRELOAD,
@@ -163,7 +163,7 @@ describe('Date timescale changes', () => {
       };
       const expectedSecond = {
         type: CHANGE_CUSTOM_INTERVAL,
-        value: customInterval,
+        interval: customInterval,
         delta,
       };
       store.dispatch(changeCustomInterval(delta, customInterval));
@@ -188,7 +188,7 @@ describe('Date timescale changes', () => {
       };
       const expectedSecond = {
         type: CHANGE_INTERVAL,
-        value: interval,
+        interval,
         delta,
         customSelected: true,
       };

--- a/web/js/modules/date/reducers.js
+++ b/web/js/modules/date/reducers.js
@@ -51,17 +51,19 @@ export function dateReducer(state = dateReducerState, action) {
         ...state,
         selectedB: util.dateAdd(state.selected, 'day', -7),
       };
-    case CHANGE_CUSTOM_INTERVAL:
+    case CHANGE_CUSTOM_INTERVAL: {
+      const { interval, delta } = action;
       return {
         ...state,
-        customInterval: action.value,
-        customDelta: action.delta,
-        customSelected: true,
+        customInterval: interval,
+        customDelta: delta,
+        customSelected: !(!interval && !delta),
       };
+    }
     case CHANGE_INTERVAL:
       return {
         ...state,
-        interval: action.value,
+        interval: action.interval,
         delta: action.delta,
         customSelected: action.customSelected,
       };

--- a/web/js/modules/date/reducers.test.js
+++ b/web/js/modules/date/reducers.test.js
@@ -45,7 +45,7 @@ describe('dateReducer', () => {
       expect(
         dateReducer(dateReducerState, {
           type: CHANGE_CUSTOM_INTERVAL,
-          value: 4,
+          interval: 4,
           delta: 10,
         }),
       ).toEqual({
@@ -64,7 +64,7 @@ describe('dateReducer', () => {
       expect(
         dateReducer(dateReducerState, {
           type: CHANGE_INTERVAL,
-          value: 2,
+          interval: 2,
           delta: 1,
           customSelected: false,
         }),


### PR DESCRIPTION
## Description

Fixes WV-1978

- Reduce number of props passed down to interval components
- Reduce duplicated code, move to child components
- When subdaily layer is added and a custom interval is not selected, set custom interval to `10 Minute`
- When subdaily layer is removed and a subdaily interval is selected, reset interval to `1 day`
- Do not change interval on subdaily layer add if a custom interval is set

## How To Test

1. Go [here](http://localhost:3000/?l=Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-10-08-T00%3A00%3A00Z)
2. Add Geostationary layer
3. Confirm '10 Minute' custom interval is automatically set
4. Remove Geostationary layer
5. Confirm interval is reset to '1 Day'
6. Confirm custom interval cleared (e.g. interval list only shows 'Year', 'Month', 'Day', 'Custom')
---
1. Go to [here]( http://localhost:3000/?z=4&ics=true&ici=3&icd=10&l=GOES-East_ABI_GeoColor,Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-10-08-T00%3A00%3A00Z)
2. Confirm '10 Day' custom interval selected
3. Confirm Geostationary layer present
4. Remove Geostationary layer
5. Confirm '10 Day' custom interval remains
---
1. Go to [here](http://localhost:3000/?v=-101.78083389251249,-115.8943357672287,57.54729110748751,72.14663154725893&ics=true&ici=3&icd=3&lg=true&t=2021-10-20-T15%3A03%3A34Z)
2. Confirm '3 Day' custom interval selected
3. Add a geostationary layer
4. Confirm '3 Day' custom interval remains
