### PR TITLE
WV-2450: Fix web mercator support

### DIFF
--- a/tasks/upload.js
+++ b/tasks/upload.js
@@ -109,7 +109,11 @@ if (!name) {
 async function upload() {
   console.log(`Uploading to ${host}`);
   try {
-    await ssh.connect({ host, username, privateKey: key });
+    await ssh.connect({
+      host,
+      username,
+      privateKeyPath: key,
+    });
     let cmd = `
       [ -e ${root}/${name}/${worldview} ] &&
       rm -rf ${root}/${name} &&

--- a/tasks/upload.js
+++ b/tasks/upload.js
@@ -5,7 +5,7 @@ const os = require('os');
 const path = require('path');
 const yargs = require('yargs');
 const shell = require('shelljs');
-const NodeSSH = require('node-ssh');
+const { NodeSSH } = require('node-ssh');
 
 const ssh = new NodeSSH();
 

--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -13,6 +13,7 @@ import { changeUnits } from '../../modules/measure/actions';
 import { getFormattedCoordinates, getNormalizedCoordinate } from '../location-search/util';
 import { areCoordinatesWithinExtent } from '../../modules/location-search/util';
 import { CONTEXT_MENU_LOCATION, MAP_SINGLE_CLICK, MAP_CONTEXT_MENU } from '../../util/constants';
+import { CRS } from '../../modules/map/constants';
 
 const { events } = util;
 
@@ -25,14 +26,14 @@ function RightClickMenu(props) {
     map, proj, unitOfMeasure, onToggleUnits, isCoordinateSearchActive, allMeasurements, measurementIsActive, isMobile,
   } = props;
   const { crs } = proj.selected;
-  const measurementsInProj = !!Object.keys(allMeasurements[crs]).length;
+  const measurementsInProj = !!(Object.keys(allMeasurements[crs]) || []).length;
   const handleClick = () => (show ? setShow(false) : null);
 
   function handleContextEvent(event) {
     if (measurementIsActive) return;
     event.originalEvent.preventDefault();
     const coord = map.getCoordinateFromPixel(event.pixel);
-    const tCoord = transform(coord, crs, 'EPSG:4326');
+    const tCoord = transform(coord, crs, CRS.GEOGRAPHIC);
     const [lon, lat] = getNormalizedCoordinate(tCoord);
 
     if (areCoordinatesWithinExtent(proj, [lon, lat])) {
@@ -86,7 +87,7 @@ function RightClickMenu(props) {
     };
   });
 
-  const mobileStyle = isMobile && 'react-contextmenu-mobile';
+  const mobileStyle = isMobile ? 'react-contextmenu-mobile' : '';
 
   return show && (
     <div id="context-menu">

--- a/web/js/components/dateline/datelines.js
+++ b/web/js/components/dateline/datelines.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Line from './line';
 import util from '../../util/util';
 import { getSelectedDate } from '../../modules/date/selectors';
+import { CRS } from '../../modules/map/constants';
 
 function DateLines(props) {
   const {
@@ -53,7 +54,7 @@ function DateLines(props) {
   };
 
   useEffect(() => {
-    if (!proj.selected.crs === 'EPSG:4326') {
+    if (!proj.selected.crs === CRS.GEOGRAPHIC) {
       setHideLines(true);
     }
   }, [proj]);
@@ -111,7 +112,7 @@ const mapStateToProps = (state) => {
     proj, map, compare, settings, modal,
   } = state;
   const isImageDownload = modal.id === 'TOOLBAR_SNAPSHOT' && modal.isOpen;
-  const isGeographic = proj.selected.crs === 'EPSG:4326';
+  const isGeographic = proj.selected.crs === CRS.GEOGRAPHIC;
   return {
     proj,
     map: map.ui.selected,

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -6,7 +6,7 @@ import {
 import { containsExtent, isEmpty } from 'ol/extent';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
+import { CRS } from '../../modules/map/constants';
 
 const isValidExtent = (extent) => {
   if (extent.length !== 4) return false;
@@ -29,7 +29,7 @@ const Input = ({
       const newInputValue = Number(inputValue);
       const newArray = lodashClone(boundingBoxArray);
       newArray[index] = newInputValue;
-      const crsCorrectedExtent = olProj.transformExtent(newArray, 'EPSG:4326', crs);
+      const crsCorrectedExtent = olProj.transformExtent(newArray, CRS.GEOGRAPHIC, crs);
 
       if (containsExtent(viewExtent, crsCorrectedExtent)
       && isValidExtent(newArray)

--- a/web/js/components/location-search/ol-coordinates-marker.js
+++ b/web/js/components/location-search/ol-coordinates-marker.js
@@ -11,6 +11,7 @@ import { areCoordinatesWithinExtent } from '../../modules/location-search/util';
 import { reverseGeocode } from '../../modules/location-search/util-api';
 import util from '../../util/util';
 import { MAP_SINGLE_CLICK, MAP_CONTEXT_MENU, CONTEXT_MENU_LOCATION } from '../../util/constants';
+import { CRS } from '../../modules/map/constants';
 
 const { events } = util;
 
@@ -62,7 +63,7 @@ export class CoordinatesMarker extends Component {
     // handle reverse geocoding mouse click
     const pixels = e.pixel;
     const coord = map.getCoordinateFromPixel(pixels);
-    const tCoord = transform(coord, crs, 'EPSG:4326');
+    const tCoord = transform(coord, crs, CRS.GEOGRAPHIC);
     const [lon, lat] = getNormalizedCoordinate(tCoord);
 
     if (!areCoordinatesWithinExtent(proj, [lon, lat])) {

--- a/web/js/components/map/ol-coordinates.js
+++ b/web/js/components/map/ol-coordinates.js
@@ -11,6 +11,7 @@ import util from '../../util/util';
 import { getNormalizedCoordinate } from '../location-search/util';
 import { changeCoordinateFormat } from '../../modules/settings/actions';
 import { MAP_MOUSE_MOVE, MAP_MOUSE_OUT } from '../../util/constants';
+import { CRS } from '../../modules/map/constants';
 
 const { events } = util;
 const getContainerWidth = (format) => {
@@ -65,7 +66,7 @@ class OlCoordinates extends React.Component {
       this.clearCoord();
       return;
     }
-    let pcoord = transform(coord, crs, 'EPSG:4326');
+    let pcoord = transform(coord, crs, CRS.GEOGRAPHIC);
     // eslint-disable-next-line prefer-const
     let [lon, lat] = pcoord;
     if (Math.abs(lat) > 90) {
@@ -73,7 +74,7 @@ class OlCoordinates extends React.Component {
       return;
     }
     if (Math.abs(lon) > 180) {
-      if (crs === 'EPSG:4326' && Math.abs(lon) < 250) {
+      if (crs === CRS.GEOGRAPHIC && Math.abs(lon) < 250) {
         pcoord = getNormalizedCoordinate([lon, lat]);
       } else {
         this.clearCoord();

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -39,6 +39,7 @@ import {
   MAP_ENABLE_CLICK_ZOOM,
 } from '../../util/constants';
 import { areCoordinatesWithinExtent } from '../../modules/location-search/util';
+import { CRS } from '../../modules/map/constants';
 
 const { events } = util;
 
@@ -75,9 +76,9 @@ function OlMeasureTool (props) {
   useEffect(() => {
     if (olMap != null) {
       const regionFromCrs = {
-        'EPSG:4326': 'geographic',
-        'EPSG:3413': 'arctic',
-        'EPSG:3031': 'antarctic',
+        [CRS.GEOGRAPHIC]: 'geographic',
+        [CRS.ARCTIC]: 'arctic',
+        [CRS.ANTARCTIC]: 'antarctic',
       };
 
       const geographyToTerminate = regionFromCrs[previousCrs];
@@ -266,7 +267,7 @@ function OlMeasureTool (props) {
       condition(e) {
         const pixel = [e.originalEvent.x, e.originalEvent.y];
         const coord = olMap.getCoordinateFromPixel(pixel);
-        const tCoord = transform(coord, crs, 'EPSG:4326');
+        const tCoord = transform(coord, crs, CRS.GEOGRAPHIC);
         return areCoordinatesWithinExtent(proj, tCoord);
       },
     });

--- a/web/js/components/measure-tool/measure-tooltip.js
+++ b/web/js/components/measure-tool/measure-tooltip.js
@@ -13,8 +13,9 @@ import {
   getGeographicLibDistance,
   getGeographicLibArea,
 } from './util';
+import { CRS } from '../../modules/map/constants';
 
-const geographicProj = 'EPSG:4326';
+
 const metersPerKilometer = 1000;
 const ftPerMile = 5280;
 const sqFtPerSqMile = 27878400;
@@ -58,7 +59,7 @@ export default function MeasureTooltip(props) {
    * @return {String} - The formatted distance measurement
    */
   const getFormattedLength = () => {
-    const transformedLine = geometry.clone().transform(crs, geographicProj);
+    const transformedLine = geometry.clone().transform(crs, CRS.GEOGRAPHIC);
     const metricLength = getGeographicLibDistance(transformedLine);
     if (unitOfMeasure === 'km') {
       return metricLength > 100
@@ -77,7 +78,7 @@ export default function MeasureTooltip(props) {
    * @return {String} - The formatted area measurement
    */
   const getFormattedArea = () => {
-    const transformedPoly = geometry.clone().transform(crs, geographicProj);
+    const transformedPoly = geometry.clone().transform(crs, CRS.GEOGRAPHIC);
     const metricArea = getGeographicLibArea(transformedPoly);
     if (unitOfMeasure === 'km') {
       return metricArea > 10000
@@ -112,12 +113,12 @@ export default function MeasureTooltip(props) {
     // Distance & Area measurement coordinates are stored differently, so identify based on geometry type
     const yCoord = geometry instanceof OlGeomPolygon ? coordinates[coordinates.length - 4] : coordinates[coordinates.length - 2];
     const xCoord = geometry instanceof OlGeomPolygon ? coordinates[coordinates.length - 3] : coordinates[coordinates.length - 1];
-    const tCoord = transform([xCoord, yCoord], crs, 'EPSG:4326');
+    const tCoord = transform([xCoord, yCoord], crs, CRS.GEOGRAPHIC);
     return areCoordinatesWithinExtent(proj, tCoord);
   };
 
   const tooltipValue = getMeasurementValue();
-  const coordinatesAreValid = crs === 'EPSG:4326' ? checkGeographicCoordValidity(tooltipValue) : checkPolarCoordValidity();
+  const coordinatesAreValid = crs === CRS.GEOGRAPHIC ? checkGeographicCoordValidity(tooltipValue) : checkPolarCoordValidity();
 
   if (coordinatesAreValid) {
     return (

--- a/web/js/components/measure-tool/util.js
+++ b/web/js/components/measure-tool/util.js
@@ -5,9 +5,9 @@ import {
 import geographiclib from 'geographiclib';
 import shpWrite from 'shp-write';
 import FileSaver from 'file-saver';
+import { CRS } from '../../modules/map/constants';
 
 const geod = geographiclib.Geodesic.WGS84;
-const geographicProj = 'EPSG:4326';
 
 /**
  * Shift x value of every coord except the last,
@@ -35,7 +35,7 @@ function checkForXFlip(geom, projection) {
   const coords = geom.getCoordinates();
   const [x1] = coords[coords.length - 2];
   const [x2] = coords[coords.length - 1];
-  if (Math.abs(x1 - x2) > 180 && projection === geographicProj) {
+  if (Math.abs(x1 - x2) > 180 && projection === CRS.GEOGRAPHIC) {
     if (x1 < x2) {
       geom.setCoordinates(shiftXCoords(coords, 360));
     } else if (x1 > x2) {
@@ -53,7 +53,7 @@ function checkForXFlip(geom, projection) {
 export function transformLineStringArc(geom, projection) {
   const coords = [];
   const distance = 50000; // meters between segments
-  const transformedGeom = checkForXFlip(geom, projection).clone().transform(projection, geographicProj);
+  const transformedGeom = checkForXFlip(geom, projection).clone().transform(projection, CRS.GEOGRAPHIC);
   transformedGeom.forEachSegment((segStart, segEnd) => {
     const line = geod.InverseLine(segStart[1], segStart[0], segEnd[1], segEnd[0]);
     const n = Math.ceil(line.s13 / distance);
@@ -63,7 +63,7 @@ export function transformLineStringArc(geom, projection) {
       coords.push([r.lon2, r.lat2]);
     }
   });
-  return new OlGeomMultiLineString([coords]).transform(geographicProj, projection);
+  return new OlGeomMultiLineString([coords]).transform(CRS.GEOGRAPHIC, projection);
 }
 
 /**
@@ -73,7 +73,7 @@ export function transformLineStringArc(geom, projection) {
  */
 export function transformPolygonArc(geom, projection) {
   const coords = [];
-  const transformedGeom = geom.clone().transform(projection, geographicProj);
+  const transformedGeom = geom.clone().transform(projection, CRS.GEOGRAPHIC);
   const distance = 50000; // meters between segments
   const polyCoords = transformedGeom.getCoordinates()[0];
   for (let i = 0; i < polyCoords.length - 1; i += 1) {
@@ -90,7 +90,7 @@ export function transformPolygonArc(geom, projection) {
       coords.push([r.lon2, r.lat2]);
     }
   }
-  return new OlGeomPolygon([coords]).transform(geographicProj, projection);
+  return new OlGeomPolygon([coords]).transform(CRS.GEOGRAPHIC, projection);
 }
 
 /**

--- a/web/js/components/sidebar/events-filter.js
+++ b/web/js/components/sidebar/events-filter.js
@@ -13,6 +13,7 @@ import {
 } from '../../modules/natural-events/actions';
 import util from '../../util/util';
 import DateRangeSelector from '../date-selector/date-range-selector';
+import { CRS } from '../../modules/map/constants';
 
 function EventFilterModalBody (props) {
   const {
@@ -190,7 +191,7 @@ const mapStateToProps = (state) => {
     selectedCategories, selectedDates, showAll,
   } = events;
 
-  const isPolarProj = proj.selected.crs === 'EPSG:3031' || proj.selected.crs === 'EPSG:3413';
+  const isPolarProj = proj.selected.crs === CRS.ANTARCTIC || proj.selected.crs === CRS.ARCTIC;
 
   return {
     isPolarProj,

--- a/web/js/containers/gif.js
+++ b/web/js/containers/gif.js
@@ -26,6 +26,7 @@ import { getStampProps, svgToPng, getNumberOfSteps } from '../modules/animation/
 import { changeCropBounds } from '../modules/animation/actions';
 import { subdailyLayersActive } from '../modules/layers/selectors';
 import { formatDisplayDate } from '../modules/date/util';
+import { CRS } from '../modules/map/constants';
 
 const DEFAULT_URL = 'http://localhost:3002/api/v1/snapshot';
 const gifStream = new GifStream();
@@ -106,8 +107,8 @@ class GIF extends Component {
       map.ui.selected,
     );
     const { crs } = proj;
-    const geolonlat1 = olProj.transform(lonlats[0], crs, 'EPSG:4326');
-    const geolonlat2 = olProj.transform(lonlats[1], crs, 'EPSG:4326');
+    const geolonlat1 = olProj.transform(lonlats[0], crs, CRS.GEOGRAPHIC);
+    const geolonlat2 = olProj.transform(lonlats[1], crs, CRS.GEOGRAPHIC);
     const resolution = imageUtilCalculateResolution(
       Math.round(map.ui.selected.getView().getZoom()),
       isGeoProjection,

--- a/web/js/containers/image-download.js
+++ b/web/js/containers/image-download.js
@@ -29,6 +29,7 @@ import {
   updateBoundaries,
 } from '../modules/image-download/actions';
 import { getNormalizedCoordinate } from '../components/location-search/util';
+import { CRS } from '../modules/map/constants';
 
 const DEFAULT_URL = 'http://localhost:3002/api/v1/snapshot';
 
@@ -73,7 +74,7 @@ class ImageDownloadContainer extends Component {
     const { proj, map } = this.props;
     const coordinate = map.ui.selected.getCoordinateFromPixel([Math.floor(pixelX), Math.floor(pixelY)]);
     const { crs } = proj.selected;
-    const [x, y] = olProj.transform(coordinate, crs, 'EPSG:4326');
+    const [x, y] = olProj.transform(coordinate, crs, CRS.GEOGRAPHIC);
 
     return [Number(x.toFixed(4)), Number(y.toFixed(4))];
   }
@@ -88,8 +89,8 @@ class ImageDownloadContainer extends Component {
   getBoundaries(lonLat1, lonLat2) {
     const { map, proj } = this.props;
     const { crs } = proj.selected;
-    const lonLatBottomLeft = olProj.transform(lonLat1, 'EPSG:4326', crs);
-    const lonLatTopRight = olProj.transform(lonLat2, 'EPSG:4326', crs);
+    const lonLatBottomLeft = olProj.transform(lonLat1, CRS.GEOGRAPHIC, crs);
+    const lonLatTopRight = olProj.transform(lonLat2, CRS.GEOGRAPHIC, crs);
     const {
       x, y, x2, y2,
     } = imageUtilGetPixelValuesFromCoords(lonLatBottomLeft, lonLatTopRight, map.ui.selected);
@@ -158,8 +159,8 @@ class ImageDownloadContainer extends Component {
     const {
       x, y, x2, y2,
     } = boundaries;
-    const lonLat1 = olProj.transform(bottomLeftLatLong, 'EPSG:4326', crs);
-    const lonLat2 = olProj.transform(topRightLatLong, 'EPSG:4326', crs);
+    const lonLat1 = olProj.transform(bottomLeftLatLong, CRS.GEOGRAPHIC, crs);
+    const lonLat2 = olProj.transform(topRightLatLong, CRS.GEOGRAPHIC, crs);
     const isGeoProjection = proj.id === 'geographic';
     const fileTypes = isGeoProjection ? fileTypesGeo : fileTypesPolar;
     const resolutions = isGeoProjection ? resolutionsGeo : resolutionsPolar;

--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -24,7 +24,7 @@ import { selectVectorFeatures as selectVectorFeaturesActionCreator } from '../..
 import { changeCursor as changeCursorActionCreator } from '../../modules/map/actions';
 import { ACTIVATE_VECTOR_ZOOM_ALERT, ACTIVATE_VECTOR_EXCEEDED_ALERT, DISABLE_VECTOR_EXCEEDED_ALERT } from '../../modules/alerts/constants';
 import util from '../../util/util';
-import { FULL_MAP_EXTENT } from '../../modules/map/constants';
+import { CRS, FULL_MAP_EXTENT } from '../../modules/map/constants';
 import {
   GRANULE_HOVERED,
   GRANULE_HOVER_UPDATE,
@@ -156,7 +156,7 @@ export class VectorInteractions extends React.Component {
       isCoordinateSearchActive, measureIsActive, granuleFootprints,
     } = this.props;
     const coord = map.getCoordinateFromPixel(pixel);
-    const [lon, lat] = transform(coord, crs, 'EPSG:4326');
+    const [lon, lat] = transform(coord, crs, CRS.GEOGRAPHIC);
 
     if (measureIsActive || isCoordinateSearchActive) {
       return;
@@ -259,7 +259,7 @@ function mapStateToProps(state) {
   const granulePlatform = getGranulePlatform(state);
 
   const { maxExtent } = config.projections[proj.id];
-  const visibleExtent = proj.selected.crs === 'EPSG:4326' ? FULL_MAP_EXTENT : maxExtent;
+  const visibleExtent = proj.selected.crs === CRS.GEOGRAPHIC ? FULL_MAP_EXTENT : maxExtent;
 
   return {
     activeLayers,

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -33,6 +33,7 @@ import {
   fetchAvailableTools as fetchAvailableToolsAction,
   validateLayersConceptIds as validateLayersConceptIdsAction,
 } from '../../modules/smart-handoff/actions';
+import { CRS } from '../../modules/map/constants';
 
 import { formatDisplayDate } from '../../modules/date/util';
 
@@ -179,8 +180,8 @@ class SmartHandoff extends Component {
     const { crs } = proj;
 
     // Retrieve the lat/lon coordinates based on the defining boundary and map projection
-    const bottomLeft = olProj.transform(lonlats[0], crs, 'EPSG:4326');
-    const topRight = olProj.transform(lonlats[1], crs, 'EPSG:4326');
+    const bottomLeft = olProj.transform(lonlats[0], crs, CRS.GEOGRAPHIC);
+    const topRight = olProj.transform(lonlats[1], crs, CRS.GEOGRAPHIC);
     let [x1, y1] = bottomLeft;
     let [x2, y2] = topRight;
 

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -9,7 +9,7 @@ import {
   stopLoading,
   LOADING_GRANULES,
 } from '../../modules/loading/actions';
-import { FULL_MAP_EXTENT } from '../../modules/map/constants';
+import { FULL_MAP_EXTENT, CRS } from '../../modules/map/constants';
 import { openBasicContent } from '../../modules/modal/actions';
 import { getCacheOptions } from '../../modules/layers/util';
 import { getGranulesUrl as getGranulesUrlSelector } from '../../modules/smart-handoff/selectors';
@@ -208,7 +208,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const granules = datelineShiftGranules(visibleGranules, date, crs);
     const tileLayers = new OlCollection(createGranuleTileLayers(granules, def, attributes));
     granuleLayer.setLayers(tileLayers);
-    granuleLayer.setExtent(crs === 'EPSG:4326' ? FULL_MAP_EXTENT : maxExtent);
+    granuleLayer.setExtent(crs === CRS.GEOGRAPHIC ? FULL_MAP_EXTENT : maxExtent);
     granuleLayer.set('granuleGroup', true);
     granuleLayer.set('layerId', `${id}-${group}`);
     granuleLayer.wv = {

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -12,6 +12,7 @@ import { transform } from 'ol/proj';
 import { Polygon as OlGeomPolygon } from 'ol/geom';
 import * as OlExtent from 'ol/extent';
 import util from '../../util/util';
+import { CRS } from '../../modules/map/constants';
 
 /**
  * Shift granules to hande dateline cross.  Granules are shifted if:
@@ -25,7 +26,7 @@ import util from '../../util/util';
 export const datelineShiftGranules = (granules, currentDate, crs) => {
   const currentDayDate = new Date(currentDate).getUTCDate();
   const datelineShiftNeeded = (() => {
-    if (crs !== 'EPSG:4326') return false;
+    if (crs !== CRS.GEOGRAPHIC) return false;
     const sameDays = granules.every(({ date }) => new Date(date).getUTCDate() === currentDayDate);
     return !sameDays;
   })();
@@ -231,7 +232,7 @@ export const getCMRQueryDateUpdateOptions = (CMRDateStoreForLayer, date, startQu
  */
 export const transformGranuleData = (entry, date, crs) => {
   const line = new OlGeomLineString([]);
-  const maxDistance = crs === 'EPSG:4326' ? 270 : Number.POSITIVE_INFINITY;
+  const maxDistance = crs === CRS.GEOGRAPHIC ? 270 : Number.POSITIVE_INFINITY;
   const points = entry.polygons[0][0].split(' ');
   const dayNight = entry.day_night_flag;
   const polygonCoords = [];
@@ -261,7 +262,7 @@ export const transformGranuleData = (entry, date, crs) => {
 };
 
 export const transformGranulesForProj = (granules, crs) => granules.map((granule) => {
-  const transformedPolygon = granule.polygon.map((coords) => transform(coords, 'EPSG:4326', crs));
+  const transformedPolygon = granule.polygon.map((coords) => transform(coords, CRS.GEOGRAPHIC, crs));
   return {
     ...granule,
     polygon: transformedPolygon,

--- a/web/js/map/natural-events/event-markers.js
+++ b/web/js/map/natural-events/event-markers.js
@@ -17,6 +17,7 @@ import EventIcon from '../../components/sidebar/event-icon';
 import { selectEvent as selectEventAction } from '../../modules/natural-events/actions';
 import { getDefaultEventDate } from '../../modules/natural-events/util';
 import { getFilteredEvents } from '../../modules/natural-events/selectors';
+import { CRS } from '../../modules/map/constants';
 
 const icons = [
   'Dust and Haze',
@@ -86,7 +87,7 @@ class EventMarkers extends React.Component {
 
       let { coordinates } = geometry;
 
-      const transformCoords = (coords) => olProj.transform(coords, 'EPSG:4326', crs);
+      const transformCoords = (coords) => olProj.transform(coords, CRS.GEOGRAPHIC, crs);
 
       // polar projections require transform of coordinates to crs
       if (proj.selected.id !== 'geographic') {
@@ -224,7 +225,7 @@ const createPin = function(id, category, isSelected, title, hideTooltip) {
   });
 };
 
-const createBoundingBox = function(coordinates, title, proj = 'EPSG:4326') {
+const createBoundingBox = function(coordinates, title, proj = CRS.GEOGRAPHIC) {
   const lightStroke = new OlStyleStyle({
     stroke: new OlStyleStroke({
       color: [255, 255, 255, 0.6],
@@ -240,7 +241,7 @@ const createBoundingBox = function(coordinates, title, proj = 'EPSG:4326') {
       lineDash: [8, 12],
     }),
   });
-  const boxPolygon = new OlGeomPolygon(coordinates).transform('EPSG:4326', proj);
+  const boxPolygon = new OlGeomPolygon(coordinates).transform(CRS.GEOGRAPHIC, proj);
   const boxFeature = new OlFeature({
     geometry: boxPolygon,
     name: title,

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -13,7 +13,7 @@ import {
 } from './cluster';
 import { selectEvent as selectEventAction } from '../../modules/natural-events/actions';
 import { getFilteredEvents } from '../../modules/natural-events/selectors';
-
+import { CRS } from '../../modules/map/constants';
 
 import {
   getTrackLines, getTrackPoint, getArrows, getClusterPointEl,
@@ -237,8 +237,8 @@ const getTracksAndPoints = function(eventObj, proj, map, selectedDate, callback)
       // polar projections require transform of coordinates to crs
       if (proj.selected.id !== 'geographic') {
         const { crs } = proj.selected;
-        prevCoordinates = olProj.transform(prevCoordinates, 'EPSG:4326', crs);
-        nextCoordinates = olProj.transform(nextCoordinates, 'EPSG:4326', crs);
+        prevCoordinates = olProj.transform(prevCoordinates, CRS.GEOGRAPHIC, crs);
+        nextCoordinates = olProj.transform(nextCoordinates, CRS.GEOGRAPHIC, crs);
       }
       const lineSegmentArray = [prevCoordinates, nextCoordinates];
       const arrowOverlay = getArrows(lineSegmentArray, map);

--- a/web/js/map/natural-events/natural-events.js
+++ b/web/js/map/natural-events/natural-events.js
@@ -15,6 +15,7 @@ import {
   activateLayersForEventCategory as activateLayersForEventCategoryAction,
 } from '../../modules/layers/actions';
 import { getFilteredEvents } from '../../modules/natural-events/selectors';
+import { CRS } from '../../modules/map/constants';
 
 import EventTrack from './event-track';
 import EventMarkers from './event-markers';
@@ -140,13 +141,13 @@ class NaturalEvents extends React.Component {
 
     // check for polygon geometries and/or perform projection coordinate transform
     let coordinates;
-    const transformCoords = (coords) => olProj.transform(coords, 'EPSG:4326', crs);
+    const transformCoords = (coords) => olProj.transform(coords, CRS.GEOGRAPHIC, crs);
 
     if (geometry.type === 'Polygon') {
       const transformedCoords = geometry.coordinates[0].map(transformCoords);
       coordinates = olExtent.boundingExtent(transformedCoords);
     } else {
-      coordinates = olProj.transform(geometry.coordinates, 'EPSG:4326', crs);
+      coordinates = olProj.transform(geometry.coordinates, CRS.GEOGRAPHIC, crs);
     }
     return fly(map, proj, coordinates, zoom, null);
   };

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -2,6 +2,7 @@ import OlOverlay from 'ol/Overlay';
 import * as olProj from 'ol/proj';
 import { mapUtilZoomAction } from '../util';
 import { formatDisplayDate } from '../../modules/date/util';
+import { CRS } from '../../modules/map/constants';
 
 /**
 * Create event point
@@ -34,7 +35,7 @@ export const getTrackPoint = function(proj, clusterPoint, isSelected, callback) 
   const eventID = properties.event_id;
   let { coordinates } = clusterPoint.geometry;
   if (proj.selected.id !== 'geographic') {
-    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
+    coordinates = olProj.transform(coordinates, CRS.GEOGRAPHIC, proj.selected.crs);
   }
   overlayEl.className = isSelected
     ? 'track-marker-case track-marker-case-selected'
@@ -197,7 +198,7 @@ export const getClusterPointEl = function (proj, cluster, map, pointClusterObj) 
   let { coordinates } = cluster.geometry;
   const mapView = map.getView();
   if (proj.selected.id !== 'geographic') {
-    coordinates = olProj.transform(coordinates, 'EPSG:4326', proj.selected.crs);
+    coordinates = olProj.transform(coordinates, CRS.GEOGRAPHIC, proj.selected.crs);
   }
   const sizeClass = number < 10 ? 'small' : number < 20 ? 'medium' : 'large';
 

--- a/web/js/modules/core/actions.js
+++ b/web/js/modules/core/actions.js
@@ -1,4 +1,4 @@
-export function requestAction(
+export async function requestAction(
   dispatch,
   actionName,
   url,
@@ -7,19 +7,17 @@ export function requestAction(
   options,
 ) {
   dispatch(startRequest(actionName, id));
-  return new Promise((resolve, reject) => fetch(url, options)
-    .then((response) => (mimeType === 'application/json'
-      ? response.json()
-      : response.text()
-    ))
-    .then((data) => {
-      dispatch(fetchSuccess(actionName, data, id));
-      resolve(data);
-    })
-    .catch((error) => {
-      dispatch(fetchFailure(actionName, error, id));
-      reject(error);
-    }));
+  try {
+    const response = await fetch(url, options);
+    const data = mimeType === 'application/json'
+      ? await response.json()
+      : await response.text();
+    dispatch(fetchSuccess(actionName, data, id));
+    return data;
+  } catch (error) {
+    dispatch(fetchFailure(actionName, error, id));
+    console.error(error);
+  }
 }
 
 export function startRequest(actionName, id) {

--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -6,6 +6,7 @@ import { transform } from 'ol/proj';
 import util from '../../util/util';
 import { formatDisplayDate } from '../date/util';
 import { nearestInterval } from '../layers/util';
+import { CRS } from '../map/constants';
 
 const GEO_ESTIMATION_CONSTANT = 256.0;
 const POLAR_ESTIMATION_CONSTANT = 0.002197265625;
@@ -141,7 +142,7 @@ export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime,
   // handle adding coordinates marker
   if (markerCoordinates.length > 0) {
     const coords = markerCoordinates.reduce((validCoords, { longitude: lon, latitude: lat }) => {
-      const mCoord = transform([lon, lat], 'EPSG:4326', crs);
+      const mCoord = transform([lon, lat], CRS.GEOGRAPHIC, crs);
       // const inExtent = containsCoordinate(boundingExtent(bbox), mCoord);
       return validCoords.concat([mCoord[0], mCoord[1]]);
     }, []);
@@ -330,7 +331,7 @@ export function imageUtilGetPixelValuesFromCoords(bottomLeft, topRight, map) {
  * Y,X order, otherwise in X,Y order.
  */
 export function bboxWMS13(lonlats, crs) {
-  if (crs === 'EPSG:4326') {
+  if (crs === CRS.GEOGRAPHIC) {
     return `${lonlats[0][1]},${lonlats[0][0]},${lonlats[1][1]},${
       lonlats[1][0]
     }`;

--- a/web/js/modules/location-search/util.js
+++ b/web/js/modules/location-search/util.js
@@ -8,7 +8,7 @@ import { transform } from 'ol/proj';
 import LocationMarker from '../../components/location-search/location-marker';
 import safeLocalStorage from '../../util/local-storage';
 import { fly } from '../../map/util';
-import { FULL_MAP_EXTENT } from '../map/constants';
+import { FULL_MAP_EXTENT, CRS } from '../map/constants';
 
 const { LOCATION_SEARCH_COLLAPSED } = safeLocalStorage.keys;
 
@@ -24,7 +24,7 @@ export function animateCoordinates(map, proj, coordinates, zoom) {
 
   let [x, y] = coordinates;
   if (proj !== 'geographic') {
-    [x, y] = transform(coordinates, 'EPSG:4326', crs);
+    [x, y] = transform(coordinates, CRS.GEOGRAPHIC, crs);
   }
   fly(map, proj, [x, y], zoom);
 }
@@ -37,8 +37,8 @@ export function animateCoordinates(map, proj, coordinates, zoom) {
  */
 export function areCoordinatesWithinExtent(proj, coordinates) {
   const { maxExtent, crs } = proj.selected;
-  const extent = crs === 'EPSG:4326' ? FULL_MAP_EXTENT : maxExtent;
-  const coord = crs === 'EPSG:4326' ? coordinates : transform(coordinates, 'EPSG:4326', crs);
+  const extent = crs === CRS.GEOGRAPHIC ? FULL_MAP_EXTENT : maxExtent;
+  const coord = crs === CRS.GEOGRAPHIC ? coordinates : transform(coordinates, CRS.GEOGRAPHIC, crs);
   return containsCoordinate(extent, coord); // expects X then Y!
 }
 
@@ -57,7 +57,7 @@ export function getCoordinatesMarker(proj, coordinatesObject, results, removeMar
   // transform coordinates if not CRS EPSG:4326
   let transformedCoords = coordinates;
   if (proj !== 'geographic') {
-    transformedCoords = transform(coordinates, 'EPSG:4326', crs);
+    transformedCoords = transform(coordinates, CRS.GEOGRAPHIC, crs);
   }
 
   const pinProps = {

--- a/web/js/modules/map/constants.js
+++ b/web/js/modules/map/constants.js
@@ -16,6 +16,13 @@ export const LEFT_WING_ORIGIN = [-540, 90];
 export const RIGHT_WING_ORIGIN = [180, 90];
 export const CENTER_MAP_ORIGIN = [-180, 90];
 
+export const CRS = {
+  ARCTIC: 'EPSG:3413',
+  ANTARCTIC: 'EPSG:3031',
+  GEOGRAPHIC: 'EPSG:4326',
+  WEB_MERCATOR: 'EPSG:3857',
+};
+
 export const RESOLUTION_FOR_LARGE_WMS_TILES = [
   0.3515625,
   0.17578125,

--- a/web/js/modules/measure/reducers.js
+++ b/web/js/modules/measure/reducers.js
@@ -3,14 +3,17 @@ import {
   UPDATE_MEASUREMENTS,
   TOGGLE_MEASURE_ACTIVE,
 } from './constants';
+import { CRS } from '../map/constants';
 
 const defaultState = {
   isActive: false,
   unitOfMeasure: 'km',
   allMeasurements: {
-    'EPSG:3413': {},
-    'EPSG:4326': {},
-    'EPSG:3031': {},
+    ...Object.values(CRS)
+      .reduce((prev, key) => ({
+        ...prev,
+        [key]: {},
+      }), {}),
   },
 };
 
@@ -26,15 +29,18 @@ export default function measureReducer(state = defaultState, action) {
         ...state,
         isActive: action.value,
       };
-    case UPDATE_MEASUREMENTS:
+    case UPDATE_MEASUREMENTS: {
+      const newMeasurementObj = {};
+      Object.entries(action.value).forEach(([key, value]) => {
+        newMeasurementObj[key] = value;
+      });
       return {
         ...state,
         allMeasurements: {
-          'EPSG:3413': action.value['EPSG:3413'],
-          'EPSG:4326': action.value['EPSG:4326'],
-          'EPSG:3031': action.value['EPSG:3031'],
+          ...newMeasurementObj,
         },
       };
+    }
     default:
       return state;
   }

--- a/web/js/modules/natural-events/actions.js
+++ b/web/js/modules/natural-events/actions.js
@@ -41,12 +41,16 @@ export function requestSources() {
       console.warn(`Using mock sources data: ${mockSources}`);
       sourcesURL = `mock/sources_data.json-${mockSources}`;
     }
-    requestAction(
-      dispatch,
-      REQUEST_SOURCES,
-      sourcesURL,
-      'application/json',
-    );
+    try {
+      requestAction(
+        dispatch,
+        REQUEST_SOURCES,
+        sourcesURL,
+        'application/json',
+      );
+    } catch (e) {
+      console.error(e);
+    }
   };
 }
 

--- a/web/js/modules/natural-events/util.js
+++ b/web/js/modules/natural-events/util.js
@@ -7,6 +7,7 @@ import util from '../../util/util';
 import {
   LIMIT_EVENT_REQUEST_COUNT,
 } from './constants';
+import { CRS } from '../map/constants';
 
 export function parseEvent(eventString) {
   const values = eventString.split(',');
@@ -127,9 +128,9 @@ export function getEventsRequestURL (state) {
   // represent exact bounds seen in app since they are expressed in EPSG:4326
   // format which is the only format the API supports
   const extentBounds = {
-    'EPSG:4326': [-180, 90, 180, -90],
-    'EPSG:3413': [-180, 40, 180, 90],
-    'EPSG:3031': [-180, -90, 180, -40],
+    [CRS.GEOGRAPHIC]: [-180, 90, 180, -90],
+    [CRS.ARCTIC]: [-180, 40, 180, 90],
+    [CRS.ANTARCTIC]: [-180, -90, 180, -40],
   };
   const { crs } = proj.selected;
   const selectedMap = map && map.ui.selected;
@@ -139,7 +140,7 @@ export function getEventsRequestURL (state) {
     status: 'all',
     limit: LIMIT_EVENT_REQUEST_COUNT,
   };
-  const useBbox = bbox && bbox.length && crs === 'EPSG:4326';
+  const useBbox = bbox && bbox.length && crs === CRS.GEOGRAPHIC;
   params.bbox = useBbox ? bbox : extentBounds[crs];
 
   if (start && end) {
@@ -185,7 +186,7 @@ export const validateGeometryCoords = (geometry, proj) => {
   const { coordinates, type } = geometry;
   const { crs, maxExtent } = proj;
   const passesFilter = (coords) => {
-    const tCoords = transform(coords, 'EPSG:4326', crs);
+    const tCoords = transform(coords, CRS.GEOGRAPHIC, crs);
     return containsCoordinate(maxExtent, tCoords);
   };
   if (type === 'Point') {


### PR DESCRIPTION
## Description

* Constants for CRS codes
* Safety check for non-existant proj in measurement
* Better request reducer error handling

## How To Test

* Build against the GITC-SIT environment in `worldview-options-gibs`
  * `IGNORE_ERRORS=true CONFIG_ENV=gitc-sit npm run build`
* Load the app and confirm you can switch to mercator projection 
* Create measurements in web mercator projection
* Switch between projections and create measurements
* Confirm measurements show when switching back
