### PR TITLE
WV-2376: Update Readme and other documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,9 +10,8 @@ documentation, get started by submitting an issue or pull request!
 
 If you have any questions or ideas, or notice any problems or bugs, first
 [search open issues](https://github.com/nasa-gibs/worldview/issues) to see if
-the issue has already been submitted. We may already be
-[working on the issue](#what-were-working-on). If you think your issue is new,
-you're welcome to [create a new issue](https://github.com/nasa-gibs/worldview/issues/new).
+the issue has already been submitted. If you think your issue is new,
+you're welcome to [create a new issue](https://github.com/nasa-gibs/worldview/issues/new/choose).
 
 ## Pull Requests
 
@@ -62,7 +61,7 @@ our style guides automatically:
 
 All of the unit tests for this project need to pass before your submission will
 be accepted. If you add new functionality, please consider adding tests for that
-functionality as well. See [Testing](doc/testing.md) for more information about
+functionality as well. See [Testing](/doc/testing.md) for more information about
 testing.
 
 ### Commits
@@ -81,84 +80,4 @@ Improve contributing docs and consolidate them in the standard location https://
 ## What We're Working On
 
 Please see our [Roadmap](https://github.com/nasa-gibs/worldview/projects/7) for
-an overview of what we're planning. We also track the progress of [Worldview](https://github.com/nasa-gibs/worldview)
-using the public [ZenHub Projects Board](https://app.zenhub.com/workspaces/worldview-591b38dffb1c761edb0bc54a/board).
-
-We use GitHub labels to organize issues we're working on. Here are the labels
-we use, along with descriptions of what they mean. Click on the headings or badges below to see the GitHub issues tagged with each label.
-
-### [`bug` ![Issues tagged with 'bug'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/bug.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
-
-Things that appear to be broken or are not working as intended.
-
-### [`documentation` ![Issues tagged with 'documentation' ](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/documentation.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Adocumentation)
-
-An issue that requires an update to our documentation.
-
-### [`enhancement` ![Issues tagged with 'enhancement' ](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/enhancement.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
-
-An enhancement to an existing feature.
-
-### [`Epic` ![Issues tagged with 'Epic' ](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/Epic.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3AEpic)
-
-A large objective consisting of multiple issues.
-
-### [`external dependency` ![Issues tagged with 'external dependency'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/external%20dependency.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22external%20dependency%22)
-
-Issues that are waiting on something out of our control.
-
-### [`good first issue` ![Issues tagged with 'good first issue'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/good%20first%20issue.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3A%22good%20first%20issue%22)
-
-These issues might be a good place to start if you want to contribute for the first time.
-
-### [`help wanted` ![Issues tagged with 'help wanted'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/help%20wanted.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3A%22help%20wanted%22)
-
-These issues might be a good place to start if you want to contribute.
-
-### [`idea` ![Issues tagged with 'idea'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/idea.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Aidea)
-
-These are ideas, user stories, or feature requests that don't yet qualify as a new feature, probably because the specifics haven't been worked out yet.
-
-### [`invalid` ![Issues tagged with 'invalid'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/invalid.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Ainvalid)
-
-These are issues that are no longer relevant or are not considered valid issues.
-
-### [`investigate` ![Issues tagged with 'investigate'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/investigate.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Ainvestigate)
-
-These are issues that require further investigation to be considered as valid issues.
-
-### [`new feature` ![Issues tagged with 'new feature'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/new%20feature.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3A%22new%20feature%22)
-
-These are new features to be developed at some point in the future.
-
-### [`project management` ![Issues tagged with 'project management'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/project%20management.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3A%22project%20management%22)
-
-These are issues that require changes outside of the code repository.
-
-### [`question` ![Issues tagged with 'question'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/question.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Aquestion)
-
-These are questions related to a problem and/or issues that require further investigation.
-
-### [`quickfix` ![Issues tagged with 'quickfix'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/quickfix.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Aquickfix)
-
-These are issues which require minimal effort to address.
-
-### [`security` ![Issues tagged with 'security'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/security.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Asecurity)
-
-These are issues which address a known vulnerability.
-
-### [`SIT` ![Issues tagged with 'SIT'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/SIT.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3ASIT)
-
-These are issues which were found during systems integration testing (SIT).
-
-### [`technical` ![Issues tagged with 'technical'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/technical.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Atechnical)
-
-These issues are related to our technical implementation (refactoring, dependency changes, etc.), they're developer focused, and don't directly add new features for end users.
-
-### [`UAT` ![Issues tagged with 'UAT'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/UAT.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3AUAT)
-
-These are issues which were found during user acceptance testing (UAT).
-
-### [`wontfix` ![Issues tagged with 'wontfix'](https://img.shields.io/github/issues-raw/nasa-gibs/worldview/wontfix.svg)](https://github.com/nasa-gibs/worldview/issues?q=is%3Aopen+is%3Aissue+label%3Awontfix)
-
-These are issues that we don't plan to fix.
+an overview of what we're planning.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,7 @@ our style guides automatically:
 
 All of the unit tests for this project need to pass before your submission will
 be accepted. If you add new functionality, please consider adding tests for that
-functionality as well. See [Testing](/doc/testing.md) for more information about
+functionality as well. See [Testing](../doc/testing.md) for more information about
 testing.
 
 ### Commits

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@
 This code was originally developed at NASA/Goddard Space Flight Center for
 the Earth Science Data and Information System (ESDIS) project.
 
-Copyright © 2013 - 2020 United States Government as represented by the
+Copyright © 2013 - 2022 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 
@@ -131,7 +131,7 @@ customarily used for software exchange.
 **B.** Each Recipient must ensure that the following copyright notice appears
 prominently in the Subject Software:
 
-    Copyright © 2012-2018 United States Government
+    Copyright © 2012-2022 United States Government
     as represented by the Administrator of the
     National Aeronautics and Space Administration.
     All Rights Reserved.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,7 +7,7 @@ Copyright © 2013 - 2022 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 
-## [NASA OPEN SOURCE AGREEMENT VERSION 1.3](https://ti.arc.nasa.gov/opensource/nosa/)
+## [NASA OPEN SOURCE AGREEMENT VERSION 1.3](https://opensource.gsfc.nasa.gov/nosa.php)
 
 THIS OPEN SOURCE AGREEMENT ("AGREEMENT") DEFINES THE RIGHTS OF USE,
 REPRODUCTION, DISTRIBUTION, MODIFICATION AND REDISTRIBUTION OF CERTAIN
@@ -163,7 +163,7 @@ Agreement.
 **F.** In an effort to track usage and maintain accurate records of the
 Subject Software, each Recipient, upon receipt of the Subject Software, is
 requested to register with Government Agency by visiting the following website:
-[https://opensource.arc.nasa.gov](https://opensource.arc.nasa.gov). Recipient’s
+[https://opensource.gsfc.nasa.gov](https://opensource.gsfc.nasa.gov). Recipient’s
 name and personal information shall be used for statistical purposes only.
 Once a Recipient makes a Modification available, it is requested that the
 Recipient inform Government Agency at the web site provided above how to

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ updated daily and are within three hours of observation - showing the entire Ear
 management, air quality measurements, and flood monitoring. Some satellite
 imagery layers span almost 30 years, providing a long term view of our dynamic
 planet. The underlying data is available for download, and Arctic and Antarctic
-views of several imagery layers are available for a “full globe” perspective.
+views of several imagery layers are available for a “full globe” perspective. Geostationary imagery layers are also now available. These are provided in ten minute increments for the last 90 days. These full disk hemispheric views allow for almost real-time viewing of changes occurring around most of the world.
 
 Worldview uses [OpenLayers](http://openlayers.org/) to display imagery from the
 [Global Imagery Browse Services (GIBS)](https://earthdata.nasa.gov/gibs). This
@@ -39,7 +39,7 @@ cd worldview
 npm ci
 ```
 
-View the [Configuration](doc/configuration.md) section for information on how to install the official EOSDIS Worldview configuration, or to add your own custom configuration.
+View the [Configuration](doc/config/configuration.md) section for information on how to install the official EOSDIS Worldview configuration, or to add your own custom configuration.
 
 ### Dependencies
 
@@ -97,7 +97,7 @@ Contact us via GitHub or by sending an email to
 
 ## Contribute
 
-We welcome your contributions! Feel free to [open an issue](https://github.com/nasa-gibs/worldview/issues/new) or [submit a PR](https://github.com/nasa-gibs/worldview/compare).
+We welcome your contributions! Feel free to [open an issue](https://github.com/nasa-gibs/worldview/issues/new/choose) or [submit a PR](https://github.com/nasa-gibs/worldview/compare).
 
 Please review [CONTRIBUTING.md](.github/CONTRIBUTING.md) for contribution guidelines before getting started.
 


### PR DESCRIPTION
## Description

Fixes WV-2376.

Updated broken links, license year, removed text about zenhub and tracking issues in github.

@nasa-gibs/worldview
