### PR TITLE
WV-2398: Fix iOS browser crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "worldview",
-      "version": "3.32.0",
+      "version": "3.34.0",
       "hasInstallScript": true,
       "license": "NASA-1.3",
       "dependencies": {
@@ -36,7 +36,7 @@
         "moment": "^2.29.4",
         "moment-locales-webpack-plugin": "^1.2.0",
         "node-dir": "^0.1.17",
-        "ol": "7.0.0",
+        "ol": "7.1.0",
         "ol-mapbox-style": "9.1.0",
         "p-queue": "^7.3.0",
         "proj4": "2.6.1",
@@ -7618,7 +7618,8 @@
     },
     "node_modules/earcut": {
       "version": "2.2.4",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -15809,12 +15810,13 @@
       "license": "MIT"
     },
     "node_modules/ol": {
-      "version": "7.0.0",
-      "license": "BSD-2-Clause",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
+      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
       "dependencies": {
         "earcut": "^2.2.3",
         "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.0.0",
+        "ol-mapbox-style": "9.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -15825,14 +15827,6 @@
     },
     "node_modules/ol-mapbox-style": {
       "version": "9.1.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-        "mapbox-to-css-font": "^2.4.1"
-      }
-    },
-    "node_modules/ol/node_modules/ol-mapbox-style": {
-      "version": "9.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
@@ -28657,7 +28651,9 @@
       "dev": true
     },
     "earcut": {
-      "version": "2.2.4"
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -34235,22 +34231,15 @@
       "dev": true
     },
     "ol": {
-      "version": "7.0.0",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.1.0.tgz",
+      "integrity": "sha512-mAeV5Ca4mFhYaJoGWNZnIMN5VNnFTf63FgZjBiYu/DjQDGKNsD5QyvvqVziioVdOOgl6b8rPB/ypj2XNBinPwA==",
       "requires": {
         "earcut": "^2.2.3",
         "geotiff": "2.0.4",
-        "ol-mapbox-style": "9.0.0",
+        "ol-mapbox-style": "9.1.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
-      },
-      "dependencies": {
-        "ol-mapbox-style": {
-          "version": "9.0.0",
-          "requires": {
-            "@mapbox/mapbox-gl-style-spec": "^13.23.1",
-            "mapbox-to-css-font": "^2.4.1"
-          }
-        }
       }
     },
     "ol-mapbox-style": {

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "moment": "^2.29.4",
     "moment-locales-webpack-plugin": "^1.2.0",
     "node-dir": "^0.1.17",
-    "ol": "7.0.0",
+    "ol": "7.1.0",
     "ol-mapbox-style": "9.1.0",
     "p-queue": "^7.3.0",
     "proj4": "2.6.1",

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -430,7 +430,6 @@ export default function mapLayerBuilder(config, cache, store) {
     return new OlLayerTile({
       extent: polygon ? granuleExtent : extent,
       preload: 0,
-      className: def.id,
       source: tileSource,
     });
   }
@@ -519,7 +518,6 @@ export default function mapLayerBuilder(config, cache, store) {
       extent: layerExtent,
       source: tileSource,
       renderMode: 'vector',
-      className: def.id,
       preload: 0,
       ...isMaxBreakPoint && { maxResolution: breakPointResolution },
       ...isMinBreakPoint && { minResolution: breakPointResolution },
@@ -630,7 +628,6 @@ export default function mapLayerBuilder(config, cache, store) {
 
     const layer = new OlLayerTile({
       preload: 0,
-      className: def.id,
       extent,
       ...!!resolutionBreakPoint && { minResolution: resolutionBreakPoint },
       source: tileSource,


### PR DESCRIPTION
## Description

Changes were introduced in OL 6.14.2 that causes browsers to crash on iOS for us after reaching a certain number of layers rendered.  See https://github.com/openlayers/openlayers/issues/14171

The inclusion of the `className` property when creating layers on our end prevents canvas re-use between layers which causes a large performance hit, leading to the crash on iOS devices.  Removing `className` fixes the issue.

## How To Test

* Pull changes
* `npm ci`
* Open the app on an actual iOS device
* Load any fire event (this will add many layers)
* Confirm the app does not crash

You will need to find a way to hit your local dev server from an iOS device, such as using a reverse proxy like [ngrok](https://ngrok.com/).  This error did not seem to happen in simulated devices and definitely won't occur in a desktop browser set to mobile size.

