### PR TITLE
WV-2426: Fix measurements when changing projections

### DIFF
--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -123,6 +123,8 @@ function OlMeasureTool (props) {
 
   useEffect(recalculateAllMeasurements, [unitOfMeasure]);
 
+  useEffect(recalculateAllMeasurements, [crs]);
+
   const areaBgFill = new OlStyleFill({
     color: 'rgba(213, 78, 33, 0.1)',
   });


### PR DESCRIPTION
## Description

Previously when creating a measurement in the geographic projection, changing to a polar projection and changing the unit of measurement; upon returning to the geographic projection, the measurement distances would be incorrect. This updates the ol-measure-tool to recalculate the measurements every time the crs prop updates (whenever you change projections). 

## How To Test

1. Create a long distance measurement from North America to Africa or Europe. 
2. Note the distance in both miles and kilometers. 
3. Switch to a polar projection.
4. Change the unit of measurement.
5. Return to the geographic projection.
6. The measure tooltip should show the correct measurement distance from your original measurement. 

