### PR TITLE
WV-2222: Handle granule animation

### DIFF
--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -34,7 +34,10 @@ class PlayQueue extends React.Component {
       loadedItems: 0,
     };
     this.fetchTimes = [0];
-    this.queue = new PQueue({ concurrency: CONCURRENT_REQUESTS });
+    this.queue = new PQueue({
+      concurrency: CONCURRENT_REQUESTS,
+      timeout: 3000,
+    });
     this.inQueueObject = {};
     this.bufferObject = {};
     this.bufferArray = [];
@@ -47,7 +50,7 @@ class PlayQueue extends React.Component {
   componentDidMount() {
     this.mounted = true;
     this.queue.on('completed', (dateStr) => {
-      console.debug(dateStr, Date.now(), this.queue.size);
+      console.debug(dateStr, this.queue.size);
     });
     this.playingDate = this.getStartDate();
     this.checkQueue();

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -138,13 +138,7 @@ class PlayQueue extends React.Component {
     }
   }
 
-  // Filter outliers (e.g. layers that have already been loaded)
-  getFetchTimes = () => this.fetchTimes.filter((time) => time >= MIN_REQUEST_TIME);
-
-  getAverageFetchTime = () => {
-    const filteredTimes = this.getFetchTimes();
-    return filteredTimes.length && filteredTimes.reduce((a, b) => a + b) / filteredTimes.length;
-  }
+  getAverageFetchTime = () => this.fetchTimes.length && this.fetchTimes.reduce((a, b) => a + b) / this.fetchTimes.length
 
   calcBufferSize() {
     // NOTE: for some reason playback takes about 1.5 times as long as it is calculated to be
@@ -187,7 +181,7 @@ class PlayQueue extends React.Component {
     if (currentBufferSize < this.defaultBufferSize) {
       return false;
     }
-    if (this.getFetchTimes().length < this.defaultBufferSize) {
+    if (this.fetchTimes.length < this.defaultBufferSize) {
       this.checkQueue();
       return false;
     }
@@ -282,7 +276,6 @@ class PlayQueue extends React.Component {
     const nextDateStr = toString(nextDate);
     const dateInRange = nextDate <= endDate && nextDate >= startDate;
     const shouldQueue = !this.inQueueObject[nextDateStr] && !this.bufferObject[nextDateStr];
-
     if (shouldQueue && dateInRange) {
       this.addDate(nextDate);
     }
@@ -304,7 +297,9 @@ class PlayQueue extends React.Component {
     await this.queue.add(async () => {
       const startTime = Date.now();
       await promiseImageryForTime(date);
-      this.fetchTimes.push(Date.now() - startTime);
+      const elapsedTime = Date.now() - startTime;
+      const fetchTime = elapsedTime >= MIN_REQUEST_TIME ? elapsedTime : MIN_REQUEST_TIME;
+      this.fetchTimes.push(fetchTime);
       this.setState({ loadedItems: loadedItems += 1 });
       return strDate;
     });
@@ -312,9 +307,9 @@ class PlayQueue extends React.Component {
     if (!this.mounted) return;
     this.bufferObject[strDate] = strDate;
     delete this.inQueueObject[strDate];
-    const bufferLength = this.bufferArray.length;
+    const currentBufferSize = util.objectLength(this.bufferObject);
 
-    if (!initialLoad || this.canPreloadAll || bufferLength >= this.defaultBufferSize) {
+    if (!initialLoad || this.canPreloadAll || currentBufferSize >= this.defaultBufferSize) {
       this.checkQueue();
       this.checkShouldPlay();
     }

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -222,7 +222,10 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
    * @returns {object} - Granule layer
   */
   const createGranuleLayer = async (def, attributes, options) => {
-    const { proj: { selected: { crs, maxExtent } } } = store.getState();
+    const {
+      animation: { isPlaying },
+      proj: { selected: { crs, maxExtent } },
+    } = store.getState();
     const { id } = def;
     const { date, group } = attributes;
     const granuleAttributes = await getGranuleAttributes(def, options);
@@ -242,7 +245,11 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       ...granuleAttributes,
       filteredGranules: granules,
     };
-    store.dispatch(updateGranuleLayerState(layer));
+
+    // Don't update during animation due to the performance hit
+    if (!isPlaying) {
+      store.dispatch(updateGranuleLayerState(layer));
+    }
 
     return layer;
   };

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -68,7 +68,6 @@ import {
 } from '../modules/map/constants';
 import { getLeadingExtent, promiseImageryForTime } from '../modules/map/util';
 import { updateVectorSelection } from '../modules/vector-styles/util';
-import { hasVectorLayers } from '../modules/layers/util';
 import { animateCoordinates, getCoordinatesMarker, areCoordinatesWithinExtent } from '../modules/location-search/util';
 import { reverseGeocode } from '../modules/location-search/util-api';
 import { startLoading, stopLoading, PRELOAD_TILES } from '../modules/loading/actions';
@@ -264,12 +263,16 @@ export default function mapui(models, config, store) {
   /**
    * During animation we swap Vector tiles for WMS for better performance.
    * Once animation completes, we need to call reloadLayers to reload and replace
-   * the WMS tiles with Vector tiles
+   * the WMS tiles with Vector tiles.
+   *
+   * We also disable granule layer state updates due to performance reasons and so
+   * need to trigger a layer state update once animation fisnishes.
    */
   const onStopAnimation = function() {
     const state = store.getState();
-    const hasActiveVectors = hasVectorLayers(getActiveLayers(state));
-    if (hasActiveVectors) {
+    const activeLayers = getActiveLayers(state);
+    const needsRefresh = activeLayers.some(({ type }) => type === 'granule' || type === 'vector');
+    if (needsRefresh) {
       // The SELECT_DATE and STOP_ANIMATION actions happen back to back and both
       // try to modify map layers asynchronously so we need to set a timeout to allow
       // the updateDate() function to complete before trying to call reloadLayers() here

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -289,9 +289,6 @@ export async function promiseImageryForTime(state, date, activeString) {
   } = map.ui;
   const layers = getActiveVisibleLayersAtDate(state, date, activeString);
   await Promise.all(layers.map(async (layer) => {
-    if (layer.type === 'granule') {
-      return Promise.resolve();
-    }
     const options = { date, group: activeString };
     const key = layerKey(layer, options, state);
     const layerGroup = cache.getItem(key) || await createLayer(layer, options);


### PR DESCRIPTION
## Description

* Granule layer requests can complete much faster than other layers due to how little of the map is covered by imagery.  For this reasons, the request times were under the minimum request time we were filtering out when calculating average request times to determine the animation buffer size.
* Instead of filtering out minimum request times, replace very short request times with a defined minimum so we can't end up in a scenario where there are no request times to make calculations on.

## How To Test

* Checkout `wv-2228-config` branch
* npm run build
* Checkout `wv-2222-2` branch
* `npm run watch`

Here are a few test links with different time intervals:

### Swath-at-a-time
http://localhost:3000/?v=-157.67582306496837,-207.06684752843876,229.40823518764688,204.67224628166792&z=4&ics=true&ici=5&icd=102&as=2019-09-23-T00%3A00%3A00Z&ae=2019-09-24-T23%3A50%3A00Z&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule_v1_NRT,Coastlines_15m&lg=true&al=true&av=10&ab=on&t=2019-09-22-T22%3A54%3A00Z

### Granule-at-a-time
http://localhost:3000/?v=-157.67582306496837,-207.06684752843876,229.40823518764688,204.67224628166792&z=4&ics=true&ici=5&icd=6&as=2019-09-23-T05%3A10%3A00Z&ae=2019-09-24-T03%3A50%3A00Z&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule_v1_NRT,Coastlines_15m&lg=true&al=true&av=10&ab=on&t=2019-09-23-T07%3A10%3A00Z

### Ten Minute Intervals
http://localhost:3000/?v=-232.10321165414558,-207.06684752843876,303.8356237768241,204.67224628166792&z=4&ics=true&ici=5&icd=10&as=2019-09-23-T05%3A10%3A00Z&ae=2019-09-24-T03%3A50%3A00Z&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule_v1_NRT,Coastlines_15m&lg=true&al=true&av=10&ab=on&t=2019-09-23-T10%3A10%3A00Z


