### PR TITLE
wv-2119 - remove adjacent day wrap

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/merged/RSS_Merged_Wind_Climatology_Monthly.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/merged/RSS_Merged_Wind_Climatology_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "layergroup": "Wind Speed",
       "product": "rss1windnv7r01",
-      "group": "overlays",
-      "wrapadjacentdays": true
+      "group": "overlays"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/merged/RSS_Total_Precipitable_Water_Climatology_Monthly.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/merged/RSS_Total_Precipitable_Water_Climatology_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "layergroup": "Precipitation Rate",
       "product": "rss1tpwnv7r01",
-      "group": "overlays",
-      "wrapadjacentdays": true
+      "group": "overlays"
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes WV-2119

Removed wrapadjacentdays from two RSS monthly layers, Wind Speed and Total Precipitable Water. 
Check the following link to see that the imagery does not wrap at the datelines: 
 /?v=-562.9943795102406,-263.1721691000521,416.3054800403213,226.20283089994794&l=RSS_Merged_Wind_Climatology_Monthly,RSS_Total_Precipitable_Water_Climatology_Monthly,Coastlines_15m&lg=true&t=2020-12-01-T06%3A00%3A00Z

