### PR TITLE
WV-2152: Disable layer controls during animation

### DIFF
--- a/web/css/sidebar-panel.css
+++ b/web/css/sidebar-panel.css
@@ -121,7 +121,6 @@ a.atexpand {
 
 .sidebar-panel li.item {
   padding: 0;
-  cursor: move;
   margin: 0 auto;
 }
 
@@ -204,7 +203,7 @@ img.sidebar-panel-item-img {
   display: block;
 }
 
-img.hideReg {
+.visibility img {
   height: 14px;
   width: 20px;
 }
@@ -242,7 +241,7 @@ li.item.productsitem.inmotion,
   border-color: #fff;
 }
 
-.productsitem a.hdanchor.hideReg {
+.productsitem a.visibility {
   width: 30px;
   background-color: #ccc;
   position: absolute;
@@ -250,25 +249,41 @@ li.item.productsitem.inmotion,
   bottom: 0;
   cursor: pointer;
   border-right: 1px solid #333;
+  &.layer-enabled:hover {
+    background: #fff;
+  }
+  &.disabled:hover {
+    cursor: not-allowed;
+  }
+  &.layer-visible.disabled:hover {
+    cursor: not-allowed;
+    background: #c5c5c8;
+    .svg-inline--fa {
+      color: #333;
+    }
+  }
+  &.layer-hidden.disabled:hover {
+    background: #666;
+    cursor: not-allowed;
+    .svg-inline--fa {
+      color: #c5c5c8;
+    }
+  }
+  .layer-eye-icon {
+    text-align: center;
+    display: inline-block;
+    width: 100%;
+    position: absolute;
+    top: 50%;
+    margin-top: -10px;
+    font-size: 18px;
+  }
 }
 
-.productsitem.layer-visible a.hdanchor:hover {
-  background: #fff;
-}
-
-.productsitem .layer-eye-icon {
-  text-align: center;
-  display: inline-block;
-  width: 100%;
-  position: absolute;
-  top: 50%;
-  margin-top: -10px;
-  font-size: 18px;
-}
 .productsitem svg.svg-inline--fa {
   color: #333;
 }
-.productsitem .hdanchor:hover .layer-eye-icon {
+.productsitem .visibility:hover .layer-eye-icon {
   color: #000;
 }
 .layer-hidden svg.svg-inline--fa {
@@ -447,10 +462,10 @@ li.item.productsitem.inmotion,
 }
 
 .productsitem {
+  cursor: grab;
   & .layer-info {
     background-color: #ccc;
     min-height: 40px;
-    cursor: grab;
     & .layer-buttons {
       position: absolute;
       right: 0;
@@ -474,7 +489,6 @@ li.item.productsitem.inmotion,
   & .layer-main {
     width: auto;
     margin-left: 30px;
-    cursor: default;
     min-height: 40px;
     overflow: hidden;
   }
@@ -482,14 +496,6 @@ li.item.productsitem.inmotion,
 
 .productsitem.zotted .layer-main {
   margin-left: 41px;
-}
-
-.productsitem.layer-hidden a.hdanchor {
-  background: #666;
-}
-
-.productsitem.layer-hidden a.hdanchor:hover {
-  background: rgba(255, 255, 255, 1);
 }
 
 .productsitem.layer-hidden .layer-info h4,
@@ -512,16 +518,21 @@ li.item.productsitem.inmotion,
   height: 42px;
 }
 
-.sidebar-panel li.item.productsitem.disabled.layer-hidden:hover {
-  border-color: transparent;
+.productsitem.layer-hidden a.visibility {
+  background: #666;
 }
 
-.disabled.layer-hidden a.hdanchor:hover {
+.sidebar-panel li.item.productsitem.disabled:hover {
+  border-color: transparent;
+  cursor: default;
+}
+
+.disabled.layer-hidden a.visibility:hover {
   background: rgba(255, 255, 255, 0.2);
   cursor: default;
 }
 
-.productsitem.disabled.layer-hidden a.hdanchor:hover svg.svg-inline--fa {
+.productsitem.disabled.layer-hidden a.visibility:hover svg.svg-inline--fa {
   color: #c5c5c8;
 }
 
@@ -574,7 +585,7 @@ li.item.productsitem.inmotion,
       font-size: 26px;
       margin-top: -13px;
     }
-    a.hdanchor.hideReg {
+    a.visibility {
       width: 45px;
     }
   }

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -51,7 +51,9 @@ function LayerList(props) {
     toggleCollapse,
     isMobile,
     numVisible,
+    isAnimating,
   } = props;
+
   const { dragHandleProps = {} } = props;
   const groupLayerIds = layers.map(({ id }) => id);
   const layersInProj = layers.filter(({ projections }) => projections[projId]);
@@ -127,7 +129,7 @@ function LayerList(props) {
     );
   };
 
-  const renderDropdownMenu = () => (
+  const renderDropdownMenu = () => !isAnimating && (
     <Dropdown className="layer-group-more-options" isOpen={showDropdownMenu} toggle={toggleDropdownMenuVisible}>
       <DropdownToggle>
         <FontAwesomeIcon
@@ -209,6 +211,7 @@ LayerList.propTypes = {
   dragHandleProps: PropTypes.object,
   getNames: PropTypes.func,
   groupId: PropTypes.string,
+  isAnimating: PropTypes.bool,
   isMobile: PropTypes.bool,
   isEmbedModeActive: PropTypes.bool,
   layers: PropTypes.array,
@@ -225,7 +228,7 @@ LayerList.propTypes = {
 
 const mapStateToProps = (state, ownProps) => {
   const {
-    embed, proj, config, map,
+    embed, proj, config, map, animation,
   } = state;
   const { isEmbedModeActive } = embed;
   const zots = lodashGet(map, 'ui.selected')
@@ -245,6 +248,7 @@ const mapStateToProps = (state, ownProps) => {
     getNames: (layerId) => getTitles(config, layerId, proj.id),
     available: (layerId) => availableSelector(state)(layerId),
     numVisible,
+    isAnimating: animation.isPlaying,
   };
 };
 

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -29,6 +29,7 @@ function LayersContainer (props) {
     isCompareActive,
     isEmbedModeActive,
     isMobile,
+    isAnimating,
     overlayGroups,
     overlays,
     reorderOverlayGroups,
@@ -66,7 +67,7 @@ function LayersContainer (props) {
         key={groupName}
         draggableId={groupName}
         index={idx}
-        isDragDisabled={isEmbedModeActive}
+        isDragDisabled={isEmbedModeActive || isAnimating}
       >
         {(provided) => (
           <li
@@ -178,7 +179,7 @@ function LayersContainer (props) {
 const mapStateToProps = (state, ownProps) => {
   const { compareState } = ownProps;
   const {
-    browser, compare, embed, layers,
+    browser, compare, embed, layers, animation,
   } = state;
   const isCompareActive = compare.active;
   const { isEmbedModeActive } = embed;
@@ -195,6 +196,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
+    isAnimating: animation.isPlaying,
     isCompareActive,
     isEmbedModeActive,
     isMobile,
@@ -232,6 +234,7 @@ LayersContainer.propTypes = {
   groupOverlays: PropTypes.bool,
   height: PropTypes.number,
   isActive: PropTypes.bool,
+  isAnimating: PropTypes.bool,
   isCompareActive: PropTypes.bool,
   isEmbedModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,


### PR DESCRIPTION
## Description

* Prevents layers/groups from being modified during animation playback since this can essentially break an in-progress animation.
* Prevent showing/hiding a layer that is "disabled" (no imagery at date)

## How To Test

1. [Load the app via this URL](http://localhost:3000/?v=-136.93290062204383,-67.32407163823656,-81.02150667305224,-12.521867723501241&z=4&ics=true&ici=5&icd=10&as=2022-01-17-T03%3A00%3A00Z&ae=2022-01-17-T06%3A00%3A00Z&l=Coastlines_15m,GOES-East_ABI_Band13_Clean_Infrared,MODIS_Aqua_CorrectedReflectance_TrueColor(hidden)&lg=true&al=true&av=1&ab=on&t=2022-01-17-T04%3A20%3A00Z)
2. Play the animation
3. Confirm that layers cannot be shown/hidden via eye icon
4. Confirm that layer options are not accessible
5. Confirm that layers cannot be re-ordered
6. Confirm that layer groups cannot be re-ordered

