### PR TITLE
WV-2309: Allow toggling associated layers

### DIFF
--- a/schemas/layer-config.json
+++ b/schemas/layer-config.json
@@ -183,6 +183,10 @@
           "description": "TODO should be removed for vis metadata replacement!",
           "type": "string"
         },
+        "associatedLayers": {
+          "description": "ID of an associated layers (e.g. a corresponding granule layer)",
+          "type": "string"
+        },
         "layer": {
           "type": "string"
         },

--- a/web/js/components/layer/settings/associated-layers-toggle.js
+++ b/web/js/components/layer/settings/associated-layers-toggle.js
@@ -9,18 +9,28 @@ import {
 import { getOrbitTrackTitle } from '../../../modules/layers/util';
 import { getActiveLayersMap } from '../../../modules/layers/selectors';
 
-const OrbitTracksToggle = (props) => {
+const AssociatedLayersToggle = (props) => {
   const {
-    trackLayers,
+    associatedLayers,
     addLayer,
     removeLayer,
     activeLayers,
   } = props;
 
+  const getTitle = (layer) => {
+    const [splitTitle] = layer.title.split('(');
+    if (layer.type === 'granule') {
+      return `Granule - ${splitTitle}`;
+    } if (layer.track) {
+      return `Orbit Track - ${getOrbitTrackTitle(layer)}`;
+    }
+    return `Daily Composite - ${splitTitle}`;
+  };
+
   return (
     <div className="layer-orbit-tracks settings-component">
-      <h2 className="wv-header"> Orbit Tracks </h2>
-      { trackLayers.map((layer) => {
+      <h2 className="wv-header"> Associated Layers </h2>
+      { associatedLayers.map((layer) => {
         const { id } = layer;
         const isEnabled = !!activeLayers[id];
         const onCheck = () => (isEnabled ? removeLayer(id) : addLayer(id));
@@ -28,10 +38,10 @@ const OrbitTracksToggle = (props) => {
           <Checkbox
             id={id}
             key={id}
-            title="Enable/disable orbit tracks for this layer"
+            title="Enable/disable this layer"
             checked={isEnabled}
             onCheck={onCheck}
-            label={getOrbitTrackTitle(layer)}
+            label={getTitle(layer)}
           />
         );
       }) }
@@ -40,10 +50,13 @@ const OrbitTracksToggle = (props) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const { config } = state;
-  const { tracks } = ownProps.layer;
+  const { config: { layers } } = state;
+  const { tracks = [], associatedLayers = [] } = ownProps.layer;
+  const showLayers = associatedLayers
+    .map((id) => layers[id])
+    .concat(tracks.map((id) => layers[id]));
   return {
-    trackLayers: tracks.map((trackName) => config.layers[trackName]),
+    associatedLayers: showLayers,
     activeLayers: getActiveLayersMap(state),
   };
 };
@@ -60,11 +73,11 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(OrbitTracksToggle);
+)(AssociatedLayersToggle);
 
-OrbitTracksToggle.propTypes = {
+AssociatedLayersToggle.propTypes = {
   activeLayers: PropTypes.object,
   addLayer: PropTypes.func,
   removeLayer: PropTypes.func,
-  trackLayers: PropTypes.array,
+  associatedLayers: PropTypes.array,
 };

--- a/web/js/components/layer/settings/layer-settings.js
+++ b/web/js/components/layer/settings/layer-settings.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 
 import Opacity from './opacity';
 import Palette from './palette';
-import OrbitTracks from './orbit-tracks-toggle';
+import AssociatedLayers from './associated-layers-toggle';
 import VectorStyle from './vector-style';
 import PaletteThreshold from './palette-threshold';
 import GranuleLayerDateList from './granule-date-list';
@@ -339,6 +339,8 @@ class LayerSettings extends React.Component {
       layer,
       palettedAllowed,
     } = this.props;
+    const hasAssociatedLayers = layer.associatedLayers && layer.associatedLayers.length;
+    const hasTracks = layer.tracks && layer.tracks.length;
 
     if (layer.type !== 'vector') {
       renderCustomizations = customPalettesIsActive && palettedAllowed && layer.palette
@@ -358,7 +360,7 @@ class LayerSettings extends React.Component {
         />
         {this.renderGranuleSettings()}
         {renderCustomizations}
-        {layer.tracks && layer.tracks.length && <OrbitTracks layer={layer} />}
+        {(hasAssociatedLayers || hasTracks) && <AssociatedLayers layer={layer} />}
       </>
     );
   }

--- a/web/scss/components/checkbox.scss
+++ b/web/scss/components/checkbox.scss
@@ -5,20 +5,24 @@
     margin: 3px 1px;
     vertical-align: middle;
   }
-}
 
-.wv-checkbox input {
-  position: absolute;
-  opacity: 0;
-  cursor: pointer;
-  height: 24px;
-  width: 24px;
-  left: 0;
-}
+  input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 24px;
+    width: 24px;
+    left: 0;
+  }
 
-.wv-checkbox label {
-  color: #fff;
-  cursor: pointer;
+  label {
+    color: #fff;
+    cursor: pointer;
+
+    span {
+      line-height: 22px;
+    }
+  }
 }
 
 .wv-checkbox::before {


### PR DESCRIPTION
## Description

In addition to showing checkboxes for associated orbit track layers, additional layers can be added to a layer config with the property: `"associatedLayers": [ "layer_id" ]`

## How To Test

1. Check out `granule-configs` branch
2. `npm run build`
3. Check out this branch
4. `npm run watch`
5. Confirm the NOAA20 granule and CR layers link to each other: http://localhost:3000/?z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule_v1_NRT,Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=true&t=2019-09-24-T18%3A37%3A18Z
