### PR TITLE
ARM nodejs support - Resolve Issue #3814

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,14 @@ RUN cd /usr/src && \
     pip install --upgrade pip && \
     pip --version
 RUN mkdir -p /usr/local/stow
-RUN cd /usr/local/stow && \
-    curl -O https://nodejs.org/download/release/v14.16.0/node-v14.16.0-linux-x64.tar.xz && \
-    tar xf node-v14.16.0-linux-x64.tar.xz && \
-    rm -f /usr/local/stow/node/node-v14.16.0-linux-x64.tar.xz && \
-    rm -f /usr/local/stow/node-v14.16.0-linux-x64/{LICENSE,*.md} && \
-    stow -S node-v14.16.0-linux-x64
+RUN arch=$(uname -a | awk '{ print $14 }') && \
+    if [ $arch = "x86_64" ] ; then arch=$(echo "${arch//86_}") ; fi && \
+    cd /usr/local/stow && \
+    curl -O https://nodejs.org/download/release/v14.16.0/node-v14.16.0-linux-$arch.tar.xz && \
+    tar xf node-v14.16.0-linux-$arch.tar.xz && \
+    rm -f /usr/local/stow/node/node-v14.16.0-linux-$arch.tar.xz && \
+    rm -f /usr/local/stow/node-v14.16.0-linux-$arch/{LICENSE,*.md} && \
+    stow -S node-v14.16.0-linux-$arch
 
 WORKDIR /build
 # Only what is needed to run the development server and run the Selenium tests


### PR DESCRIPTION
Fix "node: cannot execute binary" for ARM64 devices.
Patch tested and successful on x86_64 & ARM64 architectures.

Dockerfile fetches x64 nodejs by default, unable to execute on an ARM64 devices.
With patch applied, Docker on ARM support is present, whereas pre-patch support is broken.
Everything else fine in regards to ARM support.

![Screenshot (3)](https://user-images.githubusercontent.com/44081787/153982828-ef84877c-c76f-4d3f-ade2-f2014faf6627.png)


Test
`npm run docker:start`
`npm run docker:shell`
> `uname -a`
> `#!/bin/bash
arch=$(uname -a | awk '{ print $14 }')
if [ $arch = "x86_64" ]
then
        arc=$(echo "${arch//86_}")
        echo $arch
else
        echo $arch
fi`

@nasa-gibs/worldview