### PR TITLE
WV-1995: Prioritize References measurement group in Layer List

### DIFF
--- a/e2e/features/image-download/layers-test.js
+++ b/e2e/features/image-download/layers-test.js
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   'List layers in draw order': function(c) {
-    bookmark(c, startParams.concat(['l=MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Features_15m,MODIS_Terra_Aerosol']));
+    bookmark(c, startParams.concat(['l=MODIS_Terra_CorrectedReflectance_TrueColor,MODIS_Terra_Aerosol,Reference_Features_15m']));
     openImageDownloadPanel(c);
     clickDownload(c);
     c.expect.element('#wv-image-download-url').to.have.attribute('url')
@@ -28,7 +28,7 @@ module.exports = {
     openImageDownloadPanel(c);
     clickDownload(c);
     c.expect.element('#wv-image-download-url').to.have.attribute('url')
-      .and.to.contain('LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Features_15m,MODIS_Terra_Aerosol');
+      .and.to.contain('LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor,MODIS_Terra_Aerosol,Reference_Features_15m');
   },
 
   'Do not include obscured layers': function(c) {

--- a/e2e/features/layers/layers-sidebar-test.js
+++ b/e2e/features/layers/layers-sidebar-test.js
@@ -52,11 +52,11 @@ const groupedLayerIdOrder = [
   'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
 ];
 const ungroupedReorderdLayerIdOrder = [
-  'active-MODIS_Combined_Value_Added_AOD',
-  'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
+  'active-Reference_Features_15m',
   'active-VIIRS_SNPP_Thermal_Anomalies_375m_All',
   'active-VIIRS_NOAA20_Thermal_Anomalies_375m_All',
-  'active-Reference_Features_15m',
+  'active-MODIS_Combined_Value_Added_AOD',
+  'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
 ];
 
 module.exports = {

--- a/web/js/modules/layers/actions.test.js
+++ b/web/js/modules/layers/actions.test.js
@@ -64,10 +64,10 @@ describe('Layer actions', () => {
   });
 
   test('REMOVE_LAYER action removes layer by id', () => {
-    const def = layers[0];
+    const def = layers[1];
     store.dispatch(removeLayer('aqua-aod'));
     const actionResponse = store.getActions()[0];
-    const responseLayers = [layers[1], layers[2], layers[3]];
+    const responseLayers = [layers[0], layers[2], layers[3]];
 
     const expectedPayload = {
       type: LAYER_CONSTANTS.REMOVE_LAYER,
@@ -92,8 +92,8 @@ describe('Layer actions', () => {
     const expectedPayload = {
       type: LAYER_CONSTANTS.REMOVE_GROUP,
       activeString: 'active',
-      layersToRemove: [layers[0], layers[1]],
-      layers: [layers[2], layers[3]],
+      layersToRemove: [layers[1], layers[2]],
+      layers: [layers[0], layers[3]],
       granuleLayers: {},
     };
     expect(actionResponse).toEqual(expectedPayload);
@@ -106,7 +106,7 @@ describe('Layer actions', () => {
       type: LAYER_CONSTANTS.TOGGLE_OVERLAY_GROUPS,
       activeString: 'active',
       groupOverlays: false,
-      layers,
+      layers: [layers[1], layers[2], layers[0], layers[3] ],
       overlayGroups: [],
     };
     expect(actionResponse).toEqual(expectedPayload);
@@ -117,7 +117,8 @@ describe('Layer actions', () => {
     store = mockStore(getState(layers));
     store.dispatch(updateDatesOnProjChange('arctic'));
     const actionResponse = store.getActions()[0];
-    const { startDate, endDate, dateRanges: [firstRange, secondRange] } = actionResponse.layersA[0];
+    console.log(actionResponse)
+    const { startDate, endDate, dateRanges: [firstRange, secondRange] } = actionResponse.layersA[1];
 
     expect(startDate).toEqual('2019-07-21T00:36:00Z');
     expect(endDate).toEqual('2019-09-24T22:30:00Z');

--- a/web/js/modules/layers/actions.test.js
+++ b/web/js/modules/layers/actions.test.js
@@ -106,7 +106,7 @@ describe('Layer actions', () => {
       type: LAYER_CONSTANTS.TOGGLE_OVERLAY_GROUPS,
       activeString: 'active',
       groupOverlays: false,
-      layers: [layers[1], layers[2], layers[0], layers[3] ],
+      layers: [layers[1], layers[2], layers[0], layers[3]],
       overlayGroups: [],
     };
     expect(actionResponse).toEqual(expectedPayload);
@@ -117,7 +117,6 @@ describe('Layer actions', () => {
     store = mockStore(getState(layers));
     store.dispatch(updateDatesOnProjChange('arctic'));
     const actionResponse = store.getActions()[0];
-    console.log(actionResponse)
     const { startDate, endDate, dateRanges: [firstRange, secondRange] } = actionResponse.layersA[1];
 
     expect(startDate).toEqual('2019-07-21T00:36:00Z');

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -273,6 +273,7 @@ export const subdailyLayersActive = createSelector(
 
 export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection, groupOverlays) {
   let layers = lodashCloneDeep(layersParam);
+  // console.log("before ",layers)
   if (projection) {
     layers = layers.filter((layer) => layer.projections[projection]);
   }
@@ -304,16 +305,51 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
   }
   def.opacity = lodashIsUndefined(spec.opacity) ? 1.0 : spec.opacity;
 
+  // groupIdx === number value; returns -1 when adding a new layer while GSL is off
+    // groupIdx finds the index of layers array where matches (something).. it's not relevant when GSL is off
+    // the entire first if statement is just checking if the GSL setting is on..
+  // groupOverlays === boolean value; hits in else1 as false when adding layer while GSL is off
+  // layers === array of objects that have the values of each overlay selected in the sidebar
+  // def === object; it contains the value of the layer that is being added (as it appears in the layers array)
+  // unshift adds an element to beginning of an arry and returns new length of array
+  // layers.unshift(def) is the line that puts the new layer at the beginning of the array when GSL is off
+  // need to make a utility function that loops through the layers array and finds the index of
+    // the last object that has a laygroup of "Reference"
+
+
   // Place new layer in the appropriate array position
   if (def.group === 'overlays') {
     // TODO assuming first group in the array again here
     const groupIdx = layers.findIndex(({ layergroup }) => layergroup === def.layergroup);
+
+    const findLastRefLayer = (layers) => {
+      let lastRefIndex = 0;
+      let index = 0;
+
+      layers.forEach(layer => {
+        if(layer.layergroup === 'Reference'){
+         lastRefIndex = index;
+        }
+        index++;
+      })
+      return lastRefIndex + 1;
+    }
+
+    const lastReferenceLayerIndex = findLastRefLayer(layers)
+    console.log(lastReferenceLayerIndex)
+
+
+
     if (groupOverlays && groupIdx >= 0) {
       layers.splice(groupIdx, 0, def);
     } else {
-      layers.unshift(def);
+
+      // layers.unshift(def);
+      layers.splice(lastReferenceLayerIndex, 0, def)
+      // console.log("after ", layers)
     }
   } else {
+    // console.log("else2 ",groupOverlays)
     const overlaysLength = overlayLength || layers.filter((layer) => layer.group === 'overlays').length;
     layers.splice(overlaysLength, 0, def);
   }

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -273,7 +273,6 @@ export const subdailyLayersActive = createSelector(
 
 export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection, groupOverlays) {
   let layers = lodashCloneDeep(layersParam);
-  // console.log("before ",layers)
   if (projection) {
     layers = layers.filter((layer) => layer.projections[projection]);
   }

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -305,18 +305,6 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
   }
   def.opacity = lodashIsUndefined(spec.opacity) ? 1.0 : spec.opacity;
 
-  // groupIdx === number value; returns -1 when adding a new layer while GSL is off
-    // groupIdx finds the index of layers array where matches (something).. it's not relevant when GSL is off
-    // the entire first if statement is just checking if the GSL setting is on..
-  // groupOverlays === boolean value; hits in else1 as false when adding layer while GSL is off
-  // layers === array of objects that have the values of each overlay selected in the sidebar
-  // def === object; it contains the value of the layer that is being added (as it appears in the layers array)
-  // unshift adds an element to beginning of an arry and returns new length of array
-  // layers.unshift(def) is the line that puts the new layer at the beginning of the array when GSL is off
-  // need to make a utility function that loops through the layers array and finds the index of
-    // the last object that has a laygroup of "Reference"
-
-
   // Place new layer in the appropriate array position
   if (def.group === 'overlays') {
     // TODO assuming first group in the array again here
@@ -326,30 +314,23 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
       let lastRefIndex = 0;
       let index = 0;
 
-      layers.forEach(layer => {
-        if(layer.layergroup === 'Reference'){
-         lastRefIndex = index;
+      layers.forEach((layer) => {
+        if (layer.layergroup === 'Reference') {
+          lastRefIndex = index;
         }
-        index++;
-      })
+        index += 1;
+      });
       return lastRefIndex + 1;
-    }
+    };
 
-    const lastReferenceLayerIndex = findLastRefLayer(layers)
-    console.log(lastReferenceLayerIndex)
-
-
+    const lastReferenceLayerIndex = findLastRefLayer(layers);
 
     if (groupOverlays && groupIdx >= 0) {
       layers.splice(groupIdx, 0, def);
     } else {
-
-      // layers.unshift(def);
-      layers.splice(lastReferenceLayerIndex, 0, def)
-      // console.log("after ", layers)
+      layers.splice(lastReferenceLayerIndex, 0, def);
     }
   } else {
-    // console.log("else2 ",groupOverlays)
     const overlaysLength = overlayLength || layers.filter((layer) => layer.group === 'overlays').length;
     layers.splice(overlaysLength, 0, def);
   }

--- a/web/js/modules/layers/selectors.test.js
+++ b/web/js/modules/layers/selectors.test.js
@@ -33,7 +33,7 @@ test('adds base layer', () => {
 
   const layerList = getLayers(getState(layers), {}).map((x) => x.id);
 
-  expect(layerList).toEqual(['mask', 'terra-cr', 'terra-aod']);
+  expect(layerList).toEqual(['terra-cr', 'mask', 'terra-aod']);
 });
 
 test('adds overlay layer', () => {

--- a/web/js/modules/layers/util.test.js
+++ b/web/js/modules/layers/util.test.js
@@ -30,37 +30,37 @@ test('Layer parser, retrieves correct number of palette layers from permalink st
 });
 test('Layer parser, gets correct palette layer ID', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.id).toBe('AMSRE_Brightness_Temp_89H_Night');
 });
 test('Layer parser, gets correct custom palette id from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.custom[0]).toBe('red_2');
 });
 test('Layer parser, gets squashed boolean from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.squash[0]).toBe(true);
 });
 test('Layer parser, gets correct min value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.min[0]).toBe(224);
 });
 test('Layer parser, gets correct max value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.max[0]).toBe(294);
 });
 test('Layer parser, gets correct max value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.opacity).toBe(0.54);
 });
 test('Layer parser, retrieves hidden palette layer from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.opacity).toBe(0.54);
 });
 test('Layer parser, retrieves correct number of vector layers from permalink string', () => {
@@ -69,17 +69,17 @@ test('Layer parser, retrieves correct number of vector layers from permalink str
 });
 test('Layer parser, gets correct vector layer ID', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.id).toBe('OrbitTracks_Aqua_Ascending');
 });
 test('Layer parser, gets correct custom vector style id from permalink string', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.custom[0]).toBe('yellow1');
 });
 test('Layer parser, retrieves hidden vector layer from permalink string', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[0];
+  const layer = layers[1];
   expect(layer.opacity).toBe(0.46);
 });
 test('serialize layers and palettes', () => {

--- a/web/js/modules/palettes/util.test.js
+++ b/web/js/modules/palettes/util.test.js
@@ -90,11 +90,12 @@ describe('permalink 1.1', () => {
 
     const layer1 = stateFromLocation.layers.active.layers[0];
     const layer2 = stateFromLocation.layers.active.layers[1];
-    expect(layer1.id).toBe('terra-aod');
-    expect(layer1.custom).toBe('blue-1');
 
-    expect(layer2.id).toBe('aqua-aod');
-    expect(layer2.custom).toBe('red-1');
+    expect(layer1.id).toBe('aqua-aod');
+    expect(layer1.custom).toBe('red-1');
+
+    expect(layer2.id).toBe('terra-aod');
+    expect(layer2.custom).toBe('blue-1');
   });
 
   test('disregard palettes value if palette assigned to a layer that is not active', () => {


### PR DESCRIPTION
## Description

This updates the order in which layers are added to give priority to the reference layers group. Now by default, new layers will always populate beneath the last reference layer if the `group similar layers` option is off or under the reference group if the option is on. If a user reorders a non-reference layer between or before the reference layers, any new layers added will still populate under the last reference layer.

## How To Test

1. Starting with the default reference layers, ensure that the `group similar layers` option is off and add any non-reference overlay layer. Observe that the layer is added under the last reference layer. 
2. Add another non-reference overlay layer and observe that this layer has also been added directly after the last reference layer. 
3. Move the most recent layer that you added to the 2nd position (behind coastlines) and then add another non-reference overlay layer. Observe that this layer is added to the 5th position (behind place labels). 
4. Check the `Group Similar Layers` checkbox and observe that each of the layer groups is ordered beneath the reference layer group.
5. Uncheck the `Group Similar Layers` checkbox and observe that the original layer order has been preserved. 


