### PR TITLE
WV-2095 Make it easier to click on the blue pointing finger on mobile

### DIFF
--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -281,7 +281,7 @@ li.item.productsitem.inmotion,
 .productsitem .layer-main .layer-pointer-icon {
   position: absolute;
   right: 4px;
-  top: 38px;
+  bottom: 7px;
 }
 .productsitem .layer-pointer-icon svg.svg-inline--fa {
   color: #22a;


### PR DESCRIPTION
# Description
On mobile, the blue pointing finger, that is visible on every vector layer, is hard to click on.  

# Fixes
Adjusted CSS of blue pointing finger so that it is position on the bottom right of the layer box in the sidebar.  Changed the absolute position from `top: 38px;` to `bottom: 4px;`.

# How To Test
This can be tested by shrinking the browser window down until the mobile CSS switches on, then do the following:
1. Click "Add Layer" button.
2. Search for "fires" and select first result ("Fires and Thermal Anomalies").  Or choose any layer that has vector imaging.
3. Close the search window and there should be a blue pointing hand in the layer box that was just added.  If zoomed out, the hand will be crossed out with a red X.  If zoomed in enough, the red X will disappear and the blue hand will appear.  Both of these should be clickable.