### PR TITLE
WV-1959: Remove format property from a layer config

### DIFF
--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_Thermal_Anomalies_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_Thermal_Anomalies_Night.json
@@ -7,7 +7,6 @@
       "description": "modis/terra/MODIS_Terra_Thermal_Anomalies_All",
       "tags": "hotspots vectors",
       "group": "overlays",
-      "format": "image/png",
       "period": "daily",
       "layergroup": "Fires and Thermal Anomalies",
       "type": "vector",


### PR DESCRIPTION
## Description

Fixes an issue where this layer's format showed as "png" in the GIBS docs when it should be shown as vector.




