### PR TITLE
WV-2396: Dateline tooltip hover delay

### DIFF
--- a/web/js/components/dateline/line.js
+++ b/web/js/components/dateline/line.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef} from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import OlOverlay from 'ol/Overlay';
 import util from '../../util/util';
@@ -17,173 +17,123 @@ const lineStyles = {
 };
 
 export default function Line (props) {
+  const {
+    id,
+    alwaysShow,
+    date,
+    lineX,
+    lineY,
+    isCompareActive,
+    style,
+    map,
+    height,
+    setTextCoords,
+    textCoords,
+    hideText,
+  } = props;
 
   const [overlay, setOverlay] = useState('');
-  const [hovered, setHovered] = useState(false);
-  const [textActive, setTextActive] = useState(props.alwaysShow);
+  const [hovered, toggleHovered] = useState(false);
+  const [textActive, toggleTextActive] = useState(alwaysShow);
+  const prevAlwaysShow = usePrevious(alwaysShow);
 
   const nodeRef = useRef();
   const timerRef = useRef();
 
-  // constructor(props) {
-    // super(props);
-    // this.state = {
-    //   overlay: '',
-    //   hovered: false,
-    //   textActive: props.alwaysShow,
-    // };
-    // this.nodeRef = React.createRef();
-    // this.timerRef = React.createRef();
-  // }
-
-  // componentDidMount() {
-  //   const { lineX, map } = props;
-  //   const overlay = new OlOverlay({
-  //     element: nodeRef.current,
-  //     stopEvent: false,
-  //   });
-  //   overlay.setPosition([lineX, 90]);
-  //   map.addOverlay(overlay);
-  //   // this.setState({ overlay });
-  //   setOverlay({ overlay })
-  // }
-
-  //componentDidMount()
   useEffect(() => {
-    const { lineX, map } = props;
     const newOverlay = new OlOverlay({
       element: nodeRef.current,
       stopEvent: false,
     });
     newOverlay.setPosition([lineX, 90]);
     map.addOverlay(newOverlay);
+    setOverlay(newOverlay);
+  }, []);
 
-    setOverlay(newOverlay)
-    console.log("CDM Overlay", overlay)
-    console.log("newOverlay", newOverlay)
-  }, [])
-
-  const prevAlwaysShow = usePrevious(props.alwaysShow)
-
-  //componentDidUpdate
   useEffect(() => {
-    console.log("componentDidUpdate")
-    const { lineX, lineY, alwaysShow } = props;
-
-    console.log("CDU overlay",overlay)
-
-    // overlay.setPosition([lineX, lineY]);
-
+    if (overlay !== '') return overlay.setPosition([lineX, lineY]);
     if (!alwaysShow && alwaysShow !== prevAlwaysShow) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      setTextActive(true)
+      toggleTextActive(true);
     }
-  })
-
-  // componentDidUpdate(prevProps) {
-  //   const { lineX, lineY, alwaysShow } = props;
-  //   const { overlay } = state;
-  //   overlay.setPosition([lineX, lineY]);
-  //   if (!alwaysShow && alwaysShow !== prevProps.alwaysShow) {
-  //     // eslint-disable-next-line react/no-did-update-set-state
-  //     this.setState({ textActive: false });
-  //   }
-  // }
+  });
 
   const mouseOver = () => {
-    setHovered(true)
-  }
+    toggleHovered(true);
+  };
 
   const mouseOut = () => {
-    setHovered(false)
-  }
+    toggleHovered(false);
+  };
 
   const mouseOverHidden = (e) => {
-    const { map, setTextCoords } = props;
     const coords = map.getCoordinateFromPixel([e.clientX, e.clientY]);
-
     timerRef.current = setTimeout(() => {
       setTextCoords(coords);
-      setTextActive(true)
+      toggleTextActive(true);
     }, 500);
-  }
+  };
 
   const mouseLeaveHidden = () => {
     clearTimeout(timerRef.current);
-    setTextActive(false)
-  }
+    toggleTextActive(false);
+  };
 
-  // render() {
-    const {
-      id,
-      alwaysShow,
-      date,
-      lineX,
-      isCompareActive,
-      style,
-      map,
-      height,
-      textCoords,
-      hideText,
-    } = props;
-    // const { hovered, textActive } = this.state;
+  const {
+    strokeWidth, dashArray, color, svgStyle, width,
+  } = lineStyles;
+  const useOpacity = alwaysShow || util.browser.mobileAndTabletDevice || hovered
+    ? lineStyles.opacity
+    : '0';
 
-    const {
-      strokeWidth, dashArray, color, svgStyle, width,
-    } = lineStyles;
-    const useOpacity = alwaysShow || util.browser.mobileAndTabletDevice || hovered
-      ? lineStyles.opacity
-      : '0';
-
-    return (
-      <>
-        <svg
-          id={id}
-          ref={nodeRef}
-          className="dateline-case"
-          style={svgStyle}
-          height={height}
-          width={width}
-          onMouseOver={mouseOver}
-          onMouseOut={mouseOut}
-        >
-          <line
-            strokeWidth={strokeWidth}
-            stroke={color}
-            opacity={useOpacity}
-            x1={strokeWidth / 2}
-            x2={strokeWidth / 2}
-            strokeDasharray={dashArray}
-            y1="0"
-            y2={height}
-          />
-          <line
-            className="dateline-hidden"
-            onMouseOver={mouseOverHidden}
-            onMouseLeave={mouseLeaveHidden}
-            style={style}
-            opacity="0"
-            x1={strokeWidth / 2}
-            x2={strokeWidth / 2}
-            strokeWidth={strokeWidth}
-            stroke={color}
-            y1="0"
-            y2={height}
-          />
-        </svg>
-        <LineText
-          active={!hideText && (alwaysShow || textActive)}
-          map={map}
-          date={date}
-          x={lineX}
-          y={90}
-          isCompareActive={isCompareActive}
-          isLeft={lineX < 0}
-          textCoords={textCoords}
+  return (
+    <>
+      <svg
+        id={id}
+        ref={nodeRef}
+        className="dateline-case"
+        style={svgStyle}
+        height={height}
+        width={width}
+        onMouseOver={mouseOver}
+        onMouseOut={mouseOut}
+      >
+        <line
+          strokeWidth={strokeWidth}
+          stroke={color}
+          opacity={useOpacity}
+          x1={strokeWidth / 2}
+          x2={strokeWidth / 2}
+          strokeDasharray={dashArray}
+          y1="0"
+          y2={height}
         />
-      </>
-    );
-  }
+        <line
+          className="dateline-hidden"
+          onMouseOver={mouseOverHidden}
+          onMouseLeave={mouseLeaveHidden}
+          style={style}
+          opacity="0"
+          x1={strokeWidth / 2}
+          x2={strokeWidth / 2}
+          strokeWidth={strokeWidth}
+          stroke={color}
+          y1="0"
+          y2={height}
+        />
+      </svg>
+      <LineText
+        active={!hideText && (alwaysShow || textActive)}
+        map={map}
+        date={date}
+        x={lineX}
+        y={90}
+        isCompareActive={isCompareActive}
+        isLeft={lineX < 0}
+        textCoords={textCoords}
+      />
+    </>
+  );
+}
 
 
 Line.propTypes = {

--- a/web/js/components/dateline/line.js
+++ b/web/js/components/dateline/line.js
@@ -70,7 +70,7 @@ export default function Line (props) {
     timerRef.current = setTimeout(() => {
       setTextCoords(coords);
       toggleTextActive(true);
-    }, 500);
+    }, 300);
   };
 
   const mouseLeaveHidden = () => {

--- a/web/js/components/dateline/line.js
+++ b/web/js/components/dateline/line.js
@@ -24,6 +24,7 @@ class Line extends React.Component {
       textActive: props.alwaysShow,
     };
     this.nodeRef = React.createRef();
+    this.timerRef = React.createRef();
   }
 
   componentDidMount() {
@@ -61,13 +62,18 @@ class Line extends React.Component {
 
   mouseOverHidden = (e) => {
     const { map, setTextCoords } = this.props;
-    setTextCoords(map.getCoordinateFromPixel([e.clientX, e.clientY]));
-    this.setState({
-      textActive: true,
-    });
+    const coords = map.getCoordinateFromPixel([e.clientX, e.clientY]);
+
+    this.timerRef.current = setTimeout(() => {
+      setTextCoords(coords);
+      this.setState({
+        textActive: true,
+      });
+    }, 500);
   }
 
-  mouseOutHidden = () => {
+  mouseLeaveHidden = () => {
+    clearTimeout(this.timerRef.current);
     this.setState({ textActive: false });
   }
 
@@ -118,8 +124,7 @@ class Line extends React.Component {
           <line
             className="dateline-hidden"
             onMouseOver={this.mouseOverHidden}
-            onMouseMove={this.mouseOverHidden}
-            onMouseOut={this.mouseOutHidden}
+            onMouseLeave={this.mouseLeaveHidden}
             style={style}
             opacity="0"
             x1={strokeWidth / 2}

--- a/web/js/util/customHooks.js
+++ b/web/js/util/customHooks.js
@@ -1,0 +1,10 @@
+import { useState, useEffect, useRef} from 'react';
+
+//customHook to get previous value of a prop... see prevProps from class components
+export default function usePrevious (value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current;
+};

--- a/web/js/util/customHooks.js
+++ b/web/js/util/customHooks.js
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef} from 'react';
+import { useEffect, useRef } from 'react';
 
-//customHook to get previous value of a prop... see prevProps from class components
+// customHook to get previous value of a prop... see prevProps for class components
 export default function usePrevious (value) {
   const ref = useRef();
   useEffect(() => {
-    ref.current = value
-  }, [value])
+    ref.current = value;
+  }, [value]);
   return ref.current;
-};
+}


### PR DESCRIPTION
## Description

When browsing granules it can be difficult to view granules very close to the dateline because every time you move the mouse over the dateline the tooltip will move to your current mouse position. This update changes the logic so that the tool tip only moves to your mouse position if you hover over the dateline for at least 500ms. 

I felt that the Line component that this logic is located in was a good component to update from a class component to a function component since it can utilize several modern hooks. This will improve performance and make it easy to make future changes to this component. 

I have also create a customHook file located in the util directory. I added a custom hook for getting the previous value of a prop or state property. This is very useful as unlike class components, function components do not have the built in ability to pass `prevProps` in a `componentDidUpdate` lifecycle function.

## How To Test

Go to the global settings and set the dateline to `always` show. Hover over the dateline for 500ms or more and observe how the tooltip does not move right away. If you move your mouse over the dateline without hovering over the tooltip, the tooltip should not move at all.




