### PR TITLE
WV-2312: Add ellipsis to running data category label when too long

### DIFF
--- a/web/scss/features/palettes.scss
+++ b/web/scss/features/palettes.scss
@@ -58,11 +58,15 @@
 .wv-palettes-max,
 .wv-palettes-min,
 .wv-palettes-title,
+.wv-running-category-label,
 .wv-running-label {
   white-space: nowrap;
   overflow: hidden;
   display: inline-block;
   text-overflow: ellipsis;
+}
+.wv-running-category-label {
+  max-width: 197px;
 }
 
 .layer-hidden .wv-palettes-max,

--- a/web/scss/features/palettes.scss
+++ b/web/scss/features/palettes.scss
@@ -47,6 +47,10 @@
   font-size: 10px;
   bottom: 0;
   width: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  display: inline-block;
+  text-overflow: ellipsis;
 }
 
 .wv-palettes-max,
@@ -55,16 +59,6 @@
   position: absolute;
 }
 
-.wv-palettes-max,
-.wv-palettes-min,
-.wv-palettes-title,
-.wv-running-category-label,
-.wv-running-label {
-  white-space: nowrap;
-  overflow: hidden;
-  display: inline-block;
-  text-overflow: ellipsis;
-}
 .wv-running-category-label {
   max-width: 197px;
 }


### PR DESCRIPTION
## Description
Add ellipsis to running data category label when too long

[If this is a relatively large or complex change, start a discussion by explaining why you chose the solution you did and what alternatives you considered, etc...]

## How To Test

1. Open to http://localhost:3000/?v=18.318884587017255,17.140617271901622,44.38045724914454,26.637384542196887&l=OrbitTracks_Aura_Ascending,OrbitTracks_Aqua_Descending,OrbitTracks_Aqua_Ascending,Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2022-06-07-T13%3A11%3A58Z
2. Verify expected result
3. try other orbit tracks


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
