### PR TITLE
WV-2404: Update context menu sizing

### DIFF
--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -22,7 +22,7 @@ function RightClickMenu(props) {
   const [toolTipToggleTime, setToolTipToggleTime] = useState(0);
   const [formattedCoordinates, setFormattedCoordinates] = useState();
   const {
-    map, proj, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements, measurementIsActive,
+    map, proj, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements, measurementIsActive, isMobile,
   } = props;
   const { crs } = proj.selected;
   const measurementsInProj = !!Object.keys(allMeasurements[crs]).length;
@@ -86,6 +86,8 @@ function RightClickMenu(props) {
     };
   });
 
+  const mobileStyle = isMobile && 'react-contextmenu-mobile';
+
   return show && (
     <div id="context-menu">
       <CopyClipboardTooltip
@@ -97,6 +99,7 @@ function RightClickMenu(props) {
         <MenuItem
           onClick={() => copyCoordsToClipboard()}
           attributes={{ id: 'context-menu-copy' }}
+          className={mobileStyle}
         >
           <span id="copy-coordinates-to-clipboard-button">
             {formattedCoordinates}
@@ -105,6 +108,7 @@ function RightClickMenu(props) {
         <MenuItem
           onClick={() => addPlaceMarkerHandler(pixelCoords, map, crs)}
           attributes={{ id: 'context-menu-add-marker' }}
+          className={mobileStyle}
         >
           Add Place Marker
         </MenuItem>
@@ -112,12 +116,14 @@ function RightClickMenu(props) {
         <MenuItem
           onClick={() => handleMeasurementMenu('distance')}
           attributes={{ id: 'context-menu-measure-distance' }}
+          className={mobileStyle}
         >
           Measure Distance
         </MenuItem>
         <MenuItem
           onClick={() => handleMeasurementMenu('area')}
           attributes={{ id: 'context-menu-measure-area' }}
+          className={mobileStyle}
         >
           Measure Area
         </MenuItem>
@@ -126,6 +132,7 @@ function RightClickMenu(props) {
         <MenuItem
           onClick={() => handleMeasurementMenu('clear')}
           attributes={{ id: 'context-menu-clear-measurements' }}
+          className={mobileStyle}
         >
           Remove Measurements
         </MenuItem>
@@ -133,6 +140,7 @@ function RightClickMenu(props) {
         <MenuItem
           onClick={() => handleMeasurementMenu('units')}
           attributes={{ id: 'context-menu-change-units' }}
+          className={mobileStyle}
         >
           Change Units to
           {' '}
@@ -145,7 +153,7 @@ function RightClickMenu(props) {
 
 function mapStateToProps(state) {
   const {
-    map, proj, measure, locationSearch, config,
+    map, proj, measure, locationSearch, config, screenSize,
   } = state;
   const { unitOfMeasure, allMeasurements, isActive } = measure;
   const { coordinates, isCoordinateSearchActive } = locationSearch;
@@ -158,6 +166,7 @@ function mapStateToProps(state) {
     coordinates,
     isCoordinateSearchActive,
     config,
+    isMobile: screenSize.isMobileDevice,
   };
 }
 
@@ -174,6 +183,7 @@ RightClickMenu.propTypes = {
   isCoordinateSearchActive: PropTypes.bool,
   allMeasurements: PropTypes.object,
   measurementIsActive: PropTypes.bool,
+  isMobile: PropTypes.bool,
 };
 
 export default connect(

--- a/web/scss/features/context-menu.scss
+++ b/web/scss/features/context-menu.scss
@@ -11,6 +11,11 @@
   transition: opacity 250ms ease !important;
 }
 
+.react-contextmenu-mobile {
+  font-size: 14px !important;
+  padding: 0.75rem 1.25rem !important;
+}
+
 .react-contextmenu.react-contextmenu--visible {
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
## Description

The context menu choices on mobile devices were too small. This updates the sizing for the menu options to be more mobile friendly.

## How To Test

Go into a mobile view and perform a context click (press and hold) and observe larger menu choices.


