### PR TITLE
WV-2214: Fix compare date labels

### DIFF
--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -158,26 +158,27 @@ const addLineOverlay = function(map, dateA, dateB) {
   draggerCircleEl.className = 'swipe-dragger-circle';
   firstLabel.className = 'ab-swipe-span left-label';
   secondLabel.className = 'ab-swipe-span right-label';
-  const isSameDate = dateA === dateB;
-  const dateAText = 'A: ';
-  const dateBText = 'B: ';
-  if (!isSameDate) {
-    firstLabel.className += ' show-date-label';
-    secondLabel.className += ' show-date-label';
-  }
+
   const dateElA = document.createElement('span');
   const dateElB = document.createElement('span');
   dateElA.className = 'monospace';
   dateElB.className = 'monospace';
 
-  dateElA.appendChild(document.createTextNode(dateA));
-  dateElB.appendChild(document.createTextNode(dateB));
-
+  const isSameDate = dateA === dateB;
+  const dateAText = 'A';
+  const dateBText = 'B';
   firstLabel.appendChild(document.createTextNode(dateAText));
-  firstLabel.appendChild(dateElA);
-
   secondLabel.appendChild(document.createTextNode(dateBText));
-  secondLabel.appendChild(dateElB);
+
+  if (!isSameDate) {
+    firstLabel.className += ' show-date-label';
+    secondLabel.className += ' show-date-label';
+    dateElA.appendChild(document.createTextNode(`: ${dateA}`));
+    dateElB.appendChild(document.createTextNode(`: ${dateB}`));
+
+    firstLabel.appendChild(dateElA);
+    secondLabel.appendChild(dateElB);
+  }
 
   draggerEl.className = 'ab-swipe-dragger';
   lineCaseEl.className = 'ab-swipe-line';
@@ -265,6 +266,7 @@ const dragLine = function(listenerObj, lineCaseEl, map) {
   window.addEventListener(listenerObj.move, move);
   window.addEventListener(listenerObj.end, end);
 };
+
 /**
  * Add listeners for layer clipping
  * @param {Object} layer | Ol Layer object
@@ -274,6 +276,7 @@ const applyLayerListeners = function(layer) {
   layer.on('postrender', restore);
   bottomLayers.push(layer);
 };
+
 /**
  * Layers need to be inversely clipped so that they can't be seen through
  * the other layergroup in cases where the layergroups layer opacity is < 100%

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -737,16 +737,18 @@ export default function mapui(models, config, store, ui) {
     ).filter(({ visible }) => visible);
 
     visibleLayers.forEach((def) => {
+      const temporalLayer = ['subdaily', 'daily', 'monthly', 'yearly']
+        .includes(def.period);
       const index = findLayerIndex(def);
-      if (!['subdaily', 'daily', 'monthly', 'yearly'].includes(def.period)) {
-        return;
-      }
+      const hasVectorStyles = config.vectorStyles && lodashGet(def, 'vectorStyle.id');
+
       if (compare.active && layers.length) {
         updateCompareLayer(def, index, mapLayerCollection);
-      } else {
+      } else if (temporalLayer) {
         mapLayerCollection.setAt(index, createLayer(def));
       }
-      if (config.vectorStyles && lodashGet(def, 'vectorStyle.id')) {
+
+      if (hasVectorStyles && temporalLayer) {
         updateVectorStyles(def);
       }
     });

--- a/web/scss/features/compare.scss
+++ b/web/scss/features/compare.scss
@@ -10,14 +10,14 @@
   user-select: none;
 
   & .show-date-label {
-    width: 120px;
+    width: 130px;
   }
 
   & .left-label {
-    left: -23px;
+    left: -28px;
 
     &.show-date-label {
-      left: -129px;
+      left: -140px;
     }
   }
 


### PR DESCRIPTION
## Description

- Make sure compare labels update even when no temporal layers
- Fix compare label styling when A & B dates are the same

## How To Test


1. Load app with same date on both sides of compare
2. Confirm date does not show in A/B label
3. Change date on either side
4. Confirm dates now show in A/B label
