### PR TITLE
Documentation link style is incorrect in Embed modal

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -279,7 +279,7 @@ class ShareLinkContainer extends Component {
             <p>
               Embed @NAME@ in your website. See our
               {' '}
-              <a className="share-embed-doc-link" href="https://github.com/nasa-gibs/worldview/blob/main/doc/embed.md" target="_blank" rel="noopener noreferrer">documentation</a>
+              <a id="share-embed-doc-link" className="share-embed-doc-link" href="https://github.com/nasa-gibs/worldview/blob/main/doc/embed.md" target="_blank" rel="noopener noreferrer">documentation</a>
               {' '}
               for a guide.
             </p>

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -92,11 +92,12 @@
     }
   }
 
-  a.share-embed-doc-link {
+  a.share-embed-doc-link, #share-embed-doc-link {
     color: #7bf;
 
     &:hover {
       color: #7df;
+      text-decoration: underline;
     }
   }
 

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -92,7 +92,8 @@
     }
   }
 
-  a.share-embed-doc-link, #share-embed-doc-link {
+  a.share-embed-doc-link,
+  #share-embed-doc-link {
     color: #7bf;
 
     &:hover {


### PR DESCRIPTION
## Description
There is a link to "Documentation" in the Embed modal which required styling. The link is white which matches the text & the text becomes black on mouse hover, making it difficult to read. This PR applies existing styles (variations of light blue) from share.scss to this link.

## How To Test
Load WV, select the Share icon, select Embed & confirm that the hyperlink is styled appropriately normally & when hovered.

## Notes
There is no WV ticket number associated with this PR due to it's simplicity.

@nasa-gibs/worldview
