### PR TITLE
Update geostationary latency; 3 misr layers to inactive

### DIFF
--- a/config/default/common/config/metadata/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.md
+++ b/config/default/common/config/metadata/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Clean Infrared (10.3 um, Band 13) layer from the GOES-East Advanced Baseline Imager (ABI) is useful for detecting clouds all times of day and night and is quite useful in retrievals of cloud top height. It is used to identify and classify cloud and other atmospheric features, estimate cloud-top brightness temperature and cloud particle size, convective severe weather signatures, and hurricane intensity. This infrared window is not strongly affected by atmospheric water vapor.
 

--- a/config/default/common/config/metadata/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.md
+++ b/config/default/common/config/metadata/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Red Visible (0.64 um, Band 2) layer from the GOES-East Advanced Baseline Imager (ABI) is used primarily to monitor the evolution of clouds throughout the daylight hours. It is also useful for identifying small-scale features such as river fog/clear air boundaries, or overshooting tops of cumulus clouds. It can also be used to identify daytime snow and ice cover, diagnose low-level cloud-drift winds, assist with detections of volcanic ash and analysis of hurricanes and winter storms.
 

--- a/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Air_Mass.md
+++ b/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Air_Mass.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Air Mass layer from the GOES-West Advanced Baseline Imager (ABI) is used primarily for distinguishing between polar and tropical air masses, especially along frontal boundaries and identify high, mid, and low-level clouds. It can also be used to infer cyclogenesis by identifying warm, dry, ozone-rich descending stratospheric air associated with jet streams and potential vorticity (PV) anomalies. The RGB image is comprised of Bands 6.2-7.3, 9.6-10.4 and 6.2.
 

--- a/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.md
+++ b/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Clean Infrared (10.3 um, Band 13) layer from the GOES-West Advanced Baseline Imager (ABI) is useful for detecting clouds all times of day and night and is quite useful in retrievals of cloud top height. It is used to identify and classify cloud and other atmospheric features, estimate cloud-top brightness temperature and cloud particle size, convective severe weather signatures, and hurricane intensity. This infrared window is not strongly affected by atmospheric water vapor.
 

--- a/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.md
+++ b/config/default/common/config/metadata/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Red Visible (0.64 um, Band 2) layer from the GOES-West Advanced Baseline Imager (ABI) is used primarily to monitor the evolution of clouds throughout the daylight hours. It is also useful for identifying small-scale features such as river fog/clear air boundaries, or overshooting tops of cumulus clouds. It can also be used to identify daytime snow and ice cover, diagnose low-level cloud-drift winds, assist with detections of volcanic ash and analysis of hurricanes and winter storms.
 

--- a/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Air_Mass.md
+++ b/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Air_Mass.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Air Mass layer from the Himawari-8 Advanced Himawari Imager (AHI) is used primarily for distinguishing between polar and tropical air masses, especially along frontal boundaries and identify high, mid, and low-level clouds. It can also be used to infer cyclogenesis by identifying warm, dry, ozone-rich descending stratospheric air associated with jet streams and potential vorticity (PV) anomalies. The RGB image is comprised of Bands 6.2-7.3, 9.6-10.4 and 6.2.
 

--- a/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.md
+++ b/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Clean Infrared (10.3 um, Band 13) layer from the Advanced Himawari Imager (AHI) is useful for detecting clouds all times of day and night and is quite useful in retrievals of cloud top height. It is used to identify and classify cloud and other atmospheric features, estimate cloud-top brightness temperature and cloud particle size, convective severe weather signatures, and hurricane intensity. This infrared window is not strongly affected by atmospheric water vapor.
 

--- a/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.md
+++ b/config/default/common/config/metadata/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.md
@@ -1,4 +1,4 @@
-Note: This layer is generally available for the **most recent 30 days**, though certain historical ranges are also preserved.
+Note: This layer is generally available for the **most recent 90 days**, though certain historical ranges are also preserved.
 
 The Red Visible (0.64 um, Band 3) layer from the Advanced Himawari Imager (AHI) is used primarily to monitor the evolution of clouds throughout the daylight hours. It is also useful for identifying small-scale features such as river fog/clear air boundaries, or overshooting tops of cumulus clouds. It can also be used to identify daytime snow and ice cover, diagnose low-level cloud-drift winds, assist with detections of volcanic ash and analysis of hurricanes and winter storms.
 

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
@@ -15,7 +15,7 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30
+        "rollingWindow": 90
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
@@ -18,11 +18,11 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2019-09-01T10:00:00Z",
-            "endDate": "2019-09-05T18:00:00Z",
+            "endDate": "2019-09-05T17:40:00Z",
             "dateInterval": "10"
           },
           {

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
@@ -14,7 +14,7 @@
         "day"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2019-09-01T10:00:00Z",

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
@@ -15,7 +15,14 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30
+        "rollingWindow": 90,
+        "historicalRanges": [
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
+            "dateInterval": "10"
+          }
+        ]
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
@@ -18,7 +18,7 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2021-09-13T09:50:00Z",
@@ -28,6 +28,11 @@
           {
             "startDate": "2021-09-30T16:00:00Z",
             "endDate": "2021-09-30T16:00:00Z",
+            "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T06:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
             "dateInterval": "10"
           }
         ]

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
@@ -14,11 +14,16 @@
         "day"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2021-09-30T21:00:00Z",
             "endDate": "2021-09-30T21:00:00Z",
+            "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
             "dateInterval": "10"
           }
         ]

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_GeoColor.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_GeoColor.json
@@ -21,6 +21,11 @@
             "startDate": "2021-07-21T00:30:00Z",
             "endDate": "2019-08-05T22:30:00Z",
             "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
+            "dateInterval": "10"
           }
         ]
       }

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Air_Mass.json
@@ -15,7 +15,7 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2020-01-03",
@@ -25,6 +25,11 @@
           {
             "startDate": "2021-10-01T00:00:00Z",
             "endDate": "2021-10-01T00:00:00Z",
+            "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
             "dateInterval": "10"
           }
         ]

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band13_Clean_Infrared.json
@@ -18,7 +18,7 @@
         "night"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2020-01-03",
@@ -28,6 +28,11 @@
           {
             "startDate": "2021-09-30T16:00:00Z",
             "endDate": "2021-09-30T16:00:00Z",
+            "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
             "dateInterval": "10"
           }
         ]

--- a/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/himawari/Himawari_AHI_Band3_Red_Visible_1km.json
@@ -14,7 +14,7 @@
         "day"
       ],
       "availability": {
-        "rollingWindow": 30,
+        "rollingWindow": 90,
         "historicalRanges": [
           {
             "startDate": "2020-01-03",
@@ -24,6 +24,11 @@
           {
             "startDate": "2021-09-30T02:00:00Z",
             "endDate": "2021-09-30T02:00:00Z",
+            "dateInterval": "10"
+          },
+          {
+            "startDate": "2021-12-19T00:00:00Z",
+            "endDate": "2022-01-16T23:50:00Z",
             "dateInterval": "10"
           }
         ]

--- a/config/default/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
@@ -10,6 +10,7 @@
       "layergroup": "DHR Reflectance",
       "product": "MIL3MLS",
       "wrapadjacentdays": true,
+      "inactive": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
@@ -10,6 +10,7 @@
       "layergroup": "Radiance",
       "product": "MIL3MRD",
       "wrapadjacentdays": true,
+      "inactive": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
@@ -10,6 +10,7 @@
       "layergroup": "Radiance",
       "product": "MIL3MRD",
       "wrapadjacentdays": true,
+      "inactive": true,
       "daynight": [
         "day"
       ]


### PR DESCRIPTION
## Description

Fixes WV-2277 and WV-2208.

- [ ] Updated the Geostationary imagery to 90 day rolling window - GOES-East/GOES-West/Himawari-8, Red Visible, Clean Infrared and Air Mass.
- [ ] Three MISR layers set to inactive as they have not been updated since 2020 (but may be updated in the future)- MISR_Radiance_Average_Natural_Color_Monthly, MISR_Radiance_Average_Infrared_Color_Monthly, MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly


[If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]

## How To Test

[Provide whatever information a reviewer might need to know in order to verify that the changes made in this PR are working as expected. If there are special build steps that need to be taken in order to get these changes to run (building while on a separate branch, running `npm ci`, etc) include them here.]

- For bugfixes: What steps need to be taken in the UI to verify the bug is fixed?
- For enhancements and features: What is the expected functionality being added/modified? How can a reviewer verify this?

1. Open with these URL parameters
2. ...
3. Verify expected result


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
