### PR TITLE
WV-2318: Smart handoffs for granule layers

### DIFF
--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -8,8 +8,9 @@ export default function GranuleCount (props) {
     currentExtent,
     getGranulesUrl,
     displayDate,
+    startDate,
+    endDate,
     showGranuleHelpModal,
-    selectedLayer,
     selectedCollection,
     selectedDate,
   } = props;
@@ -46,14 +47,15 @@ export default function GranuleCount (props) {
     let newTotalGranules = 0;
     let newSelectedGranules;
     let newGranuleDownloadSize = 0;
-    const { dateRanges } = selectedLayer;
+
     const params = {
       conceptId: selectedCollection.value,
       pageSize: 500,
     };
-    if (dateRanges) {
-      params.startDate = `${selectedDate}T00:00:00.000Z`;
-      params.endDate = `${selectedDate}T23:59:59.999Z`;
+
+    if (startDate && endDate) {
+      params.startDate = startDate;
+      params.endDate = endDate;
     }
 
     const granulesRequestUrl = getGranulesUrl(params);
@@ -155,7 +157,8 @@ GranuleCount.propTypes = {
   getGranulesUrl: PropTypes.func,
   currentExtent: PropTypes.object,
   displayDate: PropTypes.string,
-  selectedLayer: PropTypes.object,
+  startDate: PropTypes.string,
+  endDate: PropTypes.string,
   selectedDate: PropTypes.string,
   selectedCollection: PropTypes.object,
   showGranuleHelpModal: PropTypes.func,

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -23,9 +23,6 @@ const getLayerId = (state, { layer }) => layer && layer.id;
 
 export const getStartingLayers = createSelector([getConfig], (config) => resetLayers(config));
 
-/**
- * Is overlay grouping currently enabled?
- */
 export const isGroupingEnabled = ({ compare, layers }) => layers[compare.activeString].groupOverlays;
 
 /**


### PR DESCRIPTION
## Description

- Smart handoffs handling for granule layers


## How To Test

1. Checkout `granule-configs` branch, pull latest
2. `npm run build`
3. Checkout this branch
4. `npm run watch`

Note:  The granule test layers only have NRT collections associated with them but, the imagery from GIBS is from 2019.  Therefore, when handing off to Earthdata Search, no results will show.  Similarly, the CMR request for a granule count will always show none.


