### PR TITLE
Fix sticky tooltip (events)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21076,30 +21076,16 @@
       }
     },
     "reactstrap": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.9.0.tgz",
-      "integrity": "sha512-pmf33YjpNZk1IfrjqpWCUMq9hk6GzSnMWBAofTBNIRJQB1zQ0Au2kzv3lPUAFsBYgWEuI9iYa/xKXHaboSiMkQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-8.1.1.tgz",
+      "integrity": "sha512-m4IIdTHBT5wtcPts4w4rYngKuqIUC1BpncVxCTeIj4BQDxwjdab0gGyKJKfgXgArn6iI6syiDyez/h2tLWFjsw==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": "^7.2.0",
         "classnames": "^2.2.3",
         "prop-types": "^15.5.8",
-        "react-popper": "^1.3.6",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-popper": "^1.3.3",
         "react-transition-group": "^2.3.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.14.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        }
       }
     },
     "read-all-stream": {

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "react-resizable": "^1.9.0",
     "react-swipe-to-delete-component": "^0.5.4",
     "react-visibility-sensor": "^5.1.1",
-    "reactstrap": "^8.0.1",
+    "reactstrap": "8.1.x",
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",
     "redux-location-state": "^2.6.0",


### PR DESCRIPTION
## Description

Fixes #wv2030.

Sticky events tooltips in all projections

## Notes on fix
* Some change between version 8.1.1 and 8.2.0 of reactstrap caused this error https://github.com/reactstrap/reactstrap/blob/master/CHANGELOG.md#820-2019-12-05
* I just reverted to version 8.1.1
## How To Test

1. Open with /?v=-1170538.2839823957,1437366.6096462607,-222826.28398239566,1966774.6096462607&p=antarctic&e=EONET_5390,2021-10-22&efs=true&efd=2021-06-23,2021-10-21&efc=dustHaze,manmade,seaLakeIce,severeStorms,snow,volcanoes,waterColor,wildfires&l=MODIS_Terra_Sea_Ice(hidden),MODIS_Aqua_Sea_Ice(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Night(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Day(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Night(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Day(hidden),MODIS_Aqua_Brightness_Temp_Band31_Night(hidden),MODIS_Aqua_Brightness_Temp_Band31_Day(hidden),MODIS_Terra_Brightness_Temp_Band31_Night(hidden),MODIS_Terra_Brightness_Temp_Band31_Day(hidden),VIIRS_SNPP_DayNightBand_ENCC(hidden),VIIRS_SNPP_DayNightBand_At_Sensor_Radiance(hidden),Reference_Labels_15m,Reference_Features_15m,Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-10-22-T00%3A00%3A00Z
2. click another iceberg
3. Tooltip should not stick


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
