### PR TITLE
WV-2168: Refine animation calculation to prevent stuttering

### DIFF
--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -181,8 +181,8 @@ class PlayQueue extends React.Component {
   isPreloadSufficient() {
     const { numberOfFrames } = this.props;
     const currentBufferSize = util.objectLength(this.bufferObject);
-    if (this.canPreloadAll) {
-      return currentBufferSize === numberOfFrames;
+    if (currentBufferSize === numberOfFrames) {
+      return true;
     }
     if (currentBufferSize < this.defaultBufferSize) {
       return false;
@@ -312,8 +312,9 @@ class PlayQueue extends React.Component {
     if (!this.mounted) return;
     this.bufferObject[strDate] = strDate;
     delete this.inQueueObject[strDate];
+    const bufferLength = this.bufferArray.length;
 
-    if (!initialLoad || this.canPreloadAll) {
+    if (!initialLoad || this.canPreloadAll || bufferLength >= this.defaultBufferSize) {
       this.checkQueue();
       this.checkShouldPlay();
     }

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -6,10 +6,25 @@ import { Progress } from 'reactstrap';
 import LoadingIndicator from './loading-indicator';
 import util from '../../util/util';
 
+// We assume anything this fast or faster is a frame that was pulled from the cache
+const MIN_REQUEST_TIME = 200; // milliseconds
 const CONCURRENT_REQUESTS = 3;
 const toString = (date) => util.toISOStringSeconds(date);
 const toDate = (dateString) => util.parseDateUTC(dateString);
 
+/**
+ * A component that handles buffering datetimes for animation frames.  Only mounted while playback
+ * is active, unmounts when playback stops.
+ *
+ * The buffering logic is as follows:
+ * - Make at least 10 requests (assuming there are >= 10 frames) to determine the avg fetch time for a frame
+ * - While making initial requests, if any return too quickly (e.g. they were cached), keep making
+ *   requests until at least 10 "real" requests can be made to determine average fetch time
+ * - Based on how long it took to load the first 10, calculate how many additional frames
+ *   need to be pre-loaded, based on avg fetch time and playback speed, in order for playback to begin
+ *   without having to stop to buffer.
+ *
+ */
 class PlayQueue extends React.Component {
   constructor(props) {
     super(props);
@@ -115,24 +130,20 @@ class PlayQueue extends React.Component {
       return;
     }
     for (let i = 0; i < this.defaultBufferSize; i += 1) {
-      this.addDate(currentDate);
+      this.addDate(currentDate, true);
       currentDate = this.getNextBufferDate();
       if (toString(currentDate) === lastInQueue) {
-        this.addDate(currentDate);
+        this.addDate(currentDate, true);
       }
     }
   }
 
+  // Filter outliers (e.g. layers that have already been loaded)
+  getFetchTimes = () => this.fetchTimes.filter((time) => time >= MIN_REQUEST_TIME);
+
   getAverageFetchTime = () => {
-    const { subDailyMode } = this.props;
-    const defaultTime = subDailyMode ? 1800 : 750;
-    // Filter outliers (e.g. layers that have already been loaded)
-    const filteredTimes = this.fetchTimes.filter((time) => time >= 200);
-    const averageFetchTime = filteredTimes.length
-      && filteredTimes.reduce((a, b) => a + b) / filteredTimes.length;
-    // If we don't have enough real times, use a reasonable default
-    const averageTime = filteredTimes.length >= 10 ? averageFetchTime : defaultTime;
-    return averageTime;
+    const filteredTimes = this.getFetchTimes();
+    return filteredTimes.length && filteredTimes.reduce((a, b) => a + b) / filteredTimes.length;
   }
 
   calcBufferSize() {
@@ -154,18 +165,17 @@ class PlayQueue extends React.Component {
       bufferSize = Math.ceil(preloadTime / 1000);
     }
 
-    console.debug('fetch time: ', (avgFetchTime / 1000).toFixed(2));
-    console.debug('Play time: ', (totalPlayTime / 1000).toFixed(2), (remainingPlayTime / 1000).toFixed(2));
     const totalLoadTime = ((avgFetchTime * numberOfFrames) / 1000 / CONCURRENT_REQUESTS).toFixed(2);
-    console.debug('rLoad time: ', totalLoadTime, (remainingLoadTime / 1000).toFixed(2));
-    console.debug('total frames:', numberOfFrames);
+    console.debug('Total frames: ', numberOfFrames);
+    console.debug('Avg fetch time: ', (avgFetchTime / 1000).toFixed(2));
+    console.debug('Play time (t/r): ', (totalPlayTime / 1000).toFixed(2), (remainingPlayTime / 1000).toFixed(2));
+    console.debug('Load time (t/r): ', totalLoadTime, (remainingLoadTime / 1000).toFixed(2));
 
     const totalBuffer = bufferSize + this.defaultBufferSize;
     if (totalBuffer >= numberOfFrames) {
-      this.minBufferLength = numberOfFrames;
-    } else {
-      this.minBufferLength = totalBuffer;
+      return numberOfFrames;
     }
+    return totalBuffer;
   }
 
   isPreloadSufficient() {
@@ -177,10 +187,14 @@ class PlayQueue extends React.Component {
     if (currentBufferSize < this.defaultBufferSize) {
       return false;
     }
-    if (!this.minBufferLength) {
-      this.calcBufferSize();
+    if (this.getFetchTimes().length < this.defaultBufferSize) {
+      this.checkQueue();
+      return false;
     }
-    console.debug(`buffer: ${currentBufferSize} / ${this.minBufferLength}`);
+    if (!this.minBufferLength) {
+      this.minBufferLength = this.calcBufferSize();
+    }
+    console.debug(`Buffer: ${currentBufferSize} / ${this.minBufferLength}`);
     return currentBufferSize >= this.minBufferLength;
   }
 
@@ -222,14 +236,13 @@ class PlayQueue extends React.Component {
    * Either do inital preload or queue next item
    */
   checkQueue() {
-    const currentDate = toDate(this.playingDate);
-    const nextInQueue = this.minBufferLength
-      ? this.getNextBufferDate()
-      : this.getLastInQueue();
-
     if (!this.bufferArray[0] && !this.inQueueObject[this.playingDate]) {
+      const currentDate = toDate(this.playingDate);
       this.initialPreload(currentDate);
-    } else if (
+      return;
+    }
+    const nextInQueue = toString(this.getNextBufferDate());
+    if (
       !this.bufferObject[nextInQueue]
       && !this.inQueueObject[nextInQueue]
       && !this.canPreloadAll
@@ -278,7 +291,7 @@ class PlayQueue extends React.Component {
   /**
    * Gets next date based on current increments
    */
-  async addDate(date) {
+  async addDate(date, initialLoad) {
     const { promiseImageryForTime } = this.props;
     let { loadedItems } = this.state;
     const strDate = toString(date);
@@ -299,8 +312,11 @@ class PlayQueue extends React.Component {
     if (!this.mounted) return;
     this.bufferObject[strDate] = strDate;
     delete this.inQueueObject[strDate];
-    this.checkQueue();
-    this.checkShouldPlay();
+
+    if (!initialLoad || this.canPreloadAll) {
+      this.checkQueue();
+      this.checkShouldPlay();
+    }
   }
 
   play() {
@@ -430,7 +446,6 @@ PlayQueue.propTypes = {
   isLoopActive: PropTypes.bool,
   onClose: PropTypes.func,
   numberOfFrames: PropTypes.number,
-  subDailyMode: PropTypes.bool,
   snappedCurrentDate: PropTypes.object,
 };
 

--- a/web/js/containers/animation-widget.js
+++ b/web/js/containers/animation-widget.js
@@ -445,7 +445,6 @@ class AnimationWidget extends React.Component {
       delta,
       interval,
       numberOfFrames,
-      subDailyMode,
     } = this.props;
     const { speed, collapsed } = this.state;
 
@@ -470,7 +469,6 @@ class AnimationWidget extends React.Component {
             selectDate={selectDate}
             togglePlaying={onPushPause}
             promiseImageryForTime={promiseImageryForTime}
-            subDailyMode={subDailyMode}
             onClose={onPushPause}
           />
         )}


### PR DESCRIPTION
## Description

The primary issue that would still cause stuttering was the case where the user had already loaded some of the steps within the pre-buffering range of 10 frames which we make to determine an average request time on which to base the calculation for how many _additional_ frames to request before beginning playback.  

To reproduce the original issue:
NOTE: You may need to throttle your connection slightly to reproduce since we were falling back to some fixed estimated load times in cases where an average could not be calculated.
1. [load this URL](https://worldview.earthdata.nasa.gov/?as=2021-05-20-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2021-09-06-T14%3A00%3A00Z)  
2. Step backwards 10 times (this loads the frames you're about to play back)
3. Start playback
4. At some point, if your connection speed is not fast enough, playback will catch up to the buffer and stuttering will occur.

### Solution

* Always make _at least_ 10 real requests that are not being pulled from the cache so we can have a reliable average fetch time and not rely on a guesstimated average time as a fallback like we did before.  For example, if 5 of the initial 10 steps were pulled from the cache, keep adding to the pre-buffer until 15 total frames are loaded.

## How To Test

In the following scenarios that "start in the middle", try stepping backwards 5-10 steps to pre-load frames to ensure the original issue is no longer reproducible.  The other scenarios are here to ensure nothing was broken while making these changes.

* Less than 10 frames
	* [Start in the middle](http://localhost:3000/?as=2022-01-01-T00%3A00%3A00Z&ae=2022-01-07-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2022-01-03-T16%3A00%3A00Z)
	* [Start before start date](http://localhost:3000/?as=2022-01-01-T00%3A00%3A00Z&ae=2022-01-07-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2021-12-29-T12%3A00%3A00Z)
* Exactly 10 frames
	* [Start in the middle](http://localhost:3000/?as=2022-01-21-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2022-01-24-T14%3A00%3A00Z)
	* [Start before start date](http://localhost:3000/?as=2022-01-21-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2022-01-16-T10%3A00%3A00Z)
* Exactly 11 frames
	* [Start in the middle](http://localhost:3000/?as=2022-01-20-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2022-01-24-T10%3A00%3A00Z)
	* [Start before start date](http://localhost:3000/?as=2022-01-20-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2022-01-17-T08%3A00%3A00Z)
* A lot more than 10 frames
	* [Start before start date](http://localhost:3000/?as=2021-05-20-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2021-05-07-T10%3A00%3A00Z)
	* [Start in the middle](http://localhost:3000/?as=2021-05-20-T00%3A00%3A00Z&ae=2022-01-30-T00%3A00%3A00Z&al=true&av=10&ab=on&t=2021-09-06-T14%3A00%3A00Z)

