### PR TITLE
WV-2464: Dateline text initially active on hover setting

### DIFF
--- a/web/js/components/dateline/datelines.js
+++ b/web/js/components/dateline/datelines.js
@@ -9,7 +9,7 @@ import { CRS } from '../../modules/map/constants';
 
 function DateLines(props) {
   const {
-    map, proj, date, isCompareActive, mapIsRendered, alwaysShow, hideText,
+    map, proj, date, isCompareActive, mapIsRendered, alwaysShow, hideText, isMobilePhone, isMobileTablet,
   } = props;
 
   if (!mapIsRendered) return null;
@@ -89,6 +89,8 @@ function DateLines(props) {
         date={date}
         textCoords={textCoords}
         setTextCoords={setTextCoords}
+        isMobilePhone={isMobilePhone}
+        isMobileTablet={isMobileTablet}
       />
       <Line
         id="dateline-right"
@@ -102,6 +104,8 @@ function DateLines(props) {
         date={util.dateAdd(date, 'day', -1)}
         textCoords={textCoords}
         setTextCoords={setTextCoords}
+        isMobilePhone={isMobilePhone}
+        isMobileTablet={isMobileTablet}
       />
     </>
   );
@@ -113,6 +117,7 @@ const mapStateToProps = (state) => {
   } = state;
   const isImageDownload = modal.id === 'TOOLBAR_SNAPSHOT' && modal.isOpen;
   const isGeographic = proj.selected.crs === CRS.GEOGRAPHIC;
+  const { isMobilePhone, isMobileTablet } = state.screenSize;
   return {
     proj,
     map: map.ui.selected,
@@ -121,6 +126,8 @@ const mapStateToProps = (state) => {
     mapIsRendered: map.rendered,
     hideText: isImageDownload || !isGeographic,
     alwaysShow: isImageDownload || settings.alwaysShowDatelines,
+    isMobilePhone,
+    isMobileTablet,
   };
 };
 
@@ -132,6 +139,8 @@ DateLines.propTypes = {
   mapIsRendered: PropTypes.bool,
   alwaysShow: PropTypes.bool,
   hideText: PropTypes.bool,
+  isMobilePhone: PropTypes.bool,
+  isMobileTablet: PropTypes.bool,
 };
 
 export default connect(

--- a/web/js/components/dateline/line.js
+++ b/web/js/components/dateline/line.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import OlOverlay from 'ol/Overlay';
-import util from '../../util/util';
 import LineText from './text';
 import usePrevious from '../../util/customHooks';
 
@@ -30,6 +29,8 @@ export default function Line (props) {
     setTextCoords,
     textCoords,
     hideText,
+    isMobilePhone,
+    isMobileTablet,
   } = props;
 
   const [overlay, setOverlay] = useState('');
@@ -51,37 +52,37 @@ export default function Line (props) {
   }, []);
 
   useEffect(() => {
-    if (overlay !== '') return overlay.setPosition([lineX, lineY]);
     if (!alwaysShow && alwaysShow !== prevAlwaysShow) {
       toggleTextActive(false);
     }
+    if (overlay !== '') return overlay.setPosition([lineX, lineY]);
   });
 
   const mouseOver = () => {
     toggleHovered(true);
+    toggleTextActive(true);
   };
 
   const mouseOut = () => {
     toggleHovered(false);
+    toggleTextActive(false);
   };
 
   const mouseOverHidden = (e) => {
     const coords = map.getCoordinateFromPixel([e.clientX, e.clientY]);
     timerRef.current = setTimeout(() => {
       setTextCoords(coords);
-      toggleTextActive(true);
     }, 300);
   };
 
   const mouseLeaveHidden = () => {
     clearTimeout(timerRef.current);
-    toggleTextActive(false);
   };
 
   const {
     strokeWidth, dashArray, color, svgStyle, width,
   } = lineStyles;
-  const useOpacity = alwaysShow || util.browser.mobileAndTabletDevice || hovered
+  const useOpacity = alwaysShow || isMobilePhone || isMobileTablet || hovered
     ? lineStyles.opacity
     : '0';
 
@@ -135,7 +136,6 @@ export default function Line (props) {
   );
 }
 
-
 Line.propTypes = {
   alwaysShow: PropTypes.bool,
   date: PropTypes.object,
@@ -149,5 +149,7 @@ Line.propTypes = {
   setTextCoords: PropTypes.func,
   textCoords: PropTypes.array,
   hideText: PropTypes.bool,
+  isMobilePhone: PropTypes.bool,
+  isMobileTablet: PropTypes.bool,
 };
 

--- a/web/js/components/dateline/line.js
+++ b/web/js/components/dateline/line.js
@@ -53,7 +53,7 @@ export default function Line (props) {
   useEffect(() => {
     if (overlay !== '') return overlay.setPosition([lineX, lineY]);
     if (!alwaysShow && alwaysShow !== prevAlwaysShow) {
-      toggleTextActive(true);
+      toggleTextActive(false);
     }
   });
 


### PR DESCRIPTION
## Description

When the `Show Antimeridian / Approximate Date Line` setting was set to `On Hover`, the dateline text was still showing on the map on the initial load. Updated the logic so that if the setting is set to `On Hover`, the text field only appears when the dateline is hovered.

## How To Test

1. Open the global settings menu and select `On Hover` for the setting `Show Antimeridian / Approximate Date Line` setting.
2. Zoom out to see where the datelines would appear.
3. Observe that the dateline text fields do not appear unless you have hover over the dateline.

