### PR TITLE
WV-2427: Drop python 2 check

### DIFF
--- a/tasks/pythonInstall.sh
+++ b/tasks/pythonInstall.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 # Install python dependencies
-PYTHON_VERSION="$(python -V 2>&1)"
-
-if command -v python3 &>/dev/null; then
-  echo "Installing pipenv and dependencies with python3"
-  python3 -m pip install pipenv==2020.11.15
-  python3 -m pipenv install
-elif [[ $PYTHON_VERSION = *"Python 3"* ]]; then
-  echo "Installing pipenv and dependencies  with python"
-  pip install pipenv
-  pipenv install
-else
-  echo "Please install or update python v3"
-fi
+echo "Installing pipenv and dependencies with python3"
+python3 -m pip install pipenv==2022.9.21
+python3 -m pipenv install


### PR DESCRIPTION
## Description
* Drop python 2 check, assume python 3
* Update pipenv version to latest


## How To Test

* `npm run python` 
* Confirm latest pipenv and dependencies install succesfully
* `npm run build`
* `npm run start`
* Confirm app loads and works as expected
