### PR TITLE
wv-2210 Add OMPS SO2 to Volcano Events

### DIFF
--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -690,10 +690,26 @@
                     ],
                     [
                         "AIRS_Prata_SO2_Index_Day",
-                        true
+                        false
                     ],
                     [
                         "AIRS_Prata_SO2_Index_Night",
+                        false
+                    ],
+                    [
+                        "OMPS_SO2_Upper_Troposphere_and_Stratosphere",
+                        false
+                    ],
+                    [
+                        "OMPS_SO2_Middle_Troposphere",
+                        false
+                    ],
+                    [
+                        "OMPS_SO2_Lower_Troposphere",
+                        true
+                    ],
+                    [
+                        "OMPS_SO2_Planetary_Boundary_Layer",
                         false
                     ],
                     [


### PR DESCRIPTION
## Description

Fixes WV-2210

Added 4 OMPS Sulfur Dioxide layers to Volcano Events. The Lower Troposphere layer is on by default. The rest are hidden by default.

## How To Test

1. Go to Events and filter by Volcanoes. 
2. In the Layer List, check to see if Sulfur Dioxide (Lower Troposphere) is on by default. Check to see the 3 other (Planetary Boundary, Middle Troposphere and Upper Troposphere) layers are hidden by default. 

@nasa-gibs/worldview