### PR TITLE
WV-2356

### DIFF
--- a/.github/workflows/build-test-app.yml
+++ b/.github/workflows/build-test-app.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: |
           npm run start &
-          sleep 5
+          sleep 10
           npm run e2e:headless:chrome:localStorageDisabled
           npm run e2e:headless:chrome
 
@@ -52,7 +52,7 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         run: |
           npm run start &
-          sleep 5
+          sleep 10
           npm run e2e:headless:firefox:localStorageDisabled
           npm run e2e:headless:firefox
 


### PR DESCRIPTION
## Description


Sometimes a request for a layer metadata config during build time would fail silently, resulting in important fields missing for that layer (e.g. `title`) during runtime.