### PR TITLE
Add image download select globe option

### DIFF
--- a/e2e/features/image-download/select-global.js
+++ b/e2e/features/image-download/select-global.js
@@ -1,0 +1,49 @@
+const { zoomIn, zoomOut } = require('../../reuseables/zoom');
+const { bookmark } = require('../../reuseables/bookmark');
+const { normalizeViewport } = require('../../reuseables/normalize-viewport');
+const {
+  openImageDownloadPanel,
+  closeImageDownloadPanel,
+  clickDownload,
+} = require('../../reuseables/image-download');
+
+const startParams = [
+  'p=geographic',
+  'v=-180,-90,180,90',
+  'l=MODIS_Terra_CorrectedReflectance_TrueColor',
+  't=2018-06-01',
+  'imageDownload=',
+];
+
+const globalSelectInput = '#image-global-cb';
+module.exports = {
+  after(client) {
+    client.end();
+  },
+  'Verify that global select is present and not selected': function(c) {
+    normalizeViewport(c, 1024, 768);
+    bookmark(c, startParams);
+    openImageDownloadPanel(c);
+    c.expect.element(globalSelectInput).to.be.present;
+    c.expect.element(globalSelectInput).to.not.be.selected;
+  },
+
+  'Verify that checking checkbox updates bounding-box labels': function(c) {
+    c.expect.element('#wv-image-top').text.to.not.contain('180.0000');
+    c.click(globalSelectInput);
+    c.expect.element('#wv-image-top').text.to.contain('180.0000');
+  },
+  'Verify that checkbox is gone after zoom and bounding box is no longer around globe': function(c) {
+    closeImageDownloadPanel(c);
+    zoomIn(c);
+    openImageDownloadPanel(c);
+    c.expect.element(globalSelectInput).to.not.be.present;
+    c.expect.element('#wv-image-top').text.to.not.contain('180.0000');
+  },
+  'Verify that checkbox is back after zooming back out': function(c) {
+    closeImageDownloadPanel(c);
+    zoomOut(c);
+    openImageDownloadPanel(c);
+    c.expect.element(globalSelectInput).to.be.present;
+  },
+};

--- a/e2e/features/image-download/select-global.js
+++ b/e2e/features/image-download/select-global.js
@@ -4,7 +4,6 @@ const { normalizeViewport } = require('../../reuseables/normalize-viewport');
 const {
   openImageDownloadPanel,
   closeImageDownloadPanel,
-  clickDownload,
 } = require('../../reuseables/image-download');
 
 const startParams = [

--- a/e2e/reuseables/zoom.js
+++ b/e2e/reuseables/zoom.js
@@ -3,4 +3,8 @@ module.exports = {
     c.click('button.wv-map-zoom-in');
     c.pause(300);
   },
+  zoomOut(c) {
+    c.click('button.wv-map-zoom-out');
+    c.pause(300);
+  },
 };

--- a/web/js/components/image-download/global-select.js
+++ b/web/js/components/image-download/global-select.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Checkbox from '../util/checkbox';
+
+const MAX_LAT_LONG_EXTENT = [-180, -90, 180, 90];
+
+const GlobalSelectCheckbox = (props) => {
+  const { onLatLongChange, viewExtent, geoLatLong } = props;
+  const BoundingBoxArray = [geoLatLong[0][0], geoLatLong[0][1], geoLatLong[1][0], geoLatLong[1][1]];
+  const onCheck = () => onLatLongChange(MAX_LAT_LONG_EXTENT);
+  const globalIsNotSelected = MAX_LAT_LONG_EXTENT.some((latLongValue, index) => latLongValue !== BoundingBoxArray[index]);
+  // If full extent is not visible don't show checkbox
+  const globalIsNotInView = MAX_LAT_LONG_EXTENT.some((latLongValue, index) => (index < 2 ? latLongValue < viewExtent[index] : latLongValue > viewExtent[index]));
+  if (globalIsNotInView) return null;
+
+  return (
+    <div className="p-1">
+      <Checkbox
+        onCheck={onCheck}
+        checked={!globalIsNotSelected}
+        id="image-global-cb"
+        label="Select Entire Globe"
+      />
+    </div>
+  );
+};
+GlobalSelectCheckbox.propTypes = {
+  onLatLongChange: PropTypes.func,
+  viewExtent: PropTypes.array,
+  geoLatLong: PropTypes.array,
+};
+
+export default GlobalSelectCheckbox;
+

--- a/web/js/components/image-download/panel.js
+++ b/web/js/components/image-download/panel.js
@@ -10,6 +10,7 @@ import SelectionList from '../util/selector';
 import ResTable from './grid';
 import AlertUtil from '../util/alert';
 import LatLongSelect from './lat-long-inputs';
+import GlobalSelectCheckbox from './global-select';
 
 const MAX_DIMENSION_SIZE = 8200;
 const RESOLUTION_KEY = {
@@ -193,6 +194,11 @@ export default class ImageResSelection extends React.Component {
           {filetypeSelect}
           {worldfileSelect}
           <LatLongSelect
+            viewExtent={viewExtent}
+            geoLatLong={geoLatLong}
+            onLatLongChange={onLatLongChange}
+          />
+          <GlobalSelectCheckbox
             viewExtent={viewExtent}
             geoLatLong={geoLatLong}
             onLatLongChange={onLatLongChange}


### PR DESCRIPTION
## Description

Depends on #3898 merging

Fixes #wv-2316 

- [x] Add Select Entire Globe checkbox
- [x] Only show when entire globe is visible
- [x] Add e2e tests

## How To Test

1. Open Image download with full extents visible
2. . Click the checkbox.
3. See that selection updates
4. download image
5. Verify correct image is downloaded
6. Verify that checkbox isn't there when zoomed past full extent
7. Verify that checkbox isn't there when in polar views

@nasa-gibs/worldview
