### PR TITLE
WV-2111: Fix preloading when layers have different temporal resolution.

### DIFF
--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -284,10 +284,9 @@ export async function promiseImageryForTime(state, date, activeString) {
   const {
     cache, selected, createLayer, layerKey,
   } = map.ui;
-  const options = { date, group: activeString };
   const layers = getActiveVisibleLayersAtDate(state, date, activeString);
-
   await Promise.all(layers.map((layer) => {
+    const options = { date, group: activeString };
     const key = layerKey(layer, options, state);
     const layerGroup = cache.getItem(key) || createLayer(layer, options);
     return promiseLayerGroup(layerGroup, selected);


### PR DESCRIPTION
## Description

Fixes WV-2111

- Make sure we don't pass the same options to separate `createLayer` calls since the date gets modified

## How To Test

1. Open [this link](http://localhost:3000/?v=-115.84745817409079,33.517252033226676,-95.3840386576233,45.04010611809468&z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_Thermal_Anomalies_375m_All,GOES-East_ABI_GeoColor,MODIS_Aqua_CorrectedReflectance_TrueColor&lg=true&t=2021-12-30-T22%3A50%3A00Z) and wait moment for tiles to load + preload
2. Step forward several times
3. Confirm tiles were preloaded for each step
4. Open animation tool
5. Press play
6. Confirm tiles preload before playback starts


