### PR TITLE
WV 1988 Layer picker should show category in mobile view

### DIFF
--- a/web/css/layer-categories.css
+++ b/web/css/layer-categories.css
@@ -16,8 +16,12 @@
 }
 
 .categories-dropdown-header {
-  height: 45px;
   margin-top: 2px;
+  text-align: center;
+}
+
+.selected-category {
+  margin-bottom:10px;
 }
 
 .categories-dropdown,

--- a/web/css/layer-categories.css
+++ b/web/css/layer-categories.css
@@ -21,7 +21,7 @@
 }
 
 .selected-category {
-  margin-bottom:10px;
+  margin-bottom: 10px;
 }
 
 .categories-dropdown,

--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -633,7 +633,7 @@
     height: calc(var(--vh, 1vh) * 100 - 70px);
   }
   .browse-search-width .search-layers-container.browse {
-    height: calc(var(--vh, 1vh) * 100 - 93px);
+    height: calc(var(--vh, 1vh) * 100 - 122px);
   }
   .browse-search-width .search-layers-container.recent-layers {
     height: calc(var(--vh, 1vh) * 100 - 95px);

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -170,6 +170,11 @@ function BrowseLayers (props) {
       );
   }
 
+  function renderSelectedCategoryName() {
+    return selectedCategoryName == '' ? null
+    : <div className='selected-category'>{selectedCategoryName}</div>
+  }
+
   function renderMobileDropdown() {
     return (
       <div className="categories-dropdown-header">
@@ -195,7 +200,8 @@ function BrowseLayers (props) {
           </DropdownMenu>
         </Dropdown>
         {recentLayersHeader()}
-        {selectedCategoryName}
+
+        {renderSelectedCategoryName()}
       </div>
     );
   }

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -255,7 +255,6 @@ function mapStateToProps(state) {
     proj,
     productPicker,
     layers,
-    lastAction,
   } = state;
   const {
     mode,
@@ -273,7 +272,6 @@ function mapStateToProps(state) {
     categoryType,
     categoryTabNames: config.categoryGroupOrder,
     measurementConfig: config.measurements,
-    lastAction,
     layerConfig: layers.layerConfig,
     listScrollTop,
     recentLayers,

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -32,8 +32,10 @@ import safeLocalStorage from '../../../../util/local-storage';
 function BrowseLayers (props) {
   const {
     browser,
+    category,
     categoryTabNames,
     categoryType,
+    lastAction,
     mode,
     width,
     recentLayers,
@@ -253,9 +255,11 @@ function mapStateToProps(state) {
     proj,
     productPicker,
     layers,
+    lastAction,
   } = state;
   const {
     mode,
+    category,
     categoryType,
     listScrollTop,
     selectedMeasurement,
@@ -265,9 +269,11 @@ function mapStateToProps(state) {
   return {
     browser,
     mode,
+    category: category ? category.title : '',
     categoryType,
     categoryTabNames: config.categoryGroupOrder,
     measurementConfig: config.measurements,
+    lastAction,
     layerConfig: layers.layerConfig,
     listScrollTop,
     recentLayers,

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -32,7 +32,6 @@ import safeLocalStorage from '../../../../util/local-storage';
 function BrowseLayers (props) {
   const {
     browser,
-    category,
     categoryTabNames,
     categoryType,
     mode,
@@ -217,11 +216,10 @@ function BrowseLayers (props) {
 
 BrowseLayers.propTypes = {
   browser: PropTypes.object,
-  category: PropTypes.string,
   categoryTabNames: PropTypes.array,
   categoryType: PropTypes.string,
   clearRecentLayers: PropTypes.func,
-  lastAction: PropTypes.object,
+  selectedCategoryName: PropTypes.string,
   mode: PropTypes.string,
   recentLayers: PropTypes.array,
   selectCategoryType: PropTypes.func,

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -66,7 +66,7 @@ function BrowseLayers (props) {
     && selectedProjection === 'geographic'
     && categoryType !== 'recent';
 
-  const selectedCategoryName = useSelector(state => state.productPicker.category.title);
+  const selectedCategoryName = useSelector((state) => state.productPicker.category.title);
   /**
    * Update category type in which to show
    * e.g. Hazards and disasters or science disciplines

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -66,6 +66,7 @@ function BrowseLayers (props) {
     && selectedProjection === 'geographic'
     && categoryType !== 'recent';
 
+  const selectedCategoryName = useSelector(state => state.productPicker.category.title);
   /**
    * Update category type in which to show
    * e.g. Hazards and disasters or science disciplines
@@ -192,6 +193,7 @@ function BrowseLayers (props) {
           </DropdownMenu>
         </Dropdown>
         {recentLayersHeader()}
+        {selectedCategoryName}
       </div>
     );
   }

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -68,7 +68,7 @@ function BrowseLayers (props) {
     && selectedProjection === 'geographic'
     && categoryType !== 'recent';
 
-  const selectedCategoryName = (lastAction.type === 'PRODUCT_PICKER/TOGGLE_CATEGORY_MODE') ? '' : category;
+  const selectedCategoryName = lastAction.type === 'PRODUCT_PICKER/TOGGLE_CATEGORY_MODE' ? '' : category;
 
   /**
    * Update category type in which to show
@@ -172,8 +172,8 @@ function BrowseLayers (props) {
   }
 
   function renderSelectedCategoryName() {
-    return selectedCategoryName == '' ? null
-    : <div className='selected-category'>{selectedCategoryName}</div>
+    return selectedCategoryName === '' ? null
+      : <div className="selected-category">{selectedCategoryName}</div>;
   }
 
   function renderMobileDropdown() {
@@ -224,9 +224,11 @@ function BrowseLayers (props) {
 
 BrowseLayers.propTypes = {
   browser: PropTypes.object,
+  category: PropTypes.string,
   categoryTabNames: PropTypes.array,
   categoryType: PropTypes.string,
   clearRecentLayers: PropTypes.func,
+  lastAction: PropTypes.object,
   mode: PropTypes.string,
   recentLayers: PropTypes.array,
   selectCategoryType: PropTypes.func,

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -68,7 +68,8 @@ function BrowseLayers (props) {
     && selectedProjection === 'geographic'
     && categoryType !== 'recent';
 
-  const selectedCategoryName = useSelector((state) => state.productPicker.category.title);
+  const selectedCategoryName = (lastAction.type === 'PRODUCT_PICKER/TOGGLE_CATEGORY_MODE') ? '' : category;
+
   /**
    * Update category type in which to show
    * e.g. Hazards and disasters or science disciplines

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -35,11 +35,11 @@ function BrowseLayers (props) {
     category,
     categoryTabNames,
     categoryType,
-    lastAction,
     mode,
     width,
     recentLayers,
     selectCategoryType,
+    selectedCategoryName,
     selectedProjection,
     toggleMeasurementsTab,
     toggleFeatureTab,
@@ -67,8 +67,6 @@ function BrowseLayers (props) {
   const isCategoryDisplay = mode === 'category'
     && selectedProjection === 'geographic'
     && categoryType !== 'recent';
-
-  const selectedCategoryName = lastAction.type === 'PRODUCT_PICKER/TOGGLE_CATEGORY_MODE' ? '' : category;
 
   /**
    * Update category type in which to show
@@ -171,11 +169,6 @@ function BrowseLayers (props) {
       );
   }
 
-  function renderSelectedCategoryName() {
-    return selectedCategoryName === '' ? null
-      : <div className="selected-category">{selectedCategoryName}</div>;
-  }
-
   function renderMobileDropdown() {
     return (
       <div className="categories-dropdown-header">
@@ -202,7 +195,7 @@ function BrowseLayers (props) {
         </Dropdown>
         {recentLayersHeader()}
 
-        {renderSelectedCategoryName()}
+        {selectedCategoryName && <div className="selected-category">{selectedCategoryName}</div>}
       </div>
     );
   }
@@ -278,7 +271,7 @@ function mapStateToProps(state) {
   return {
     browser,
     mode,
-    category: category ? category.title : '',
+    selectedCategoryName: category && category.title,
     categoryType,
     categoryTabNames: config.categoryGroupOrder,
     measurementConfig: config.measurements,

--- a/web/js/modules/product-picker/reducers.js
+++ b/web/js/modules/product-picker/reducers.js
@@ -198,6 +198,7 @@ export function productPickerReducer(state = productPickerState, action) {
       return {
         ...state,
         mode: 'category',
+        category: null,
         selectedLayer: null,
         selectedMeasurement: null,
         selectedMeasurementSourceIndex: 0,


### PR DESCRIPTION
## Description

When in mobile view, the layer picker doesn't show the category that the user has selected under "Hazards and Disasters" or "Science Disciplines".  It's unclear which category the user is currently browsing once inside that category.

### Fixes

Added the category name below the parent category.  Used `mapStateToProps()` to call the `category.title` and `lastAction.type` from the Redux store.  When a category is selected or a child of a category is selected (i.e., if `category.title` contains a value), a div containing the category name will appear below the dropdown menu.  If the back button is pressed (i.e., `lastAction.type === 'PRODUCT_PICKER/TOGGLE_CATEGORY_MODE'`), then the div containing the category name is removed.

The toggling of the div is keyed off of the `selectedCategoryName` const.  This const is either blank if the back button pressed, otherwise assign to it the value of `category.title` from the Redux store. 

To create the div below the dropdown menu, the function `renderSelectedCategoryName()` is called.  If the const `selectedCategoryname` is blank, return nothing so that the space below the dropdown menu collapses.  Otherwise, the function will return the div containing the category name and create space below the dropdown menu for itself.

## How To Test

[Provide whatever information a reviewer might need to know in order to verify that the changes made in this PR are working as expected. If there are special build steps that need to be taken in order to get these changes to run (building while on a separate branch, running `npm ci`, etc) include them here.]

To test this feature, you will need to be in mobile view.  You can do this by shrinking your browser until the app switches to mobile mode, or accessing the Chrome Dev Tools and clicking the mobile device icon to simulate viewing on a mobile device.

Once in mobile mode, do the following:
- Open the Layers panel by clicking/tapping the Layers icon (has a "7" on it).
- Click/tap "+ Add Layers".
- Select any of the layers below or their categories.
- On the next page with the orange arrows, you will see the name of selected category below the "Hazards and Disasters", "Scientific Disciplines", etc. dropdown.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
