### PR TITLE
WV-2391: Measurement tools become unavailable if Projection changed during measurement

### DIFF
--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -71,10 +71,9 @@ function OlMeasureTool (props) {
     return ref.current;
   }
 
-  // Listen for a projection change
+  // Monitor for projection change & terminate any incomplete measurement from the previous projection
   useEffect(() => {
     if (olMap != null) {
-      // Terminate draw for the *previous* projection
       const regionFromCrs = {
         'EPSG:4326': 'geographic',
         'EPSG:3413': 'arctic',
@@ -84,7 +83,6 @@ function OlMeasureTool (props) {
       const geographyToTerminate = regionFromCrs[crs];
       terminateDraw(map.ui.proj[geographyToTerminate]);
 
-      // Delete stray tooltips
       if (document.getElementsByClassName('tooltip-active').length > 0) {
         map.ui.proj[geographyToTerminate].removeOverlay(tooltipOverlay);
       }

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -70,15 +70,12 @@ function OlMeasureTool (props) {
     if (init) {
       const inactiveProjections = getInactiveProjections(olMap.proj);
       // Terminate draw for both *inactive* projections
-      for (const area in inactiveProjections) {
-      // Object.values(inactiveProjections).forEach((area) => {
-        // console.log(inactiveProjections[area]);
-        console.log(map.ui.proj[inactiveProjections[area]]);
-        terminateDraw(map.ui.proj.geographic);
+      Object.values(inactiveProjections).forEach((area) => {
+        terminateDraw(map.ui.proj[area]);
         // map.ui.proj[area].removeOverlay(tooltipOverlay);
-      };
+      });
     }
-  }, [crs]);
+  }, [crs])
 
   useEffect(() => {
     if (!init) {

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -62,15 +62,15 @@ function OlMeasureTool (props) {
     map, olMap, crs, unitOfMeasure, toggleMeasureActive, updateMeasurements, projections, proj,
   } = props;
 
-  console.log("OlMeasureTool running");
-
   // Listen for changes made to the crs value which indicates a projection change
   // This listens correctly but FIRES on the new olMap projection(?).
   // This works if you simply change projections.
   // This fails if you change projections & start a new measurement
   useEffect(() => {
+    // Don't fire on the initial page load
     if (init) {
-      terminateDraw(); // Don't fire on the initial page load
+      terminateDraw();
+      clearMeasurements();
     }
   }, [crs]);
 

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -75,7 +75,13 @@ function OlMeasureTool (props) {
   useEffect(() => {
     if (olMap != null) {
       // Terminate draw for the *previous* projection
-      const geographyToTerminate = getProjectionFromCrs(previousCrs);
+      const regionFromCrs = {
+        'EPSG:4326': 'geographic',
+        'EPSG:3413': 'arctic',
+        'EPSG:3031': 'antarctic',
+      };
+
+      const geographyToTerminate = regionFromCrs[crs];
       terminateDraw(map.ui.proj[geographyToTerminate]);
 
       // Delete stray tooltips
@@ -331,15 +337,6 @@ function OlMeasureTool (props) {
       vectorLayers[crs].setMap(null);
       vectorLayers[crs] = null;
     }
-  }
-
-  function getProjectionFromCrs(crs) {
-    const regionFromCrs = {
-      'EPSG:4326': 'geographic',
-      'EPSG:3413': 'arctic',
-      'EPSG:3031': 'antarctic',
-    };
-    return regionFromCrs[crs];
   }
 
   return null;

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -64,12 +64,15 @@ function OlMeasureTool (props) {
   // Listen for changes made to the crs value which indicates a projection change
   useEffect(() => {
     // Don't fire on the initial page load
+    console.log(olMap);
     if (init) {
       const inactiveProjections = getInactiveProjections(olMap.proj);
       // Terminate draw for both *inactive* projections
-      for (const area in inactiveProjections) {
-        terminateDraw(map.ui.proj[inactiveProjections[area]]);
-      }
+      // for (const area in inactiveProjections) {
+      Object.values(inactiveProjections).forEach((area) => {
+        terminateDraw(map.ui.proj[area]);
+        // map.ui.proj[area].removeOverlay(tooltipOverlay);
+      });
     }
   }, [crs]);
 
@@ -322,7 +325,7 @@ function OlMeasureTool (props) {
   }
 
   function getInactiveProjections(activeProj) {
-    return ['geographic', 'arctic', 'antarctic'].filter(item => item !== activeProj);
+    return ['geographic', 'arctic', 'antarctic'].filter((item) => item !== activeProj);
   }
 
   return null;

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -40,15 +40,16 @@ import {
 } from '../../util/constants';
 import { areCoordinatesWithinExtent } from '../../modules/location-search/util';
 
+
 const { events } = util;
 
 let tooltipElement;
 let tooltipOverlay;
 let init = false;
-let draw;
 const allMeasurements = {};
 const vectorLayers = {};
 const sources = {};
+let draw;
 
 /**
  * A component to add measurement functionality to the OL map
@@ -57,6 +58,7 @@ function OlMeasureTool (props) {
   let drawChangeListener;
   let rightClickListener;
   let twoFingerTouchListener;
+
   const {
     map, olMap, crs, unitOfMeasure, toggleMeasureActive, updateMeasurements, projections, proj,
   } = props;
@@ -64,15 +66,17 @@ function OlMeasureTool (props) {
   // Listen for changes made to the crs value which indicates a projection change
   useEffect(() => {
     // Don't fire on the initial page load
-    console.log(olMap);
+    // console.log(map);
     if (init) {
       const inactiveProjections = getInactiveProjections(olMap.proj);
       // Terminate draw for both *inactive* projections
-      // for (const area in inactiveProjections) {
-      Object.values(inactiveProjections).forEach((area) => {
-        terminateDraw(map.ui.proj[area]);
+      for (const area in inactiveProjections) {
+      // Object.values(inactiveProjections).forEach((area) => {
+        // console.log(inactiveProjections[area]);
+        console.log(map.ui.proj[inactiveProjections[area]]);
+        terminateDraw(map.ui.proj.geographic);
         // map.ui.proj[area].removeOverlay(tooltipOverlay);
-      });
+      };
     }
   }, [crs]);
 
@@ -201,6 +205,8 @@ function OlMeasureTool (props) {
    * End the current measurement interaction & remove the visual representation from the map
    */
   const terminateDraw = (olMaptoTerminate = olMap) => {
+    console.log('terminateDraw');
+    // console.log(olMaptoTerminate);
     tooltipElement = null;
     toggleMeasureActive(false);
     olMaptoTerminate.removeInteraction(draw);

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -68,7 +68,7 @@ function OlMeasureTool (props) {
     const ref = useRef();
     useEffect(() => {
       ref.current = data;
-    },[data]);
+    }, [data]);
     return ref.current;
   }
 

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -80,7 +80,7 @@ function OlMeasureTool (props) {
         'EPSG:3031': 'antarctic',
       };
 
-      const geographyToTerminate = regionFromCrs[crs];
+      const geographyToTerminate = regionFromCrs[previousCrs];
       terminateDraw(map.ui.proj[geographyToTerminate]);
 
       if (document.getElementsByClassName('tooltip-active').length > 0) {

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -62,23 +62,14 @@ function OlMeasureTool (props) {
   } = props;
 
   // Listen for changes made to the crs value which indicates a projection change
-  // This listens correctly but FIRES on the new olMap projection(?).
   useEffect(() => {
     // Don't fire on the initial page load
     if (init) {
-      // We don't want to terminate the *current* projection, we need to terminate the *previous* projection
-      // Identify the current proj & terminate draw for the other 2 projections
-      console.log(`crs: ${crs}`);
-      console.log(map)
-      console.log(map.ui.proj.geographic.interactions.array_);
-
-      let inactiveProjections = getInactiveProjections(crs);
-      console.log(JSON.stringify(inactiveProjections));
-
-      terminateDraw(map.ui.proj.geographic);
-
-
-
+      const inactiveProjections = getInactiveProjections(olMap.proj);
+      // Terminate draw for both *inactive* projections
+      for (const area in inactiveProjections) {
+        terminateDraw(map.ui.proj[inactiveProjections[area]]);
+      }
     }
   }, [crs]);
 
@@ -285,7 +276,6 @@ function OlMeasureTool (props) {
     draw.on('drawstart', drawStartCallback);
     draw.on('drawend', drawEndCallback);
     rightClickListener = olMap.on('contextmenu', (evt) => {
-      console.log('rightClickListener');
       evt.preventDefault();
       terminateDraw();
       olMap.removeOverlay(tooltipOverlay);
@@ -331,14 +321,8 @@ function OlMeasureTool (props) {
     }
   }
 
-  function getInactiveProjections(activeCrs) {
-    let regionFromCrs = {
-      'EPSG:4326': 'geographic',
-      'EPSG:3413': 'arctic',
-      'EPSG:3031': 'antarctic',
-    };
-    delete regionFromCrs[activeCrs];
-    return regionFromCrs;
+  function getInactiveProjections(activeProj) {
+    return ['geographic', 'arctic', 'antarctic'].filter(item => item !== activeProj);
   }
 
   return null;

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -66,16 +66,18 @@ function OlMeasureTool (props) {
   // Listen for changes made to the crs value which indicates a projection change
   useEffect(() => {
     // Don't fire on the initial page load
-    // console.log(map);
     if (init) {
       const inactiveProjections = getInactiveProjections(olMap.proj);
+
       // Terminate draw for both *inactive* projections
       Object.values(inactiveProjections).forEach((area) => {
         terminateDraw(map.ui.proj[area]);
-        // map.ui.proj[area].removeOverlay(tooltipOverlay);
+        if (document.getElementsByClassName('tooltip-active').length > 0) {
+          map.ui.proj[area].removeOverlay(tooltipOverlay);
+        }
       });
     }
-  }, [crs])
+  }, [crs]);
 
   useEffect(() => {
     if (!init) {
@@ -202,8 +204,6 @@ function OlMeasureTool (props) {
    * End the current measurement interaction & remove the visual representation from the map
    */
   const terminateDraw = (olMaptoTerminate = olMap) => {
-    console.log('terminateDraw');
-    // console.log(olMaptoTerminate);
     tooltipElement = null;
     toggleMeasureActive(false);
     olMaptoTerminate.removeInteraction(draw);
@@ -211,6 +211,7 @@ function OlMeasureTool (props) {
     OlObservableUnByKey(rightClickListener);
     OlObservableUnByKey(twoFingerTouchListener);
     events.trigger(MAP_ENABLE_CLICK_ZOOM);
+    draw = null;
   };
 
   const drawStartCallback = ({ feature }) => {


### PR DESCRIPTION
## Description
In current WV, if a user is in the middle of a measurement (having set at least 1 point) & changes the projection the measurement tools are unavailable in the other projections. The user can return to the initial projection & complete/discard the initial measurement which restores proper function for all projections.

The goal of this PR is to change this behavior such that if a user changes projections mid-measurement we should terminate the active measurement & allow the user to start a new measurement in the new projection. 

Note: Previously completed measurements are retained across projection changes.

## How To Test
Start a measurement, change projection, return to the initial projection & confirm the measurement has been terminated.

Test an active measurement from each projection to each projection, confirming proper termination.
Test active distance measurement(s) & active area measurement(s).
Test with completed measurement followed by an active measurement when changing projection. 
