### PR TITLE
WV-2183: When using right click to cancel a measurement, the right click menu appears

### DIFF
--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -19,7 +19,7 @@ function RightClickMenu(props) {
   const [toolTipToggleTime, setToolTipToggleTime] = useState(0);
   const [formattedCoordinates, setFormattedCoordinates] = useState();
   const {
-    map, crs, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements,
+    map, crs, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements, measurementIsActive,
   } = props;
   const [getMap, setMap] = useState(map);
   const measurementsInProj = !!Object.keys(allMeasurements[crs]).length;
@@ -27,6 +27,7 @@ function RightClickMenu(props) {
   const handleClick = () => (show ? setShow(false) : null);
 
   function handleContextEvent(event, olMap) {
+    if (measurementIsActive) return;
     event.originalEvent.preventDefault();
     const coord = olMap.getCoordinateFromPixel(event.pixel);
     const [lon, lat] = transform(coord, crs, 'EPSG:4326');
@@ -126,7 +127,7 @@ function mapStateToProps(state) {
   const {
     map, proj, measure, locationSearch, config,
   } = state;
-  const { unitOfMeasure, allMeasurements } = measure;
+  const { unitOfMeasure, allMeasurements, isActive } = measure;
   const { crs } = proj.selected;
   const { coordinates, isCoordinateSearchActive } = locationSearch;
   return {
@@ -134,6 +135,7 @@ function mapStateToProps(state) {
     crs,
     unitOfMeasure,
     allMeasurements,
+    measurementIsActive: isActive,
     coordinates,
     isCoordinateSearchActive,
     config,
@@ -152,6 +154,7 @@ RightClickMenu.propTypes = {
   onToggleUnits: PropTypes.func,
   isCoordinateSearchActive: PropTypes.bool,
   allMeasurements: PropTypes.object,
+  measurementIsActive: PropTypes.bool,
 };
 
 export default connect(


### PR DESCRIPTION
## Description

Fixes: When using right click to cancel a measurement, the right click menu appears.  The menu should not appear when right clicking to cancel a measurement.

## How To Test
1. Pull down this branch then run `npm run build && npm start`
2. Open [localhost](http://localhost:3000)
3. Either right-click or open the measure tools on the bottom right and start a new measurement.  Doesn't matter if its a distance measurement or area measurement.
4. Click a couple points on the map, but do not complete the measurement.
5. Right-click.  The measurement should cancel and no right-click menu should appear.