### PR TITLE
WV-2033 Remove wrapadjacentdays from multi-day layers

### DIFF
--- a/config/default/common/config/wv.json/layers/airs/AIRS_L3_Carbon_Dioxide_AIRS_AMSU_Monthly.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L3_Carbon_Dioxide_AIRS_AMSU_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "product": "AIRX3C2M",
       "inactive": true,
-      "wrapadjacentdays": true,
       "layergroup": "Carbon Dioxide"
     }
   }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L3_Carbon_Dioxide_IR_Monthly.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L3_Carbon_Dioxide_IR_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "product": "AIRS3C2M",
       "inactive": true,
-      "wrapadjacentdays": true,
       "layergroup": "Carbon Dioxide"
     }
   }

--- a/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_3Month.json
+++ b/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_3Month.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
       "product": "AQUARIUS_L3_SSS_SMI_SEASONAL-CLIMATOLOGY_V5",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_RunningMean.json
+++ b/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_RunningMean.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
       "product": "AQUARIUS_L3_SSS_SMI_7DAY-RUNNINGMEAN_V5",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_Snapshot.json
+++ b/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_7Day_Snapshot.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
       "product": "AQUARIUS_L3_SSS_SMI_7DAY_V5",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Monthly.json
+++ b/config/default/common/config/wv.json/layers/aquarius/Aquarius_Sea_Surface_Salinity_L3_Monthly.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
       "product": "AQUARIUS_L3_SSS_SMI_MONTHLY-CLIMATOLOGY_V5",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_7Day_Snapshot.json
+++ b/config/default/common/config/wv.json/layers/aquarius/Aquarius_Wind_Speed_L3_7Day_Snapshot.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Wind Speed",
       "product": "AQUARIUS_L3_WIND_SPEED_SMI_7DAY_V4",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Diffuse_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Diffuse_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Diffuse_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Diffuse_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Direct_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Direct_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Direct_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Direct_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_UV_Index_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_Surface_UV_Index_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Combined_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-Aqua-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Longwave_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Longwave_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Shortwave_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Shortwave_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Total_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_CRE_Net_Total_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Longwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Net_Total_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CERES_EBAF-Surface",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Longwave_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Longwave_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Net_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Net_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Shortwave_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_CRE_Shortwave_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Incoming_Solar_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Incoming_Solar_Flux_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Net_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_EBAF_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CERES_EBAF-TOA",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Longwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Diffuse_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Diffuse_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Diffuse_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Diffuse_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Direct_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Direct_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Direct_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Direct_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Down_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Down_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Up_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_Shortwave_Flux_Up_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_UV_Index_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_Surface_UV_Index_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Surface Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Longwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Shortwave_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_All_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_All_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ceres/CERES_Terra_TOA_Window_Region_Flux_Clear_Sky_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "TOA Flux",
       "product": "CER_SYN1deg-Month_Terra-MODIS",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_Bands157_Global_Annual.json
+++ b/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_Bands157_Global_Annual.json
@@ -10,7 +10,6 @@
       "layergroup": "Corrected Reflectance",
       "product": "",
       "inactive": true,
-      "wrapX": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_Bands743_Global_Annual.json
+++ b/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_Bands743_Global_Annual.json
@@ -10,7 +10,6 @@
       "layergroup": "Corrected Reflectance",
       "product": "",
       "inactive": true,
-      "wrapX": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual.json
+++ b/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Annual.json
@@ -10,7 +10,6 @@
       "layergroup": "Corrected Reflectance",
       "product": "",
       "inactive": true,
-      "wrapX": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Monthly.json
+++ b/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_CorrectedReflectance_TrueColor_Global_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Corrected Reflectance",
       "product": "",
       "inactive": true,
-      "wrapX": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Annual.json
+++ b/config/default/common/config/wv.json/layers/landsat/Landsat_WELD_NDVI_Global_Annual.json
@@ -10,7 +10,6 @@
       "layergroup": "Vegetation Indices",
       "product": "",
       "inactive": true,
-      "wrapX": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/ldas/GLDAS_Near_Surface_Air_Temperature_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ldas/GLDAS_Near_Surface_Air_Temperature_Monthly.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Temperature",
       "product": "GLDAS_NOAH10_M.2.0",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/ldas/GLDAS_Surface_Total_Precipitation_Rate_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ldas/GLDAS_Surface_Total_Precipitation_Rate_Monthly.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Precipitation Rate",
       "product": "GLDAS_NOAH10_M.2.0",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/ldas/GLDAS_Underground_Soil_Moisture_Monthly.json
+++ b/config/default/common/config/wv.json/layers/ldas/GLDAS_Underground_Soil_Moisture_Monthly.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Soil Moisture",
       "product": "GLDAS_NOAH10_M.2.0",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_2m_Air_Temperature_Assimilated_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_2m_Air_Temperature_Assimilated_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Temperature",
-      "product": "M2IMNXASM",
-      "wrapadjacentdays": true
+      "product": "M2IMNXASM"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_2m_Air_Temperature_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_2m_Air_Temperature_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Temperature",
-      "product": "M2TMNXSLV",
-      "wrapadjacentdays": true
+      "product": "M2TMNXSLV"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Aerosol_Optical_Depth_Analysis_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Aerosol_Optical_Depth_Analysis_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Aerosol Optical Depth",
-      "product": "M2IMNXGAS",
-      "wrapadjacentdays": true
+      "product": "M2IMNXGAS"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Air_Temperature_250hPa_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Air_Temperature_250hPa_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Temperature",
-      "product": "M2IMNPASM",
-      "wrapadjacentdays": true
+      "product": "M2IMNPASM"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Carbon_Monoxide_Emission_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Carbon_Monoxide_Emission_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Carbon Monoxide",
-      "product": "M2TMNXCHM",
-      "wrapadjacentdays": true
+      "product": "M2TMNXCHM"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Convective_Rainwater_Source_700hPa_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Convective_Rainwater_Source_700hPa_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Convective Rainwater Source",
-      "product": "M2TMNPMST",
-      "wrapadjacentdays": true
+      "product": "M2TMNPMST"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Dust_Surface_Mass_Concentration_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Dust_Surface_Mass_Concentration_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Dust",
-      "product": "M2TMNXAER",
-      "wrapadjacentdays": true
+      "product": "M2TMNXAER"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Dust_Surface_Mass_Concentration_PM25_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Dust_Surface_Mass_Concentration_PM25_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Dust",
-      "product": "M2TMNXAER",
-      "wrapadjacentdays": true
+      "product": "M2TMNXAER"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Evaporation_Land_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Evaporation_Land_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Evaporation",
-      "product": "M2TMNXLND",
-      "wrapadjacentdays": true
+      "product": "M2TMNXLND"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Evaporation_from_Turbulence_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Evaporation_from_Turbulence_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Evaporation",
-      "product": "M2TMNXINT",
-      "wrapadjacentdays": true
+      "product": "M2TMNXINT"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_ISCCP_Cloud_Albedo_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_ISCCP_Cloud_Albedo_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Cloud Albedo",
-      "product": "M2TMNXCSP",
-      "wrapadjacentdays": true
+      "product": "M2TMNXCSP"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Incident_Shortwave_Over_Land_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Incident_Shortwave_Over_Land_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Radiation",
-      "product": "M2TMNXLFO",
-      "wrapadjacentdays": true
+      "product": "M2TMNXLFO"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Open_Water_Latent_Energy_Flux_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Open_Water_Latent_Energy_Flux_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Open Water Latent Energy Flux",
-      "product": "M2TMNXOCN",
-      "wrapadjacentdays": true
+      "product": "M2TMNXOCN"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Ozone_Mixing_Ratio_50hPa_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Ozone_Mixing_Ratio_50hPa_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Ozone",
-      "product": "M2IMNPANA",
-      "wrapadjacentdays": true
+      "product": "M2IMNPANA"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Precipitation_Bias_Corrected_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Precipitation_Bias_Corrected_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "rain",
       "group": "overlays",
       "layergroup": "Precipitation Rate",
-      "product": "M2TMNXFLX",
-      "wrapadjacentdays": true
+      "product": "M2TMNXFLX"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Relative_Humidity_After_Moist_700hPa_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Relative_Humidity_After_Moist_700hPa_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Relative Humidity",
-      "product": "M2TMNPCLD",
-      "wrapadjacentdays": true
+      "product": "M2TMNPCLD"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_SO2_Column_Mass_Density_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_SO2_Column_Mass_Density_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "sulfur dioxide sulphur dioxide so2",
       "group": "overlays",
       "layergroup": "Sulfur Dioxide",
-      "product": "M2TMNXAER",
-      "wrapadjacentdays": true
+      "product": "M2TMNXAER"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Snow_Depth_Over_Glaciated_Surface_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Snow_Depth_Over_Glaciated_Surface_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Snow Depth",
-      "product": "M2TMNXGLC",
-      "wrapadjacentdays": true
+      "product": "M2TMNXGLC"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Snowfall_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Snowfall_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Precipitation Rate",
-      "product": "M2TMNXFLX",
-      "wrapadjacentdays": true
+      "product": "M2TMNXFLX"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Soil_Water_Root_Zone_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Soil_Water_Root_Zone_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Soil Moisture",
-      "product": "M2TMNXLND",
-      "wrapadjacentdays": true
+      "product": "M2TMNXLND"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Albedo_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Albedo_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Surface Albedo",
-      "product": "M2TMNXRAD",
-      "wrapadjacentdays": true
+      "product": "M2TMNXRAD"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Pressure_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Pressure_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Surface Pressure",
-      "product": "M2IMNPASM",
-      "wrapadjacentdays": true
+      "product": "M2IMNPASM"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Skin_Temperature_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Skin_Temperature_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Temperature",
-      "product": "M2TMNXSLV",
-      "wrapadjacentdays": true
+      "product": "M2TMNXSLV"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Wind_Speed_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Surface_Wind_Speed_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Wind Speed",
-      "product": "M2IMNXLFO",
-      "wrapadjacentdays": true
+      "product": "M2IMNXLFO"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Aerosol_Optical_Thickness_550nm_Extinction_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Aerosol_Optical_Thickness_550nm_Extinction_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Aerosol Optical Depth",
-      "product": "M2TMNXAER",
-      "wrapadjacentdays": true
+      "product": "M2TMNXAER"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Aerosol_Optical_Thickness_550nm_Scattering_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Aerosol_Optical_Thickness_550nm_Scattering_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Aerosol Optical Depth",
-      "product": "M2TMNXAER",
-      "wrapadjacentdays": true
+      "product": "M2TMNXAER"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Dust_Deposition_Dry_Wet_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Dust_Deposition_Dry_Wet_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Dust",
-      "product": "M2TMNXADG",
-      "wrapadjacentdays": true
+      "product": "M2TMNXADG"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Precipitable_Water_Vapor_Monthly.json
+++ b/config/default/common/config/wv.json/layers/merra/MERRA2_Total_Precipitable_Water_Vapor_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Precipitation Rate",
-      "product": "M2IMNXINT",
-      "wrapadjacentdays": true
+      "product": "M2IMNXINT"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/misr/MISR_Aerosol_Optical_Depth_Avg_Green_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Aerosol_Optical_Depth_Avg_Green_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Aerosol Optical Depth",
-      "product": "MIL3MAE",
-      "wrapadjacentdays": true
+      "product": "MIL3MAE"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_0.5km_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_0.5km_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Cloud Top Height",
-      "product": "MIL3MCLD",
-      "wrapadjacentdays": true
+      "product": "MIL3MCLD"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-2.0km_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-2.0km_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Cloud Top Height",
-      "product": "MIL3MCLD",
-      "wrapadjacentdays": true
+      "product": "MIL3MCLD"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Directional_Hemispherical_Reflectance_Average_Natural_Color_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "DHR Reflectance",
       "product": "MIL3MLS",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/misr/MISR_Land_NDVI_Average_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Land_NDVI_Average_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MIL3MLS",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Infrared_Color_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Radiance",
       "product": "MIL3MRD",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_Radiance_Average_Natural_Color_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Radiance",
       "product": "MIL3MRD",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/misr/MISR_TOA_Albedo_Average_Red_Monthly.json
+++ b/config/default/common/config/wv.json/layers/misr/MISR_TOA_Albedo_Average_Red_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "top of atmosphere",
       "group": "overlays",
       "layergroup": "TOA Albedo",
-      "product": "MIL3MAL",
-      "wrapadjacentdays": true
+      "product": "MIL3MAL"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_EVI_16Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_EVI_16Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MYD13Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_EVI_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_EVI_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MYD13A3",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD11A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day_TES.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD21A2",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD11A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD21C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD21C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD11C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MYD11C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Aqua_Descending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_NDVI_16Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_NDVI_16Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MYD13Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_NDVI_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_NDVI_Monthly.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MYD13A3",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_8DAY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_ANNUAL_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_4km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_MONTHLY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_8DAY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_ANNUAL_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_MidIR_9km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_MID-IR_MONTHLY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_8DAY_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Day_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_8DAY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_4km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_8DAY_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Day_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_8DAY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_ANNUAL_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SST_Thermal_9km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_AQUA_L3_SST_THERMAL_MONTHLY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Snow_Cover_Monthly_Average_Pct.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Snow_Cover_Monthly_Average_Pct.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Snow Cover",
       "product": "MYD10CM",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Snow_Extent_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Snow_Extent_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Snow Extent",
       "product": "MYD10A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands121_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands121_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MYD09Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands143_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands143_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MYD09A1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands721_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_SurfaceReflectance_Bands721_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MYD09A1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_FPAR_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_FPAR_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "FPAR",
       "product": "MYD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Gross Primary Productivity",
       "product": "MYD17A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_LAI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_LAI_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Leaf Area Index",
       "product": "MYD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Photosynthesis, Net",
       "product": "MYD17A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L3_IGBP_Land_Cover_Type_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L3_IGBP_Land_Cover_Type_Annual.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Cover",
       "product": "MCD12Q1",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_FPAR_4Day.json
+++ b/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_FPAR_4Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "FPAR",
       "product": "MCD15A3H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_FPAR_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_FPAR_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "FPAR",
       "product": "MCD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_LAI_4Day.json
+++ b/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_LAI_4Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Leaf Area Index",
       "product": "MCD15A3H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_LAI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/combined/MODIS_Combined_L4_LAI_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Leaf Area Index",
       "product": "MCD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MOD13Q4N",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_EVI_16Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_EVI_16Day.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MOD13Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_EVI_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_EVI_Monthly.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Vegetation Indices",
       "product": "MYD13A3",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD11A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day_TES.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD21A2",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Terra_Descending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD11A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD21C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Terra_Descending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD11C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Terra_Descending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
       "product": "MOD11C3",
-      "wrapadjacentdays": true,
       "tracks": [
         "OrbitTracks_Terra_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Water_Mask.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Water_Mask.json
@@ -9,7 +9,6 @@
       "layergroup": "Water Bodies",
       "product": "MOD44W",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_NDVI_16Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_NDVI_16Day.json
@@ -9,7 +9,6 @@
       "tags": "ndvi normalized difference vegetation index",
       "layergroup": "Vegetation Indices",
       "product": "MOD13Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_NDVI_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_NDVI_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ndvi normalized difference vegetation index",
       "layergroup": "Vegetation Indices",
       "product": "MOD13A3",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_8DAY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_ANNUAL_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_4km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_MONTHLY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_8DAY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_ANNUAL_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_MidIR_9km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_MID-IR_MONTHLY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_8DAY_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Day_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_4KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_8DAY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_4km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_4KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_8DAY_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Day_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_9KM_DAYTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_8DAY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Annual.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Annual.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_ANNUAL_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
@@ -9,7 +9,6 @@
       "tags": "ssc podaac PO.DAAC",
       "layergroup": "Sea Surface Temperature",
       "product": "MODIS_TERRA_L3_SST_THERMAL_MONTHLY_9KM_NIGHTTIME_V2014.0",
-      "wrapadjacentdays": true,
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Snow_Cover_Monthly_Average_Pct.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Snow_Cover_Monthly_Average_Pct.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Snow Cover",
       "product": "MOD10CM",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Snow_Extent_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Snow_Extent_8Day.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Snow Extent",
       "product": "MOD10A2",
-      "wrapadjacentdays": true,
       "daynight": [
         "day",
         "night"

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands121_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands121_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MOD09Q1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands143_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands143_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MOD09A1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands721_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SurfaceReflectance_Bands721_8Day.json
@@ -9,7 +9,6 @@
       "group": "baselayers",
       "layergroup": "Land Surface Reflectance",
       "product": "MOD09A1",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_FPAR_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_FPAR_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "FPAR",
       "product": "MOD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Gross Primary Productivity",
       "product": "MOD17A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_LAI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_LAI_8Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Leaf Area Index",
       "product": "MOD15A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.json
@@ -8,7 +8,6 @@
       "group": "overlays",
       "layergroup": "Photosynthesis, Net",
       "product": "MOD17A2H",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
@@ -9,7 +9,6 @@
       "tags": "ndvi normalized difference vegetation index",
       "layergroup": "Vegetation Indices",
       "product": "MOD13Q4N",
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ],

--- a/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Day.json
+++ b/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Carbon Monoxide",
       "product": "MOP03JM",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Night.json
+++ b/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Surface_Mixing_Ratio_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Carbon Monoxide",
       "product": "MOP03JM",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "night"

--- a/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Day.json
+++ b/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Day.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Carbon Monoxide",
       "product": "MOP03JM",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "day"

--- a/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Night.json
+++ b/config/default/common/config/wv.json/layers/mopitt/MOPITT_CO_Monthly_Total_Column_Night.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Carbon Monoxide",
       "product": "MOP03JM",
-      "wrapadjacentdays": true,
       "inactive": true,
       "daynight": [
         "night"

--- a/config/default/common/config/wv.json/layers/multi-mission/aviso/AVISO_Absolute_Dynamic_Topography.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/aviso/AVISO_Absolute_Dynamic_Topography.json
@@ -9,7 +9,6 @@
       "group": "overlays",
       "layergroup": "Absolute Dynamic Topography",
       "product": "AVISO_L4_DYN_TOPO_1DEG_1MO",
-      "wrapadjacentdays": true,
       "inactive": true
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Meridional_Wind_Speed_Monthly.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Meridional_Wind_Speed_Monthly.json
@@ -9,8 +9,7 @@
       "layergroup": "Wind Speed",
       "product": "CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
       "group": "overlays",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Scalar_Wind_Speed_Monthly.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Scalar_Wind_Speed_Monthly.json
@@ -9,8 +9,7 @@
       "layergroup": "Wind Speed",
       "product": "CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
       "group": "overlays",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Zonal_Wind_Speed_Monthly.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/merged/CCMP_REMSS_Zonal_Wind_Speed_Monthly.json
@@ -9,8 +9,7 @@
       "layergroup": "Wind Speed",
       "product": "CCMP_MEASURES_ATLAS_L4_OW_L3_5A_MONTHLY_WIND_VECTORS_FLK",
       "group": "overlays",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/trmm_orbview/LIS_High_Resolution_Full_Climatology_Combined_Flash_Rate_Climatology.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/trmm_orbview/LIS_High_Resolution_Full_Climatology_Combined_Flash_Rate_Climatology.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/ols/OLS_DMSP_F10_Digital_Derived_Lightning.json
+++ b/config/default/common/config/wv.json/layers/ols/OLS_DMSP_F10_Digital_Derived_Lightning.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "olsdig10",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/ols/OLS_DMSP_F12_Digital_Derived_Lightning.json
+++ b/config/default/common/config/wv.json/layers/ols/OLS_DMSP_F12_Digital_Derived_Lightning.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "olsdig12",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Flash_Rate_Climatology.json
+++ b/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Flash_Rate_Climatology.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Raw_Flashes.json
+++ b/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Raw_Flashes.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Scaled_Flashes.json
+++ b/config/default/common/config/wv.json/layers/orbview/OTD_High_Resolution_Full_Climatology_OTD_Scaled_Flashes.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/seawifs/SWDB_Aerosol_Angstrom_Exponent_Monthly.json
+++ b/config/default/common/config/wv.json/layers/seawifs/SWDB_Aerosol_Angstrom_Exponent_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Aerosol Optical Depth",
       "product": "SWDB_L3M05",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/seawifs/SWDB_Aerosol_Optical_Thickness_550nm_Monthly.json
+++ b/config/default/common/config/wv.json/layers/seawifs/SWDB_Aerosol_Optical_Thickness_550nm_Monthly.json
@@ -10,7 +10,6 @@
       "layergroup": "Aerosol Optical Depth",
       "product": "SWDB_L3M05",
       "inactive": true,
-      "wrapadjacentdays": true,
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_CAP_8Day_RunningMean.json
+++ b/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_CAP_8Day_RunningMean.json
@@ -7,8 +7,7 @@
       "description": "smap/SMAP_L3_Sea_Surface_Salinity_CAP_8Day_RunningMean",
       "tags": "sss podaac PO.DAAC",
       "group": "overlays",
-      "layergroup": "Sea Surface Salinity",
-      "wrapadjacentdays": true
+      "layergroup": "Sea Surface Salinity"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_CAP_Monthly.json
+++ b/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_CAP_Monthly.json
@@ -7,8 +7,7 @@
       "description": "smap/SMAP_L3_Sea_Surface_Salinity_CAP_Monthly",
       "tags": "sss podaac PO.DAAC",
       "group": "overlays",
-      "layergroup": "Sea Surface Salinity",
-      "wrapadjacentdays": true
+      "layergroup": "Sea Surface Salinity"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_REMSS_8Day_RunningMean.json
+++ b/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_REMSS_8Day_RunningMean.json
@@ -8,8 +8,7 @@
       "tags": "sss podaac PO.DAAC",
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
-      "product": "SMAP_RSS_L3_SSS_SMI_8DAY-RUNNINGMEAN_V4",
-      "wrapadjacentdays": true
+      "product": "SMAP_RSS_L3_SSS_SMI_8DAY-RUNNINGMEAN_V4"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_REMSS_Monthly.json
+++ b/config/default/common/config/wv.json/layers/smap/SMAP_L3_Sea_Surface_Salinity_REMSS_Monthly.json
@@ -8,8 +8,7 @@
       "tags": "sss podaac PO.DAAC",
       "group": "overlays",
       "layergroup": "Sea Surface Salinity",
-      "product": "SMAP_RSS_L3_SSS_SMI_MONTHLY_V4",
-      "wrapadjacentdays": true
+      "product": "SMAP_RSS_L3_SSS_SMI_MONTHLY_V4"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/srtm/SRTM_Color_Index.json
+++ b/config/default/common/config/wv.json/layers/srtm/SRTM_Color_Index.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Terrain Elevation",
       "product": "SRTMGL1",
-      "wrapadjacentdays": true
+      "wrapX": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Flash_Rate_Climatology.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Raw_Flashes.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Raw_Flashes.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Scaled_Flashes.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_High_Resolution_Full_Climatology_LIS_Scaled_Flashes.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lohrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Full_Climatology_LIS_Mean_Flash_Rate.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Full_Climatology_LIS_Mean_Flash_Rate.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lisvhrfc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Monthly_Climatology_LIS_Mean_Flash_Rate.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Monthly_Climatology_LIS_Mean_Flash_Rate.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lisvhrmc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Seasonal_Climatology_LIS_Mean_Flash_Rate.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Seasonal_Climatology_LIS_Mean_Flash_Rate.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Lightning",
       "product": "lisvhrsc",
-      "inactive": true,
-      "wrapadjacentdays": true
+      "inactive": true
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes WV-2033

Removed `wrapadjacentdays` from multi day layers - Annual, 3 month/seasonal, monthly, 16 Day, 8 Day, 7 Day/Weekly, 4 Day to reduce confusion when imagery crosses the date line that show dates.

@nasa-gibs/worldview
