### PR TITLE
Remove startDate from Orbit Tracks

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Ascending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2002-05-04",
       "palette": {
         "id": "OrbitTracks_Aqua_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2002-05-04",
       "palette": {
         "id": "OrbitTracks_Aqua_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Ascending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2004-07-15",
       "palette": {
         "id": "OrbitTracks_Aura_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2004-07-15",
       "palette": {
         "id": "OrbitTracks_Aura_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Ascending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2006-04-28",
       "palette": {
         "id": "OrbitTracks_Calipso_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2006-04-28",
       "palette": {
         "id": "OrbitTracks_Calipso_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Ascending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2006-06-06",
       "palette": {
         "id": "OrbitTracks_CloudSat_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Descending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2006-06-06",
       "palette": {
         "id": "OrbitTracks_CloudSat_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Ascending.json
@@ -10,7 +10,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
-      "startDate": "2014-02-27",
       "palette": {
         "id": "OrbitTracks_GPM_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Descending.json
@@ -10,7 +10,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
-      "startDate": "2014-02-27",
       "palette": {
         "id": "OrbitTracks_GPM_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
@@ -11,7 +11,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
-      "startDate": "2018-09-15",
       "palette": {
         "id": "OrbitTracks_ICESAT-2_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
@@ -11,7 +11,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
-      "startDate": "2018-09-15",
       "palette": {
         "id": "OrbitTracks_ICESAT-2_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Ascending.json
@@ -11,7 +11,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
-      "startDate": "1998-11-20",
       "palette": {
         "id": "OrbitTracks_ISS_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Descending.json
@@ -11,7 +11,6 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
-      "startDate": "1998-11-20",
       "palette": {
         "id": "OrbitTracks_ISS_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Ascending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "1999-04-15",
       "palette": {
         "id": "OrbitTracks_Landsat-7_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Descending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "1999-04-15",
       "palette": {
         "id": "OrbitTracks_Landsat-7_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Ascending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2013-02-11",
       "palette": {
         "id": "OrbitTracks_Landsat-8_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Descending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2013-02-11",
       "palette": {
         "id": "OrbitTracks_Landsat-8_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Ascending.json
@@ -13,7 +13,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2018-11-07",
       "palette": {
         "id": "OrbitTracks_METOP-C_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2018-11-07",
       "palette": {
         "id": "OrbitTracks_METOP-C_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Ascending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2014-07-02",
       "palette": {
         "id": "OrbitTracks_OCO-2_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2014-07-02",
       "palette": {
         "id": "OrbitTracks_OCO-2_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Ascending.json
@@ -13,7 +13,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2018-12-01",
       "palette": {
         "id": "OrbitTracks_SAOCOM1-A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Descending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2018-12-01",
       "palette": {
         "id": "OrbitTracks_SAOCOM1-A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Ascending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2012-05-08",
       "palette": {
         "id": "OrbitTracks_SMAP_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Descending.json
@@ -13,7 +13,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2012-05-08",
       "palette": {
         "id": "OrbitTracks_SMAP_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Ascending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2014-06-23",
       "palette": {
         "id": "OrbitTracks_Sentinel-1A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Descending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2014-06-23",
       "palette": {
         "id": "OrbitTracks_Sentinel-1A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Ascending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2016-04-25",
       "palette": {
         "id": "OrbitTracks_Sentinel-1B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Descending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2016-04-25",
       "palette": {
         "id": "OrbitTracks_Sentinel-1B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Ascending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2015-06-24",
       "palette": {
         "id": "OrbitTracks_Sentinel-2A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Descending.json
@@ -15,7 +15,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2015-06-24",
       "palette": {
         "id": "OrbitTracks_Sentinel-2A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Ascending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2017-03-08",
       "palette": {
         "id": "OrbitTracks_Sentinel-2B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Descending.json
@@ -15,7 +15,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2017-03-08",
       "palette": {
         "id": "OrbitTracks_Sentinel-2B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Ascending.json
@@ -15,7 +15,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2017-10-14",
       "palette": {
         "id": "OrbitTracks_Sentinel-5P_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Descending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2017-10-14",
       "palette": {
         "id": "OrbitTracks_Sentinel-5P_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Ascending.json
@@ -15,7 +15,6 @@
         "day"
       ],
       "track": "ascending",
-      "startDate": "2011-10-28",
       "palette": {
         "id": "OrbitTracks_Suomi_NPP_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Descending.json
@@ -14,7 +14,6 @@
         "night"
       ],
       "track": "descending",
-      "startDate": "2011-10-28",
       "palette": {
         "id": "OrbitTracks_Suomi_NPP_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Ascending.json
@@ -13,7 +13,6 @@
         "night"
       ],
       "track": "ascending",
-      "startDate": "2000-02-24",
       "palette": {
         "id": "OrbitTracks_Terra_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Descending.json
@@ -14,7 +14,6 @@
         "day"
       ],
       "track": "descending",
-      "startDate": "2000-02-24",
       "palette": {
         "id": "OrbitTracks_Terra_Descending",
         "immutable": true


### PR DESCRIPTION
## Description

Fixes WV-2033

Removed startDate dates from all Orbit Track files. The dates in the GC should be correct. 

@nasa-gibs/worldview
