### PR TITLE
Remove CMR link to MOP02R_NRT

### DIFF
--- a/config/default/common/config/metadata/layers/mopitt/MOPITT_CO_Daily_Total_Column_L2.md
+++ b/config/default/common/config/metadata/layers/mopitt/MOPITT_CO_Daily_Total_Column_L2.md
@@ -2,4 +2,8 @@ The MOPITT Carbon Monoxide (Level 2, Daily, Day/Night, Total Column) layer shows
 
 The MOPITT Carbon Monoxide (L2, Daily, Day/Night, Total Column) layer is available from the Measurements of Pollution in the Troposphere (MOPITT) instrument on the Terra satellite. The sensor resolution is 22 km at nadir, imagery resolution is 2 km, and the temporal resolution is daily.
 
-References: [MOP02R_NRT] (https://cmr.earthdata.nasa.gov/search/concepts/C1398625065-MOPITT.html)
+Data Download: [Level 2 NRT](http://lance1.acom.ucar.edu/data/L2/)
+
+References: [MOPITT Near Real-Time Data Download Service](http://lance1.acom.ucar.edu/)
+
+


### PR DESCRIPTION
MOP02R_NRT is no longer available in CMR

Replaced CMR link in layer description to point to MOPITT download page. PR has been opened to remove the conceptId from the layer-metadata.

@nasa-gibs/worldview
