### PR TITLE
Updated text to reflect 30 min updates to layers

### DIFF
--- a/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_1-Day.md
+++ b/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_1-Day.md
@@ -13,13 +13,18 @@ Common situations in which the flood product may be unable to accurately identif
 - Dark volcanic rock or soils: such areas can be identified as water, and thus will routinely be reported as flood.
 - Springtime snow melt ponding on fields: such water can appear as pixellated flood across flat areas of agricultural fields. Although this is unusual water, it is often very shallow, and not moving, and thus typically not a flood in the normal sense. Checking the reflectance imagery will typically show such areas on the edge of larger areas of snow extent, or, looking back in time, will show them recently covered by snow.
 
+
 #### Spatial Coverage
 Non-polar global land areas (below 70 degrees latitude), comprising 223 10x10 degree tiles (see Figure 4 in [User Guide](https://earthdata.nasa.gov/files/MCDWD_UserGuide_RevB.pdf) for included tiles).
 
 #### Sensor/Image Resolution
-Nominal equatorial resolution is ~232 m per pixel, and decreasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
+Nominal equatorial resolution is ~232 m per pixel, with resolution increasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
 
 #### Frequency
 One product per day, per tile. During the day, data products are updated as NRT MOD09 data are received (an initial product may be updated if additional intersecting swath data is later received).
+
+To help estimate if the final flood product (for the day) is available in Worldview for a given area of interest, users can check if both the Terra and Aqua Corrected Reflectance layers are displaying for the area.  If they are, the flood product has likely also been updated (or will be within an hour).
+
+Flood products displayed in Worldview are updated every 30 minutes, approximately on the hour and at 30 minutes past the hour.
 
 References: MCDWD_L3_NRT [doi:10.5067/MODIS/MCDWD_L3_NRT.061](https://doi.org/10.5067/MODIS/MCDWD_L3_NRT.061)

--- a/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_2-Day.md
+++ b/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_2-Day.md
@@ -2,6 +2,9 @@ The MODIS Near Real-Time (NRT) Global Flood Product (MCDWD) provides a daily glo
 
 Users are advised to compare the flood product against the contributing MODIS reflectance imagery (such as 7-2-1 Corrected Reflectance; search for “721” after clicking “Add Layers”) , for the compositing period to ensure reported flood areas do not correspond to areas of cloud shadow. [Learn more...](https://earthdata.nasa.gov/earth-observation-data/near-real-time/mcdwd-nrt#ed-flood-faq)
 
+#### Current Issues
+Far west tiles (Hawaii, Alaska):  Due to issues with processing imagery around the international dateline for this product, far west tiles will sometimes appear with data at the start of the day, long before Terra or Aqua have observed for the day. Users are advised to disregard such data, until the Corrected Reflectance layers confirm current-day observations have been processed.
+
 #### Limitations
 Common situations in which the flood product may be unable to accurately identify flood include:
 
@@ -15,9 +18,13 @@ Common situations in which the flood product may be unable to accurately identif
 Non-polar global land areas (below 70 degrees latitude), comprising 223 10x10 degree tiles (see Figure 4 in [User Guide](https://earthdata.nasa.gov/files/MCDWD_UserGuide_RevB.pdf) for included tiles).
 
 #### Sensor/Image Resolution
-Nominal equatorial resolution is ~232 m per pixel, and decreasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
+Nominal equatorial resolution is ~232 m per pixel, with resolution increasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
 
 #### Frequency
 One product per day, per tile. During the day, data products are updated as NRT MOD09 data are received (an initial product may be updated if additional intersecting swath data is later received).
+
+To help estimate if the final flood product (for the day) is available in Worldview for a given area of interest, users can check if both the Terra and Aqua Corrected Reflectance layers are displaying for the area. If they are, the flood product has likely also been updated (or will be within an hour).
+
+Flood products displayed in Worldview are updated every 30 minutes, approximately on the hour and at 30 minutes past the hour.
 
 References: MCDWD_L3_NRT [doi:10.5067/MODIS/MCDWD_L3_NRT.061](https://doi.org/10.5067/MODIS/MCDWD_L3_NRT.061)

--- a/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_3-Day.md
+++ b/config/default/common/config/metadata/layers/modis/combined/MODIS_Combined_Flood_3-Day.md
@@ -2,6 +2,9 @@ The MODIS Near Real-Time (NRT) Global Flood Product (MCDWD) provides a daily glo
 
 Users are advised to compare the flood product against the contributing MODIS reflectance imagery (such as 7-2-1 Corrected Reflectance; search for “721” after clicking “Add Layers”) , for the compositing period to ensure reported flood areas do not correspond to areas of cloud shadow. [Learn more...](https://earthdata.nasa.gov/earth-observation-data/near-real-time/mcdwd-nrt#ed-flood-faq)
 
+#### Current Issues
+Far west tiles (Hawaii, Alaska):  Due to issues with processing imagery around the international dateline for this product, far west tiles will sometimes appear with data at the start of the day, long before Terra or Aqua have observed for the day. Users are advised to disregard such data, until the Corrected Reflectance layers confirm current-day observations have been processed.
+
 #### Limitations
 Common situations in which the flood product may be unable to accurately identify flood include:
 
@@ -15,9 +18,13 @@ Common situations in which the flood product may be unable to accurately identif
 Non-polar global land areas (below 70 degrees latitude), comprising 223 10x10 degree tiles (see Figure 4 in [User Guide](https://earthdata.nasa.gov/files/MCDWD_UserGuide_RevB.pdf) for included tiles).
 
 #### Sensor/Image Resolution
-Nominal equatorial resolution is ~232 m per pixel, and decreasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
+Nominal equatorial resolution is ~232 m per pixel, with resolution increasing toward the poles (~116 m at 60 degrees latitude). Note the higher apparent resolution towards the poles is simply an artifact of the lat/lon (geographic) projection used, and not intrinsic to the data.
 
 #### Frequency
 One product per day, per tile. During the day, data products are updated as NRT MOD09 data are received (an initial product may be updated if additional intersecting swath data is later received).
+
+To help estimate if the final flood product (for the day) is available in Worldview for a given area of interest, users can check if both the Terra and Aqua Corrected Reflectance layers are displaying for the area. If they are, the flood product has likely also been updated (or will be within an hour).
+
+Flood products displayed in Worldview are updated every 30 minutes, approximately on the hour and at 30 minutes past the hour.
 
 References: MCDWD_L3_NRT [doi:10.5067/MODIS/MCDWD_L3_NRT.061](https://doi.org/10.5067/MODIS/MCDWD_L3_NRT.061)

--- a/web/css/layers.css
+++ b/web/css/layers.css
@@ -291,11 +291,15 @@
 .layer-metadata li,
 .source-metadata li {
   line-height: 16px;
+  margin-bottom: 5px;
 }
+
 .source-metadata ul,
 .layer-metadata ul {
   list-style-position: inside;
+  margin-bottom: 15px;
 }
+
 .layer-metadata hr {
   background: #aaa;
 }


### PR DESCRIPTION
## Description

Fixes WV-2078

Update layer descriptions to include information about 30 minute updates and current issues; update layer.css to include more space for bulleted lists in layer descriptions.

## How To Test

1. Open with these URL parameters: /?v=-314.6261971313322,-139.61680333919352,180.27019026609207,99.96411125572035&l=MODIS_Combined_Flood_3-Day(hidden),MODIS_Combined_Flood_2-Day,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2022-01-12-T18%3A03%3A11Z
2. Check layer descriptions for updates to current issues, 30 minute frequency update and proper spacing after bulleted list.
3. Verify expected result
