### PR TITLE
WV-2393 Setting area of interest without moving bounding box

### DIFF
--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -229,7 +229,7 @@ class SmartHandoff extends Component {
     }
   }
 
-  initalBoundary(boundaries, setExtent) {
+  setInitialExtent(boundaries, setExtent) {
     const { proj, map, selectedCollection } = this.props;
 
     const lonlats = imageUtilGetCoordsFromPixelValues(
@@ -269,7 +269,7 @@ class SmartHandoff extends Component {
         event: 'smart_handoffs_toggle_true_target_area',
       });
       this.setState({ showBoundingBox: true });
-      this.initalBoundary(boundaries, true);
+      this.setInitialExtent(boundaries, true);
     } else {
       this.setState({
         showBoundingBox: false,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -158,19 +158,24 @@ class SmartHandoff extends Component {
 
     if (!selectedCollection) return;
 
-    const {
+    let newBoundaries = boundaries;
+
+    let {
       x,
       y,
       width,
       height,
-    } = boundaries;
+    } = boundaries
 
-    const newBoundaries = {
-      x,
-      y,
-      x2: x + width,
-      y2: y + height,
-    };
+    if(boundaries.hasOwnProperty('width')){
+
+      newBoundaries = {
+        x,
+        y,
+        x2: x + width,
+        y2: y + height,
+      };
+  }
 
     const lonlats = imageUtilGetCoordsFromPixelValues(
       newBoundaries,
@@ -229,36 +234,6 @@ class SmartHandoff extends Component {
     }
   }
 
-  setInitialExtent(boundaries, setExtent) {
-    const { proj, map, selectedCollection } = this.props;
-
-    const lonlats = imageUtilGetCoordsFromPixelValues(
-      boundaries,
-      map.ui.selected,
-    );
-    const { crs } = proj;
-
-    // Retrieve the lat/lon coordinates based on the defining boundary and map projection
-    const bottomLeft = olProj.transform(lonlats[0], crs, 'EPSG:4326');
-    const topRight = olProj.transform(lonlats[1], crs, 'EPSG:4326');
-    const [x1, y1] = bottomLeft;
-    const [x2, y2] = topRight;
-
-    const extent = {
-      southWest: `${x1.toFixed(5)},${y1.toFixed(5)}`,
-      northEast: `${x2.toFixed(5)},${y2.toFixed(5)}`,
-    };
-
-    const coordinates = {
-      bottomLeft: util.formatCoordinate([x1, y1]),
-      topRight: util.formatCoordinate([x2, y2]),
-    };
-
-    if (selectedCollection && extent) {
-      this.updateExtent(coordinates, boundaries, setExtent && extent);
-    }
-  }
-
   /**
    * Handle bounding box checkbox toggle
    */
@@ -269,7 +244,7 @@ class SmartHandoff extends Component {
         event: 'smart_handoffs_toggle_true_target_area',
       });
       this.setState({ showBoundingBox: true });
-      this.setInitialExtent(boundaries, true);
+      this.onBoundaryChange(boundaries, true);
     } else {
       this.setState({
         showBoundingBox: false,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -229,16 +229,47 @@ class SmartHandoff extends Component {
     }
   }
 
+  initalBoundary(boundaries, setExtent) {
+    const { proj, map, selectedCollection } = this.props;
+
+    const lonlats = imageUtilGetCoordsFromPixelValues(
+      boundaries,
+      map.ui.selected,
+    );
+    const { crs } = proj;
+
+    // Retrieve the lat/lon coordinates based on the defining boundary and map projection
+    const bottomLeft = olProj.transform(lonlats[0], crs, 'EPSG:4326');
+    const topRight = olProj.transform(lonlats[1], crs, 'EPSG:4326');
+    const [x1, y1] = bottomLeft;
+    const [x2, y2] = topRight;
+
+    const extent = {
+      southWest: `${x1.toFixed(5)},${y1.toFixed(5)}`,
+      northEast: `${x2.toFixed(5)},${y2.toFixed(5)}`,
+    };
+
+    const coordinates = {
+      bottomLeft: util.formatCoordinate([x1, y1]),
+      topRight: util.formatCoordinate([x2, y2]),
+    };
+
+    if (selectedCollection && extent) {
+      this.updateExtent(coordinates, boundaries, setExtent && extent);
+    }
+  }
+
   /**
    * Handle bounding box checkbox toggle
    */
   onCheckboxToggle() {
-    const { showBoundingBox } = this.state;
+    const { showBoundingBox, boundaries } = this.state;
     if (!showBoundingBox) {
       googleTagManager.pushEvent({
         event: 'smart_handoffs_toggle_true_target_area',
       });
       this.setState({ showBoundingBox: true });
+      this.initalBoundary(boundaries, true);
     } else {
       this.setState({
         showBoundingBox: false,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -158,8 +158,6 @@ class SmartHandoff extends Component {
 
     if (!selectedCollection) return;
 
-    let newBoundaries = boundaries;
-
     const {
       x,
       y,
@@ -167,14 +165,12 @@ class SmartHandoff extends Component {
       height,
     } = boundaries;
 
-    if (Object.prototype.hasOwnProperty.call(boundaries, 'width')) {
-      newBoundaries = {
-        x,
-        y,
-        x2: x + width,
-        y2: y + height,
-      };
-    }
+    const newBoundaries = {
+      x,
+      y,
+      x2: width ? x + width : boundaries.x2,
+      y2: height ? y + height : boundaries.y2,
+    };
 
     const lonlats = imageUtilGetCoordsFromPixelValues(
       newBoundaries,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -160,22 +160,21 @@ class SmartHandoff extends Component {
 
     let newBoundaries = boundaries;
 
-    let {
+    const {
       x,
       y,
       width,
       height,
-    } = boundaries
+    } = boundaries;
 
-    if(boundaries.hasOwnProperty('width')){
-
+    if (Object.prototype.hasOwnProperty.call(boundaries, 'width')) {
       newBoundaries = {
         x,
         y,
         x2: x + width,
         y2: y + height,
       };
-  }
+    }
 
     const lonlats = imageUtilGetCoordsFromPixelValues(
       newBoundaries,

--- a/web/js/modules/smart-handoff/util.js
+++ b/web/js/modules/smart-handoff/util.js
@@ -41,6 +41,14 @@ function getHandoffParams (queryInput, options) {
     projection, conceptId, startDate, endDate, currentExtent, showBoundingBox,
   } = options;
 
+  for (const property in options) {
+    if(options[property] === undefined){
+      console.error(`${property} is undefined.`)
+    } else if(options[property] === {}){
+      console.error(`${property} is an empty object.`)
+    }
+  }
+
   const getParam = ({ ValueType, ValueName }) => {
     if (ValueType === 'temporalRange') {
       if (startDate && endDate) {

--- a/web/js/modules/smart-handoff/util.js
+++ b/web/js/modules/smart-handoff/util.js
@@ -41,13 +41,13 @@ function getHandoffParams (queryInput, options) {
     projection, conceptId, startDate, endDate, currentExtent, showBoundingBox,
   } = options;
 
-  for (const property in options) {
-    if(options[property] === undefined){
-      console.error(`${property} is undefined.`)
-    } else if(options[property] === {}){
-      console.error(`${property} is an empty object.`)
+  Object.entries(options).forEach(([key, value]) => {
+    if (value === undefined) {
+      console.error(`${key} is undefined.`);
+    } else if (value === {}) {
+      console.error(`${key} is an empty object.`);
     }
-  }
+  });
 
   const getParam = ({ ValueType, ValueName }) => {
     if (ValueType === 'temporalRange') {


### PR DESCRIPTION
## Description

When adding a layer, checking the 'Set Area of Interest' box and then clicking 'Download via Earthdata Search' without moving the box, you would be linked to a new page that would present an error saying an unknown error had occurred. This was happening because the SmartHandoff component was only rendering the coordinates and boundaries necessary to generate a working download link when the bounding crop box was moved or resized. More specifically, the currentExtent state property was being left blank if you pressed the download link before moving or resizing the bounding box. This was fixed by adding calling the `onBoundaryChange` function within the `onCheckboxToggle` function. A conditonal check within `onBoundryChange` was necessary since the `boundaries` object already had the correct properties. 


## How To Test

1. Load any aerosol layer such as 'Deep Blue Aerosol Angstrom Exponent (Land and Ocean)'.
2. Click the data tab
3.  Select the Near Real-Time selection of the Aerosol layer.
4. Check the 'Set Area of Interest' box but do (!not!) move or resize the bounding box.
5. Click the 'Download via Earthdata Search' button'.
6. Click continue on the 'Leaving Worldview' modal.
7. Verify that the link does not provide an error message. 






