### PR TITLE
WV-1931-hotfix

### DIFF
--- a/e2e/features/location-search/location-search-test.js
+++ b/e2e/features/location-search/location-search-test.js
@@ -2,7 +2,7 @@ const reuseables = require('../../reuseables/skip-tour.js');
 const localSelectors = require('../../reuseables/selectors.js');
 
 // encoded id; originally coordinates-map-marker_38.8904,-77.032
-const testMarkerEncodedID = '.coordinates-map-marker_38__2E__8904__2C__-77__2E__032';
+const testMarkerEncodedID = '.coordinates-map-marker_-77__2E__032__2C__38__2E__8904';
 const TIME_LIMIT = 10000;
 
 const {

--- a/web/js/components/location-search/location-marker.js
+++ b/web/js/components/location-search/location-marker.js
@@ -7,9 +7,9 @@ import { getCoordinatesMetadata } from './ol-coordinates-marker-util';
 export default function LocationMarker ({
   reverseGeocodeResults, removeMarker, coordinatesObject, isMobile, dialogVisible = true,
 }) {
-  const coordinates = [coordinatesObject.latitude, coordinatesObject.longitude];
+  const coordinates = [coordinatesObject.longitude, coordinatesObject.latitude];
   const [latitude, longitude] = coordinates;
-  const tooltipId = util.encodeId(`coordinates-map-marker_${latitude},${longitude}`);
+  const tooltipId = util.encodeId(`coordinates-map-marker_${longitude},${latitude}`);
   const geocodeProperties = { latitude, longitude, reverseGeocodeResults };
   const coordinatesMetadata = getCoordinatesMetadata(geocodeProperties);
   const [showDialog, setShowDialog] = useState(dialogVisible);

--- a/web/js/components/location-search/location-search-modal.js
+++ b/web/js/components/location-search/location-search-modal.js
@@ -125,8 +125,8 @@ class LocationSearchModal extends Component {
       this.setInputAlertIcon(true);
     } else {
       const [latitude, longitude] = coordinatesPending;
-      reverseGeocode([latitude, longitude]).then((results) => {
-        setPlaceMarker([latitude, longitude], results);
+      reverseGeocode([longitude, latitude]).then((results) => {
+        setPlaceMarker([longitude, latitude], results);
       });
       this.clearAlerts();
       updateValue('');

--- a/web/js/components/location-search/location-search-modal.js
+++ b/web/js/components/location-search/location-search-modal.js
@@ -124,9 +124,9 @@ class LocationSearchModal extends Component {
       this.setExtentAlert(true);
       this.setInputAlertIcon(true);
     } else {
-      const [longitude, latitude] = coordinatesPending;
-      reverseGeocode([longitude, latitude]).then((results) => {
-        setPlaceMarker([longitude, latitude], results);
+      const [latitude, longitude] = coordinatesPending;
+      reverseGeocode([latitude, longitude]).then((results) => {
+        setPlaceMarker([latitude, longitude], results);
       });
       this.clearAlerts();
       updateValue('');
@@ -191,7 +191,7 @@ class LocationSearchModal extends Component {
       const { latitude, longitude } = coordinatesInputValue;
       this.clearAlerts();
       clearSuggestions();
-      updatePendingCoordinates([longitude, latitude]);
+      updatePendingCoordinates([latitude, longitude]);
     } else if (!value) {
       // clear on empty input
       this.debounceGetSuggestions.cancel();

--- a/web/js/components/location-search/location-search-modal.js
+++ b/web/js/components/location-search/location-search-modal.js
@@ -124,7 +124,7 @@ class LocationSearchModal extends Component {
       this.setExtentAlert(true);
       this.setInputAlertIcon(true);
     } else {
-      const [latitude, longitude] = coordinatesPending;
+      const [longitude, latitude] = coordinatesPending;
       reverseGeocode([longitude, latitude]).then((results) => {
         setPlaceMarker([longitude, latitude], results);
       });
@@ -188,10 +188,10 @@ class LocationSearchModal extends Component {
     const coordinatesInputValue = isValidCoordinates(value);
     if (coordinatesInputValue) {
       this.debounceGetSuggestions.cancel();
-      const { latitude, longitude } = coordinatesInputValue;
+      const { longitude, latitude } = coordinatesInputValue;
       this.clearAlerts();
       clearSuggestions();
-      updatePendingCoordinates([latitude, longitude]);
+      updatePendingCoordinates([longitude, latitude]);
     } else if (!value) {
       // clear on empty input
       this.debounceGetSuggestions.cancel();

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -85,7 +85,7 @@ export default function mapui(models, config, store, ui) {
     proj: {}, // One map for each projection
     selected: null, // The map for the selected projection
     selectedVectors: {},
-    activeMarker: null,
+    markers: [],
     runningdata,
     layerKey,
     createLayer,
@@ -235,6 +235,40 @@ export default function mapui(models, config, store, ui) {
     updateProjection(true);
   };
 
+
+
+  /*
+   * Remove coordinates marker from all projections
+   *
+   * @method removeCoordinatesMarker
+   * @static
+   *
+   * @returns {void}
+   */
+  const removeCoordinatesMarker = (coordinatesObject) => {
+    self.markers.forEach((marker) => {
+      if (marker.id === coordinatesObject.id) {
+        marker.setMap(null);
+        self.selected.removeOverlay(marker);
+      }
+    });
+  };
+
+  /*
+   * Remove all coordinates markers
+   *
+   * @method removeAllCoordinatesMarkers
+   * @static
+   *
+   * @returns {void}
+   */
+  const removeAllCoordinatesMarkers = () => {
+    self.markers.forEach((marker) => {
+      marker.setMap(null);
+      self.selected.removeOverlay(marker);
+    });
+  };
+
   /*
    * Handle reverse geocode and add map marker with results
    *
@@ -247,6 +281,7 @@ export default function mapui(models, config, store, ui) {
     const state = store.getState();
     const { locationSearch, proj } = state;
     const { coordinates } = locationSearch;
+    removeAllCoordinatesMarkers();
     if (coordinates && coordinates.length > 0) {
       coordinates.forEach((coordinatesObject) => {
         const latestCoordinates = [coordinatesObject.latitude, coordinatesObject.longitude];
@@ -259,24 +294,6 @@ export default function mapui(models, config, store, ui) {
       });
     }
   };
-
-  /*
-   * Remove coordinates marker
-   *
-   * @method removeCoordinatesMarker
-   * @static
-   *
-   * @returns {void}
-   */
-  const removeCoordinatesMarker = (coordinatesObject) => {
-    const map = self.selected;
-    self.activeMarker = map.getOverlayById(coordinatesObject.id);
-    if (self.activeMarker) {
-      self.activeMarker.setMap(null);
-      self.selected.removeOverlay(self.activeMarker);
-    }
-  };
-
   /*
    * Add map coordinate marker and update store
    *
@@ -316,7 +333,7 @@ export default function mapui(models, config, store, ui) {
       return false;
     }
 
-    self.activeMarker = marker;
+    self.markers.push(marker);
     self.selected.addOverlay(marker);
     self.selected.renderSync();
 

--- a/web/js/modules/location-search/actions.js
+++ b/web/js/modules/location-search/actions.js
@@ -63,6 +63,7 @@ export function setPlaceMarker(coordinates, reverseGeocodeResults, isInputSearch
     const state = getState();
     const {
       proj,
+      locationSearch,
     } = state;
 
     if (reverseGeocodeResults) {
@@ -73,10 +74,22 @@ export function setPlaceMarker(coordinates, reverseGeocodeResults, isInputSearch
     }
 
     const coordinatesWithinExtent = areCoordinatesWithinExtent(proj, coordinates);
+    const stateCoordinates = locationSearch.coordinates;
+    const markerAlreadyExists = stateCoordinates.find((stateCoordinate) => stateCoordinate.latitude === coordinates[0] && stateCoordinate.longitude === coordinates[1]);
     if (!coordinatesWithinExtent) {
       return dispatch({
         type: SET_MARKER,
         coordinates: [],
+      });
+    }
+
+    if (markerAlreadyExists) {
+      return dispatch({
+        type: SET_MARKER,
+        coordinates: markerAlreadyExists,
+        reverseGeocodeResults,
+        isCoordinatesSearchActive: isInputSearch,
+        flyToExistingMarker: true,
       });
     }
 

--- a/web/js/modules/location-search/util.js
+++ b/web/js/modules/location-search/util.js
@@ -154,18 +154,20 @@ export function serializeCoordinatesWrapper(coordinates, state) {
   const { map, proj } = state;
   const serializeCoordinates = (coordinate) => {
     const coordinateValues = [coordinate.latitude, coordinate.longitude];
-    if (map.ui.selected) {
-      const coordinatesWithinExtent = areCoordinatesWithinExtent(proj, coordinateValues);
-      if (!coordinatesWithinExtent) {
-        return;
-      }
-    }
+    if (!map.ui.selected) return null;
+    const coordinatesWithinExtent = areCoordinatesWithinExtent(proj, coordinateValues);
+    if (!coordinatesWithinExtent) return null;
     return coordinateValues;
   };
 
-  const serializeCoordinatesArray = (coordinatesArray) => coordinatesArray.map((coordinate) => serializeCoordinates(coordinate));
+  const serializeCoordinatesArray = (coordinatesArray) => coordinatesArray
+    .map((coordinate) => serializeCoordinates(coordinate))
+    .filter((coordinate) => coordinate !== null);
   const coordinatesURL = Array.isArray(coordinates) ? serializeCoordinatesArray(coordinates) : serializeCoordinates(coordinates);
-  return coordinatesURL.join('+');
+  if (coordinatesURL.length > 0) {
+    const result = coordinatesURL.length === 1 ? coordinatesURL : coordinatesURL.join('+');
+    return result;
+  }
 }
 
 /**

--- a/web/js/modules/location-search/util.js
+++ b/web/js/modules/location-search/util.js
@@ -154,19 +154,18 @@ export function serializeCoordinatesWrapper(coordinates, state) {
   const { map, proj } = state;
   const serializeCoordinates = (coordinate) => {
     const coordinateValues = [coordinate.latitude, coordinate.longitude];
-    if (!map.ui.selected) return null;
+    if (!map.ui.selected) return;
     const coordinatesWithinExtent = areCoordinatesWithinExtent(proj, coordinateValues);
-    if (!coordinatesWithinExtent) return null;
+    if (!coordinatesWithinExtent) return;
     return coordinateValues;
   };
 
   const serializeCoordinatesArray = (coordinatesArray) => coordinatesArray
     .map((coordinate) => serializeCoordinates(coordinate))
-    .filter((coordinate) => coordinate !== null);
+    .filter((coordinate) => coordinate);
   const coordinatesURL = Array.isArray(coordinates) ? serializeCoordinatesArray(coordinates) : serializeCoordinates(coordinates);
   if (coordinatesURL.length > 0) {
-    const result = coordinatesURL.length === 1 ? coordinatesURL : coordinatesURL.join('+');
-    return result;
+    return coordinatesURL.join('+');
   }
 }
 


### PR DESCRIPTION
## Description

Hotfix for `release-3.21.0`.   Fixes the following issues:
- [ ] Coordinates being reversed in map marker info box and when copying to clipboard.  
- [ ] "Remove Map Marker" tooltip persists after closing/removing marker.
- [ ] Errors when adding markers in one projection, switching to another projection, then refreshing the page.

## How To Test
**Test 1**
1. Right-click to add a marker on the map. Map a note of the coordinates displayed on context menu.
2. Check that the coordinates on the info box match what is on the context menu.
3. Click the copy icon on the marker box.
4. Paste them somewhere and make sure they match the coordinates displayed on context menu.

**Test 2**
1. Add a few markers in Geographic
2. Change to Arctic/Antarctic Projection, add a marker
3. Go back to Geographic and hover (do not click) over the x to remove the markers. 
4. Click on the X.
5. The tooltip that appeared on hover should disappear along with the marker and its info box.
6. Change back to Arctic/Antarctic and repeat steps 3 through 5.

**Test 3**
1. Open Dev Tools/Console
2. Add some place markers in Geographic
3. Add some place markers in Arctic/Antarctic
4. When in a polar projection, refresh the page or save the URL and open in a new tab
5. No errors should appear on page load.
