### PR TITLE
WV-2448: Change default Corrected Reflectance layer & initial map position

### DIFF
--- a/config/default/common/config/wv.json/defaults.json
+++ b/config/default/common/config/wv.json/defaults.json
@@ -3,11 +3,11 @@
         "projection": "geographic",
         "startingLayers": [
             {
-                "id": "MODIS_Terra_CorrectedReflectance_TrueColor"
+                "id": "MODIS_Terra_CorrectedReflectance_TrueColor",
+                "hidden": "true"
             },
             {
-                "id": "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                "hidden": "true"
+                "id": "MODIS_Aqua_CorrectedReflectance_TrueColor"
             },
             {
                 "id": "VIIRS_SNPP_CorrectedReflectance_TrueColor",

--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -56,7 +56,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -68,7 +68,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -142,11 +142,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -212,11 +212,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -238,11 +238,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -268,7 +268,7 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands367",
@@ -276,7 +276,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -316,11 +316,11 @@
                 "Volcanoes": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -376,7 +376,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -384,7 +384,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
@@ -478,11 +478,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -556,11 +556,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -590,11 +590,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -632,7 +632,7 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands367",
@@ -640,7 +640,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -674,11 +674,11 @@
                 "Volcanoes": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -768,7 +768,7 @@
                 "Manmade": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -784,7 +784,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_SurfaceReflectance_Bands121",
@@ -814,11 +814,11 @@
                 "Dust and Haze": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -890,7 +890,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -906,7 +906,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
@@ -980,11 +980,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -1054,12 +1054,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
-
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_SNPP_CorrectedReflectance_TrueColor",

--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -64,11 +64,11 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -126,19 +126,16 @@ export function mapIsExtentValid(extent) {
  */
 export function getLeadingExtent(loadtime) {
   let curHour = loadtime.getUTCHours();
-  const timeOffset = 8;
-
   // For earlier hours when data is still being filled in, force a far eastern perspective
   if (curHour < 3) {
     curHour = 23;
   } else if (curHour < 9) {
     curHour = 0;
-  } else {
-    curHour -= timeOffset;
   }
 
   // Compute east/west bounds
-  const minLon = 20.6015625 + curHour * (-200.53125 / 23.0);
+  const timeOffset = 8;
+  const minLon = 20.6015625 + (curHour - timeOffset) * (-200.53125 / 23.0);
   const maxLon = minLon + 159.328125;
 
   const minLat = -46.546875;

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -126,12 +126,15 @@ export function mapIsExtentValid(extent) {
  */
 export function getLeadingExtent(loadtime) {
   let curHour = loadtime.getUTCHours();
+  const timeOffset = 8;
 
   // For earlier hours when data is still being filled in, force a far eastern perspective
   if (curHour < 3) {
     curHour = 23;
   } else if (curHour < 9) {
     curHour = 0;
+  } else {
+    curHour -= timeOffset;
   }
 
   // Compute east/west bounds

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -125,19 +125,12 @@ export function mapIsExtentValid(extent) {
  * @returns {object} Extent Array
  */
 export function getLeadingExtent(loadtime) {
-  let curHour = loadtime.getUTCHours();
-  // For earlier hours when data is still being filled in, force a far eastern perspective
-  if (curHour < 3) {
-    curHour = 23;
-  } else if (curHour < 9) {
-    curHour = 0;
-  }
+  const curHour = loadtime.getUTCHours();
 
-  // Compute east/west bounds
-  // eastWestOffset > 0 move the default map to the east. eastWestOffset < 0 move the default map to the west.
-  const eastWestOffset = 8;
-  const minLonConst = 20;
-  const maxLongConst = 160;
+  // These values are specifically tuned for the Aqua/MODIS default Corrected Reflectance Layer
+  const eastWestOffset = curHour * 0.6;
+  const minLonConst = 10;
+  const maxLongConst = 170;
   const minLonMultiplier = -200 / 23;
   const minLon = minLonConst + (curHour - eastWestOffset) * minLonMultiplier;
   const maxLon = minLon + maxLongConst;

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -112,12 +112,6 @@ export function mapIsExtentValid(extent) {
 /*
  * Set default extent according to time of day:
  *
- * at 00:00 UTC, start at far eastern edge of
- * map: "20.6015625,-46.546875,179.9296875,53.015625"
- *
- * at 23:00 UTC, start at far western edge of map:
- * "-179.9296875,-46.546875,-20.6015625,53.015625"
- *
  * @method getLeadingExtent
  * @static
  * @param {Object} Time

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -134,12 +134,16 @@ export function getLeadingExtent(loadtime) {
   }
 
   // Compute east/west bounds
-  const timeOffset = 8;
-  const minLon = 20.6015625 + (curHour - timeOffset) * (-200.53125 / 23.0);
-  const maxLon = minLon + 159.328125;
+  // eastWestOffset > 0 move the default map to the east. eastWestOffset < 0 move the default map to the west.
+  const eastWestOffset = 8;
+  const minLonConst = 20;
+  const maxLongConst = 160;
+  const minLonMultiplier = -200 / 23;
+  const minLon = minLonConst + (curHour - eastWestOffset) * minLonMultiplier;
+  const maxLon = minLon + maxLongConst;
 
-  const minLat = -46.546875;
-  const maxLat = 53.015625;
+  const minLat = -47;
+  const maxLat = 53;
 
   return [minLon, minLat, maxLon, maxLat];
 }


### PR DESCRIPTION
## Description
Terra will be adjusting its orbital configuration on October 12, 2022 at which point it will not produce data. We need to alter the following in WV:

- Change the default Corrected Reflectance layer from Terra/MODIS to Aqua/MODIS.
- Adjust the default map position to be more eastward to compensate for Aqua/MODIS later overpass time compared to Terra.
- Update default Natural Event preference from Terra/MODIS to Aqua/MODIS.
- Tour stories: change the default layer for the Intro to Worldview story from Terra/MODIS to Aqua/MODIS.

## How To Test
- Load the PR.
- Run `npm run build:config` to update the configuration.
- Load WV & confirm:
  - The default Corrected Reflectance Layer is loading Aqua/MODIS properly.
  - The map view is sufficiently eastward, meaning graphics fill the majority of the visible map on initial load
  - All "Events" are defaulting to Aqua/MODIS in the layer selector
  - Tour Stories: Intro To Worldview is using Aqua/MODIS Layer

@nasa-gibs/worldview
