### PR TITLE
Point to new GIBS API Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ views of several imagery layers are available for a “full globe” perspective
 
 Worldview uses [OpenLayers](http://openlayers.org/) to display imagery from the
 [Global Imagery Browse Services (GIBS)](https://earthdata.nasa.gov/gibs). This
-imagery can also be used [with libraries such as Leaflet, Cesium, Google Maps](https://wiki.earthdata.nasa.gov/display/GIBS/Map+Library+Usage)
-or [custom GDAL scripts](https://wiki.earthdata.nasa.gov/display/GIBS/Map+Library+Usage#expand-GDALBasics).
+imagery can also be used [with libraries such as Leaflet, Cesium, Google Maps](https://nasa-gibs.github.io/gibs-api-docs/map-library-usage/)
+or [custom GDAL scripts](https://nasa-gibs.github.io/gibs-api-docs/map-library-usage/#gdal).
 We encourage interested developers to fork Worldview or build their own clients
 using GIBS services.
 

--- a/config/default/common/brand/about/acknowledgements.md
+++ b/config/default/common/brand/about/acknowledgements.md
@@ -71,7 +71,7 @@
 <p>Please also note that Worldview provides the “best available” layer information to users; this often means
         providing a “best” layer that prioritizes the composition of imagery products as follows: 1) Latest Version
         Standard Product; 2) Latest Version NRT; 3) Previous Version Standard Product; 4) Previous Version NRT. <a
-                href="https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers#GIBSAPIforDevelopers-%22BestAvailable%22Layers"
+                href="https://nasa-gibs.github.io/gibs-api-docs/access-advanced-topics/#best-available-layers"
                 target="_blank" rel="noopener noreferrer">Learn more about “Best Available” Layers from GIBS</a>.</p>
 <p>Other layers and information are provided by:</p>
 <ul>

--- a/doc/config/configuration.md
+++ b/doc/config/configuration.md
@@ -21,7 +21,7 @@ To quickly switch between different configurations, use a symlink for `config/ac
 ## Updating the Configuration
 
 After making any changes to configuration files, rebuild the app for the changes to take effect.
-Use the `npm run build` command to make a request to [the GIBS GetCapabilities API](https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers) to update layer configurations and rebuild the
+Use the `npm run build` command to make a request to [the GIBS GetCapabilities API](https://nasa-gibs.github.io/gibs-api-docs/) to update layer configurations and rebuild the
 configuration file used by the application. After a successful build, this file can be found at: `build/options/config/wv.json`
 
 If you want to only rebuild `wv.json`, using GetCapabilities files that were previously requested,

--- a/doc/developing.md
+++ b/doc/developing.md
@@ -5,7 +5,7 @@
 
 This project uses `npm` to run build scripts and other tasks. The scripts are a combination of JavaScript, Bash, and Python scripts. Webpack is used as a module bundler.
 
-**`npm run build`**: Main build script cleans previous build directory, gets available imagery metadata via the [GIBS `GetCapabilities` API](https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers), adds the build configuration (options), and builds the Webpack bundle in Development mode. Generates the build in `build/`. If you have a custom configuration subdirectory, pass it to the command with `npm run build -- subdirectory_name`.
+**`npm run build`**: Main build script cleans previous build directory, gets available imagery metadata via the [GIBS `GetCapabilities` API](https://nasa-gibs.github.io/gibs-api-docs/), adds the build configuration (options), and builds the Webpack bundle in Development mode. Generates the build in `build/`. If you have a custom configuration subdirectory, pass it to the command with `npm run build -- subdirectory_name`.
 
 To build the app with an incomplete configuration, prefix the command like this:
 `IGNORE_ERRORS=true npm run build`.

--- a/web/js/components/smart-handoffs/smart-handoff-granule-alert.js
+++ b/web/js/components/smart-handoffs/smart-handoff-granule-alert.js
@@ -13,7 +13,7 @@ const GranuleAlertModalBody = () => (
       <a href="https://earthdata.nasa.gov/earth-observation-data/near-real-time/near-real-time-versus-standard-products" target="_blank" rel="noopener noreferrer">Near Real-Time (NRT)</a>
       {' '}
       and then &quot;backfilled&quot; by the corresponding Standard (STD) product when it is available. @NAME@ displays them on a
-      <a href="https://wiki.earthdata.nasa.gov/display/GIBS/GIBS+API+for+Developers#GIBSAPIforDevelopers-%22BestAvailable%22Layers" target="_blank" rel="noopener noreferrer"> &quot;Best Available&quot; </a>
+      <a href="https://nasa-gibs.github.io/gibs-api-docs/access-advanced-topics/#best-available-layers" target="_blank" rel="noopener noreferrer"> &quot;Best Available&quot; </a>
       basis, showing Standard-quality imagery if it is available, NRT otherwise.
     </p>
     <p>


### PR DESCRIPTION
## Description

Updated URLs to point to new GIBS API docs located at nasa-gibs.github.io/gibs-api-docs/ 