### PR TITLE
WV-2182 Grey out/make unavailable "Remove Measurements" in Measure tool and Right click menu

### DIFF
--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -19,7 +19,7 @@ function RightClickMenu(props) {
   const [toolTipToggleTime, setToolTipToggleTime] = useState(0);
   const [formattedCoordinates, setFormattedCoordinates] = useState();
   const {
-    map, crs, unitOfMeasure, onToggleUnits, isCoordinateSearchActive,
+    map, crs, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements,
   } = props;
   const [getMap, setMap] = useState(map);
 
@@ -66,6 +66,11 @@ function RightClickMenu(props) {
     };
   };
 
+  const checkForMeasurements = () => {
+    if (Object.keys(allMeasurements[crs]).length) return false;
+    return true;
+  };
+
   useEffect(() => {
     if (isCoordinateSearchActive) return;
     events.on('map:singleclick', handleClick);
@@ -100,7 +105,10 @@ function RightClickMenu(props) {
           <MenuItem onClick={() => handleMeasurementMenu('area')}>
             Measure Area
           </MenuItem>
-          <MenuItem onClick={() => handleMeasurementMenu('clear')}>
+          <MenuItem
+            disabled={checkForMeasurements()}
+            onClick={() => handleMeasurementMenu('clear')}
+          >
             Remove Measurements
           </MenuItem>
           <MenuItem onClick={() => handleMeasurementMenu('units')}>
@@ -120,13 +128,14 @@ function mapStateToProps(state) {
   const {
     map, proj, measure, locationSearch, config,
   } = state;
-  const { unitOfMeasure } = measure;
+  const { unitOfMeasure, allMeasurements } = measure;
   const { crs } = proj.selected;
   const { coordinates, isCoordinateSearchActive } = locationSearch;
   return {
     map,
     crs,
     unitOfMeasure,
+    allMeasurements,
     coordinates,
     isCoordinateSearchActive,
     config,
@@ -144,6 +153,7 @@ RightClickMenu.propTypes = {
   unitOfMeasure: PropTypes.string,
   onToggleUnits: PropTypes.func,
   isCoordinateSearchActive: PropTypes.bool,
+  allMeasurements: PropTypes.object,
 };
 
 export default connect(

--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -22,6 +22,7 @@ function RightClickMenu(props) {
     map, crs, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements,
   } = props;
   const [getMap, setMap] = useState(map);
+  const measurementsInProj = !!Object.keys(allMeasurements[crs]).length;
 
   const handleClick = () => (show ? setShow(false) : null);
 
@@ -66,11 +67,6 @@ function RightClickMenu(props) {
     };
   };
 
-  const checkForMeasurements = () => {
-    if (Object.keys(allMeasurements[crs]).length) return false;
-    return true;
-  };
-
   useEffect(() => {
     if (isCoordinateSearchActive) return;
     events.on('map:singleclick', handleClick);
@@ -105,12 +101,14 @@ function RightClickMenu(props) {
           <MenuItem onClick={() => handleMeasurementMenu('area')}>
             Measure Area
           </MenuItem>
+          {measurementsInProj
+          && (
           <MenuItem
-            disabled={checkForMeasurements()}
             onClick={() => handleMeasurementMenu('clear')}
           >
             Remove Measurements
           </MenuItem>
+          )}
           <MenuItem onClick={() => handleMeasurementMenu('units')}>
             Change Units to
             {' '}

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -46,6 +46,7 @@ const OPTIONS_ARRAY = [
     iconName: 'trash',
     id: 'clear-measurements-button',
     key: 'measure:clear',
+    hidden: true,
   },
   DOWNLOAD_GEOJSON,
   // DOWNLOAD_SHAPEFILE,
@@ -88,6 +89,8 @@ class MeasureMenu extends Component {
     const listSize = isTouchDevice ? 'large' : 'small';
     // DOWNLOAD_SHAPEFILE.hidden = !measurementsInProj || isMobile;
     DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
+    const getRemoveOptionIndex = OPTIONS_ARRAY.findIndex((item) => item.text === 'Remove Measurements');
+    OPTIONS_ARRAY[getRemoveOptionIndex].hidden = !measurementsInProj;
     return (
       <>
         <Form>


### PR DESCRIPTION
## Description

Both the "Remove measurements" item is the context menu and the measurements toolbar are removed/unavailable if there aren't any current measurements on the map. 

### No measurements on map means no "Remove Measurements" buttons.
![image](https://user-images.githubusercontent.com/95651563/154334511-d57004f1-f9f5-44e6-995d-7e0ae321b30b.png)
![image](https://user-images.githubusercontent.com/95651563/154334552-6bef7bad-89cd-49fe-bba1-09d9aff429e8.png)

### Measurements on map means "Remove Measurements" button is visible.
![image](https://user-images.githubusercontent.com/95651563/154334674-a17f1eb4-95e4-4adc-820e-1906dc60e9a8.png)
![image](https://user-images.githubusercontent.com/95651563/154334691-2c1289c4-9fba-431d-bff2-81a41becde03.png)

## How To Test
1. Download this branch and run `npm run build && npm start`
1. Open up [localhost](http://localhost:3000)
1.  Right click anywhere on the map. No "Remove Measurements" item should be visible on the right click menu.
1. On the bottom right, click the measurement tool bar.  No "Remove Measurements" item should be visible on the menu. 
1. Either right click or use the measurements toolbar and make a measurement.
1. Right click and "Remove Measurements" should be visible on the right click menu.
1. Open the measurements tool bar again and "Remove Measurements" should be visible.
