### PR TITLE
WV-1959

### DIFF
--- a/rpm/httpd.conf
+++ b/rpm/httpd.conf
@@ -11,3 +11,7 @@ AddHandler cgi-script .cgi
 <Directory /usr/share/worldview/web/service>
     Options ExecCGI
 </Directory>
+
+<Directory /usr/share/worldview/web/config>
+   Header set Access-Control-Allow-Origin "*"
+</Directory>


### PR DESCRIPTION
## Description

In order to allow requesting the PROD deployed version of our `wv.json` so that we can dynamically generate a docs page of layers, we need to be able to request  `config/wv.json` from other domains (e.g. `localhost` to test and `github.io` for the deployed docs)

This change allows cross-origin requests for only the `config/` directory.