### PR TITLE
WV-2402: Fix timeline minute arrow up styling to not block timeline axis

### DIFF
--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -885,12 +885,6 @@
   }
 }
 
-.layer-detail-container.search {
-  border-top: 5px solid #d54e21;
-  padding-left: 2px;
-  background-image: linear-gradient(#aaa, #ddd 15%);
-}
-
 .custom-layer-dialog-mobile {
   width: 100% !important;
   max-width: 100% !important;

--- a/web/scss/features/timeline.scss
+++ b/web/scss/features/timeline.scss
@@ -114,7 +114,8 @@ button:focus {
     position: absolute;
     top: -15px;
     height: 30px;
-    width: 100%;
+
+    // width: 100%;
     max-width: inherit;
   }
 


### PR DESCRIPTION
## Description

* Fix timeline up arrow styling to not block timeline axis
* Fix layer detail panel styling (See WV-2456)

## How To Test

* Load a geostationary layer and confirm the minute arrow controls don't block portions of the timeline
* Open the layer picker and select a layer to see details, confirm the background for the details matches what is seen in PROD


