### PR TITLE
WV-2178: Eye Icon obscures layer list text in embed mode

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -307,6 +307,8 @@ function LayerRow (props) {
     return baseClasses;
   };
 
+  const getMainLayerClasses = () => (isAnimating ? 'layer-main layer-visible' : 'layer-main');
+
   const visibilityTitle = !isVisible && !isDisabled
     ? 'Show layer'
     : isDisabled
@@ -340,7 +342,7 @@ function LayerRow (props) {
 
       <Zot zot={zot} layer={layer.id} isMobile={isMobile} />
 
-      <div className="layer-main">
+      <div className={getMainLayerClasses()}>
         <div className="layer-info" style={{ minHeight: isVectorLayer ? '60px' : '40px' }}>
           <div className="layer-buttons">
             {showButtons && renderControls()}

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -307,8 +307,6 @@ function LayerRow (props) {
     return baseClasses;
   };
 
-  const getMainLayerClasses = () => (isAnimating ? 'layer-main layer-visible' : 'layer-main');
-
   const visibilityTitle = !isVisible && !isDisabled
     ? 'Show layer'
     : isDisabled
@@ -323,26 +321,28 @@ function LayerRow (props) {
 
   const renderLayerRow = () => (
     <>
-      <a
-        id={`hide${encodedLayerId}`}
-        className={getVisibilityToggleClass()}
-        aria-label={visibilityTitle}
-        onClick={() => !isAnimating && !isDisabled && toggleVisibility(layer.id, !isVisible)}
-      >
-        {!isAnimating && (
+      {!isEmbedModeActive && (
+        <a
+          id={`hide${encodedLayerId}`}
+          className={getVisibilityToggleClass()}
+          aria-label={visibilityTitle}
+          onClick={() => !isAnimating && !isDisabled && toggleVisibility(layer.id, !isVisible)}
+        >
+          {!isAnimating && (
           <UncontrolledTooltip
             placement="right"
             target={`hide${encodedLayerId}`}
           >
             {visibilityTitle}
           </UncontrolledTooltip>
-        )}
-        <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" />
-      </a>
+          )}
+          <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" />
+        </a>
+      )}
 
       <Zot zot={zot} layer={layer.id} isMobile={isMobile} />
 
-      <div className={getMainLayerClasses()}>
+      <div className="layer-main">
         <div className="layer-info" style={{ minHeight: isVectorLayer ? '60px' : '40px' }}>
           <div className="layer-buttons">
             {showButtons && renderControls()}

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -102,10 +102,6 @@
         margin-left: 0;
       }
 
-      & .layer-main.layer-visible {
-        margin-left: 30px;
-      }
-
       &.layer-hidden {
         display: none;
       }

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -102,6 +102,10 @@
         margin-left: 0;
       }
 
+      & .layer-main.layer-visible {
+        margin-left: 30px;
+      }
+
       &.layer-hidden {
         display: none;
       }


### PR DESCRIPTION
## Description

Pressing Play for animation in embed mode shows eye icon in layer list and obscures text.  This PR adds an additional class to the `layer-main` div, `layer-visible`, when the `isAnimating` is true.  The CSS in `layer-visible` is only activated when embed mode is active as it is a child of the `.embed-mode` class.

![image](https://user-images.githubusercontent.com/95651563/155409050-486dfe5f-981a-42fd-b354-567b5bb7bd95.png)

## How To Test
1. Open this URL: [localhost](http://localhost:3000/?v=-201.9310639120965,-30.11912669963873,-150.66569698303718,-10.790295040630024&z=4&ics=true&ici=5&icd=10&as=2022-01-15-T04%3A00%3A00Z&ae=2022-01-15-T05%3A20%3A00Z&em=true&l=Coastlines_15m,GOES-West_ABI_GeoColor&lg=true&al=true&ab=on&t=2022-01-15-T04%3A00%3A00Z) and click to interact with the app.
2. Press the play button on the animation menu on the bottom left.
3. The eyeball icon in the layers list should not be overlaying or obscuring the layer information like in the screenshot.