### PR TITLE
WV-2237 - Darken text color for H4 in layer picker descriptions

### DIFF
--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -327,6 +327,12 @@
   margin: 0 4px;
 }
 
+.source-metadata .layer-description .layer-metadata{
+  h1, h2, h3, h4, h5, h6 {
+    color:#333;
+  }
+}
+
 .source-metadata .layer-description .layer-date-start .monospace,
 .source-metadata .layer-description .layer-date-end .monospace {
   @include wv-date-chip;

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -327,14 +327,14 @@
   margin: 0 4px;
 }
 
-.source-metadata .layer-description .layer-metadata{
+.source-metadata .layer-description .layer-metadata {
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
-    color:#333;
+    color: #333;
   }
 }
 

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -328,7 +328,12 @@
 }
 
 .source-metadata .layer-description .layer-metadata{
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color:#333;
   }
 }

--- a/web/scss/features/sidebar-panel.scss
+++ b/web/scss/features/sidebar-panel.scss
@@ -219,7 +219,7 @@ li.item ul.palette li {
 .layer-description .layer-metadata h4,
 .layer-description .layer-metadata h5,
 .layer-description .layer-metadata h6 {
-  color: #333;
+  color: #ccc;
   font-weight: 700;
 }
 

--- a/web/scss/features/sidebar-panel.scss
+++ b/web/scss/features/sidebar-panel.scss
@@ -219,7 +219,7 @@ li.item ul.palette li {
 .layer-description .layer-metadata h4,
 .layer-description .layer-metadata h5,
 .layer-description .layer-metadata h6 {
-  color: #ddd;
+  color: #333;
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Description

Updates SCSS to make heading tags a dark gray for the layer picker descriptions.  They were too light and unreadable before.

## How To Test

- After pulling down changes and starting up the server, go to [localhost](http://localhost:3000)
- On the left sidebar menu, click "Add Layers"
- In the searchbox, search for `modis corrected`
- Click on "Corrected Reflectance (Bands 3-6-7)"
- In the description box on the right, the headings "Snow and Ice", "Vegetation", and "Water" should be a dark gray.