### PR TITLE
WV-2157: Reduce/improve preloading

### DIFF
--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -77,7 +77,7 @@ export default function mapui(models, config, store, ui) {
     duration: animationDuration,
   });
   const cache = new Cache(400);
-  const layerQueue = new PQueue({ concurrency: 5 });
+  const layerQueue = new PQueue({ concurrency: 3 });
   const { createLayer, layerKey } = mapLayerBuilder(config, cache, store);
   const self = {
     cache,
@@ -195,7 +195,7 @@ export default function mapui(models, config, store, ui) {
       case dateConstants.SELECT_DATE:
       case layerConstants.TOGGLE_LAYER_VISIBILITY:
       case layerConstants.TOGGLE_OVERLAY_GROUP_VISIBILITY: {
-        updateDate();
+        updateDate(action.outOfStep);
         break;
       }
       case dateConstants.ARROW_DOWN:
@@ -722,7 +722,7 @@ export default function mapui(models, config, store, ui) {
     compareMapUi.update(compare.activeString);
   }
 
-  function updateDate() {
+  function updateDate(outOfStepChange) {
     const state = store.getState();
     const { compare = {} } = state;
     const layerGroup = getLayerGroup(state);
@@ -750,7 +750,9 @@ export default function mapui(models, config, store, ui) {
       }
     });
     updateLayerVisibilities();
-    layerQueue.add(preloadNextTiles);
+    if (!outOfStepChange) {
+      preloadNextTiles();
+    }
   }
 
   /**
@@ -781,16 +783,15 @@ export default function mapui(models, config, store, ui) {
         preloaded: true,
         lastPreloadDate: subsequentDate,
       });
-      await promiseImageryForTime(state, subsequentDate, useActiveString);
+      layerQueue.add(() => promiseImageryForTime(state, subsequentDate, useActiveString));
       return;
     }
 
-    await promiseImageryForTime(state, nextDate, useActiveString);
-    await promiseImageryForTime(state, prevDate, useActiveString);
+    layerQueue.add(() => promiseImageryForTime(state, nextDate, useActiveString));
+    layerQueue.add(() => promiseImageryForTime(state, prevDate, useActiveString));
 
     if (!date && !arrowDown) {
-      layerQueue.add(() => preloadNextTiles(nextDate, useActiveString));
-      layerQueue.add(() => preloadNextTiles(prevDate, useActiveString));
+      preloadNextTiles(subsequentDate, useActiveString);
     }
   }
 

--- a/web/js/modules/date/actions.js
+++ b/web/js/modules/date/actions.js
@@ -69,8 +69,9 @@ export function selectDate(date) {
     const selectedDate = date > maxDate ? maxDate : date;
     const direction = selectedDate > prevDate ? 'right' : 'left';
     const directionChange = direction && lastArrowDirection !== direction;
+    const outOfStep = outOfStepChange(state, selectedDate);
 
-    if (preloaded && (directionChange || outOfStepChange(state, selectedDate))) {
+    if (preloaded && directionChange) {
       dispatch(clearPreload());
     }
     dispatch({
@@ -78,6 +79,7 @@ export function selectDate(date) {
       activeString,
       value: selectedDate,
       lastArrowDirection: direction,
+      outOfStep,
     });
   };
 }

--- a/web/js/modules/date/actions.test.js
+++ b/web/js/modules/date/actions.test.js
@@ -17,7 +17,6 @@ import {
 } from './constants';
 import fixtures from '../../fixtures';
 import { addLayer, getLayers } from '../layers/selectors';
-import util from '../../util/util';
 
 const config = fixtures.config();
 function getState(layers) {
@@ -52,7 +51,7 @@ const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
 
 // test variables
-const mockDate = util.now();
+const mockDate = new Date('2022-01-01');
 const customInterval = 3;
 const delta = 5;
 const interval = 3;
@@ -86,12 +85,17 @@ describe('Date timescale changes', () => {
         activeString: 'selected',
         value: mockDate,
         lastArrowDirection: 'left',
+        outOfStep: true,
       };
       let layers = addLayer('terra-cr', {}, [], config.layers, 0);
       layers = addMockLayer('aqua-cr', layers);
       const store = mockStore({
         date: {
           preloaded: true,
+          selected: mockDate,
+          delta: 1,
+          interval: 1,
+          unit: 'year',
         },
         compare: {
           isCompareA: true,
@@ -113,6 +117,7 @@ describe('Date timescale changes', () => {
 
   test(`selectDate action returns ${SELECT_DATE} as type and selectedB as activeString and ${mockDate} as value`,
     () => {
+      const prevDate = new Date('2021-01-01');
       const expectedFirst = {
         type: CLEAR_PRELOAD,
       };
@@ -120,13 +125,18 @@ describe('Date timescale changes', () => {
         type: SELECT_DATE,
         activeString: 'selectedB',
         value: mockDate,
-        lastArrowDirection: 'left',
+        lastArrowDirection: 'right',
+        outOfStep: false,
       };
       let layers = addLayer('terra-cr', {}, [], config.layers, 0);
       layers = addMockLayer('aqua-cr', layers);
       const store = mockStore({
         date: {
           preloaded: true,
+          selectedB: prevDate,
+          delta: 1,
+          interval: 1,
+          unit: 'year',
         },
         compare: {
           isCompareA: false,


### PR DESCRIPTION
## Description

- don't preload on out of step change
- update tests


## How To Test

1. Load app
2. Confirm prev/next step is preloaded
3. Step backward
4. Confirm one step (two from current date) is preloaded
5. Change the date by moving the time slider
6. Confirm no dates are preloaded
7. Change the date by using the year/month/day input arrows
8. Confirm no dates are preloaded
9. Change the time step interval
10. Confirm prev/next step of new interval is preloaded



