### PR TITLE
WV-2098 "Add layers" issue in Android 11 when in portrait mode.

### DIFF
--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -42,7 +42,6 @@ class ModalContainer extends Component {
       id,
       isOpen,
       customProps,
-      orientation,
       isMobile,
       screenHeight,
       screenWidth,

--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -55,12 +55,11 @@ class ModalContainer extends Component {
       desktopOnly,
     } = newProps;
 
-    const orientationChanged = orientation !== prevProps.orientation;
     const screenHeightChanged = screenHeight !== prevProps.screenHeight;
     const screenWidthChanged = screenWidth !== prevProps.screenWidth;
     const toggleFunction = toggleWithClose(onToggle, onClose, isOpen);
     if (isMobile && isOpen) {
-      if (desktopOnly || orientationChanged) {
+      if (desktopOnly) {
         toggleFunction();
       }
       if (customProps.mobileFullScreen && (screenHeightChanged || screenWidthChanged)) {


### PR DESCRIPTION
# Description
The original issue was noted as a bug in Android, but after reviewing more, it's an issue with screens that have a short height.  The original bug was noticed when the "Add Layer" button was click and the user tapped the "Search" field.  When this happens, the keyboard pops up and the modal that contains the list of layers disappears.

# Fixes
In `web/js/containers/modal.js` there was an expression checking if the orientation of the device changed.  If the orientation changed, the `toggleFunction()` was called and the modal closes.  This function was triggered when the keyboard popped up after tapping into the search input field.  Having the keyboard pop up caused the viewport size to switch from portrait to landscape and, thus, closing the modal.

It's possible there was a purpose for this behavior (closing on orientation changed) but none come to mind.

# Testing
- This can be tested in a browser by shrinking the window down until the mobile view engages.  
- Make sure the window is in a portrait-type ration.  
- Click the "Add Layer" button, tap the "Search" box, then resize the window so that it's ratio is landscape to imitate a keyboard opening on Android.  (Or you can open this on an Android phone and follow the steps indicated above.) 
- Before pulling down this branch, the bug will occur and the modal will close.  After pulling down this branch, following these steps will prevent the modal from closing.