### PR TITLE
WV-2313: Fix issue with layers added on event selection

### DIFF
--- a/web/js/map/natural-events/natural-events.js
+++ b/web/js/map/natural-events/natural-events.js
@@ -120,9 +120,9 @@ class NaturalEvents extends React.Component {
 
     this.setState({ prevSelectedEvent: { id, date } });
 
+    selectDate(useDate);
     this.getZoomPromise(event, eventDate, !isIdChange, isInitialLoad).then(() => {
       if (!isInitialLoad) {
-        selectDate(useDate);
         if (categoryChange) {
           activateLayersForEventCategory(event.categories[0].title);
         }

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -196,9 +196,8 @@ export default function mapui(models, config, store) {
       case paletteConstants.SET_CUSTOM:
       case paletteConstants.SET_DISABLED_CLASSIFICATION:
       case paletteConstants.CLEAR_CUSTOM:
-        return setTimeout(reloadLayers, 100);
       case layerConstants.ADD_LAYERS_FOR_EVENT:
-        return setTimeout(reloadLayers, 1500);
+        return setTimeout(reloadLayers, 100);
       case vectorStyleConstants.SET_FILTER_RANGE:
       case vectorStyleConstants.SET_VECTORSTYLE:
       case vectorStyleConstants.CLEAR_VECTORSTYLE:
@@ -627,7 +626,6 @@ export default function mapui(models, config, store) {
     const state = store.getState();
     const { compare } = state;
 
-    console.log('map - reloadLayers');
     if (!config.features.compare || !compare.active) {
       const compareMapDestroyed = !compare.active && compareMapUi.active;
       if (compareMapDestroyed) {
@@ -691,8 +689,6 @@ export default function mapui(models, config, store) {
   function updateLayerVisibilities() {
     const state = store.getState();
     const layerGroup = self.selected.getLayers();
-
-    console.log('map - updateLayerVisibilities');
 
     const setRenderable = (layer, parentCompareGroup) => {
       const { id, group } = layer.wv;
@@ -910,8 +906,6 @@ export default function mapui(models, config, store) {
         .map(({ wv }) => lodashGet(wv, 'def.id'))
         .includes(id),
     ).filter(({ visible }) => visible);
-
-    console.log('map - updateDate');
 
     const layerPromises = visibleLayers.map(async (def) => {
       const { id, type } = def;

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -196,8 +196,9 @@ export default function mapui(models, config, store) {
       case paletteConstants.SET_CUSTOM:
       case paletteConstants.SET_DISABLED_CLASSIFICATION:
       case paletteConstants.CLEAR_CUSTOM:
-      case layerConstants.ADD_LAYERS_FOR_EVENT:
         return setTimeout(reloadLayers, 100);
+      case layerConstants.ADD_LAYERS_FOR_EVENT:
+        return setTimeout(reloadLayers, 1500);
       case vectorStyleConstants.SET_FILTER_RANGE:
       case vectorStyleConstants.SET_VECTORSTYLE:
       case vectorStyleConstants.CLEAR_VECTORSTYLE:

--- a/web/js/modules/natural-events/util.js
+++ b/web/js/modules/natural-events/util.js
@@ -152,19 +152,23 @@ export function getEventsRequestURL (state) {
   return `${baseUrl}/events${util.toQueryString(params)}`;
 }
 
+export const toEventDateString = (d) => d.toISOString().split('T')[0];
+
 /**
  *
  * @param {*} event
  */
-export function getDefaultEventDate(event) {
-  const preDate = event.geometry[0] && event.geometry[0].date;
-  let date = new Date(preDate).toISOString().split('T')[0];
-  if (event.geometry.length < 2) return date;
-  const category = event.categories.title || event.categories[0].title;
-  const today = util.now().toISOString().split('T')[0];
+export function getDefaultEventDate({ geometry, categories }) {
+  const preDate = geometry[0] && geometry[0].date;
+  let date = toEventDateString(new Date(preDate));
+  if (geometry.length < 2) {
+    return date;
+  }
+  const category = categories.title || categories[0].title;
+  const today = toEventDateString(util.now());
   // For storms that happened today, get previous date
   if (date === today && category === 'Severe Storms') {
-    [date] = new Date(event.geometry[1].date).toISOString().split('T');
+    [date] = toEventDateString(new Date(geometry[1].date));
   }
   return date;
 }


### PR DESCRIPTION
## Description

There were a few problems related to this:

* The map `reloadLayers` function wasn't being called when event category layers were added so, even though they showed in the sidebar they weren't added to the map
* Since a lot of the `map/ui.js` functions were made async, there was a race condition between `updateDate` and `reloadLayers` that happened when selecting an event since we were trying to respond to two separate synchronous Redux actions by calling two async functions potentially in parallel, causing them to modify the same map object at the same time which created issues.
* Removed a `CHANGE_TAB` that appears to be leftover from the old data download approach (can't think of a reason why we would need to reload layers when switching to or from that tab anymore)
* Cleaned up a little bit of code around setting the date for an event

## How To Test

* Retry steps in ticket
* Try various event related behaviors to ensure nothing was inadvertently affected



