### PR TITLE
Removed orbit tracks from multi day MODIS layers

### DIFF
--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_8Day_Day_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MYD21A2",
-      "tracks": [
-        "OrbitTracks_Aqua_Ascending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MYD21C3",
-      "tracks": [
-        "OrbitTracks_Aqua_Ascending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MYD21C3",
-      "tracks": [
-        "OrbitTracks_Aqua_Ascending"
-      ],
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Day.json
@@ -8,10 +8,6 @@
       "tags": "lst",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MYD11C3",
-      "tracks": [
-        "OrbitTracks_Aqua_Ascending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L3_Land_Surface_Temp_Monthly_Night.json
@@ -8,10 +8,6 @@
       "tags": "lst",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MYD11C3",
-      "tracks": [
-        "OrbitTracks_Aqua_Descending"
-      ],
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_8Day_Day_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MOD21A2",
-      "tracks": [
-        "OrbitTracks_Terra_Descending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Day_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MOD21C3",
-      "tracks": [
-        "OrbitTracks_Terra_Descending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_CMG_Night_TES.json
@@ -8,10 +8,6 @@
       "tags": "lst TES",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MOD21C3",
-      "tracks": [
-        "OrbitTracks_Terra_Ascending"
-      ],
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Day.json
@@ -8,10 +8,6 @@
       "tags": "lst",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MOD11C3",
-      "tracks": [
-        "OrbitTracks_Terra_Descending"
-      ],
       "daynight": [
         "day"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Night.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_Land_Surface_Temp_Monthly_Night.json
@@ -8,10 +8,6 @@
       "tags": "lst",
       "group": "overlays",
       "layergroup": "Land Surface Temperature",
-      "product": "MOD11C3",
-      "tracks": [
-        "OrbitTracks_Terra_Ascending"
-      ],
       "daynight": [
         "night"
       ]

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly.json
@@ -2,7 +2,7 @@
   "layers": {
     "MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly": {
       "id": "MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly",
-      "title": "Sea Surface Temperature (L3, Night, Monthly,  Thermal, 9 km)",
+      "title": "Sea Surface Temperature (L3, Night, Monthly, Thermal, 9 km)",
       "subtitle": "Terra / MODIS",
       "description": "modis/terra/MODIS_Terra_L3_SST_Thermal_9km_Night_Monthly",
       "group": "overlays",


### PR DESCRIPTION
## Description

Fixes WV-2344.

Removed orbit tracks from some 8-day and Monthly MODIS layers that were previously missed.

@nasa-gibs/worldview
