### PR TITLE
WV-1979: Add event tracks as overlays

### DIFF
--- a/web/css/events.css
+++ b/web/css/events.css
@@ -255,7 +255,7 @@
 .event-track-line {
   z-index: 0;
 }
-.event-track-point, .event-track-cluster-point{
+.event-track-point, .event-track-cluster-point {
   z-index: 1;
 }
 

--- a/web/css/events.css
+++ b/web/css/events.css
@@ -165,7 +165,7 @@
   background: url("../images/natural-events/dot.svg");
 }
 .marker.selected {
-  z-index: 100;
+  z-index: 1;
   div {
     transform: scale(1.4);
     transform-origin: center bottom;
@@ -186,15 +186,23 @@
   z-index: 99;
 }
 .track-marker-case-selected {
-  z-index: 100;
+  z-index: 1;
+  .track-marker {
+    opacity: 0.7;
+    z-index: 1;
+  }
+  .track-marker-date {
+    top: 25px;
+    left: -34px;
+  }
+  .track-marker-date::before {
+    display: none;
+  }
 }
 .track-marker-case-hidden {
   display: none;
 }
-.track-marker-case-selected .track-marker {
-  opacity: 0.7;
-  z-index: 100;
-}
+
 .track-marker {
   width: 12px;
   height: 12px;
@@ -209,8 +217,8 @@
   display: none;
   position: absolute;
   width: 95px;
-  top: 20px;
-  left: -34px;
+  top: -30px;
+  left: -40px;
   padding: 4px;
   background-color: rgba(40, 40, 40, 0.9);
   border-radius: 3px;
@@ -221,25 +229,34 @@
   z-index: 900;
 }
 .cluster-track-marker-date {
-  top: 28px;
-  left: -29px;
+  top: -35px;
+  left: -33px;
   width: 110px;
+  z-index: 900;
 }
 .track-marker-date::before {
   position: absolute;
-  top: -4px;
-  left: 36px;
+  bottom: -5px;
+  left: 40px;
   content: "";
-  border-bottom: 5px solid #000;
-  border-bottom: 5px solid rgba(51, 51, 51, 0.9);
+  border-top: 5px solid #000;
+  border-top: 5px solid rgba(51, 51, 51, 0.9);
   border-right: 5px solid transparent;
   border-left: 5px solid transparent;
+  z-index: 900;
 }
 
 .track-marker-case:not(.track-marker-case-selected) .track-marker:hover {
   transform: scale(1.5);
   border: 1px solid #22a;
   cursor: pointer;
+}
+
+.event-track-line {
+  z-index: 0;
+}
+.event-track-point, .event-track-cluster-point{
+  z-index: 1;
 }
 
 .event-track-arrows {
@@ -283,7 +300,6 @@
   font-family: "Open Sans", sans-serif;
   width: 24px;
   height: 24px;
-  z-index: 99;
 }
 .cluster-marker:hover {
   cursor: pointer;

--- a/web/js/map/natural-events/cluster.js
+++ b/web/js/map/natural-events/cluster.js
@@ -1,5 +1,6 @@
 import Supercluster from 'supercluster';
 import lodashRound from 'lodash/round';
+import { crossesDateLine, getOverDateLineCoordinates } from '../util';
 
 /**
  * Create Supercluster Object - Uses map and reduce
@@ -32,6 +33,10 @@ export const naturalEventsClusterCreateObject = () => new Supercluster({
   setPolar: () => ({ radius: 30, maxZoom: 7 }),
   setGeo: () => ({ radius: 60, maxZoom: 12 }),
 });
+
+const firstClusterObj = naturalEventsClusterCreateObject(); // Cluster before selected event
+const secondClusterObj = naturalEventsClusterCreateObject(); // Cluster after selected event
+
 /**
  * Create a geoJSON point out of a point
  *
@@ -40,7 +45,7 @@ export const naturalEventsClusterCreateObject = () => new Supercluster({
  * @param  {String} date
  * @return {Object} geoJSON point
  */
-export const naturalEventsClusterPointToGeoJSON = (id, coordinates, date) => ({
+export const clusterPointToGeoJSON = (id, coordinates, date) => ({
   type: 'Feature',
   properties: {
     id: `${id}-${date}`,
@@ -52,11 +57,8 @@ export const naturalEventsClusterPointToGeoJSON = (id, coordinates, date) => ({
     coordinates,
   },
 });
-/**
- * @param  {Array}
- * @return {void}
- */
-export const naturalEventsClusterSort = (clusterArray) => {
+
+export const clusterSort = (clusterArray) => {
   const newArray = clusterArray.sort((a, b) => {
     const firstDate = a.properties.date || a.properties.startDate;
     const secondDate = b.properties.date || b.properties.startDate;
@@ -73,12 +75,82 @@ export const naturalEventsClusterSort = (clusterArray) => {
  * @param  {number} zoomLevel
  * @return {Object}
  */
-export const naturalEventsClusterGetPoints = (
-  superClusterObj,
-  pointArray,
-  zoomLevel,
-  extent,
-) => {
+export const getClusterPoints = (superClusterObj, pointArray, zoomLevel, extent) => {
   superClusterObj.load(pointArray);
   return superClusterObj.getClusters(extent, lodashRound(zoomLevel));
+};
+
+export const getClusters = ({ geometry, id }, proj, selectedDate, map) => {
+  const geoJSONPointsBeforeSelected = [];
+  const geoJSONPointsAfterSelected = [];
+  let selectedPoint;
+  let afterSelected = false;
+  const zoom = map.getView().getZoom();
+  const extent = proj.selected.id === 'geographic'
+    ? [-250, -90, 250, 90]
+    : [-180, -90, 180, 90];
+
+  const selectedCoords = geometry.find(({ date }) => date.split('T')[0] === selectedDate).coordinates;
+  geometry.forEach((geom) => {
+    let { coordinates } = geom;
+    const date = geom.date.split('T')[0];
+    const isSelected = selectedDate === date;
+    const isOverDateline = proj.selected.id === 'geographic'
+      ? crossesDateLine(selectedCoords, coordinates)
+      : false;
+    if (isOverDateline) {
+      // replace coordinates
+      coordinates = getOverDateLineCoordinates(coordinates);
+    }
+    // Cluster in three groups
+    if (isSelected) {
+      selectedPoint = clusterPointToGeoJSON(
+        id,
+        coordinates,
+        date,
+      );
+      afterSelected = true;
+    } else if (!afterSelected) {
+      geoJSONPointsBeforeSelected.push(
+        clusterPointToGeoJSON(id, coordinates, date),
+      );
+    } else {
+      geoJSONPointsAfterSelected.push(
+        clusterPointToGeoJSON(id, coordinates, date),
+      );
+    }
+  });
+
+  // set radius and maxZoom of superCluster object for polar vs geographic projections
+  if (proj.selected.id !== 'geographic') {
+    firstClusterObj.options.setPolar();
+    secondClusterObj.options.setPolar();
+  } else {
+    firstClusterObj.options.setGeo();
+    secondClusterObj.options.setGeo();
+  }
+
+  const clustersBeforeSelected = getClusterPoints(
+    firstClusterObj,
+    geoJSONPointsBeforeSelected,
+    zoom,
+    extent,
+  );
+  const clustersAfterSelected = getClusterPoints(
+    secondClusterObj,
+    geoJSONPointsAfterSelected,
+    zoom,
+    extent,
+  );
+  let clusters = clustersBeforeSelected.concat(
+    [selectedPoint],
+    clustersAfterSelected,
+  );
+  clusters = clusterSort(clusters);
+
+  return {
+    clusters,
+    firstClusterObj,
+    secondClusterObj,
+  };
 };

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -2,11 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import OlFeature from 'ol/Feature';
-import OlOverlay from 'ol/Overlay';
-import OlLayerVector from 'ol/layer/Vector';
-import OlSourceVector from 'ol/source/Vector';
-import OlStyleStroke from 'ol/style/Stroke';
-import OlStyleStyle from 'ol/style/Style';
 import * as olExtent from 'ol/extent';
 import OlGeomMultiLineString from 'ol/geom/MultiLineString';
 import * as olProj from 'ol/proj';
@@ -16,19 +11,15 @@ import {
 } from 'lodash';
 
 import {
-  naturalEventsClusterPointToGeoJSON,
-  naturalEventsClusterGetPoints,
-  naturalEventsClusterCreateObject,
-  naturalEventsClusterSort,
+  getClusters,
 } from './cluster';
-import { mapUtilZoomAction } from '../util';
 import { selectEvent as selectEventAction } from '../../modules/natural-events/actions';
 import { getFilteredEvents } from '../../modules/natural-events/selectors';
-import { formatDisplayDate } from '../../modules/date/util';
 
-const firstClusterObj = naturalEventsClusterCreateObject(); // Cluster before selected event
-const secondClusterObj = naturalEventsClusterCreateObject(); // Cluster after selected event
 
+import {
+  getTrack, getTrackPoint, getArrows, getClusterPointEl,
+} from './util';
 
 class EventTrack extends React.Component {
   constructor(props) {
@@ -174,6 +165,7 @@ class EventTrack extends React.Component {
     let newTrackDetails;
     const sameEvent = event && trackDetails.id === event.id;
     const sameDate = trackDetails.selectedDate === date;
+
     const createAndAddTrack = () => {
       newTrackDetails = createTrack(proj, event, map, date, selectEvent);
       map.addLayer(newTrackDetails.track);
@@ -213,126 +205,6 @@ class EventTrack extends React.Component {
 }
 
 /**
-   * Determine if track point is across the date line from the
-   * selected point
-   * @param {Array} activeCoord Coordinate array of selected track point
-   * @param {Array} nextCoord Coordinate to test against active coord
-   * @return {Boolean}
-   */
-const crossesDateLine = function(activeCoord, nextCoord) {
-  return Math.abs(activeCoord[0] - nextCoord[0]) > 180;
-};
-
-/**
- * Convert coordinates to be over date line
- * in geographic projections
- *
- * @param {Array} coordinates Coordinate array
- * @return {Array}
- */
-const getOverDateLineCoordinates = function(coordinates) {
-  const long = coordinates[0];
-  const lat = coordinates[1];
-  return long < 0
-    ? [Math.abs(180 + 180 - Math.abs(long)), lat]
-    : [-Math.abs(180 + 180 - Math.abs(long)), lat];
-};
-
-/**
- * Create vector layer
- *
- * @param  {Array} featuresArray Array of linstring
- *                               points
- * @return {Object} OpenLayers Vector Layer
- */
-const naturalEventsTrackLayer = function(proj, featuresArray) {
-  return new OlLayerVector({
-    source: new OlSourceVector({
-      features: featuresArray,
-    }),
-    extent:
-      proj.selected.id === 'geographic'
-        ? [-250, -90, 250, 90]
-        : proj.selected.maxExtent,
-    style: [getLineStyle('black', 2), getLineStyle('white', 1)],
-  });
-};
-
-/**
- * Create event point
- *
- * @param  {Object} clusterPoint
- * @param  {Boolean} isSelected
- * @param  {Function} callback
- * @return {Object} Openlayers overlay object
- */
-const naturalEventsTrackPoint = function(
-  proj,
-  clusterPoint,
-  isSelected,
-  map,
-  callback,
-) {
-  const overlayEl = document.createElement('div');
-  const circleEl = document.createElement('div');
-  const textEl = document.createElement('span');
-  const { properties } = clusterPoint;
-  const { date } = properties;
-  const eventID = properties.event_id;
-  let { coordinates } = clusterPoint.geometry;
-  if (proj.selected.id !== 'geographic') {
-    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
-  }
-  overlayEl.className = isSelected
-    ? 'track-marker-case track-marker-case-selected'
-    : 'track-marker-case';
-  overlayEl.dataset.id = eventID;
-  overlayEl.id = `track-marker-case-${date}`;
-  overlayEl.onclick = function() {
-    callback(eventID, date);
-  };
-  const displayDate = formatDisplayDate(date);
-  const content = document.createTextNode(displayDate);
-  textEl.appendChild(content);
-  textEl.className = 'track-marker-date';
-  circleEl.className = `track-marker track-marker-${date}`;
-  circleEl.id = `track-marker-${date}`;
-  overlayEl.appendChild(circleEl);
-  overlayEl.appendChild(textEl);
-  return new OlOverlay({
-    position: coordinates,
-    positioning: 'center-center',
-    element: overlayEl,
-    stopEvent: false,
-    id: eventID + date.toString(),
-  });
-};
-
-/**
- * @param  {Array} coordinateArray
- * @return {Object} Openlayers Feature
- */
-const naturalEventsTrackLine = function(coordinateArray) {
-  return new OlFeature({
-    geometry: new OlGeomMultiLineString(coordinateArray),
-  });
-};
-
-/**
- * @param  {String} color
- * @param  {Number} Width
- * @return {Object} OpenLayers Style Object
- */
-const getLineStyle = function(color, width) {
-  return new OlStyleStyle({
-    stroke: new OlStyleStroke({
-      color,
-      width,
-    }),
-  });
-};
-
-/**
  * Loop through event geometries and create
  * track points and line
  *
@@ -345,95 +217,23 @@ const getLineStyle = function(color, width) {
  */
 const createTrack = function(proj, eventObj, map, selectedDate, callback) {
   const olTrackLineFeatures = [];
-  let pointObject = {};
-  const geoJSONPointsBeforeSelected = [];
-  const geoJSONPointsAfterSelected = [];
-  let selectedPoint;
-  let clusters;
-  let afterSelected = false;
-  const zoom = map.getView().getZoom();
-  const extent = proj.selected.id === 'geographic'
-    ? [-250, -90, 250, 90]
-    : [-180, -90, 180, 90];
 
-  const { geometry } = eventObj;
-  const selectedCoords = geometry.find(({ date }) => date.split('T')[0] === selectedDate).coordinates;
-  geometry.forEach((geom, index) => {
-    let { coordinates } = geom;
-    const date = geom.date.split('T')[0];
-    const isSelected = selectedDate === date;
-    const isOverDateline = proj.selected.id === 'geographic'
-      ? crossesDateLine(selectedCoords, coordinates)
-      : false;
-    if (isOverDateline) {
-      // replace coordinates
-      coordinates = getOverDateLineCoordinates(coordinates);
-    }
-    // Cluster in three groups
-    if (isSelected) {
-      selectedPoint = naturalEventsClusterPointToGeoJSON(
-        eventObj.id,
-        coordinates,
-        date,
-      );
-      afterSelected = true;
-    } else if (!afterSelected) {
-      geoJSONPointsBeforeSelected.push(
-        naturalEventsClusterPointToGeoJSON(eventObj.id, coordinates, date),
-      );
-    } else {
-      geoJSONPointsAfterSelected.push(
-        naturalEventsClusterPointToGeoJSON(eventObj.id, coordinates, date),
-      );
-    }
-  });
-
-  // set radius and maxZoom of superCluster object for polar vs geographic projections
-  if (proj.selected.id !== 'geographic') {
-    firstClusterObj.options.setPolar();
-    secondClusterObj.options.setPolar();
-  } else {
-    firstClusterObj.options.setGeo();
-    secondClusterObj.options.setGeo();
-  }
-
-  const clustersBeforeSelected = naturalEventsClusterGetPoints(
-    firstClusterObj,
-    geoJSONPointsBeforeSelected,
-    zoom,
-    extent,
+  const { tracks, overlays } = getTracksAndPoints(eventObj, proj, map, selectedDate, callback);
+  olTrackLineFeatures.push(
+    new OlFeature({
+      geometry: new OlGeomMultiLineString(tracks),
+    }),
   );
-  const clustersAfterSelected = naturalEventsClusterGetPoints(
-    secondClusterObj,
-    geoJSONPointsAfterSelected,
-    zoom,
-    extent,
-  );
-  clusters = clustersBeforeSelected.concat(
-    [selectedPoint],
-    clustersAfterSelected,
-  );
-  clusters = naturalEventsClusterSort(clusters);
-
-  pointObject = addPoints(proj, clusters, map, selectedDate, callback);
-  olTrackLineFeatures.push(naturalEventsTrackLine(pointObject.trackArray));
 
   return {
     id: eventObj.id,
-    track: naturalEventsTrackLayer(proj, olTrackLineFeatures, map),
-    pointArray: pointObject.overlayArray,
+    track: getTrack(proj, olTrackLineFeatures, map),
+    pointArray: overlays,
     selectedDate,
     hidden: false,
   };
 };
 
-/**
- * Remove Point overlays to DOM
- *
- * @param  {Object} map OpenLayers Map Object
- * @param  {Array} pointOverlayArray
- * @return {void}
- */
 const removeOldPoints = function(map, { pointArray }) {
   lodashEach(pointArray, (pointOverlay) => {
     if (map.getOverlayById(pointOverlay.getId())) {
@@ -442,13 +242,6 @@ const removeOldPoints = function(map, { pointArray }) {
   });
 };
 
-/**
- * Add Point overlays to DOM
- *
- * @param  {Object} map OpenLayers Map Object
- * @param  {Array} pointOverlayArray
- * @return {void}
- */
 const addPointOverlays = function(map, pointOverlayArray) {
   lodashEach(pointOverlayArray, (pointOverlay) => {
     addOverlayIfIsVisible(map, pointOverlay);
@@ -473,52 +266,6 @@ const updateSelection = function(newDate) {
 };
 
 /**
- * Create rotated element that displays arrows between points
- * as repeated css background image
- *
- * @param  {Array} lineSegmentCoords Start and end points of
- *                  line in Lat/long
- * @param  {Object} map OpenLayers map Object
- * @return {Object} Openlayers overlay Object
- */
-const createArrows = function(lineSegmentCoords, map) {
-  const currentRotation = map.getView().getRotation();
-  const overlayEl = document.createElement('div');
-  const innerEl = document.createElement('div');
-
-  const clusterPadding = 20; // 10px on each side
-  const end = lineSegmentCoords[0];
-  const start = lineSegmentCoords[1];
-  const dxCoord = end[0] - start[0];
-  const dyCoord = end[1] - start[1];
-  const pixel1 = map.getPixelFromCoordinate(start);
-  const pixel2 = map.getPixelFromCoordinate(end);
-  const dx = pixel2[0] - pixel1[0];
-  const dy = pixel2[1] - pixel1[1];
-  const pixelMidPoint = [0.5 * dx + pixel1[0], 0.5 * dy + pixel1[1]];
-  const distanceInPixels = Math.sqrt((dx ** 2) + (dy ** 2));
-  const angleRadians = Math.atan2(dyCoord, dxCoord) - currentRotation;
-  const angleDegrees = -angleRadians * (180 / Math.PI);
-  const lengthOfArrowDiv = distanceInPixels - clusterPadding;
-
-  innerEl.className = 'event-track-arrows';
-  overlayEl.appendChild(innerEl);
-  overlayEl.style.width = '1px';
-  overlayEl.style.height = '1px';
-  innerEl.style.width = `${lengthOfArrowDiv}px`;
-  innerEl.style.height = '16px';
-  innerEl.style.transform = `translate(${-(lengthOfArrowDiv / 2)}px, -8px)`;
-  overlayEl.style.transform = `rotate(${angleDegrees}deg)`;
-  return new OlOverlay({
-    position: map.getCoordinateFromPixel(pixelMidPoint),
-    positioning: 'center-center',
-    stopEvent: true,
-    element: overlayEl,
-    id: `arrow${pixelMidPoint[0].toString()}${pixelMidPoint[1].toString()}`,
-  });
-};
-
-/**
  * Loop through clustered point array and create elements
  *
  * @param {Array} clusters Array of cluster objects
@@ -527,11 +274,12 @@ const createArrows = function(lineSegmentCoords, map) {
  * @param {Function} callback
  * @return {Object} Object Containing track info and elements
  */
-const addPoints = function(proj, clusters, map, selectedDate, callback) {
+const getTracksAndPoints = function(eventObj, proj, map, selectedDate, callback) {
   const overlays = [];
-  const trackArray = [];
+  const tracks = [];
+  const { clusters, firstClusterObj, secondClusterObj } = getClusters(eventObj, proj, selectedDate, map);
+
   clusters.forEach((clusterPoint, index) => {
-    let point;
     const date = clusterPoint.properties.date || clusterPoint.properties.startDate;
     const isSelected = selectedDate === date;
     const pointClusterObj = new Date(date) > new Date(selectedDate)
@@ -543,101 +291,30 @@ const addPoints = function(proj, clusters, map, selectedDate, callback) {
 
       // polar projections require transform of coordinates to crs
       if (proj.selected.id !== 'geographic') {
-        prevCoordinates = olProj.transform(
-          prevCoordinates,
-          'EPSG:4326',
-          proj.selected.crs,
-        );
-        nextCoordinates = olProj.transform(
-          nextCoordinates,
-          'EPSG:4326',
-          proj.selected.crs,
-        );
+        const { crs } = proj.selected;
+        prevCoordinates = olProj.transform(prevCoordinates, 'EPSG:4326', crs);
+        nextCoordinates = olProj.transform(nextCoordinates, 'EPSG:4326', crs);
       }
 
       const lineSegmentArray = [prevCoordinates, nextCoordinates];
-      const arrowOverlay = createArrows(lineSegmentArray, map);
+      const arrowOverlay = getArrows(lineSegmentArray, map);
       overlays.push(arrowOverlay);
-      trackArray.push(lineSegmentArray);
+      tracks.push(lineSegmentArray);
       addOverlayIfIsVisible(map, arrowOverlay);
     }
-    if (clusterPoint.properties.cluster) {
-      point = getClusterPointEl(
-        proj,
-        clusterPoint,
-        map,
-        pointClusterObj,
-        callback,
-      );
-      overlays.push(point);
-    } else {
-      point = naturalEventsTrackPoint(
-        proj,
-        clusterPoint,
-        isSelected,
-        map,
-        callback,
-      );
-      overlays.push(point);
-    }
+
+    const point = clusterPoint.properties.cluster
+      ? getClusterPointEl(proj, clusterPoint, map, pointClusterObj, callback)
+      : getTrackPoint(proj, clusterPoint, isSelected, map, callback);
+    overlays.push(point);
+
     addOverlayIfIsVisible(map, point);
   });
-  return { trackArray, overlayArray: overlays };
-};
-
-/**
- * Create cluster point
- *
- * @param  {Object} clusterPoint
- * @param  {Object} map Openlayers map object
- * @param  {Object} pointClusterObj supercluster object
- * @param  {Function} callback
- * @return {Object} Openlayers overlay object
- */
-function getClusterPointEl(proj, cluster, map, pointClusterObj) {
-  const overlayEl = document.createElement('div');
-  const circleEl = document.createElement('div');
-  const innerCircleEl = document.createElement('div');
-
-  const textEl = document.createElement('span');
-  const { properties } = cluster;
-  const clusterId = properties.cluster_id;
-  const number = properties.point_count_abbreviated;
-  const numberEl = document.createTextNode(number);
-  const { startDate, endDate } = properties;
-  const dateRangeTextEl = document.createTextNode(
-    `${formatDisplayDate(startDate)} to ${formatDisplayDate(endDate)}`,
-  );
-  let { coordinates } = cluster.geometry;
-  const mapView = map.getView();
-  if (proj.selected.id !== 'geographic') {
-    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
-  }
-  const sizeClass = number < 10 ? 'small' : number < 20 ? 'medium' : 'large';
-
-  overlayEl.className = 'cluster-track-marker-case track-marker-case';
-  textEl.className = 'cluster-track-marker-date track-marker-date';
-  textEl.appendChild(dateRangeTextEl);
-  circleEl.className = `cluster-marker cluster-marker-${sizeClass}`;
-  innerCircleEl.className = 'cluster-marker-inner';
-  innerCircleEl.appendChild(numberEl);
-  circleEl.appendChild(innerCircleEl);
-  circleEl.onclick = () => {
-    const zoomTo = pointClusterObj.getClusterExpansionZoom(clusterId);
-    const mapZoom = mapView.getZoom();
-    mapUtilZoomAction(map, zoomTo - mapZoom, 450, coordinates);
+  return {
+    tracks,
+    overlays,
   };
-  overlayEl.appendChild(circleEl);
-  overlayEl.appendChild(textEl);
-
-  return new OlOverlay({
-    position: coordinates,
-    positioning: 'center-center',
-    element: overlayEl,
-    stopEvent: false,
-    id: clusterId + properties.startDate + properties.endDate,
-  });
-}
+};
 
 function addOverlayIfIsVisible(map, overlay) {
   if (

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -85,6 +85,7 @@ class EventTrack extends React.Component {
     // NOTE: Does not cause additional listeners to be registered on subsequent calls
     map.on('moveend', this.onMoveEnd);
     map.getView().on('propertychange', this.debouncedOnPropertyChange);
+    map.once('postrender', () => { this.debouncedTrackUpdate(); });
   }
 
   updateCurrentTrack() {

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -1,8 +1,4 @@
 import OlOverlay from 'ol/Overlay';
-import OlLayerVector from 'ol/layer/Vector';
-import OlSourceVector from 'ol/source/Vector';
-import OlStyleStroke from 'ol/style/Stroke';
-import OlStyleStyle from 'ol/style/Style';
 import * as olProj from 'ol/proj';
 import { mapUtilZoomAction } from '../util';
 import { formatDisplayDate } from '../../modules/date/util';
@@ -15,13 +11,7 @@ import { formatDisplayDate } from '../../modules/date/util';
 * @param  {Function} callback
 * @return {Object} Openlayers overlay object
 */
-export const getTrackPoint = function(
-  proj,
-  clusterPoint,
-  isSelected,
-  map,
-  callback,
-) {
+export const getTrackPoint = function(proj, clusterPoint, isSelected, callback) {
   const overlayEl = document.createElement('div');
   const circleEl = document.createElement('div');
   const textEl = document.createElement('span');
@@ -58,74 +48,106 @@ export const getTrackPoint = function(
 };
 
 /**
- * Create vector layer
- *
- * @param  {Array} featuresArray Array of linstring points
- * @return {Object} OpenLayers Vector Layer
- */
-export const getTrack = function(proj, features) {
-  const extentWithWings = [-250, -90, 250, 90];
-  const extent = proj.selected.id === 'geographic'
-    ? extentWithWings
-    : proj.selected.maxExtent;
-
-  const getLineStyle = function(color, width) {
-    return new OlStyleStyle({
-      stroke: new OlStyleStroke({ color, width }),
-    });
-  };
-  return new OlLayerVector({
-    source: new OlSourceVector({ features }),
-    extent,
-    style: [getLineStyle('black', 2), getLineStyle('white', 1)],
-  });
-};
-
-
-
-/**
  * Create rotated element that displays arrows between points
  * as repeated css background image
  *
- * @param  {Array} lineSegmentCoords Start and end points of
- *                  line in Lat/long
+ * @param  {Array} lineSegmentCoords Start and end points of line in Lat/long
  * @param  {Object} map OpenLayers map Object
  * @return {Object} Openlayers overlay Object
  */
 export const getArrows = function(lineSegmentCoords, map) {
   const currentRotation = map.getView().getRotation();
   const overlayEl = document.createElement('div');
-  const innerEl = document.createElement('div');
+  const arrowEl = document.createElement('div');
 
   const clusterPadding = 20; // 10px on each side
   const end = lineSegmentCoords[0];
   const start = lineSegmentCoords[1];
   const dxCoord = end[0] - start[0];
   const dyCoord = end[1] - start[1];
-  const pixel1 = map.getPixelFromCoordinate(start);
-  const pixel2 = map.getPixelFromCoordinate(end);
-  const dx = pixel2[0] - pixel1[0];
-  const dy = pixel2[1] - pixel1[1];
-  const pixelMidPoint = [0.5 * dx + pixel1[0], 0.5 * dy + pixel1[1]];
+  const pixelStart = map.getPixelFromCoordinate(start);
+  const pixelEnd = map.getPixelFromCoordinate(end);
+  const dx = pixelEnd[0] - pixelStart[0];
+  const dy = pixelEnd[1] - pixelStart[1];
+  const pixelMidPoint = [0.5 * dx + pixelStart[0], 0.5 * dy + pixelStart[1]];
   const distanceInPixels = Math.sqrt((dx ** 2) + (dy ** 2));
   const angleRadians = Math.atan2(dyCoord, dxCoord) - currentRotation;
   const angleDegrees = -angleRadians * (180 / Math.PI);
   const lengthOfArrowDiv = distanceInPixels - clusterPadding;
 
-  innerEl.className = 'event-track-arrows';
-  overlayEl.appendChild(innerEl);
+  arrowEl.className = 'event-track-arrows';
+  arrowEl.style.width = `${lengthOfArrowDiv}px`;
+  arrowEl.style.height = '16px';
+  arrowEl.style.transform = `translate(${-(lengthOfArrowDiv / 2)}px, -8px)`;
+
+  overlayEl.appendChild(arrowEl);
   overlayEl.style.width = '1px';
   overlayEl.style.height = '1px';
-  innerEl.style.width = `${lengthOfArrowDiv}px`;
-  innerEl.style.height = '16px';
-  innerEl.style.transform = `translate(${-(lengthOfArrowDiv / 2)}px, -8px)`;
   overlayEl.style.transform = `rotate(${angleDegrees}deg)`;
+
   return new OlOverlay({
     position: map.getCoordinateFromPixel(pixelMidPoint),
     positioning: 'center-center',
     stopEvent: true,
     element: overlayEl,
     id: `arrow${pixelMidPoint[0].toString()}${pixelMidPoint[1].toString()}`,
+  });
+};
+
+export const getTrackLines = function(map, trackCoords) {
+  const svgEl = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const lineEl = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+  let lineString = '';
+  const first = trackCoords[0][0];
+  const last = trackCoords[trackCoords.length - 1][0];
+  const bottomLeft = [first[0], first[1]];
+  const topRight = [last[0], last[1]];
+
+  trackCoords.forEach(([[x1, y1], [x2, y2]]) => {
+    bottomLeft[0] = Math.min(x1, x2, bottomLeft[0]);
+    bottomLeft[1] = Math.min(y1, y2, bottomLeft[1]);
+    topRight[0] = Math.max(x1, x2, topRight[0]);
+    topRight[1] = Math.max(y1, y2, topRight[1]);
+  });
+  const pixelBottomLeft = map.getPixelFromCoordinate(bottomLeft);
+  const pixelTopRight = map.getPixelFromCoordinate(topRight);
+
+  const [minX, maxY] = pixelBottomLeft;
+  const [maxX, minY] = pixelTopRight;
+  const height = Math.abs(maxY - minY);
+  const width = Math.abs(maxX - minX);
+  const rotation = Number(map.getView().getRotation() * (180 / Math.PI)).toFixed();
+
+  svgEl.setAttribute('height', height);
+  svgEl.setAttribute('width', width);
+  svgEl.style.height = `${height}px`;
+  svgEl.style.width = `${width}px`;
+  svgEl.style.backgroundColor = 'rgba(255, 0, 0, 0.15)';
+  svgEl.style.display = 'inline-block';
+  svgEl.style.transform = `rotate(${rotation}deg)`;
+  svgEl.appendChild(lineEl);
+
+  trackCoords.forEach(([start, end], index) => {
+    const [x1, y1] = map.getPixelFromCoordinate(start);
+    const [x2, y2] = map.getPixelFromCoordinate(end);
+    const newStart = `${x1 - minX},${y1 - minY}`;
+    const newEnd = `${x2 - minX},${y2 - minY}`;
+    lineString += index === 0 ? `${newStart} ${newEnd} ` : `${newEnd} `;
+  });
+
+  lineEl.style.fill = 'transparent';
+  lineEl.style.stroke = 'black';
+  lineEl.style.strokeWidth = '1px';
+  lineEl.style.display = 'inline-block';
+  lineEl.setAttribute('points', lineString);
+
+  return new OlOverlay({
+    position: bottomLeft,
+    positioning: 'bottom-left',
+    insertFirst: true,
+    stopEvent: false,
+    element: svgEl,
+    id: 'event-track',
   });
 };
 

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -1,0 +1,183 @@
+import OlOverlay from 'ol/Overlay';
+import OlLayerVector from 'ol/layer/Vector';
+import OlSourceVector from 'ol/source/Vector';
+import OlStyleStroke from 'ol/style/Stroke';
+import OlStyleStyle from 'ol/style/Style';
+import * as olProj from 'ol/proj';
+import { mapUtilZoomAction } from '../util';
+import { formatDisplayDate } from '../../modules/date/util';
+
+/**
+* Create event point
+*
+* @param  {Object} clusterPoint
+* @param  {Boolean} isSelected
+* @param  {Function} callback
+* @return {Object} Openlayers overlay object
+*/
+export const getTrackPoint = function(
+  proj,
+  clusterPoint,
+  isSelected,
+  map,
+  callback,
+) {
+  const overlayEl = document.createElement('div');
+  const circleEl = document.createElement('div');
+  const textEl = document.createElement('span');
+  const { properties } = clusterPoint;
+  const content = document.createTextNode(formatDisplayDate(properties.date));
+  const { date } = properties;
+  const eventID = properties.event_id;
+  let { coordinates } = clusterPoint.geometry;
+  if (proj.selected.id !== 'geographic') {
+    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
+  }
+  overlayEl.className = isSelected
+    ? 'track-marker-case track-marker-case-selected'
+    : 'track-marker-case';
+  overlayEl.dataset.id = eventID;
+  overlayEl.id = `track-marker-case-${date}`;
+  overlayEl.onclick = function() {
+    callback(eventID, date);
+  };
+  textEl.appendChild(content);
+  textEl.className = 'track-marker-date';
+  circleEl.className = `track-marker track-marker-${date}`;
+  circleEl.id = `track-marker-${date}`;
+  overlayEl.appendChild(circleEl);
+  overlayEl.appendChild(textEl);
+
+  return new OlOverlay({
+    position: coordinates,
+    positioning: 'center-center',
+    element: overlayEl,
+    stopEvent: false,
+    id: eventID + date.toString(),
+  });
+};
+
+/**
+ * Create vector layer
+ *
+ * @param  {Array} featuresArray Array of linstring points
+ * @return {Object} OpenLayers Vector Layer
+ */
+export const getTrack = function(proj, features) {
+  const extentWithWings = [-250, -90, 250, 90];
+  const extent = proj.selected.id === 'geographic'
+    ? extentWithWings
+    : proj.selected.maxExtent;
+
+  const getLineStyle = function(color, width) {
+    return new OlStyleStyle({
+      stroke: new OlStyleStroke({ color, width }),
+    });
+  };
+  return new OlLayerVector({
+    source: new OlSourceVector({ features }),
+    extent,
+    style: [getLineStyle('black', 2), getLineStyle('white', 1)],
+  });
+};
+
+
+
+/**
+ * Create rotated element that displays arrows between points
+ * as repeated css background image
+ *
+ * @param  {Array} lineSegmentCoords Start and end points of
+ *                  line in Lat/long
+ * @param  {Object} map OpenLayers map Object
+ * @return {Object} Openlayers overlay Object
+ */
+export const getArrows = function(lineSegmentCoords, map) {
+  const currentRotation = map.getView().getRotation();
+  const overlayEl = document.createElement('div');
+  const innerEl = document.createElement('div');
+
+  const clusterPadding = 20; // 10px on each side
+  const end = lineSegmentCoords[0];
+  const start = lineSegmentCoords[1];
+  const dxCoord = end[0] - start[0];
+  const dyCoord = end[1] - start[1];
+  const pixel1 = map.getPixelFromCoordinate(start);
+  const pixel2 = map.getPixelFromCoordinate(end);
+  const dx = pixel2[0] - pixel1[0];
+  const dy = pixel2[1] - pixel1[1];
+  const pixelMidPoint = [0.5 * dx + pixel1[0], 0.5 * dy + pixel1[1]];
+  const distanceInPixels = Math.sqrt((dx ** 2) + (dy ** 2));
+  const angleRadians = Math.atan2(dyCoord, dxCoord) - currentRotation;
+  const angleDegrees = -angleRadians * (180 / Math.PI);
+  const lengthOfArrowDiv = distanceInPixels - clusterPadding;
+
+  innerEl.className = 'event-track-arrows';
+  overlayEl.appendChild(innerEl);
+  overlayEl.style.width = '1px';
+  overlayEl.style.height = '1px';
+  innerEl.style.width = `${lengthOfArrowDiv}px`;
+  innerEl.style.height = '16px';
+  innerEl.style.transform = `translate(${-(lengthOfArrowDiv / 2)}px, -8px)`;
+  overlayEl.style.transform = `rotate(${angleDegrees}deg)`;
+  return new OlOverlay({
+    position: map.getCoordinateFromPixel(pixelMidPoint),
+    positioning: 'center-center',
+    stopEvent: true,
+    element: overlayEl,
+    id: `arrow${pixelMidPoint[0].toString()}${pixelMidPoint[1].toString()}`,
+  });
+};
+
+/**
+ * Create cluster point
+ *
+ * @param  {Object} clusterPoint
+ * @param  {Object} map Openlayers map object
+ * @param  {Object} pointClusterObj supercluster object
+ * @param  {Function} callback
+ * @return {Object} Openlayers overlay object
+ */
+export const getClusterPointEl = function (proj, cluster, map, pointClusterObj) {
+  const overlayEl = document.createElement('div');
+  const circleEl = document.createElement('div');
+  const innerCircleEl = document.createElement('div');
+
+  const textEl = document.createElement('span');
+  const { properties } = cluster;
+  const clusterId = properties.cluster_id;
+  const number = properties.point_count_abbreviated;
+  const numberEl = document.createTextNode(number);
+  const dateRangeTextEl = document.createTextNode(
+    `${formatDisplayDate(properties.startDate)} to ${formatDisplayDate(properties.endDate)}`,
+  );
+  let { coordinates } = cluster.geometry;
+  const mapView = map.getView();
+  if (proj.selected.id !== 'geographic') {
+    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
+  }
+  const sizeClass = number < 10 ? 'small' : number < 20 ? 'medium' : 'large';
+
+  overlayEl.className = 'cluster-track-marker-case track-marker-case';
+  textEl.className = 'cluster-track-marker-date track-marker-date';
+  textEl.appendChild(dateRangeTextEl);
+  circleEl.className = `cluster-marker cluster-marker-${sizeClass}`;
+  innerCircleEl.className = 'cluster-marker-inner';
+  innerCircleEl.appendChild(numberEl);
+  circleEl.appendChild(innerCircleEl);
+  circleEl.onclick = () => {
+    const zoomTo = pointClusterObj.getClusterExpansionZoom(clusterId);
+    const mapZoom = mapView.getZoom();
+    mapUtilZoomAction(map, zoomTo - mapZoom, 450, coordinates);
+  };
+  overlayEl.appendChild(circleEl);
+  overlayEl.appendChild(textEl);
+
+  return new OlOverlay({
+    position: coordinates,
+    positioning: 'center-center',
+    element: overlayEl,
+    stopEvent: false,
+    id: clusterId + properties.startDate + properties.endDate,
+  });
+};

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -39,6 +39,7 @@ export const getTrackPoint = function(proj, clusterPoint, isSelected, callback) 
   overlayEl.appendChild(textEl);
 
   return new OlOverlay({
+    className: 'event-track-point',
     position: coordinates,
     positioning: 'center-center',
     element: overlayEl,
@@ -60,7 +61,7 @@ export const getArrows = function(lineSegmentCoords, map) {
   const overlayEl = document.createElement('div');
   const arrowEl = document.createElement('div');
 
-  const clusterPadding = 20; // 10px on each side
+  const clusterPadding = 30; // 10px on each side
   const end = lineSegmentCoords[0];
   const start = lineSegmentCoords[1];
   const dxCoord = end[0] - start[0];
@@ -144,6 +145,7 @@ export const getTrackLines = function(map, trackCoords) {
   outlineEl.setAttribute('points', lineString);
 
   return new OlOverlay({
+    className: 'event-track-line',
     position: map.getCoordinateFromPixel(topLeft),
     positioning: 'top-left',
     insertFirst: true,
@@ -198,6 +200,7 @@ export const getClusterPointEl = function (proj, cluster, map, pointClusterObj) 
   overlayEl.appendChild(textEl);
 
   return new OlOverlay({
+    className: 'event-track-cluster-point',
     position: coordinates,
     positioning: 'center-center',
     element: overlayEl,

--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -220,3 +220,17 @@ export function fly (map, proj, endPoint, endZoom = 5, rotation = 0) {
     ),
   ]);
 }
+
+export const crossesDateLine = ([active], [next]) => Math.abs(active - next) > 180;
+
+export const getOverDateLineCoordinates = (coordinates) => {
+  const long = coordinates[0];
+  const lat = coordinates[1];
+  return long < 0
+    ? [Math.abs(180 + 180 - Math.abs(long)), lat]
+    : [-Math.abs(180 + 180 - Math.abs(long)), lat];
+};
+
+export const getExtent = (proj) => (proj.selected.id === 'geographic'
+  ? [-250, -90, 250, 90]
+  : [-180, -90, 180, 90]);


### PR DESCRIPTION
## Description

Changes event tracks to be rendered as overlays rather than vector layers.  This prevents cluttering the OL map layers collection with non-imagery layers, which helps avoid bugs where we make assumptions that this collection only includes imagery layers (which has come up a few times now).

* Clean up code, break out some functions to a util file
* Render track lines as an SVG polyline
* Move track point  date tooltips to show _above_ points so mouse cursor doesn't obscure
  * Tooltips still show below for selected point so even icon doesn't obscure
* Fix an issue where switching from Events to Layers tab during animation would cause event tracks/points to not be removed from the map

---

## How to Test

1. Load app with ice/storm events: http://localhost:3000/?e=true&efs=true&efd=2021-07-25,2021-11-22&efc=severeStorms,seaLakeIce&t=2021-11-22-T17%3A03%3A25Z
2. For each of the following, after taking an action confirm tracks/points render as expected 
3. Switch between events 
4. Switch between points on a track (clicking point directly) 
5. Switch between points on a track (clicking date in event list) 
6. Drag/zoom with tracks rendered 
---
1. Load app with event selected and animation set-up: [here](http://localhost:3000/?v=88.66484375000002,7.880859375,124.73515625000002,31.119140625&as=2021-10-14-T00%3A00%3A00Z&ae=2021-10-24-T00%3A00%3A00Z&e=EONET_5947,2021-10-14&efs=true&efd=2021-07-25,2021-11-22&efc=severeStorms,seaLakeIce&l=MODIS_Aqua_Sea_Ice(hidden),MODIS_Terra_Sea_Ice(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Night(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Day(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Night(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Day(hidden),MODIS_Aqua_Brightness_Temp_Band31_Night(hidden),MODIS_Aqua_Brightness_Temp_Band31_Day(hidden),MODIS_Terra_Brightness_Temp_Band31_Night(hidden),MODIS_Terra_Brightness_Temp_Band31_Day(hidden),IMERG_Precipitation_Rate,VIIRS_SNPP_DayNightBand_ENCC(hidden),VIIRS_SNPP_DayNightBand_At_Sensor_Radiance(hidden),VIIRS_SNPP_DayNightBand_AtSensor_M15(hidden),Reference_Labels_15m,Reference_Features_15m,Coastlines_15m(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&ab=on&t=2021-10-14-T00%3A00%3A00Z)
2. Play animation
3. Switch back to layers tab
4. Confirm event tracks/points get removed


@nasa-gibs/worldview
