### PR TITLE
WV-2011: Calculated animation buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18275,6 +18275,22 @@
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
     },
+    "p-queue": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.1.0.tgz",
+      "integrity": "sha512-V+0vPJbhYkBqknPp0qnaz+dWcj8cNepfXZcsVIVEHPbFQXMPwrzCNIiM4FoxGtwHXtPzVCPHDvqCr1YrOJX2Gw==",
+      "requires": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
+    },
     "p-retry": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
@@ -18283,6 +18299,11 @@
       "requires": {
         "retry": "^0.12.0"
       }
+    },
+    "p-timeout": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.0.2.tgz",
+      "integrity": "sha512-sEmji9Yaq+Tw+STwsGAE56hf7gMy9p0tQfJojIAamB7WHJYJKf1qlsg9jqBWG8q9VCxKPhZaP/AcXwEoBcYQhQ=="
     },
     "p-try": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "node-dir": "^0.1.17",
     "ol": "6.4.x",
     "ol-mapbox-style": "6.1.x",
+    "p-queue": "^7.1.0",
     "proj4": "2.6.1",
     "promise-queue": "2.2.5",
     "prop-types": "^15.7.2",

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty as lodashIsEmpty } from 'lodash';
-import Queue from 'promise-queue';
+import PQueue from 'p-queue/dist';
 import PreloadSpinner from './preload-spinner';
 import util from '../../util/util';
 
@@ -17,7 +17,7 @@ class PlayAnimation extends React.Component {
     this.state = {
       isPlaying: false,
     };
-    this.queue = new Queue(5, Infinity);
+    this.queue = new PQueue({ concurrency: 2 });
     this.preloadObject = {};
     this.inQueueObject = {};
     this.preloadedArray = [];

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -28,25 +28,12 @@ class PlayQueue extends React.Component {
 
   componentDidMount() {
     this.mounted = true;
-
     this.queue.on('completed', (dateStr) => {
       console.debug(dateStr, Date.now(), this.queue.size);
     });
-
-    this.queue.on('active', () => {
-      // console.debug('qSize', this.queue.size);
-    });
-
     this.playingDate = this.getStartDate();
     this.checkQueue();
     this.checkShouldPlay();
-  }
-
-  componentDidUpdate(prevProps) {
-    const { isPlaying } = this.props;
-    if (prevProps.isPlaying && !isPlaying) {
-      console.debug('user pressed pause');
-    }
   }
 
   componentWillUnmount() {
@@ -121,12 +108,11 @@ class PlayQueue extends React.Component {
 
   getAverageFetchTime = () => {
     const { subDailyMode } = this.props;
-    const defaultTime = subDailyMode ? 1500 : 500;
+    const defaultTime = subDailyMode ? 1800 : 500;
     // Filter outliers (e.g. layers that have already been loaded)
     const filteredTimes = fetchTimes.filter((time) => time >= 200);
     const averageFetchTime = filteredTimes.length && filteredTimes.reduce((a, b) => a + b) / filteredTimes.length;
     // If we don't have enough real times, use a reasonably default
-    console.debug(filteredTimes);
     const averageTime = filteredTimes.length > 10 ? averageFetchTime : defaultTime;
     return averageTime;
   }
@@ -142,7 +128,6 @@ class PlayQueue extends React.Component {
     if (remainingLoadTime >= remainingPlayTime) {
       const preloadTime = remainingLoadTime - remainingPlayTime;
       totalBufferSize = Math.ceil(preloadTime / 1000);
-    // Can load before play finishes
     }
 
     console.debug('fetch time: ', (averageFetchTime / 1000).toFixed(2));
@@ -155,6 +140,9 @@ class PlayQueue extends React.Component {
 
   isPreloadSufficient() {
     const currentBufferSize = util.objectLength(this.bufferObject);
+    if (this.canPreloadAll) {
+      return true;
+    }
     if (currentBufferSize < this.defaultBufferSize) {
       return false;
     }

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -417,6 +417,7 @@ class PlayAnimation extends React.Component {
       this.checkQueue();
       if (isPlaying) {
         selectDate(currentDateParsed);
+        console.log(currentDateStr);
       }
       this.pastDates[currentDateStr] = currentDateParsed;
       this.currentPlayingDate = currentDateStr;

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -674,13 +674,14 @@ function mapStateToProps(state) {
     customInterval = customInterval > 3 ? 3 : customInterval;
   }
   const useInterval = customSelected ? customInterval || 3 : interval;
+  const useDelta = customSelected && customDelta ? customDelta : delta;
   const subDailyInterval = useInterval > 3;
   const subDailyMode = subDailyInterval && hasSubdailyLayers;
   const numberOfFrames = getNumberOfSteps(
     startDate,
     endDate,
     TIME_SCALE_FROM_NUMBER[useInterval],
-    customSelected && customDelta ? customDelta : delta,
+    useDelta,
     maxFrames,
   );
   const { rotation } = map;
@@ -693,7 +694,7 @@ function mapStateToProps(state) {
       startDate,
       endDate,
       TIME_SCALE_FROM_NUMBER[useInterval],
-      delta,
+      useDelta,
     );
   } else {
     snappedCurrentDate = currentDate;
@@ -715,7 +716,7 @@ function mapStateToProps(state) {
     hasFutureLayers,
     hasSubdailyLayers,
     subDailyMode,
-    delta: customSelected && customDelta ? customDelta : delta,
+    delta: useDelta,
     interval: TIME_SCALE_FROM_NUMBER[useInterval] || 'day',
     customDelta: customDelta || 1,
     customInterval: customInterval || 3,

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -317,9 +317,13 @@ class AnimationWidget extends React.Component {
       endDate,
     } = this.props;
     if (subDailyMode) {
-      // for subdaily, zero start and end dates to UTC XX:YY:00:00
+      // for subdaily, zero start and end dates to UTC HH:MM:00:00
+      const startMinutes = startDate.getMinutes();
+      const endMinutes = endDate.getMinutes();
+      startDate.setUTCMinutes(Math.floor(startMinutes / 10) * 10);
       startDate.setUTCSeconds(0);
       startDate.setUTCMilliseconds(0);
+      endDate.setUTCMinutes(Math.floor(endMinutes / 10) * 10);
       endDate.setUTCSeconds(0);
       endDate.setUTCMilliseconds(0);
     } else {

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -567,7 +567,6 @@ class AnimationWidget extends React.Component {
       endDate,
       onPushPause,
       isActive,
-      hasCustomPalettes,
       isDistractionFreeModeActive,
       promiseImageryForTime,
       selectDate,
@@ -596,7 +595,6 @@ class AnimationWidget extends React.Component {
             currentDate={snappedCurrentDate}
             startDate={startDate}
             endDate={endDate}
-            hasCustomPalettes={hasCustomPalettes}
             interval={interval}
             delta={delta}
             speed={speed}

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -34,8 +34,6 @@ import {
   customModalType,
 } from '../modules/date/constants';
 import {
-  getQueueLength,
-  getMaxQueueLength,
   snapToIntervalDelta,
   getNumberOfSteps,
 } from '../modules/animation/util';
@@ -573,17 +571,10 @@ class AnimationWidget extends React.Component {
       isGifActive,
       delta,
       interval,
+      numberOfFrames,
+      subDailyMode,
     } = this.props;
     const { speed, collapsed } = this.state;
-    const maxLength = getMaxQueueLength(speed);
-    const queueLength = getQueueLength(
-      startDate,
-      endDate,
-      speed,
-      interval,
-      delta,
-    );
-
 
     if (!isActive) {
       return null;
@@ -597,19 +588,18 @@ class AnimationWidget extends React.Component {
           <PlayQueue
             isLoopActive={looping}
             isPlaying={isPlaying}
-            canPreloadAll={queueLength <= maxLength}
+            numberOfFrames={numberOfFrames}
             currentDate={snappedCurrentDate}
             startDate={startDate}
             endDate={endDate}
             hasCustomPalettes={hasCustomPalettes}
-            maxQueueLength={maxLength}
-            queueLength={queueLength}
             interval={interval}
             delta={delta}
             speed={speed}
             selectDate={selectDate}
             togglePlaying={onPushPause}
             promiseImageryForTime={promiseImageryForTime}
+            subDailyMode={subDailyMode}
             onClose={onPushPause}
           />
         )}
@@ -753,6 +743,7 @@ function mapStateToProps(state) {
     ),
   };
 }
+
 const mapDispatchToProps = (dispatch) => ({
   selectDate: (val) => {
     dispatch(selectDate(val));

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -25,7 +25,7 @@ import OlLayerGroup from 'ol/layer/Group';
 import * as olProj from 'ol/proj';
 import { CALCULATE_RESPONSIVE_STATE } from 'redux-responsive';
 import Cache from 'cachai';
-import Queue from 'promise-queue';
+import PQueue from 'p-queue/dist';
 import mapDateLineBuilder from './datelinebuilder';
 import mapLayerBuilder from './layerbuilder';
 import MapRunningData from './runningdata';
@@ -77,7 +77,7 @@ export default function mapui(models, config, store, ui) {
     duration: animationDuration,
   });
   const cache = new Cache(400);
-  const layerQueue = new Queue(5, Infinity);
+  const layerQueue = new PQueue({ concurrency: 5 });
   const { createLayer, layerKey } = mapLayerBuilder(config, cache, store);
   const self = {
     cache,

--- a/web/js/modules/animation/util.js
+++ b/web/js/modules/animation/util.js
@@ -102,63 +102,6 @@ export function svgToPng(svgURL, stampHeight) {
   return newImage;
 }
 
-/**
- * Returns the queueLength based on the play speed selected
- * @method getMaxQueueLength
- * @static
- *
- * @return {number}  The queueLength amount
- */
-export function getMaxQueueLength(speed) {
-  let queueLength = 10;
-  switch (true) {
-    case speed > 8 && speed <= 10:
-      queueLength = 40;
-      break;
-    case speed > 7 && speed <= 8:
-      queueLength = 32;
-      break;
-    case speed > 5 && speed <= 7:
-      queueLength = 24;
-      break;
-    case speed > 3 && speed <= 5:
-      queueLength = 16;
-      break;
-    case speed > 0 && speed <= 3:
-      queueLength = 10;
-      break;
-    default:
-      break;
-  }
-  return queueLength;
-}
-
-/*
- * default queueLength
- *
- * @method getQueueLength
- * @static
- *
- * @param startDate {object} JS date
- * @param endDate {object} JS date
- *
- * @returns {number} new buffer length
- *
- */
-export function getQueueLength(startDate, endDate, speed, interval, delta) {
-  let day = startDate;
-  let i = 0;
-  const maxQueueLength = getMaxQueueLength(speed);
-  while (i <= maxQueueLength) {
-    i += 1;
-    day = util.dateAdd(day, interval, delta);
-    if (day > endDate) {
-      return i;
-    }
-  }
-  return i;
-}
-
 export function mapLocationToAnimationState(
   parameters,
   stateFromLocation,

--- a/web/js/modules/animation/util.js
+++ b/web/js/modules/animation/util.js
@@ -19,18 +19,18 @@ import util from '../../util/util';
 export function snapToIntervalDelta(currDate, startDate, endDate, interval, delta) {
   // moment pluralizes: 'days', 'hours', etc
   const units = `${interval}s`;
-  const dateArray = [];
   let tempDate = startDate;
-  let currentDate; let prevMoment; let
-    nextMoment;
+  let currentDate;
+  let prevMoment;
+  let nextMoment;
 
   while (tempDate <= endDate) {
     prevMoment = moment.utc(tempDate);
     nextMoment = moment.utc(tempDate).add(delta, units);
     if (currDate >= prevMoment && currDate <= nextMoment) {
       currentDate = new Date(prevMoment);
+      break;
     }
-    dateArray.push(tempDate);
     tempDate = new Date(nextMoment);
   }
   return currentDate || startDate;

--- a/web/js/modules/animation/util.test.js
+++ b/web/js/modules/animation/util.test.js
@@ -69,6 +69,15 @@ test('snapToIntervalDelta snaps at a custom hour interval', () => {
   expect(snappedDate.valueOf()).toBe(expected.valueOf());
 });
 
+test('snapToIntervalDelta snaps at custom 10 minute interval', () => {
+  const currentDate = new Date('2018-04-19 08:24:00Z');
+  const startDate = new Date('  2018-04-19 08:00:00Z');
+  const endDate = new Date('    2018-04-19 09:00:00Z');
+  const expected = new Date('2018-04-19 08:20:00Z');
+  const snappedDate = snapToIntervalDelta(currentDate, startDate, endDate, 'minute', 10);
+  expect(snappedDate.valueOf()).toBe(expected.valueOf());
+});
+
 test('snapToIntervalDelta snaps to startDate if currentDate is after endDate', () => {
   const currentDate = new Date('2019-05-15 08:00:00Z');
   const startDate = new Date('  2018-04-19 08:15:30Z');


### PR DESCRIPTION
## Description

These changes update animation so that we time how long it takes the first 15 requests to go out and then calculate a buffer size based on the the average request time and the remaining number of frames to be played back.  This could potentially be improved further by re-calculating the buffer as we go during playback but once I got this in a good working state, it didn't seem worth fiddling with it any further.  The biggest offenders (e.g. slow load times) are GeoColor layers which should be getting updated to be served as JPEG tiles rather than PNGs which will dramatically improve load times and make this kind of smart buffering less necessary.

A great deal of animation code was modified to make these changes so thorough testing of the entire animation feature is necessary, not just the improved buffering.

Console debug statements were intentionally left in until this can be more thoroughly tested since it's very difficult to debug this feature by using breakpoints due to the amount of asynchronous activity happening.  We may even consider including these in the initial release.

## ToDo

- [ ] Remove console statements before merge?

## How To Test

You will need to run `npm ci` before building/testing.

Here is a good set of different use cases to start from:

* [Begin with current date BEFORE animation start](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T11%3A50%3A00Z&ae=2022-01-12-T14%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T10%3A29%3A00Z)
* [Begin with current date AT start](http://localhost:3000/?v=119.92137737560918,24.76824888260218,156.32114025837947,64.3422372164372&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T12%3A10%3A00Z&ae=2022-01-12-T15%3A10%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T12%3A10%3A00Z)
* [Begin with current date JUST AFTER start, BEFORE end](http://localhost:3000/?v=119.92137737560918,24.76824888260218,156.32114025837947,64.3422372164372&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T12%3A10%3A00Z&ae=2022-01-12-T15%3A10%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T12%3A55%3A00Z)
* [Begin with current date AFTER start, JUST BEFORE end](http://localhost:3000/?v=119.92137737560918,24.76824888260218,156.32114025837947,64.3422372164372&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T17%3A50%3A00Z&ae=2022-01-12-T20%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T20%3A23%3A00Z)
* [Begin with current date AT animation end](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T17%3A50%3A00Z&ae=2022-01-12-T20%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T20%3A50%3A00Z)
* [Begin with current date AFTER animation end](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T17%3A50%3A00Z&ae=2022-01-12-T20%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T22%3A19%3A00Z)

* [With LESS than 15 frames](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-13-T00%3A00%3A00Z&ae=2022-01-13-T01%3A20%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&ab=on&t=2022-01-13-T01%3A02%3A00Z)
* [With MORE than 15 frames](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-12-T11%3A50%3A00Z&ae=2022-01-12-T23%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&av=8&ab=on&t=2022-01-12-T17%3A40%3A00Z)
* [With EXACTLY 15 frames](http://localhost:3000/?v=119.92137737560918,25.749168810319233,156.32114025837947,63.361317288720144&z=4&ics=true&ici=5&icd=10&as=2022-01-13-T08%3A30%3A00Z&ae=2022-01-13-T10%3A50%3A00Z&l=Reference_Labels_15m,Reference_Features_15m(hidden),Coastlines_15m,Himawari_AHI_Band13_Clean_Infrared,BlueMarble_NextGeneration&lg=true&al=true&ab=on&t=2022-01-13-T09%3A30%3A00Z)

Other variations include (some of this is covered in the above cases):
* With ONLY sub daily layers
* With ONLY daily layers
* With daily AND sub daily layers
* Looping turned ON
* Looping turned OFF
* With sub daily layers, CURRENT date NOT snapped to 10 min increment
* With sub daily layers, START date NOT snapped to 10 min increment
* With sub daily layers, END date NOT snapped to 10 min increment