### PR TITLE
WV-2479: Fix Reference Layer Ordering

### DIFF
--- a/e2e/features/animation/mobile-animation-test.js
+++ b/e2e/features/animation/mobile-animation-test.js
@@ -26,7 +26,8 @@ module.exports = {
 
   'Playing the animation changes the date of the mobile date picker': (c) => {
     c.useCss().click('#collapsed-animate-widget-phone-portrait');
-    c.pause(3000);
+    // this pause is the minimum amount of time needed to load & play the animation on a throttled connection
+    c.pause(20000);
     c.expect.element('.mobile-date-picker-select-btn-text span').text.to.equal('2019 AUG 01');
   },
 

--- a/e2e/features/layers/layers-sidebar-test.js
+++ b/e2e/features/layers/layers-sidebar-test.js
@@ -53,10 +53,10 @@ const groupedLayerIdOrder = [
 ];
 const ungroupedReorderdLayerIdOrder = [
   'active-Reference_Features_15m',
-  'active-VIIRS_SNPP_Thermal_Anomalies_375m_All',
-  'active-VIIRS_NOAA20_Thermal_Anomalies_375m_All',
   'active-MODIS_Combined_Value_Added_AOD',
   'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
+  'active-VIIRS_SNPP_Thermal_Anomalies_375m_All',
+  'active-VIIRS_NOAA20_Thermal_Anomalies_375m_All',
 ];
 
 module.exports = {
@@ -226,9 +226,9 @@ module.exports = {
         .pause(300)
         .release()
         .pause(300);
-      // .dragAndDrop(layerGroupHeader, { x: -50, y: -150})
     });
-    c.click(groupCheckbox).pause(200);
+    c.click(groupCheckbox);
+    c.pause(500);
     checkElementOrdering(c, `${overlaysGroup} ul > li`, ungroupedReorderdLayerIdOrder);
   },
 

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -326,6 +326,8 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
 
     if (groupOverlays && groupIdx >= 0) {
       layers.splice(groupIdx, 0, def);
+    } else if (def.layergroup === 'Reference') {
+      layers.unshift(def);
     } else {
       layers.splice(lastReferenceLayerIndex, 0, def);
     }


### PR DESCRIPTION
## Description

This ensures that the default reference layers are added in their original and correct order while still adding new layers under the reference layers or reference layer group.

## How To Test

Open an instance of WV and check that the reference layers are loaded in the following order:
1. Place Labels,
2. Coastlines / Borders / Roads
3. Coastlines

Add a non-reference layer and verify that the layer is rendered below the reference layers.



