### PR TITLE
WV-2297: Improve granule dateline crossing behavior

### DIFF
--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -78,6 +78,7 @@ class ModalContainer extends Component {
     const mobileTopOffset = 106;
     const top = isMobile && mobileFullScreen ? mobileTopOffset : offsetTop;
     const margin = isMobile && mobileFullScreen ? 0 : '0.5rem auto';
+    console.log('isMobile', isMobile, 'mobileFullScreen', mobileFullScreen, 'mobileTopOffset', mobileTopOffset, 'offsetTop', offsetTop, 'width', width, 'height', height);
     return {
       left: offsetLeft,
       right: offsetRight,

--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -78,7 +78,6 @@ class ModalContainer extends Component {
     const mobileTopOffset = 106;
     const top = isMobile && mobileFullScreen ? mobileTopOffset : offsetTop;
     const margin = isMobile && mobileFullScreen ? 0 : '0.5rem auto';
-    console.log('isMobile', isMobile, 'mobileFullScreen', mobileFullScreen, 'mobileTopOffset', mobileTopOffset, 'offsetTop', offsetTop, 'width', width, 'height', height);
     return {
       left: offsetLeft,
       right: offsetRight,

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -93,12 +93,13 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const { startQueryDate, endQueryDate } = getCMRQueryDates(date);
     const getGranulesUrl = getGranulesUrlSelector(store.getState());
 
-    const shortName = 'VJ102MOD'; // USE GRANULE LAYER ID
+    const shortName = 'VJ102MOD'; // TODO: USE GRANULE LAYER ID
     const params = {
       shortName,
       startDate: startQueryDate.toISOString(),
       endDate: endQueryDate.toISOString(),
-      pageSize: 2000,
+      day_night_flag: dayNightFilter,
+      pageSize: 1000,
     };
 
     // update range/extend range checks and new dates (if applicable)

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -156,7 +156,6 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       } finally {
         hideLoading();
       }
-      console.log('requested granules');
       return addGranuleCMRDateData(data, conceptId, dateRanges);
     }
     // user previously queried CMR granule dates

--- a/web/js/map/granule/granule-layer-builder.test.js
+++ b/web/js/map/granule/granule-layer-builder.test.js
@@ -11,7 +11,7 @@ import { OPEN_BASIC } from '../../modules/modal/constants';
 
 
 const mockBaseCmrApi = 'mock.cmr.api/';
-const queryString = '?shortName=VJ102MOD&temporal=2019-09-23T00%3A00%3A00.000Z%2C2019-09-25T00%3A00%3A00.000Z&pageSize=2000';
+const queryString = '?shortName=VJ102MOD&day_night_flag=DAY&temporal=2019-09-23T00%3A00%3A00.000Z%2C2019-09-25T00%3A00%3A00.000Z&pageSize=1000';
 const cmrGranules = require('../../../mock/cmr_granules.json');
 
 fetchMock.mock(`${mockBaseCmrApi}granules.json${queryString}`, cmrGranules)

--- a/web/js/map/granule/granule-layer-builder.test.js
+++ b/web/js/map/granule/granule-layer-builder.test.js
@@ -106,7 +106,7 @@ describe('granule layer builder', () => {
       def: granuleLayerDef,
     };
     const granuleLayer = await createGranuleLayer(granuleLayerDef, attributes, options);
-    const filteredDates = granuleLayer.wv.filteredGranules.map(({ date }) => date);
+    const filteredDates = granuleLayer.wv.visibleGranules.map(({ date }) => date);
 
     expect(granuleLayer.get('granuleGroup')).toEqual(true);
     expect(granuleLayer.wv.granuleDates).toEqual(expectedDates);

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -24,14 +24,12 @@ import util from '../../util/util';
  */
 export const datelineShiftGranules = (granules, currentDate, crs) => {
   const currentDayDate = new Date(currentDate).getUTCDate();
-  const datelineShiftNeeded = () => {
+  const datelineShiftNeeded = (() => {
     if (crs !== 'EPSG:4326') return false;
     const sameDays = granules.every(({ date }) => new Date(date).getUTCDate() === currentDayDate);
-    const someCross = granules.some(({ polygon }) => polygon.some(([lon]) => lon > 180 || lon < -180));
-    return someCross && !sameDays;
-  };
-
-  return !datelineShiftNeeded() ? granules : granules.map((granule) => {
+    return !sameDays;
+  })();
+  return !datelineShiftNeeded ? granules : granules.map((granule) => {
     const { date, polygon } = granule;
     const sameDay = currentDayDate === new Date(date).getUTCDate();
     const westSide = polygon.some(([lon]) => lon < 0);
@@ -92,13 +90,13 @@ export const isWithinDateRange = (date, startDate, endDate) => (startDate && end
 
 export const getGranuleFootprints = (layer) => {
   const {
-    def, filteredGranules, granuleDates,
+    def, visibleGranules, granuleDates,
   } = layer.wv;
   const { endDate, startDate } = def;
   const mostRecentGranuleDate = granuleDates[0];
   const isMostRecentDateOutOfRange = new Date(mostRecentGranuleDate) > new Date(endDate);
 
-  return filteredGranules.reduce((dates, { date, polygon }) => {
+  return visibleGranules.reduce((dates, { date, polygon }) => {
     const granuleDate = new Date(date);
     if (!isMostRecentDateOutOfRange && isWithinDateRange(granuleDate, startDate, endDate)) {
       dates[date] = polygon;

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -81,8 +81,8 @@ export const getIndexForSortedInsert = (array, date) => {
  * @method isWithinDateRange
  * @static
  * @param {object} date - date object
- * @param {object} startDate - date object
- * @param {string} endDate - date object
+ * @param {string} startDate - date string
+ * @param {string} endDate - date string
  * @returns {boolean}
  */
 export const isWithinDateRange = (date, startDate, endDate) => (startDate && endDate

--- a/web/js/map/granule/util.test.js
+++ b/web/js/map/granule/util.test.js
@@ -35,14 +35,6 @@ const singleTransformedGranule = {
 };
 
 describe('shifting dateline granules', () => {
-  it('no shift when "next" day but dateline not crossed', async () => {
-    const selectedDate = new Date('2019-09-24T00:06:00.000Z');
-    const crs = 'EPSG:4326';
-    const granules = datelineShiftGranules(mockGranules.one, selectedDate, crs);
-
-    expect(granules).toEqual(mockGranules.one);
-  });
-
   it('no shift when datline is crossed with same day', async () => {
     const selectedDate = new Date('2019-09-24T00:24:00.000Z');
     const crs = 'EPSG:4326';
@@ -51,7 +43,7 @@ describe('shifting dateline granules', () => {
     expect(granules).toEqual(mockGranules.three);
   });
 
-  it('shifts when datline is crossed and granules cross days', async () => {
+  it('shifts when granules cross days', async () => {
     const selectedDate = new Date('2019-09-24T00:12:00.000Z');
     const crs = 'EPSG:4326';
     const shiftedGranules = datelineShiftGranules(mockGranules.two, selectedDate, crs);

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -166,9 +166,6 @@ export default function mapLayerBuilder(config, cache, store) {
    * @static
    * @param {object} def - Layer Specs
    * @param {object} options - Layer options
-   * @param {object} granuleLayerParam (optional: only used for granule layers)
-   *    * @param {array} granuleDates - Reordered granule times
-   *    * @param {number} granuleCount - number of granules in layer group
    * @returns {object} OpenLayers layer
    */
   const createLayer = async (def, options = {}) => {

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -1150,6 +1150,7 @@ export default function mapui(models, config, store) {
       ],
       loadTilesWhileAnimating: true,
       loadTilesWhileInteracting: true,
+      maxTilesLoading: 32,
     });
     map.wv = {
       scaleMetric,

--- a/web/js/map/ui.js
+++ b/web/js/map/ui.js
@@ -915,13 +915,11 @@ export default function mapui(models, config, store) {
       if (compare.active && layers.length) {
         await updateCompareLayer(def, index, mapLayerCollection);
       } else if (temporalLayer) {
-        const index = findLayerIndex(def);
         if (index !== undefined && index !== -1) {
           const layerValue = layers[index];
           const layerOptions = type === 'granule'
             ? { granuleCount: getGranuleCount(state, id) }
             : { previousLayer: layerValue ? layerValue.wv : null };
-
           const updatedLayer = await createLayer(def, layerOptions);
           mapLayerCollection.setAt(index, updatedLayer);
         }

--- a/web/js/modules/smart-handoff/selectors.js
+++ b/web/js/modules/smart-handoff/selectors.js
@@ -17,6 +17,7 @@ export const getGranulesUrl = (state) => {
       bounding_box: params.bbox,
       collection_concept_id: params.conceptId,
       shortName: params.shortName,
+      day_night_flag: params.dayNight,
       temporal: getTemporal(),
       pageSize: params.pageSize,
     };


### PR DESCRIPTION
## Description

* Don't request as many granules from CMR
* Search granules more efficiently for dates that have matching imagery to fix UI sluggishness
* Change dateline crossing behavior so that if granules for more than one date are visible, they always get shifted to the right
* Increase number of simultaneously loading map tiles to 32 (from 16)

## How to test

- Checkout `granule-configs` branch
- `npm run build`
- Checkout this branch
- `npm run watch`
