### PR TITLE
Tweak buffer calculations slightly

### DIFF
--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -109,13 +109,13 @@ class PlayQueue extends React.Component {
 
   getAverageFetchTime = () => {
     const { subDailyMode } = this.props;
-    const defaultTime = subDailyMode ? 1800 : 500;
+    const defaultTime = subDailyMode ? 1800 : 750;
     // Filter outliers (e.g. layers that have already been loaded)
     const filteredTimes = this.fetchTimes.filter((time) => time >= 200);
     const averageFetchTime = filteredTimes.length
       && filteredTimes.reduce((a, b) => a + b) / filteredTimes.length;
     // If we don't have enough real times, use a reasonable default
-    const averageTime = filteredTimes.length > 10 ? averageFetchTime : defaultTime;
+    const averageTime = filteredTimes.length >= 10 ? averageFetchTime : defaultTime;
     return averageTime;
   }
 
@@ -130,10 +130,11 @@ class PlayQueue extends React.Component {
     const remainingLoadTime = (avgFetchTime * remainingFrames) / CONCURRENT_REQUESTS;
     const totalPlayTime = (numberOfFrames / speed) * 1000;
     const timeToBufferEnd = totalPlayTime - remainingPlayTime;
-    const canFinishLoadWhilePlaying = timeToBufferEnd > remainingLoadTime;
+    const framesLoadedDuringInitialBufferPlayback = timeToBufferEnd / avgFetchTime;
+    const canKeepUp = framesLoadedDuringInitialBufferPlayback >= this.defaultBufferSize;
 
-    if (!canFinishLoadWhilePlaying && remainingLoadTime >= remainingPlayTime) {
-      const preloadTime = remainingLoadTime - timeToBufferEnd;
+    if (!canKeepUp && remainingLoadTime >= remainingPlayTime) {
+      const preloadTime = remainingLoadTime - remainingPlayTime;
       bufferSize = Math.ceil(preloadTime / 1000);
     }
 


### PR DESCRIPTION
## Description

In some cases the calculations were not accurate and the playback would catch up with the buffer.  Hopefully this fixes it.  Here are some varying test cases to try:

http://localhost:3000/?as=2020-01-31-T00%3A00%3A00Z&ae=2020-07-29-T00%3A00%3A00Z&l=Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&av=6&ab=on&t=2020-04-27-T00%3A00%3A00Z

http://localhost:3000/?as=2018-04-29-T00%3A00%3A00Z&ae=2018-08-29-T00%3A00%3A00Z&l=Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&av=10&ab=on&t=2020-04-27-T00%3A00%3A00Z

http://localhost:3000/?z=4&ics=true&ici=5&icd=10&as=2022-01-25-T00%3A00%3A00Z&ae=2022-01-25-T05%3A00%3A00Z&l=GOES-East_ABI_GeoColor,Coastlines_15m&lg=true&av=2&ab=on&t=2022-01-31-T20%3A08%3A57Z

http://localhost:3000/?v=-229.52393809449177,-116.30522121255186,-30.444906144389947,100.4589081153504&z=4&ics=true&ici=5&icd=10&as=2022-01-24-T00%3A00%3A00Z&ae=2022-01-24-T05%3A00%3A00Z&l=GOES-West_ABI_Band13_Clean_Infrared,Coastlines_15m&lg=true&av=5&ab=on&t=2022-01-31-T20%3A08%3A57Z