### PR TITLE
WV-2194: Add long press functionality to context-menu.js

### DIFF
--- a/web/js/combine-ui.js
+++ b/web/js/combine-ui.js
@@ -65,6 +65,12 @@ function registerMapMouseHandlers(maps) {
     map.on('contextmenu', (event) => {
       events.trigger('map:contextmenu', event, map, crs);
     });
+    element.addEventListener('touchstart', (event) => {
+      events.trigger('map:touchstart', event, map, crs);
+    });
+    element.addEventListener('touchend', (event) => {
+      events.trigger('map:touchend', event, map, crs);
+    });
     element.addEventListener('click', (event) => {
       events.trigger('map:click', event, map, crs);
     });


### PR DESCRIPTION
## Description

Provides the ability to do long press interactions on iOS to bring up the context menu.

## How To Test

After pulling down the branch, run `npm ci && npm run build && npm start`.

### With BrowserStack

1. Open BrowserStack and select an iOS device, open Safari or Chrome, and navigate to your computer's local IP address with `:3000` after the IP address.  Example: `192.168.0.123:3000`.
1. Click and hold with your mouse on the map for 1 second.
1. Context menu should appear.
1. Test each of the menu items to see if they work properly.
1. Press and hold again.
1. Click/tap off of the context menu to make it disappear.

### Without BrowserStack
1. Opening this link [localhost](http://localhost:3000) 
2. Open Chrome DevTools (F12 or CTRL/CMD+Shift+i). 
3. Click on mobile device icon on the top-left of the Devtool tools to toggle on the device toolbar.
4. Select any device that presents the WV app in portrait orientation.
5. Repeat steps 3 - 7 from the "With BrowserStack" section.