### PR TITLE
Remove daymet v3 from configuration files

### DIFF
--- a/config/default/common/config/wv.json/layerOrder.json
+++ b/config/default/common/config/wv.json/layerOrder.json
@@ -902,8 +902,6 @@
 		"GEDI_ISS_L3_Laser_Footprint_Count_201904-202108",
 		"GEDI_ISS_L3_Canopy_Height_Mean_RH100_201904-202108",
 		"GEDI_ISS_L3_Canopy_Height_StdDev_RH100_201904-202108",
-		"Daymet_Maximum_Air_Temp_Daily",
-		"Daymet_Minimum_Air_Temp_Daily",
 		"Land_Mask",
 		"ASTER_GDEM_Color_Index",
 		"ASTER_GDEM_Color_Shaded_Relief",

--- a/config/default/common/config/wv.json/measurements/Temperature.json
+++ b/config/default/common/config/wv.json/measurements/Temperature.json
@@ -3,7 +3,7 @@
         "Temperature": {
             "id": "temperature",
             "title":    "Temperature",
-            "subtitle": "Aqua/AIRS, Aura/MLS, GLDAS, NLDAS, Daymet, MERRA-2",
+            "subtitle": "Aqua/AIRS, Aura/MLS, GLDAS, NLDAS, MERRA-2",
             "sources": {
                 "Aqua/AIRS": {
                     "id": "aqua-airs",
@@ -61,16 +61,6 @@
                     "image": "",
                     "settings": [
                         "NLDAS_Near_Surface_Air_Temperature_Primary_Monthly"
-                    ]
-                },
-                "Daymet": {
-                    "id": "daymet",
-                    "title": "Daymet",
-                    "description": "",
-                    "image": "",
-                    "settings": [
-                      "Daymet_Maximum_Air_Temp_Daily",
-                      "Daymet_Minimum_Air_Temp_Daily"
                     ]
                 },
                     "MERRA-2": {


### PR DESCRIPTION
Did not delete layer descriptions and json files, keeping for future v4 layers.

## Description

Fixes WV-2302

Removed v3 Daymet layers from layerOrder.json and Temperature.json measurement files. Kept the layer descriptions and layer config files as we will get v4 Daymet at some point. 


@nasa-gibs/worldview
