### PR TITLE
WV-2296: Resolve overzoomed granule footprint issue

### DIFF
--- a/web/js/combine-ui.js
+++ b/web/js/combine-ui.js
@@ -49,24 +49,19 @@ export default function combineUi(models, config, store) {
 function registerMapMouseHandlers(maps) {
   Object.values(maps).forEach((map) => {
     const element = map.getTargetElement();
-    const crs = map
-      .getView()
-      .getProjection()
-      .getCode();
-    element.addEventListener('mousemove', (event) => {
-      events.trigger('map:mousemove', event, map, crs);
+    const crs = map.getView().getProjection().getCode();
+
+    element.addEventListener('mouseleave', (event) => {
+      events.trigger('map:mouseout', event);
     });
-    element.addEventListener('mouseout', (event) => {
-      events.trigger('map:mouseout', event, map, crs);
+    map.on('pointermove', (event) => {
+      events.trigger('map:mousemove', event, map, crs);
     });
     map.on('singleclick', (event) => {
       events.trigger('map:singleclick', event, map, crs);
     });
     map.on('contextmenu', (event) => {
       events.trigger('map:contextmenu', event, map, crs);
-    });
-    element.addEventListener('click', (event) => {
-      events.trigger('map:click', event, map, crs);
     });
   });
 }

--- a/web/js/combine-ui.js
+++ b/web/js/combine-ui.js
@@ -54,6 +54,9 @@ function registerMapMouseHandlers(maps) {
     element.addEventListener('mouseleave', (event) => {
       events.trigger('map:mouseout', event);
     });
+    map.on('moveend', (event) => {
+      events.trigger('map:moveend', event, map, crs);
+    });
     map.on('pointermove', (event) => {
       events.trigger('map:mousemove', event, map, crs);
     });

--- a/web/js/components/map/ol-coordinates.js
+++ b/web/js/components/map/ol-coordinates.js
@@ -29,8 +29,9 @@ export default class OlCoordinates extends React.Component {
       format: null,
       width: null,
     };
-    this.mouseMove = lodashThrottle(this.mouseMove.bind(this), 8);
-    this.mouseOut = lodashThrottle(this.mouseOut.bind(this), 8);
+    const options = { leading: true, trailing: true };
+    this.mouseMove = lodashThrottle(this.mouseMove.bind(this), 200, options);
+    this.mouseOut = lodashThrottle(this.mouseOut.bind(this), 200, options);
     this.changeFormat = this.changeFormat.bind(this);
     this.setInitFormat = this.setInitFormat.bind(this);
   }
@@ -46,9 +47,8 @@ export default class OlCoordinates extends React.Component {
     events.off('map:mouseout', this.mouseOut);
   }
 
-  mouseMove(event, map, crs) {
-    const pixels = map.getEventPixel(event);
-    const coord = map.getCoordinateFromPixel(pixels);
+  mouseMove({ pixel }, map, crs) {
+    const coord = map.getCoordinateFromPixel(pixel);
     if (!coord) {
       this.clearCoord();
       return;

--- a/web/js/containers/map-interactions/ol-vector-interactions.test.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.test.js
@@ -48,6 +48,7 @@ beforeEach(() => {
 
 test('if there is a feature at pixel dispatch changeCursor action', () => {
   map.hasFeatureAtPixel = () => true;
+  map.forEachFeatureAtPixel = () => {};
   events.trigger('map:mousemove', {}, map, 'EPSG:3413');
   doAsync(() => expect(changeCursor.mock.calls.length).toBe(1));
 });

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -359,33 +359,44 @@ export const granuleFootprint = (map) => {
     });
   };
 
-  const drawFootprint = (granuleGeometry, date) => {
-    if (currentGranule[date]) {
-      return;
-    }
-    const clearGranule = () => {
-      currentGranule = {};
-      map.removeLayer(vectorLayer);
-      vectorSource.clear();
-    };
-    if (!currentGranule[date]) {
-      clearGranule();
-    }
-    if (!granuleGeometry || !date) {
-      clearGranule();
-      return;
-    }
-    currentGranule[date] = true;
-    const geometry = new OlGeomPolygon([granuleGeometry]);
+  const removeFootprint = () => {
+    currentGranule = {};
+    map.removeLayer(vectorLayer);
+    vectorSource.clear();
+  };
+
+  const drawFootprint = (points, date) => {
+    const geometry = new OlGeomPolygon([points]);
     const featureFootprint = new OlFeature({ geometry });
-    vectorSource.addFeature(featureFootprint);
     const showFill = map.getView().getZoom() < 3;
     const newVectorLayer = getVectorLayer(date, showFill);
+    vectorSource.addFeature(featureFootprint);
     vectorLayer = newVectorLayer;
     map.addLayer(vectorLayer);
   };
 
+  const addFootprint = (points, date) => {
+    if (currentGranule[date]) {
+      return;
+    }
+    if (!points || !date) {
+      removeFootprint();
+      return;
+    }
+    if (!currentGranule[date]) {
+      removeFootprint();
+    }
+    currentGranule[date] = true;
+    drawFootprint(points, date);
+  };
+
+  const updateFootprint = (points, date) => {
+    removeFootprint();
+    drawFootprint(points, date);
+  };
+
   return {
-    drawFootprint,
+    addFootprint,
+    updateFootprint,
   };
 };

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -334,27 +334,30 @@ export const granuleFootprint = (map) => {
     useSpatialIndex: false,
   });
 
-  const getVectorLayer = (text) => new OlVectorLayer({
-    className: 'granule-map-footprint',
-    source: vectorSource,
-    style: [
-      new OlStyle({
-        fill: new OlStyleFill({ color: 'rgb(0, 123, 255, 0.25)' }),
-        stroke: new OlStyleStroke({
-          color: 'rgb(0, 123, 255, 0.65)',
-          width: 3,
+  const getVectorLayer = (text, showFill) => {
+    const fill = showFill ? new OlStyleFill({ color: 'rgb(0, 123, 255, 0.25)' }) : null;
+    return new OlVectorLayer({
+      className: 'granule-map-footprint',
+      source: vectorSource,
+      style: [
+        new OlStyle({
+          fill,
+          stroke: new OlStyleStroke({
+            color: 'rgb(0, 123, 255, 0.65)',
+            width: 3,
+          }),
+          text: new OlText({
+            textAlign: 'center',
+            text,
+            font: '18px monospace',
+            fill: new OlStyleFill({ color: 'white' }),
+            stroke: new OlStyleStroke({ color: 'black', width: 2 }),
+            overflow: true,
+          }),
         }),
-        text: new OlText({
-          textAlign: 'center',
-          text,
-          font: '18px monospace',
-          fill: new OlStyleFill({ color: 'white' }),
-          stroke: new OlStyleStroke({ color: 'black', width: 2 }),
-          overflow: true,
-        }),
-      }),
-    ],
-  });
+      ],
+    });
+  };
 
   const drawFootprint = (granuleGeometry, date) => {
     if (currentGranule[date]) {
@@ -376,7 +379,8 @@ export const granuleFootprint = (map) => {
     const geometry = new OlGeomPolygon([granuleGeometry]);
     const featureFootprint = new OlFeature({ geometry });
     vectorSource.addFeature(featureFootprint);
-    const newVectorLayer = getVectorLayer(date);
+    const showFill = map.getView().getZoom() < 3;
+    const newVectorLayer = getVectorLayer(date, showFill);
     vectorLayer = newVectorLayer;
     map.addLayer(vectorLayer);
   };

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -253,14 +253,24 @@ export default function mapui(models, config, store) {
     }
   };
 
-  const onGranuleHover = (instrument, date) => {
+  const onGranuleHover = (platform, date, update) => {
     const state = store.getState();
     const proj = self.selected.getView().getProjection().getCode();
     let geometry;
-    if (instrument && date) {
+    if (platform && date) {
       geometry = getActiveGranuleFootPrints(state)[date];
     }
-    return granuleFootprints[proj].drawFootprint(geometry, date);
+    granuleFootprints[proj].addFootprint(geometry, date);
+  };
+
+  const onGranuleHoverUpdate = (platform, date) => {
+    const state = store.getState();
+    const proj = self.selected.getView().getProjection().getCode();
+    let geometry;
+    if (platform && date) {
+      geometry = getActiveGranuleFootPrints(state)[date];
+    }
+    granuleFootprints[proj].updateFootprint(geometry, date);
   };
 
   /**
@@ -300,6 +310,7 @@ export default function mapui(models, config, store) {
     });
     events.on('redux:action-dispatched', subscribeToStore);
     events.on('granule-hovered', onGranuleHover);
+    events.on('granule-hover-update', onGranuleHoverUpdate);
     window.addEventListener('orientationchange', () => {
       setTimeout(() => { updateProjection(true); }, 200);
     });


### PR DESCRIPTION
## Description

* Re-work map mouse events to ensure that footprints don't show when mouse is over a UI element

## How To Test

-  Check out `granule-configs` branch
- `npm run build`
- Check out this branch
- `npm run watch`

* Zoom in and out with granules loaded to confirm fill only shows at higher zoom levels.
* Confirm that mousing over the UI causes the footprint to disappear