### PR TITLE
WV-2093 Superscript the "2" in Surface Area Unit for Events Listings

### DIFF
--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -53,6 +53,31 @@ function Event (props) {
   }
 
   /**
+   *
+   * @param {Object} geometry | Geometry object containing magnitude data
+   * @returns Magnitude data output
+   */
+  function magnitudeOutput({ magnitudeUnit = null, magnitudeValue = null }) {
+    const unit = magnitudeUnit || null;
+    let value = magnitudeValue ? magnitudeValue.toLocaleString() : null;
+    if (!unit && !value) return;
+
+    const formattedunit = unit === 'kts' ? ' kts' : ' NM';
+    value = value.toLocaleString();
+    return (
+      <p className="magnitude">
+
+        {formattedunit === ' NM' ? 'Surface Area: ' : 'Wind Speed: '}
+        {value}
+        {formattedunit}
+        {formattedunit === ' NM' && (
+          <sup>2</sup>
+        )}
+      </p>
+    );
+  }
+
+  /**
    * Return date list for selected event
    */
   function renderDateLists() {
@@ -64,39 +89,22 @@ function Event (props) {
         >
           {event.geometry.map((geometry, index) => {
             const date = util.toISOStringDate(geometry.date);
-            function magnitudeOutput() {
-              const magnitudeUnit = geometry.magnitudeUnit ? geometry.magnitudeUnit : null;
-              const magnitudeValue = geometry.magnitudeValue ? geometry.magnitudeValue.toLocaleString() : null;
-              if (!magnitudeUnit && !magnitudeValue) return;
-              const magnitudeDisplay = magnitudeUnit === 'kts' ? 'Wind Speed: ' : 'Surface Area: ';
-              return `${magnitudeDisplay} ${magnitudeValue} ${magnitudeUnit}`;
-            }
             return (
-              <li key={`${event.id}-${date}`} className="date">
-
-                {selectedDate === date ? (
-                  <span
-                    className="active"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {formatDisplayDate(date)}
-                  </span>
-                )
-                  : (
-                    <a
-                      className="'date item-selected"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEventSelect(date);
-                      }}
-                    >
-                      {formatDisplayDate(date)}
-                    </a>
-                  )}
-
-                <p className="magnitude">
-                  {magnitudeOutput()}
-                </p>
+              <li key={`${event.id}-${date}`} className="dates">
+                <a
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEventSelect(date);
+                  }}
+                  className={
+                    selectedDate === date
+                      ? 'date item-selected active'
+                      : 'date item-selected '
+                  }
+                >
+                  {formatDisplayDate(date)}
+                </a>
+                {magnitudeOutput(geometry)}
               </li>
             );
           })}

--- a/web/js/map/natural-events/cluster.js
+++ b/web/js/map/natural-events/cluster.js
@@ -95,6 +95,8 @@ export const getClusters = ({ geometry, id }, proj, selectedDate, map) => {
   const selectedCoords = geometry.find(({ date }) => date.split('T')[0] === selectedDate).coordinates;
   geometry.forEach((geom) => {
     let { coordinates } = geom;
+    const { magnitudeUnit, magnitudeValue } = geom;
+    const magnitude = { magnitudeUnit, magnitudeValue };
     const date = geom.date.split('T')[0];
     const isSelected = selectedDate === date;
     const isOverDateline = proj.selected.id === 'geographic'

--- a/web/js/map/natural-events/cluster.js
+++ b/web/js/map/natural-events/cluster.js
@@ -95,8 +95,6 @@ export const getClusters = ({ geometry, id }, proj, selectedDate, map) => {
   const selectedCoords = geometry.find(({ date }) => date.split('T')[0] === selectedDate).coordinates;
   geometry.forEach((geom) => {
     let { coordinates } = geom;
-    const { magnitudeUnit, magnitudeValue } = geom;
-    const magnitude = { magnitudeUnit, magnitudeValue };
     const date = geom.date.split('T')[0];
     const isSelected = selectedDate === date;
     const isOverDateline = proj.selected.id === 'geographic'


### PR DESCRIPTION
## Description

This change superscripts the "2" in the Events listing for the Surface Area unit, `NM^2`.

## How To Test

1. Pull down branch and go to this link: [localhost](http://localhost:3000/?v=-68.411328125,-82.3194140625,-44.188671875,-59.5205859375&e=EONET_5357,2022-02-18&efs=true&efd=2021-10-27,2022-02-24&l=MODIS_Aqua_Sea_Ice(hidden),MODIS_Terra_Sea_Ice(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Night(hidden),VIIRS_SNPP_Brightness_Temp_BandI5_Day(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Night(hidden),VIIRS_NOAA20_Brightness_Temp_BandI5_Day(hidden),MODIS_Aqua_Brightness_Temp_Band31_Night(hidden),MODIS_Aqua_Brightness_Temp_Band31_Day(hidden),MODIS_Terra_Brightness_Temp_Band31_Night(hidden),MODIS_Terra_Brightness_Temp_Band31_Day(hidden),VIIRS_SNPP_DayNightBand_ENCC(hidden),VIIRS_SNPP_DayNightBand_At_Sensor_Radiance(hidden),VIIRS_SNPP_DayNightBand_AtSensor_M15(hidden),Reference_Labels_15m,Reference_Features_15m,Coastlines_15m(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2022-02-18-T00%3A00%3A00Z)
2. Confirm that the "Surface Area" value has a superscripted "2", like in this screenshot:
![image](https://user-images.githubusercontent.com/95651563/155597591-e8c7764d-8338-4f65-9336-d23bfd207ad8.png)
3. Check a few more iceberg events and confirm they have the same formatting for the Surface Area unit.