### PR TITLE
WV-2439: Map zoom buttons showing on mobile

### DIFF
--- a/web/js/components/map/rotation.js
+++ b/web/js/components/map/rotation.js
@@ -57,9 +57,10 @@ class Rotation extends React.Component {
     } = this.props;
     const currentRotation = Number(rotation * (180 / Math.PI)).toFixed();
     const isPolarProj = proj.id !== 'geographic' && proj.id !== 'webmerc';
+    const rotationButtonClass = isMobile ? 'wv-rotation-buttons-mobile' : 'wv-rotation-buttons';
 
     return !isDistractionFreeModeActive && isPolarProj && (
-      <div className="wv-rotation-buttons">
+      <div className={rotationButtonClass}>
         <button
           type="button"
           className="wv-map-rotate-left wv-map-zoom"

--- a/web/js/components/map/zoom.js
+++ b/web/js/components/map/zoom.js
@@ -12,8 +12,10 @@ function Zoom({
   const zoomOutDisabled = zoomLevel === 0;
   if (!map) return null;
 
+  const zoomButtonClass = isMobile ? 'wv-zoom-buttons-mobile' : 'wv-zoom-buttons';
+
   return !isDistractionFreeModeActive && (
-    <div className="wv-zoom-buttons">
+    <div className={zoomButtonClass}>
       <button
         type="button"
         disabled={zoomInDisabled}

--- a/web/scss/features/map.scss
+++ b/web/scss/features/map.scss
@@ -99,14 +99,16 @@
   border-bottom-right-radius: 10px;
 }
 
-@media (max-width: $mobile-max-width) {
-  .wv-zoom-buttons {
-    display: none;
-  }
+.wv-zoom-buttons-mobile {
+  display: none;
+}
 
-  .wv-rotation-buttons {
-    top: 96px;
-  }
+.wv-rotation-buttons-mobile {
+  top: 96px;
+  right: 10px;
+  width: 38px;
+  height: 130px;
+  position: absolute;
 
   .wv-map-rotate-left,
   .wv-map-rotate-right {


### PR DESCRIPTION
## Description

The zoom buttons were showing in mobile views when they should be hidden. This was a side effect of changing the mobile detection library. The zoom buttons are now hidden in mobile views. I also fixed the placement of the rotation buttons on polar projections.

## How To Test

Open a mobile view and observe that the zoom buttons are not visible.
View a polar projection and observe the placement of the rotation buttons.






