### PR TITLE
made iss lis layers inactive

### DIFF
--- a/config/default/common/config/wv.json/layers/iss/LIS_ISS_Flash_Count.json
+++ b/config/default/common/config/wv.json/layers/iss/LIS_ISS_Flash_Count.json
@@ -8,7 +8,8 @@
       "tags": "lightning international space station iss",
       "group": "overlays",
       "layergroup": "Lightning",
-      "product": "isslis_p0_nrt",
+      "product": "",
+      "inactive": true,
       "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_ISS_Ascending",

--- a/config/default/common/config/wv.json/layers/iss/LIS_ISS_Flash_Radiance.json
+++ b/config/default/common/config/wv.json/layers/iss/LIS_ISS_Flash_Radiance.json
@@ -8,7 +8,8 @@
       "tags": "lightning international space station iss",
       "group": "overlays",
       "layergroup": "Lightning",
-      "product": "isslis_p0_nrt",
+      "product": "",
+      "inactive": true,
       "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_ISS_Ascending",


### PR DESCRIPTION
## Description

Fixes WV-2066.

[Description of the bug or feature]

- [x] Made 2 ISS LIS Flash Count and Flash Radiance (LIS_ISS_Flash_Radiance, LIS_ISS_Flash_Count) layers inactive as version 1 is no longer being produced
- [x] Added layer notice

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
