### PR TITLE
WV-2284: Fix geostationary gifs in FireFox

### DIFF
--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -47,9 +47,7 @@ class GIF extends Component {
     } = this.getModalOffsets(boundaries);
     this.state = {
       isDownloaded: false,
-      isDownloadError: false,
       showDates: true,
-      isValidSelection: true,
       progress: 0,
       downloadedObject: {},
       offsetLeft,
@@ -243,7 +241,6 @@ class GIF extends Component {
   onGifComplete(obj, width, height) {
     if (obj.error) {
       this.setState({
-        isDownloadError: true,
         isDownloading: false,
         progress: 0,
         downloadedObject: {},

--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -93,8 +93,8 @@ class GIF extends Component {
       screenHeight,
       proj,
       onClose,
-      endDate,
-      startDate,
+      endDateStr,
+      startDateStr,
       numberOfFrames,
     } = this.props;
     const { boundaries, showDates } = this.state;
@@ -134,8 +134,8 @@ class GIF extends Component {
             increment={increment}
             projId={proj.id}
             lonlats={lonlats}
-            startDate={startDate}
-            endDate={endDate}
+            startDate={startDateStr}
+            endDate={endDateStr}
             onClick={this.createGIF}
             onCheck={this.toggleShowDates}
             numberOfFrames={numberOfFrames}
@@ -167,8 +167,10 @@ class GIF extends Component {
   }
 
   createGIF(width, height) {
-    const { getImageArray } = this.props;
-    const { boundaries } = this.state;
+    const {
+      getImageArray, startDate, endDate, url,
+    } = this.props;
+    const { boundaries, showDates } = this.state;
     const dimensions = {
       w: boundaries.y2 - boundaries.y,
       h: boundaries.x2 - boundaries.x,
@@ -178,7 +180,14 @@ class GIF extends Component {
     const stampWidthRatio = 4.889;
 
     const build = (stamp, dateStamp, stampHeight) => {
-      const imageArray = getImageArray(this.state, this.props, { width, height });
+      const options = {
+        startDate,
+        endDate,
+        url,
+        boundaries,
+        showDates,
+      };
+      const imageArray = getImageArray(options, { width, height });
       if (!imageArray) return; // won't be true if there are too many frames
 
       gifStream.createGIF(
@@ -322,8 +331,8 @@ class GIF extends Component {
     const {
       increment,
       speed,
-      endDate,
-      startDate,
+      endDateStr,
+      startDateStr,
       screenHeight,
       screenWidth,
       onClose,
@@ -368,9 +377,9 @@ class GIF extends Component {
         <GifResults
           speed={speed}
           gifObject={downloadedObject}
-          startDate={startDate}
+          startDate={startDateStr}
+          endDate={endDateStr}
           onClose={onClose}
-          endDate={endDate}
           increment={increment}
           boundaries={boundaries}
           screenWidth={screenWidth}
@@ -411,8 +420,10 @@ function mapStateToProps(state) {
     boundaries,
     proj: proj.selected,
     isActive: animation.gifActive,
-    startDate: formatDisplayDate(startDate, subdailyLayersActive(state)),
-    endDate: formatDisplayDate(endDate, subdailyLayersActive(state)),
+    startDateStr: formatDisplayDate(startDate, subdailyLayersActive(state)),
+    endDateStr: formatDisplayDate(endDate, subdailyLayersActive(state)),
+    startDate,
+    endDate,
     increment: `${increment} Between Frames`,
     speed,
     map,
@@ -425,9 +436,8 @@ function mapStateToProps(state) {
         : TIME_SCALE_FROM_NUMBER[interval],
       customSelected ? customDelta : 1,
     ),
-    getImageArray: (gifComponentProps, gifComponentState, dimensions) => getImageArray(
-      gifComponentProps,
-      gifComponentState,
+    getImageArray: (options, dimensions) => getImageArray(
+      options,
       dimensions,
       state,
     ),
@@ -446,7 +456,10 @@ export default connect(
 
 GIF.propTypes = {
   boundaries: PropTypes.object,
-  endDate: PropTypes.string,
+  startDate: PropTypes.object,
+  endDate: PropTypes.object,
+  startDateStr: PropTypes.string,
+  endDateStr: PropTypes.string,
   getImageArray: PropTypes.func,
   increment: PropTypes.string,
   map: PropTypes.object,
@@ -457,5 +470,5 @@ GIF.propTypes = {
   screenHeight: PropTypes.number,
   screenWidth: PropTypes.number,
   speed: PropTypes.number,
-  startDate: PropTypes.string,
+  url: PropTypes.string,
 };

--- a/web/js/modules/animation/selectors.js
+++ b/web/js/modules/animation/selectors.js
@@ -20,16 +20,16 @@ import { formatDisplayDate } from '../date/util';
  *
  */
 export default function getImageArray(
-  gifComponentState,
-  gifComponentProps,
+  options,
   dimensions,
   state,
 ) {
   const {
     animation, proj, map, date, locationSearch,
   } = state;
-  const { startDate, endDate, url } = gifComponentProps;
-  const { boundaries, showDates } = gifComponentState;
+  const {
+    boundaries, showDates, startDate, endDate, url,
+  } = options;
   const {
     customInterval, interval, customDelta, delta, customSelected,
   } = date;


### PR DESCRIPTION
## Description

* Firefox can't translate the same datetime strings into date objects that Chrome can so, pass down a date object where needed and string elsewhere for display.

## How To Test

Create a GIF in FireFox with geostationary layers loaded