### PR TITLE
WV 2000 Increase click target size for timeline date/time inputs to improve tablet/touchscreen UX

### DIFF
--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -105,7 +105,7 @@ button:focus {
   & .input-wrapper .date-arrows::before {
     content: "";
     position: absolute;
-    top:-15px;
+    top: -15px;
     height: 30px;
     width: 100%;
     max-width: inherit;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -101,6 +101,18 @@ button:focus {
   & .input-wrapper:hover .date-arrows {
     visibility: visible;
   }
+
+  & .input-wrapper .date-arrows::before {
+    content: "";
+    position: absolute;
+    top:-15px;
+    height: 30px;
+    width: 100%;
+    max-width: inherit;
+    // border: 1px solid red;
+
+  }
+
   & .input-wrapper:hover .date-arrows svg path {
     fill: #888;
   }
@@ -127,7 +139,9 @@ button:focus {
   & .date-arrows {
     display: block;
     height: 10px;
+    max-width: inherit;
   }
+
   & .date-arrows svg {
     vertical-align: top;
     display: block;

--- a/web/css/timeline.css
+++ b/web/css/timeline.css
@@ -109,8 +109,6 @@ button:focus {
     height: 30px;
     width: 100%;
     max-width: inherit;
-    // border: 1px solid red;
-
   }
 
   & .input-wrapper:hover .date-arrows svg path {


### PR DESCRIPTION
### What existing feature could be improved?
On an iPad it's really hard to increment/decrement the year/month/date without accidentally clicking into the text/number input box for each, which causes the keyboard overlay to pop up which can be really frustrating.

### Describe the improvement you'd like
This could easily be remedied by making the click targets for the increment/decrement buttons a bit taller. Most guidelines recommend anywhere from 28px by 28px to 44px by 44px. These buttons are currently only 44px by 11px

### Fixes Made
Instead of altering the layout and potentially breaking the UI, a new `& .input-wrapper .date-arrows` class was created with the  `::before` pseudo-element.  This expands the clickable area with a larger, invisible hitbox. 

The hitbox's height is hardcoded at `30px`, but expands to the full width of the the `#timeline-header .input-wrapper-day` parent element by using `max-width: inherit`.  The pseudo-element inherits its value from `.date-arrows`, which also has `max-width: inherit`, which in turn inherits the `max-width` property declared in `#timeline-header .input-wrapper-day`.  Essentially, the pseudo-element's width is inherited from the `#timeline-header .input-wrapper-day` element.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
