### PR TITLE
WV-2401: Dont make CMR requests for granule layers when hidden

### DIFF
--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -78,6 +78,7 @@ class ModalContainer extends Component {
     const mobileTopOffset = 106;
     const top = isMobile && mobileFullScreen ? mobileTopOffset : offsetTop;
     const margin = isMobile && mobileFullScreen ? 0 : '0.5rem auto';
+    console.log('isMobile', isMobile, 'mobileFullScreen', mobileFullScreen, 'mobileTopOffset', mobileTopOffset, 'offsetTop', offsetTop, 'width', width, 'height', height);
     return {
       left: offsetLeft,
       right: offsetRight,

--- a/web/js/containers/modal.js
+++ b/web/js/containers/modal.js
@@ -78,7 +78,6 @@ class ModalContainer extends Component {
     const mobileTopOffset = 106;
     const top = isMobile && mobileFullScreen ? mobileTopOffset : offsetTop;
     const margin = isMobile && mobileFullScreen ? 0 : '0.5rem auto';
-    console.log('isMobile', isMobile, 'mobileFullScreen', mobileFullScreen, 'mobileTopOffset', mobileTopOffset, 'offsetTop', offsetTop, 'width', width, 'height', height);
     return {
       left: offsetLeft,
       right: offsetRight,

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -268,7 +268,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
         granules.unshift(item);
       }
     }
-    return granules.reverse();
+    return granules;
   };
 
   return {

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -1,5 +1,6 @@
 import OlLayerGroup from 'ol/layer/Group';
 import { throttle as lodashThrottle, find } from 'lodash';
+import OlCollection from 'ol/Collection';
 import { DEFAULT_NUM_GRANULES } from '../../modules/layers/constants';
 import { updateGranuleLayerState } from '../../modules/layers/actions';
 import { getGranuleLayer } from '../../modules/layers/selectors';
@@ -14,7 +15,6 @@ import { getCacheOptions } from '../../modules/layers/util';
 import { getGranulesUrl as getGranulesUrlSelector } from '../../modules/smart-handoff/selectors';
 import {
   getCMRQueryDates,
-  getCMRQueryDateUpdateOptions,
   isWithinDateRange,
   transformGranuleData,
   datelineShiftGranules,
@@ -27,10 +27,6 @@ const dayNightFilter = 'DAY'; // 'DAY', 'NIGHT', 'BOTH'
 
 export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
   const CMRDataStore = {};
-  const CMRDateRanges = {
-    active: {},
-    activeB: {},
-  };
   const getGranuleUrl = getGranulesUrlSelector(store.getState());
   const baseGranuleUrl = getGranuleUrl();
   const CMR_AJAX_OPTIONS = {
@@ -81,10 +77,18 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       CMRDataStore[conceptId].push(transformedGranule);
     });
     return CMRDataStore[conceptId].sort((a, b) => {
-      const dateA = new Date(a).valueOf();
-      const dateB = new Date(b).valueOf();
+      const dateA = new Date(a.date).valueOf();
+      const dateB = new Date(b.date).valueOf();
       return dateB - dateA;
     });
+  };
+
+  const datesHaveBeenQueried = (startQueryDate, endQueryDate, existingGranules) => {
+    const latestDate = new Date(existingGranules[0].date);
+    const earliestDate = new Date(existingGranules[existingGranules.length - 1].date);
+    const startIsCovered = isWithinDateRange(startQueryDate, earliestDate, latestDate);
+    const endIsCovered = isWithinDateRange(endQueryDate, earliestDate, latestDate);
+    return startIsCovered && endIsCovered;
   };
 
   /**
@@ -92,9 +96,9 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
    * @param {object} def - Layer specs
    * @param {object} date - current selected date (Note: may not return this date, but this date will be the max returned)
   */
-  const getQueriedGranuleDates = async (def, date, activeString) => {
+  const getQueriedGranuleDates = async (def, date) => {
     const {
-      endDate, startDate, id, title, visible, dateRanges,
+      endDate, startDate, title, visible, dateRanges,
     } = def;
     const { startQueryDate, endQueryDate } = getCMRQueryDates(date);
     const getGranulesUrl = getGranulesUrlSelector(store.getState());
@@ -102,64 +106,44 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     // TODO: USE GRANULE LAYER conceptId
     const shortName = 'VJ102MOD';
     const conceptId = shortName;
+    let data = [];
 
-    // update range/extend range checks and new dates (if applicable)
-    const CMRDateStoreForLayer = CMRDateRanges[activeString][id];
-    const {
-      canExtendRange,
-      needRangeUpdate,
-      rangeStart,
-      rangeEnd,
-    } = getCMRQueryDateUpdateOptions(CMRDateStoreForLayer, date, startQueryDate, endQueryDate);
+    const existingGranules = CMRDataStore[conceptId] || [];
 
-    // if layer id and query date range not previously requested, then fetch, process, and add to CMR query object
-    if (!CMRDateStoreForLayer || (CMRDateStoreForLayer && needRangeUpdate)) {
-      // update local CMR date object for layer
-      let startDateRange = startQueryDate;
-      let endDateRange = endQueryDate;
-      if (!CMRDateStoreForLayer) {
-        CMRDateRanges[activeString][id] = {};
-      } else if (canExtendRange) {
-        startDateRange = rangeStart;
-        endDateRange = rangeEnd;
-      }
-      CMRDateRanges[activeString][id].startDate = new Date(startDateRange);
-      CMRDateRanges[activeString][id].endDate = new Date(endDateRange);
-
-      showLoading();
-      let data;
-      try {
-        const params = {
-          // conceptId,
-          shortName,
-          startDate: startQueryDate.toISOString(),
-          endDate: endQueryDate.toISOString(),
-          dayNight: dayNightFilter,
-          pageSize: 1000,
-        };
-        const response = await fetch(getGranulesUrl(params), CMR_AJAX_OPTIONS);
-        data = await response.json();
-        data = data.feed.entry;
-
-        if (data.length === 0) {
-          const dateWithinRange = isWithinDateRange(date, startDate, endDate);
-          // only show modal error if layer not set to hidden and outside of selected date range
-          if (visible && dateWithinRange) {
-            throttleDispathCMRErrorDialog(title);
-          }
-          return [];
-        }
-      } catch (e) {
-        console.error(e);
-        throttleDispathCMRErrorDialog(title);
-        return [];
-      } finally {
-        hideLoading();
-      }
-      return addGranuleCMRDateData(data, conceptId, dateRanges);
+    if (existingGranules.length && datesHaveBeenQueried(startQueryDate, endQueryDate, existingGranules)) {
+      return existingGranules;
     }
-    // user previously queried CMR granule dates
-    return CMRDataStore[conceptId];
+
+    showLoading();
+    try {
+      const params = {
+        // conceptId,
+        shortName,
+        startDate: startQueryDate.toISOString(),
+        endDate: endQueryDate.toISOString(),
+        dayNight: dayNightFilter,
+        pageSize: 1000,
+      };
+      const response = await fetch(getGranulesUrl(params), CMR_AJAX_OPTIONS);
+      data = await response.json();
+      data = data.feed.entry;
+
+      if (data.length === 0) {
+        const dateWithinRange = isWithinDateRange(date, startDate, endDate);
+        // only show modal error if layer not set to hidden and outside of selected date range
+        if (visible && dateWithinRange) {
+          throttleDispathCMRErrorDialog(title);
+        }
+        return data;
+      }
+    } catch (e) {
+      console.error(e);
+      throttleDispathCMRErrorDialog(title);
+      return data;
+    } finally {
+      hideLoading();
+    }
+    return addGranuleCMRDateData(data, conceptId, dateRanges);
   };
 
   /**
@@ -209,20 +193,25 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       animation: { isPlaying },
       proj: { selected: { crs, maxExtent } },
     } = store.getState();
-    const { id } = def;
+    const { id, startDate, endDate } = def;
     const { date, group } = attributes;
+    const granuleLayer = new OlLayerGroup();
+    granuleLayer.wv = { ...attributes };
+
+    const dateInRange = isWithinDateRange(date, new Date(startDate), new Date(endDate));
+    if (!dateInRange) {
+      return granuleLayer;
+    }
+
     const granuleAttributes = await getGranuleAttributes(def, options);
     const { visibleGranules } = granuleAttributes;
     const granules = datelineShiftGranules(visibleGranules, date, crs);
-    const tileLayers = createGranuleTileLayers(granules, def, attributes);
-    const layer = new OlLayerGroup({
-      layers: tileLayers,
-      extent: crs === 'EPSG:4326' ? FULL_MAP_EXTENT : maxExtent,
-    });
-
-    layer.set('granuleGroup', true);
-    layer.set('layerId', `${id}-${group}`);
-    layer.wv = {
+    const tileLayers = new OlCollection(createGranuleTileLayers(granules, def, attributes));
+    granuleLayer.setLayers(tileLayers);
+    granuleLayer.setExtent(crs === 'EPSG:4326' ? FULL_MAP_EXTENT : maxExtent);
+    granuleLayer.set('granuleGroup', true);
+    granuleLayer.set('layerId', `${id}-${group}`);
+    granuleLayer.wv = {
       ...attributes,
       ...granuleAttributes,
       visibleGranules: granules,
@@ -230,10 +219,10 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
 
     // Don't update during animation due to the performance hit
     if (!isPlaying) {
-      store.dispatch(updateGranuleLayerState(layer));
+      store.dispatch(updateGranuleLayerState(granuleLayer));
     }
 
-    return layer;
+    return granuleLayer;
   };
 
   /**
@@ -271,7 +260,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const granules = [];
     if (!availableGranules.length) return granules;
 
-    for (let i = availableGranules.length - 1; i >= 0 && granules.length < granuleCount; i -= 1) {
+    for (let i = 0; granules.length < granuleCount; i += 1) {
       const item = availableGranules[i];
       const { date } = item;
       const granuleDate = new Date(date);
@@ -279,7 +268,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
         granules.unshift(item);
       }
     }
-    return granules;
+    return granules.reverse();
   };
 
   return {

--- a/web/js/map/granule/granule-layer-builder.test.js
+++ b/web/js/map/granule/granule-layer-builder.test.js
@@ -7,8 +7,6 @@ import granuleLayerBuilder from './granule-layer-builder';
 import { LOADING_START, LOADING_STOP } from '../../modules/loading/constants';
 import { LOADING_GRANULES } from '../../modules/loading/actions';
 import { ADD_GRANULE_LAYER_DATES } from '../../modules/layers/constants';
-import { OPEN_BASIC } from '../../modules/modal/constants';
-
 
 const mockBaseCmrApi = 'mock.cmr.api/';
 const queryString = '?shortName=VJ102MOD&day_night_flag=DAY&temporal=2019-09-24T00%3A54%3A00.000Z%2C2019-09-24T12%3A54%3A00.000Z&pageSize=1000 ';

--- a/web/js/map/granule/granule-layer-builder.test.js
+++ b/web/js/map/granule/granule-layer-builder.test.js
@@ -11,7 +11,7 @@ import { OPEN_BASIC } from '../../modules/modal/constants';
 
 
 const mockBaseCmrApi = 'mock.cmr.api/';
-const queryString = '?shortName=VJ102MOD&day_night_flag=DAY&temporal=2019-09-23T00%3A00%3A00.000Z%2C2019-09-25T00%3A00%3A00.000Z&pageSize=1000';
+const queryString = '?shortName=VJ102MOD&day_night_flag=DAY&temporal=2019-09-24T00%3A54%3A00.000Z%2C2019-09-24T12%3A54%3A00.000Z&pageSize=1000 ';
 const cmrGranules = require('../../../mock/cmr_granules.json');
 
 fetchMock.mock(`${mockBaseCmrApi}granules.json${queryString}`, cmrGranules)
@@ -78,7 +78,7 @@ describe('granule layer builder', () => {
     expect(thirdAction.count).toEqual(thirdAction.dates.length);
   });
 
-  it('dispatches modal open action when CMR unreachable', async () => {
+  it('doesnt query cmr when date falls outside range', async () => {
     const options = {
       group: 'active',
       date: new Date(Date.UTC('2016', '08', '24', '08', '54', '00')),
@@ -88,12 +88,8 @@ describe('granule layer builder', () => {
       def: granuleLayerDef,
     };
     await createGranuleLayer(granuleLayerDef, attributes, options);
-    const [firstAction, secondAction] = store.getActions();
-
-    expect(firstAction.type).toEqual(LOADING_START);
-    expect(firstAction.key).toEqual(LOADING_GRANULES);
-    // CMR unreachable modal opened
-    expect(secondAction.type).toEqual(OPEN_BASIC);
+    const actions = store.getActions();
+    expect(actions.length).toEqual(0);
   });
 
   it('sets expected layer properties', async () => {

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -116,22 +116,9 @@ export const getGranuleFootprints = (layer) => {
     * @param {object} endQueryDate - date object
   */
 export const getCMRQueryDates = (selectedDate) => {
-  // check if selectedDate is before or after 12 to determine date request range
-  const current = new Date(new Date().setMilliseconds(0));
   const date = new Date(selectedDate);
-  const isDateAfterNoon = date.getUTCHours() > 12;
-
-  const zeroedDate = util.clearTimeUTC(date);
-
-  const dayBeforeDate = util.dateAdd(zeroedDate, 'day', -1);
-  const dayAfterDate = util.dateAdd(zeroedDate, 'day', 1);
-  const twoDayAfterDate = util.dateAdd(zeroedDate, 'day', 2);
-
-  const startQueryDate = dayBeforeDate;
-  let endQueryDate = isDateAfterNoon ? twoDayAfterDate : dayAfterDate;
-
-  // set current date if on leading edge of time coverage
-  endQueryDate = endQueryDate > current ? current : endQueryDate;
+  const startQueryDate = util.dateAdd(date, 'hour', -8);
+  const endQueryDate = util.dateAdd(date, 'hour', 4);
 
   return {
     startQueryDate,

--- a/web/js/map/granule/util.test.js
+++ b/web/js/map/granule/util.test.js
@@ -54,32 +54,10 @@ describe('shifting dateline granules', () => {
 });
 
 describe('getting CMR query date range', () => {
-  it('starts one day before, ends one day after, ', () => {
-    const selectedDate = new Date('2019-09-24T00:12:00.000Z');
-    const expectedStart = new Date('2019-09-23T00:00:00.000Z');
-    const expectedEnd = new Date('2019-09-25T00:00:00.000Z');
-
-    const { startQueryDate, endQueryDate } = getCMRQueryDates(selectedDate);
-    expect(startQueryDate).toEqual(expectedStart);
-    expect(endQueryDate).toEqual(expectedEnd);
-  });
-
-  it('if selected date is after noon: starts one day before, ends two days after', () => {
-    const selectedDate = new Date('2019-09-24T13:00:00.000Z');
-    const expectedStart = new Date('2019-09-23T00:00:00.000Z');
-    const expectedEnd = new Date('2019-09-26T00:00:00.000Z');
-
-    const { startQueryDate, endQueryDate } = getCMRQueryDates(selectedDate);
-    expect(startQueryDate).toEqual(expectedStart);
-    expect(endQueryDate).toEqual(expectedEnd);
-  });
-
-  it('if selected date is now: start one day before, end now', () => {
-    const selectedDate = new Date(new Date().setMilliseconds(0));
-    const expectedEnd = selectedDate;
-    const expectedStart = new Date(selectedDate.getTime());
-    expectedStart.setDate(selectedDate.getDate() - 1);
-    expectedStart.setUTCHours(0, 0, 0, 0);
+  it('starts 8 hours before, 4 hours after, ', () => {
+    const selectedDate = new Date('2019-09-24T00:20:00.000Z');
+    const expectedStart = new Date('2019-09-23T16:20:00.000Z');
+    const expectedEnd = new Date('2019-09-24T04:20:00.000Z');
 
     const { startQueryDate, endQueryDate } = getCMRQueryDates(selectedDate);
     expect(startQueryDate).toEqual(expectedStart);

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -413,7 +413,7 @@ export default function mapLayerBuilder(config, cache, store) {
       cacheSize: 4096,
       crossOrigin: 'anonymous',
       format,
-      transition: 0,
+      transition: 300,
       matrixSet: configMatrixSet.id,
       tileGrid: new OlTileGridWMTS(tileGridOptions),
       wrapX: false,

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -289,6 +289,9 @@ export async function promiseImageryForTime(state, date, activeString) {
   } = map.ui;
   const layers = getActiveVisibleLayersAtDate(state, date, activeString);
   await Promise.all(layers.map(async (layer) => {
+    if (layer.type === 'granule') {
+      return Promise.resolve();
+    }
     const options = { date, group: activeString };
     const key = layerKey(layer, options, state);
     const layerGroup = cache.getItem(key) || await createLayer(layer, options);


### PR DESCRIPTION
## Description

- dont preload granule layers
- dont query CMR when date is outside of visible range
- make smaller, more frequent CMR queries for better performance
- add 300ms fade in transition for wmts layers

## How To Test
 
* Checkout `granule-configs` branch
* `npm run build`
* Checkout this branch
* `npm run watch`

1. Open the app with granule imagery loaded: http://localhost:3000/?v=-201.0665583055787,-193.38317231884434,204.86652956509218,216.8487530935734&z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule_v2.1_NRT,Coastlines_15m&lg=true&t=2022-07-03-T15%3A39%3A00Z
2. Open the network tab and filter results to `granules.json` to watch CMR requests go out
3. Hide the granule layer
4. Step forward one day
5. Confirm CMR requests not sent
6. Show the granule layer
7. Change date to something outside the layer's available range (e.g. 2021)
8. Confirm CMR requests not sent




