### PR TITLE
WV-2310: Add facet for imagery type (granule, vector, raster)

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/Graticule_15m.json
+++ b/config/default/common/config/wv.json/layers/reference/Graticule_15m.json
@@ -7,7 +7,7 @@
       "group": "overlays",
       "format": "image/png",
       "noTransition": true,
-      "type": "variable",
+      
       "layergroup": "Latitude-Longitude Lines",
       "projections": {
         "arctic": {

--- a/schemas/layer-config.json
+++ b/schemas/layer-config.json
@@ -94,6 +94,7 @@
             "FPAR",
             "Flood",
             "Faraday Rotation",
+            "Granules",
             "Precipitation Rate - Featured",
             "Sea Surface Temperature - Featured",
             "Fires and Thermal Anomalies",
@@ -346,7 +347,6 @@
         "wms",
         "wmts",
         "vector",
-        "variable",
         "granule"
       ]
     },

--- a/web/js/modules/product-picker/facet-config.js
+++ b/web/js/modules/product-picker/facet-config.js
@@ -62,4 +62,11 @@ export default [
     show: 30,
     hideZeroCount: true,
   },
+  {
+    field: 'type',
+    label: 'Imagery Type',
+    filterType: 'any',
+    tooltip: 'Layer imagery type',
+    hideZeroCount: true,
+  },
 ];

--- a/web/js/modules/product-picker/format-config.js
+++ b/web/js/modules/product-picker/format-config.js
@@ -78,6 +78,16 @@ function setCoverageFacetProp(layer, selectedDate) {
   }
 }
 
+function setTypeProp(layer) {
+  const { type } = layer;
+  const rasterTypes = ['wms', 'wmts'];
+  if (rasterTypes.includes(type)) {
+    layer.type = 'Raster';
+  }
+  layer.type = capitalizeFirstLetter(layer.type);
+  return layer;
+}
+
 /**
  * Derive and format facet props from config
  * @param {*} config
@@ -88,6 +98,7 @@ export default function buildLayerFacetProps(config, selectedDate) {
   return lodashMap(layers, (layer) => {
     setCoverageFacetProp(layer, selectedDate);
     setLayerProp(layer, 'sources', layer.subtitle);
+    setTypeProp(layer);
     if (layer.daynight && layer.daynight.length) {
       if (typeof layer.daynight === 'string') {
         layer.daynight = [layer.daynight];


### PR DESCRIPTION
## Description

- Remove unused 'variable' layer type
- Update layer config schema
- Add imagery type facet

## How To Test

* Checkout `granule-configs` branch
* `npm run build`
* Checkout this branch
* `npm run watch`
* Open product picker
* Confirm new "Imagery Type" facet shows at the bottom and layers can be filtered by their type: Raster, Vector, Granule