### PR TITLE
WV-2080: Display QA datasets meaningfully

### DIFF
--- a/web/css/smart-handoff.css
+++ b/web/css/smart-handoff.css
@@ -79,7 +79,7 @@
     color: #999;
   }
   .collection-choice {
-    margin: 8px 0 8px 6px;
+    margin: 8px 0 8px 5px;
     input {
       cursor: pointer;
       position: relative;
@@ -88,7 +88,7 @@
     label {
       color: #eee;
       cursor: pointer;
-      margin: 0 5px 0 7px;
+      margin-left: 5px;
       font-size: 13px;
     }
     svg {

--- a/web/css/smart-handoff.css
+++ b/web/css/smart-handoff.css
@@ -79,7 +79,7 @@
     color: #999;
   }
   .collection-choice {
-    margin: 8px 5px 8px 15px;
+    margin: 8px 0 8px 6px;
     input {
       cursor: pointer;
       position: relative;

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -389,11 +389,14 @@ class SmartHandoff extends Component {
 
               {layer.conceptIds.filter(({ value }) => validatedConceptIds[value]).map((collection) => {
                 const {
-                  type, value, version,
+                  type, value, version, quality,
                 } = collection;
                 const inputId = `${util.encodeId(value)}-${util.encodeId(layer.id)}-collection-choice`;
                 const isSelected = (selectedCollection || {}).value === value && layerIsSelected;
                 const labelId = `${inputId}-label`;
+                const label = STD_NRT_MAP[type]
+                   + (version ? ` - v${version}` : '')
+                   + (quality ? ' (Quality)' : '');
 
                 return (
                   <div className="collection-choice" key={inputId}>
@@ -405,7 +408,7 @@ class SmartHandoff extends Component {
                       onChange={() => selectCollection(collection.value, layer.id)}
                     />
                     <label id={labelId} htmlFor={inputId}>
-                      {STD_NRT_MAP[type] + (version ? ` - v${version}` : '')}
+                      {label}
                       <FontAwesomeIcon id={`${util.encodeId(value)}-tooltip`} icon="info-circle" />
                     </label>
 


### PR DESCRIPTION
## Description

* Show quality flag for collections that have it, to allow distinguishing QA datasets from others

Here is a screenshot of what this looks like with the QA datasets included:
<img width="278" alt="Screen Shot 2021-12-22 at 3 11 47 PM" src="https://user-images.githubusercontent.com/1480000/147149865-c4973bd6-664f-445b-acc1-6fa84a5b4d2f.png">


