### PR TITLE
WV-2218: Make sure compare dates update properly

### DIFF
--- a/web/js/components/dateline/text.js
+++ b/web/js/components/dateline/text.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import OlOverlay from 'ol/Overlay';
 import util from '../../util/util';
-import { memoizedDateMonthAbbrev } from '../../modules/compare/selectors';
+import { getCompareDates } from '../../modules/compare/selectors';
 
 const textStyles = {
   textOpacity: 1,
@@ -58,7 +58,7 @@ class LineText extends React.Component {
       selected: util.dateAdd(date, 'day', 1),
       selectedB: date,
     };
-    const { dateA, dateB } = memoizedDateMonthAbbrev({ date: dateState })();
+    const { dateA, dateB } = getCompareDates({ date: dateState });
     return {
       dateLeft: dateA,
       dateRight: dateB,

--- a/web/js/containers/sidebar/compare.js
+++ b/web/js/containers/sidebar/compare.js
@@ -6,7 +6,7 @@ import {
 } from 'reactstrap';
 import LayersContainer from './layers-container';
 import { toggleActiveCompareState as toggleActiveCompareStateAction } from '../../modules/compare/actions';
-import { memoizedDateMonthAbbrev } from '../../modules/compare/selectors';
+import { getCompareDates } from '../../modules/compare/selectors';
 import MonospaceDate from '../../components/util/monospace-date';
 
 const tabHeight = 32;
@@ -88,7 +88,7 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state) => {
   const { compare } = state;
   const { isCompareA, active } = compare;
-  const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  const { dateA, dateB } = getCompareDates(state);
 
   return {
     isCompareA,

--- a/web/js/map/compare/compare.js
+++ b/web/js/map/compare/compare.js
@@ -22,7 +22,7 @@ export default function mapCompare(store) {
   const self = {};
   let comparison = null;
   let mode = 'swipe';
-  let proj = '';
+  let selectedProj = '';
 
   self.swipe = Swipe;
   self.opacity = Opacity;
@@ -47,9 +47,8 @@ export default function mapCompare(store) {
   };
 
   self.update = function (group) {
-    const state = store.getState();
     if (comparison) {
-      comparison.update(state, group);
+      comparison.update(store, group);
     }
   };
 
@@ -60,31 +59,35 @@ export default function mapCompare(store) {
    */
   self.create = function (map, compareMode) {
     const state = store.getState();
+    const { proj, compare } = state;
 
-    if (compareMode === mode && comparison && proj === state.proj.selected && self.value === state.compare.value) {
-      comparison.update(state);
+    if (compareMode === mode && comparison
+        && selectedProj === proj.selected
+        && self.value === compare.value) {
+      comparison.update(store);
     } else if (comparison) {
       mode = compareMode;
       self.destroy();
       comparison = new self[compareMode](
         map,
-        state,
+        store,
         self.EventTypeObject,
-        state.compare.value || null,
+        compare.value || null,
       ); // e.g. new self.swipe()
     } else {
       mode = compareMode;
       comparison = new self[compareMode](
         map,
-        state,
+        store,
         self.EventTypeObject,
-        state.compare.value || null,
+        compare.value || null,
       ); // e.g. new self.swipe()
     }
     self.value = state.compare.value || 50;
     self.active = true;
-    proj = state.proj.selected;
+    selectedProj = proj.selected;
   };
+
   /**
    * Return offset value (for running-data use)
    */
@@ -94,6 +97,7 @@ export default function mapCompare(store) {
     }
     return null;
   };
+
   /**
    * Destroy instance in full and nullify vars
    */

--- a/web/js/map/compare/opacity.js
+++ b/web/js/map/compare/opacity.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import OpacitySlider from '../../components/compare/opacity-slider';
-import { memoizedDateMonthAbbrev } from '../../modules/compare/selectors';
+import { getCompareDates } from '../../modules/compare/selectors';
 import util from '../../util/util';
 
 const { events } = util;
@@ -10,15 +10,16 @@ let slider;
 let value = 50;
 
 export default class Opacity {
-  constructor(olMap, state, eventListenerStringObj, valueOverride) {
+  constructor(olMap, store, eventListenerStringObj, valueOverride) {
     this.map = olMap;
     this.sliderCase = document.createElement('div');
     value = Number(valueOverride) || value;
-    this.create(state);
+    this.create(store);
   }
 
-  create(state) {
-    const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  create(store) {
+    const state = store.getState();
+    const { dateA, dateB } = getCompareDates(state);
     this.dateA = dateA;
     this.dateB = dateB;
     slider = this.createSlider(this.map.getLayers().getArray());
@@ -28,11 +29,12 @@ export default class Opacity {
   /**
    * Refresh secondLayer layer group (after date change for example)
    */
-  update(state) {
-    const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  update(store) {
+    const state = store.getState();
+    const { dateA, dateB } = getCompareDates(state);
     if (dateA !== this.dateA || dateB !== this.dateB) {
       this.destroy();
-      this.create(state);
+      this.create(store);
     } else {
       [this.firstLayer, this.secondLayer] = this.map.getLayers().getArray();
       this.oninput(value);

--- a/web/js/map/compare/spy.js
+++ b/web/js/map/compare/spy.js
@@ -1,6 +1,6 @@
 import { each as lodashEach } from 'lodash';
 import { getRenderPixel } from 'ol/render';
-import { memoizedDateMonthAbbrev } from '../../modules/compare/selectors';
+import { getCompareDates } from '../../modules/compare/selectors';
 
 let mousePosition = null;
 let spy = null;
@@ -11,32 +11,35 @@ let radius = DEFAULT_RADIUS;
 let label = null;
 
 export default class Spy {
-  constructor(olMap, state) {
+  constructor(olMap, store) {
     this.mapCase = document.getElementById('wv-map');
     this.map = olMap;
+    const state = store.getState();
     const isBInside = state.compare.isCompareA;
     this.isBInside = isBInside;
-    this.create(state);
+    this.create(store);
   }
 
   /**
    * Init spy
    * @param {Boolean} isBInside | B is the spy value -- true|false
    */
-  create(state) {
+  create(store) {
+    const state = store.getState();
     const isBInside = isCompareA(state);
     spy = this.addSpy(this.map, state);
     this.isBInside = isBInside;
-    this.update(state);
+    this.update(store);
   }
 
   /**
    * Update spy
    * @param {Boolean} isBInside | B is the spy value -- true|false
    */
-  update(state) {
+  update(store) {
+    const state = store.getState();
     const isBInside = isCompareA(state);
-    const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+    const { dateA, dateB } = getCompareDates(state);
     if (dateA !== this.dateA || dateB !== this.dateB || dateA === dateB) {
       label.innerHTML = getDateText(state);
     }
@@ -44,7 +47,7 @@ export default class Spy {
     this.dateB = dateB;
     if (this.isBInside !== isBInside) {
       this.destroy();
-      this.create(state);
+      this.create(store);
     } else {
       const mapLayers = this.map.getLayers().getArray();
       applyEventsToBaseLayers(
@@ -231,7 +234,7 @@ const applyEventsToBaseLayers = function(layer, map, callback) {
 
 const getDateText = function(state) {
   const isBInside = isCompareA(state);
-  const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  const { dateA, dateB } = getCompareDates(state);
   const isSameDate = dateA === dateB;
   let innerHtml = isBInside ? 'B' : 'A';
   if (!isSameDate) {

--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import lodashEach from 'lodash/each';
 import lodashRound from 'lodash/round';
 import util from '../../util/util';
-import { memoizedDateMonthAbbrev } from '../../modules/compare/selectors';
+import { getCompareDates } from '../../modules/compare/selectors';
 
 const { events } = util;
 
@@ -21,28 +21,28 @@ let dragging = false;
 export default class Swipe {
   constructor(
     olMap,
-    state,
+    store,
     eventListenerStringObj,
     valueOverride,
   ) {
     listenerObj = eventListenerStringObj;
     this.map = olMap;
     percentSwipe = valueOverride / 100;
-    this.create(state);
+    this.create(store);
     window.addEventListener('resize', () => {
       if (document.querySelector('.ab-swipe-line')) {
-        this.destroy();
-        this.create(state);
+        this.update(store);
       }
     });
   }
 
-  create(state) {
-    const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  create(store) {
+    const state = store.getState();
+    const { dateA, dateB } = getCompareDates(state);
     this.dateA = dateA;
     this.dateB = dateB;
     line = addLineOverlay(this.map, this.dateA, this.dateB);
-    this.update(state);
+    this.update(store);
   }
 
   getSwipeOffset = () => swipeOffset
@@ -63,11 +63,12 @@ export default class Swipe {
     }
   }
 
-  update(state, groupName) {
-    const { dateA, dateB } = memoizedDateMonthAbbrev(state)();
+  update(store, groupName) {
+    const state = store.getState();
+    const { dateA, dateB } = getCompareDates(state);
     if (dateA !== this.dateA || dateB !== this.dateB) {
       this.destroy();
-      this.create(state);
+      this.create(store);
     } else {
       const mapLayers = this.map.getLayers().getArray();
       if (!groupName) {

--- a/web/js/modules/compare/selectors.js
+++ b/web/js/modules/compare/selectors.js
@@ -1,12 +1,9 @@
-import {
-  memoize as lodashMemoize,
-} from 'lodash';
 import { createSelector } from 'reselect';
 import { getDates } from '../date/selectors';
 import { getFormattedMonthAbbrevDates } from './util';
 
 // eslint-disable-next-line import/prefer-default-export
-export const memoizedDateMonthAbbrev = createSelector(
+export const getCompareDates = createSelector(
   [getDates],
-  ({ selected, selectedB }) => lodashMemoize(() => getFormattedMonthAbbrevDates(selected, selectedB)),
+  ({ selected, selectedB }) => getFormattedMonthAbbrevDates(selected, selectedB),
 );


### PR DESCRIPTION
## Description

* We were using stale references to `state` in several compare `update` functions which could cause the wrong dates to show sometimes.

## How To Test

* Try all three compare modes
* Try changing dates, changing to the same date, resizing, etc.


