### PR TITLE
WV-2254: Fix rotate text alignment

### DIFF
--- a/web/scss/features/map.scss
+++ b/web/scss/features/map.scss
@@ -67,7 +67,6 @@
 .wv-map-rotate-right {
   display: block;
   width: 36px;
-  padding: 12px;
   height: 38px;
 }
 


### PR DESCRIPTION
## Description

Fixes #wv-2254 

[Description of the bug or feature]

- [x] Fix rotate text alignment

## How To Test

1. Go to arctic projection
2. rotate > 100 degrees
3. Verify that style looks correct

@nasa-gibs/worldview
