### PR TITLE
WV-2389 - Integrate Bitly with GITC WV

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -2,6 +2,9 @@
     "features": {
         "animation": true,
         "urlShortening": true,
+        "urlShortener": {
+            "url": "https://0helamlip2.execute-api.us-west-2.amazonaws.com/gitc-prod/"
+          },
         "customPalettes": true,
         "compare": true,
         "tour": true,

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -23,18 +23,9 @@ import HoverTooltip from '../components/util/hover-tooltip';
 import { requestShortLink } from '../modules/link/actions';
 import history from '../main';
 
-const getShortenRequestString = (mock, permalink) => {
-  const mockStr = mock || '';
-  if (/localhost/.test(window.location.href)) {
-    return 'mock/short_link.json';
-  }
-  return (
-    `service/link/shorten.cgi${
-      mockStr
-    }?url=${
-      encodeURIComponent(permalink)}`
-  );
-};
+
+
+
 
 const SOCIAL_SHARE_TABS = ['link', 'embed', 'social'];
 
@@ -50,6 +41,8 @@ class ShareLinkContainer extends Component {
       queryString: history.location.search || '',
     };
   }
+
+
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const { shortLink } = nextProps;
@@ -82,11 +75,22 @@ class ShareLinkContainer extends Component {
     if (this.unlisten) this.unlisten();
   }
 
-  getShortLink = () => {
-    const { requestShortLinkAction, mock } = this.props;
+  getShortenRequestString(permalink) {
+    const { urlShortener } = this.props;
+    if (/localhost/.test(window.location.href)) {
+      const mockPermaLink = 'https://worldview.earthdata.nasa.gov/?t=2020-08-31-T17%3A05%3A22Z&l=Reference_Labels(hidden),Reference_Features(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
+
+      return `${urlShortener.url}?url=${mockPermaLink}`;
+    }
+    return `${urlShortener.url}?url=${permalink}`;
+  }
+
+  getShortLink = async () => {
+    const { requestShortLinkAction } = this.props;
     const link = this.getPermalink();
-    const location = getShortenRequestString(mock, link);
-    return requestShortLinkAction(location);
+    const location = this.getShortenRequestString(link);
+    const shortenedUrl = await requestShortLinkAction(location);
+    return shortenedUrl;
   }
 
   onToggleShorten = () => {
@@ -346,12 +350,13 @@ function mapStateToProps(state) {
     browser, config, shortLink, sidebar, tour,
   } = state;
 
-  const { features: { urlShortening } } = config;
+  const { features: { urlShortening, urlShortener } } = config;
   const isMobile = browser.lessThan.medium;
   const embedDisableNavLink = sidebar.activeTab === 'download' || tour.active;
 
   return {
     urlShortening,
+    urlShortener,
     embedDisableNavLink,
     isMobile,
     shortLink,
@@ -381,4 +386,5 @@ ShareLinkContainer.propTypes = {
   selectedDate: PropTypes.object,
   shortLink: PropTypes.object,
   urlShortening: PropTypes.bool,
+  urlShortener: PropTypes.object,
 };

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -23,12 +23,7 @@ import HoverTooltip from '../components/util/hover-tooltip';
 import { requestShortLink } from '../modules/link/actions';
 import history from '../main';
 
-
-
-
-
 const SOCIAL_SHARE_TABS = ['link', 'embed', 'social'];
-
 class ShareLinkContainer extends Component {
   constructor(props) {
     super(props);
@@ -41,8 +36,6 @@ class ShareLinkContainer extends Component {
       queryString: history.location.search || '',
     };
   }
-
-
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const { shortLink } = nextProps;
@@ -78,7 +71,8 @@ class ShareLinkContainer extends Component {
   getShortenRequestString(permalink) {
     const { urlShortener } = this.props;
     if (/localhost/.test(window.location.href)) {
-      const mockPermaLink = 'https://worldview.earthdata.nasa.gov/?t=2020-08-31-T17%3A05%3A22Z&l=Reference_Labels(hidden),Reference_Features(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
+      // const mockPermaLink = 'https://worldview.earthdata.nasa.gov/?t=2020-08-31-T17%3A05%3A22Z&l=Reference_Labels(hidden),Reference_Features(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor';
+      const mockPermaLink = `https://worldview.earthdata.nasa.gov/${encodeURIComponent(window.location.search)}`;
 
       return `${urlShortener.url}?url=${mockPermaLink}`;
     }
@@ -381,7 +375,6 @@ export default connect(
 ShareLinkContainer.propTypes = {
   embedDisableNavLink: PropTypes.bool,
   isMobile: PropTypes.bool,
-  mock: PropTypes.string,
   requestShortLinkAction: PropTypes.func,
   selectedDate: PropTypes.object,
   shortLink: PropTypes.object,


### PR DESCRIPTION
## Description
This PR replaces the previous Bitly integration with new AWS implementation.  The new URL Shortener uses the AWS API Gateway endpoint with the URL query parameter of `?url=` with the value being the WV long url.

### Some Notes
- There are separate API Gateway endpoints for the various GITC WV deployments.  For this Github repo, the default configuration (`config/default/common/features.json`) will use the live production API Gateway endpoint.  This is so any users who download and run this repo are not using a development version of the API Gateway endpoint.

- If running a local instance of Worldview, the link shortener will only grab the URL query parameters from the localhost instance.  The URL being sent to Bitly will be `https://worldview.earthdata.nasa.gov/?<localhost url parameters>`.

## How To Test
1. After running `npm ci` and `npm run build`, start up the app with `npm run start`.
2. Navigate to http://localhost:3000.
3. Scroll to any location on the map, and change the date to anything other than the current date.
4. Open the share menu and click "Shorten Link"
5. The text box should populate with a shorten link with the domain `https://go.nasa.gov`.
6. Copy the shortened link and open the link in a new browser tab/window.
7. The shortened link should show the live production version of Worldview (`https://worldview.earthdata.nasa.gov`) with the exact same location and date you selected in the local instance.