### PR TITLE
Remove OL graticule code

### DIFF
--- a/web/js/components/animation-widget/gif-button.js
+++ b/web/js/components/animation-widget/gif-button.js
@@ -6,9 +6,7 @@ import { UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
 import {
   cloneDeep as lodashCloneDeep,
-  find as lodashFind,
   filter as lodashFilter,
-  get as lodashGet,
 } from 'lodash';
 import GifContainer from '../../containers/gif';
 import {
@@ -18,10 +16,9 @@ import {
 import { clearCustoms, refreshPalettes } from '../../modules/palettes/actions';
 import { clearRotate, refreshRotation } from '../../modules/map/actions';
 import {
-  clearGraticule, refreshGraticule, hideLayers, showLayers,
+  hideLayers, showLayers,
 } from '../../modules/layers/actions';
 import {
-  getActiveLayers,
   getAllActiveLayers,
 } from '../../modules/layers/selectors';
 import {
@@ -43,14 +40,12 @@ const GifButton = (props) => {
     onUpdateStartAndEndDate,
     hasCustomPalettes,
     isRotated,
-    hasGraticule,
     rotation,
     activePalettes,
     numberOfFrames,
     refreshStateAfterGif,
     hasNonDownloadableLayer,
     visibleLayersForProj,
-    proj,
     notify,
     isGifActive,
     zeroDates,
@@ -83,7 +78,6 @@ const GifButton = (props) => {
     const paletteStore = lodashCloneDeep(activePalettes);
     await getPromise(hasCustomPalettes, 'palette', clearCustoms, 'Notice');
     await getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
-    await getPromise(hasGraticule && proj.id === 'geographic', 'graticule', clearGraticule, 'Remove Graticule?');
     await getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
     await onUpdateStartAndEndDate(startDate, endDate);
     googleTagManager.pushEvent({
@@ -91,7 +85,7 @@ const GifButton = (props) => {
     });
 
     onCloseGif = () => {
-      refreshStateAfterGif(hasCustomPalettes ? paletteStore : undefined, rotation, hasGraticule, nonDownloadableLayers);
+      refreshStateAfterGif(hasCustomPalettes ? paletteStore : undefined, rotation, nonDownloadableLayers);
       toggleGif();
     };
     toggleGif();
@@ -133,16 +127,9 @@ const mapStateToProps = (state) => {
     activeLayersForProj,
     activePalettes,
   );
-  const activeLayers = getActiveLayers(state);
   return {
     activePalettes,
     hasCustomPalettes,
-    hasGraticule: Boolean(
-      lodashGet(
-        lodashFind(activeLayers, { id: 'Graticule' }) || {},
-        'visible',
-      ),
-    ),
     hasNonDownloadableLayer: hasNonDownloadableVisibleLayer(visibleLayersForProj),
     isGifActive: animation.gifActive,
     isRotated: Boolean(map.rotation !== 0),
@@ -159,15 +146,12 @@ const mapDispatchToProps = (dispatch) => ({
   onUpdateStartAndEndDate: (startDate, endDate) => {
     dispatch(changeStartAndEndDate(startDate, endDate));
   },
-  refreshStateAfterGif: (activePalettes, rotation, isGraticule, nonDownloadableLayers) => {
+  refreshStateAfterGif: (activePalettes, rotation, nonDownloadableLayers) => {
     if (activePalettes) {
       dispatch(refreshPalettes(activePalettes));
     }
     if (rotation) {
       dispatch(refreshRotation(rotation));
-    }
-    if (isGraticule) {
-      dispatch(refreshGraticule(isGraticule));
     }
     if (nonDownloadableLayers) {
       dispatch(showLayers(nonDownloadableLayers));
@@ -207,14 +191,12 @@ GifButton.propTypes = {
   activePalettes: PropTypes.object,
   visibleLayersForProj: PropTypes.array,
   hasCustomPalettes: PropTypes.bool,
-  hasGraticule: PropTypes.bool,
   hasNonDownloadableLayer: PropTypes.bool,
   isGifActive: PropTypes.bool,
   isRotated: PropTypes.bool,
   notify: PropTypes.func,
   numberOfFrames: PropTypes.number,
   onUpdateStartAndEndDate: PropTypes.func,
-  proj: PropTypes.object,
   refreshStateAfterGif: PropTypes.func,
   rotation: PropTypes.number,
   toggleGif: PropTypes.func,

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { ButtonToolbar, Button } from 'reactstrap';
 import {
   get as lodashGet,
-  find as lodashFind,
   cloneDeep as lodashCloneDeep,
   filter as lodashFilter,
 } from 'lodash';
@@ -25,7 +24,7 @@ import {
 import { clearCustoms, refreshPalettes } from '../modules/palettes/actions';
 import { clearRotate, refreshRotation } from '../modules/map/actions';
 import {
-  showLayers, clearGraticule, hideLayers, refreshGraticule,
+  showLayers, hideLayers,
 } from '../modules/layers/actions';
 import { notificationWarnings } from '../modules/image-download/constants';
 import Notify from '../components/image-download/notify';
@@ -116,21 +115,18 @@ class toolbarContainer extends Component {
       openModal,
       hasCustomPalette,
       isRotated,
-      hasGraticule,
       activePalettes,
       rotation,
       refreshStateAfterImageDownload,
       toggleDialogVisible,
       hasNonDownloadableLayer,
       visibleLayersForProj,
-      proj,
     } = this.props;
     const nonDownloadableLayers = hasNonDownloadableLayer ? getNonDownloadableLayers(visibleLayersForProj) : null;
     const paletteStore = lodashCloneDeep(activePalettes);
     toggleDialogVisible(false);
     await this.getPromise(hasCustomPalette, 'palette', clearCustoms, 'Notice');
     await this.getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
-    await this.getPromise(hasGraticule && proj.id === 'geographic', 'graticule', clearGraticule, 'Remove Graticule?');
     await this.getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
     await openModal(
       'TOOLBAR_SNAPSHOT',
@@ -138,7 +134,7 @@ class toolbarContainer extends Component {
         ...CUSTOM_MODAL_PROPS.TOOLBAR_SNAPSHOT,
         onClose: () => {
           refreshStateAfterImageDownload(
-            hasCustomPalette ? paletteStore : undefined, rotation, hasGraticule, nonDownloadableLayers,
+            hasCustomPalette ? paletteStore : undefined, rotation, nonDownloadableLayers,
           );
         },
       },
@@ -417,12 +413,6 @@ const mapStateToProps = (state) => {
     ),
     visibleLayersForProj,
     isRotated: Boolean(map.rotation !== 0),
-    hasGraticule: Boolean(
-      lodashGet(
-        lodashFind(activeLayersForProj, { id: 'Graticule' }) || {},
-        'visible',
-      ),
-    ),
     isDistractionFreeModeActive,
   };
 };
@@ -437,15 +427,12 @@ const mapDispatchToProps = (dispatch) => ({
   toggleShowLocationSearch: () => {
     dispatch(toggleShowLocationSearch());
   },
-  refreshStateAfterImageDownload: (activePalettes, rotation, isGraticule, nonDownloadableLayers) => {
+  refreshStateAfterImageDownload: (activePalettes, rotation, nonDownloadableLayers) => {
     if (activePalettes) {
       dispatch(refreshPalettes(activePalettes));
     }
     if (rotation) {
       dispatch(refreshRotation(rotation));
-    }
-    if (isGraticule) {
-      dispatch(refreshGraticule(isGraticule));
     }
     if (nonDownloadableLayers) {
       dispatch(showLayers(nonDownloadableLayers));
@@ -514,10 +501,8 @@ toolbarContainer.propTypes = {
   hasNonDownloadableLayer: PropTypes.bool,
   visibleLayersForProj: PropTypes.array,
   config: PropTypes.object,
-  proj: PropTypes.object,
   faSize: PropTypes.string,
   hasCustomPalette: PropTypes.bool,
-  hasGraticule: PropTypes.bool,
   isAnimatingToEvent: PropTypes.bool,
   isAboutOpen: PropTypes.bool,
   isCompareActive: PropTypes.bool,

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -6,10 +6,6 @@ import OlSourceTileWMS from 'ol/source/TileWMS';
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayerTile from 'ol/layer/Tile';
 import OlTileGridTileGrid from 'ol/tilegrid/TileGrid';
-import OlStroke from 'ol/style/Stroke';
-import OlText from 'ol/style/Text';
-import OlFill from 'ol/style/Fill';
-import OlGraticule from 'ol/layer/Graticule';
 
 import MVT from 'ol/format/MVT';
 import LayerVectorTile from 'ol/layer/VectorTile';
@@ -90,33 +86,6 @@ export default function mapLayerBuilder(config, cache, store) {
     };
   };
 
-  const getGraticule = (proj) => {
-    const graticule = new OlGraticule({
-      lonLabelStyle: new OlText({
-        font: '12px Calibri,sans-serif',
-        textBaseline: 'top',
-        fill: new OlFill({
-          color: 'rgba(0,0,0,1)',
-        }),
-        stroke: new OlStroke({
-          color: 'rgba(255,255,255,1)',
-          width: 3,
-        }),
-      }),
-      // the style to use for the lines, optional.
-      strokeStyle: new OlStroke({
-        color: 'rgb(255, 255, 255)',
-        width: 2,
-        lineDash: [0.5, 4],
-      }),
-      extent: proj.maxExtent,
-      lonLabelPosition: 1,
-      showLabels: true,
-    });
-    graticule.isVector = true;
-    return graticule;
-  };
-
   /**
    * Create a new OpenLayers Layer
    * @param {object} def
@@ -175,9 +144,6 @@ export default function mapLayerBuilder(config, cache, store) {
             break;
           case 'wms':
             layer = getLayer(createLayerWMS, def, options, attributes, wrapLayer);
-            break;
-          case 'graticule':
-            layer = getGraticule(proj);
             break;
           default:
             throw new Error(`Unknown layer type: ${type}`);

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -809,7 +809,7 @@ export default function mapui(models, config, store) {
   }
 
   /**
-   * Initiates the adding of a layer or Graticule
+   * Initiates the adding of a layer
    * @param {object} def - layer Specs
    * @returns {void}
    */

--- a/web/js/modules/image-download/constants.js
+++ b/web/js/modules/image-download/constants.js
@@ -46,13 +46,9 @@ const PALETTE_WARNING = 'One or more layers on the map have been modified (chang
   + 'snapshot. Would you like to temporarily revert to the original '
   + 'layer(s)?';
 
-const GRATICLE_WARNING = 'The graticule layer cannot be used to take a snapshot. Would you '
-  + 'like to temporarily hide this layer?';
-
 const ROTATE_WARNING = 'Image may not be downloaded when rotated. Would you like to temporarily reset rotation?';
 
 export const notificationWarnings = {
   palette: PALETTE_WARNING,
-  graticule: GRATICLE_WARNING,
   rotate: ROTATE_WARNING,
 };

--- a/web/js/modules/layers/actions.js
+++ b/web/js/modules/layers/actions.js
@@ -284,18 +284,6 @@ export function setOpacity(id, opacity) {
   };
 }
 
-export function clearGraticule() {
-  return (dispatch) => {
-    dispatch(toggleVisibility('Graticule', false));
-  };
-}
-
-export function refreshGraticule() {
-  return (dispatch) => {
-    dispatch(toggleVisibility('Graticule', true));
-  };
-}
-
 export function hideLayers(layers) {
   return (dispatch) => {
     layers.forEach((obj) => {


### PR DESCRIPTION
## Description

Removes dead code from when we used OpenLayers to render a graticule rather than using a GIBS layer.

## How To Test

- Try image download with the new graticule loaded
- Try gif creation with the new graticule loaded

@nasa-gibs/worldview
