### PR TITLE
WV-2398: Fix iOS browser crashes with too many layers loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "worldview",
-      "version": "3.32.0",
+      "version": "3.34.0",
       "hasInstallScript": true,
       "license": "NASA-1.3",
       "dependencies": {
@@ -36,7 +36,7 @@
         "moment": "^2.29.4",
         "moment-locales-webpack-plugin": "^1.2.0",
         "node-dir": "^0.1.17",
-        "ol": "7.0.0",
+        "ol": "6.14.1",
         "ol-mapbox-style": "9.1.0",
         "p-queue": "^7.3.0",
         "proj4": "2.6.1",
@@ -7615,10 +7615,6 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/earcut": {
-      "version": "2.2.4",
-      "license": "ISC"
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -15809,12 +15805,12 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "7.0.0",
-      "license": "BSD-2-Clause",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.1.tgz",
+      "integrity": "sha512-sIcUWkGud3Y2gT3TJubSHlkyMXiPVh1yxfCPHxmY8+qtm79bB9oRnei9xHVIbRRG0Ro6Ldp5E+BMVSvYCxSpaA==",
       "dependencies": {
-        "earcut": "^2.2.3",
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.0.0",
+        "geotiff": "^2.0.2",
+        "ol-mapbox-style": "^7.1.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -15832,11 +15828,13 @@
       }
     },
     "node_modules/ol/node_modules/ol-mapbox-style": {
-      "version": "9.0.0",
-      "license": "BSD-2-Clause",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
+      "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "mapbox-to-css-font": "^2.4.1",
+        "webfont-matcher": "^1.1.0"
       }
     },
     "node_modules/on-finished": {
@@ -22483,6 +22481,11 @@
       "version": "1.2.0",
       "license": "Apache-2.0"
     },
+    "node_modules/webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha512-ov8lMvF9wi4PD7fK2Axn9PQEpO9cYI0fIoGqErwd+wi8xacFFDmX114D5Q2Lw0Wlgmb+Qw/dKI2KTtimrJf85g=="
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "dev": true,
@@ -28656,9 +28659,6 @@
       "version": "0.1.2",
       "dev": true
     },
-    "earcut": {
-      "version": "2.2.4"
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "dev": true,
@@ -34235,20 +34235,24 @@
       "dev": true
     },
     "ol": {
-      "version": "7.0.0",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.14.1.tgz",
+      "integrity": "sha512-sIcUWkGud3Y2gT3TJubSHlkyMXiPVh1yxfCPHxmY8+qtm79bB9oRnei9xHVIbRRG0Ro6Ldp5E+BMVSvYCxSpaA==",
       "requires": {
-        "earcut": "^2.2.3",
-        "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.0.0",
+        "geotiff": "^2.0.2",
+        "ol-mapbox-style": "^7.1.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
       "dependencies": {
         "ol-mapbox-style": {
-          "version": "9.0.0",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
+          "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
           "requires": {
-            "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-            "mapbox-to-css-font": "^2.4.1"
+            "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+            "mapbox-to-css-font": "^2.4.1",
+            "webfont-matcher": "^1.1.0"
           }
         }
       }
@@ -38767,6 +38771,11 @@
     },
     "web-worker": {
       "version": "1.2.0"
+    },
+    "webfont-matcher": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
+      "integrity": "sha512-ov8lMvF9wi4PD7fK2Axn9PQEpO9cYI0fIoGqErwd+wi8xacFFDmX114D5Q2Lw0Wlgmb+Qw/dKI2KTtimrJf85g=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "moment": "^2.29.4",
     "moment-locales-webpack-plugin": "^1.2.0",
     "node-dir": "^0.1.17",
-    "ol": "7.0.0",
+    "ol": "6.14.1",
     "ol-mapbox-style": "9.1.0",
     "p-queue": "^7.3.0",
     "proj4": "2.6.1",


### PR DESCRIPTION
## Description

An issue was introduced in OL 6.14.2 that causes browsers to crash on iOS after reaching a certain number layers rendered.  This just downgrades us to the last good working version that did not have that issue.  [An issue was filed with the OL team here
](https://github.com/openlayers/openlayers/issues/14171)

## How To Test

* Pull changes
* `npm ci`
* Open the app on an actual iOS device
* Load any fire event (this will add many layers)
* Confirm the app does not crash

You will need to find a way to hit your local dev server from an iOS device, such as using a reverse proxy like [ngrok](https://ngrok.com/).  This error did not seem to happen in simulated devices and definitely won't occur in a desktop browser set to mobile size.

