### PR TITLE
Made Chlorophyll a layers inactive

### DIFF
--- a/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.md
+++ b/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.md
@@ -1,3 +1,5 @@
+**NOTE:** This layer is being decommissioned. Please use the new Level 2 Chlorophyll a layers - "Chlorophyll a (L2)" for Terra/MODIS, Aqua/MODIS, and Suomi NPP/VIIRS.
+
 The MODIS Chlorophyll *a* layer provides the near-surface concentration of chlorophyll *a* in milligrams of chlorophyll pigment per cubic meter (mg/m<sup>3</sup>) in the ocean.
 
 The MODIS Level 2 Chlorophyll *a* product is available from both the Terra and Aqua satellites. The sensor and imagery resolution is 1 km, and the temporal resolution is daily.

--- a/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_Chlorophyll_A.md
+++ b/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_Chlorophyll_A.md
@@ -1,3 +1,5 @@
+**NOTE:** This layer is being decommissioned. Please use the new Level 2 Chlorophyll a layers - "Chlorophyll a (L2)" for Terra/MODIS, Aqua/MODIS, and Suomi NPP/VIIRS.
+
 The MODIS Chlorophyll *a* layer provides the near-surface concentration of chlorophyll *a* in milligrams of chlorophyll pigment per cubic meter (mg/m<sup>3</sup>) in the ocean.
 
 The MODIS Chlorophyll *a* product is available from both the Terra and Aqua satellites. The sensor and imagery resolution is 1 km, and the temporal resolution is daily.

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_Chlorophyll_A.json
@@ -7,6 +7,7 @@
       "description": "modis/aqua/MODIS_Aqua_Chlorophyll_A",
       "group": "overlays",
       "layergroup": "Chlorophyll A",
+      "inactive": true,
       "tracks": [
         "OrbitTracks_Aqua_Ascending"
       ],

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_Chlorophyll_A.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_Chlorophyll_A.json
@@ -6,6 +6,7 @@
       "subtitle": "Terra / MODIS",
       "description": "modis/terra/MODIS_Terra_Chlorophyll_A",
       "group": "overlays",
+      "inactive": true,
       "tracks": [
         "OrbitTracks_Terra_Descending"
       ],


### PR DESCRIPTION
## Description

Fixes WV-2308

Made MODIS_Aqua_Chlorophyll_A and MODIS_Terra_Chlorophyll_A inactive as they are no longer being processed. Added a note to the layer description to let users know to use the new Chlorohphyll a (L2) layers.

@nasa-gibs/worldview
