### PR TITLE
WV-2485: Fix baselayer ordering/visibility 

### DIFF
--- a/e2e/features/image-download/layers-test.js
+++ b/e2e/features/image-download/layers-test.js
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   'List layers in draw order': function(c) {
-    bookmark(c, startParams.concat(['l=MODIS_Terra_CorrectedReflectance_TrueColor,MODIS_Terra_Aerosol,Reference_Features_15m']));
+    bookmark(c, startParams.concat(['l=MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Features_15m,MODIS_Terra_Aerosol']));
     openImageDownloadPanel(c);
     clickDownload(c);
     c.expect.element('#wv-image-download-url').to.have.attribute('url')
@@ -28,7 +28,7 @@ module.exports = {
     openImageDownloadPanel(c);
     clickDownload(c);
     c.expect.element('#wv-image-download-url').to.have.attribute('url')
-      .and.to.contain('LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor,MODIS_Terra_Aerosol,Reference_Features_15m');
+      .and.to.contain('LAYERS=MODIS_Terra_CorrectedReflectance_TrueColor,Reference_Features_15m,MODIS_Terra_Aerosol');
   },
 
   'Do not include obscured layers': function(c) {

--- a/e2e/features/layers/layers-sidebar-test.js
+++ b/e2e/features/layers/layers-sidebar-test.js
@@ -75,7 +75,8 @@ module.exports = {
     c.expect.element(infoDialog).to.not.be.present;
   },
   'Toggle Layer Options': (c) => {
-    c.moveToElement(firesLayer, 0, 0);
+    c.pause(500);
+    // c.moveToElement(firesLayer, 0, 0);
     c.waitForElementVisible(optionsButton, TIME_LIMIT);
     c.click(optionsButton);
     c.waitForElementVisible(optionsDialog, TIME_LIMIT);
@@ -179,9 +180,9 @@ module.exports = {
     c.pause(500);
     c.useCss();
     c.expect.element('#group-overlays-checkbox-case').to.not.have.attribute('checked');
-
+    c.moveToElement(firesLayer, 0, 0);
     c.moveToElement(overlaysGroupHeader, 0, 0);
-    c.waitForElementVisible(`${overlaysGroupHeader} ${groupOptionsBtn}`);
+    c.waitForElementPresent(`${overlaysGroupHeader} ${groupOptionsBtn}`);
     c.click(`${overlaysGroup} ${groupOptionsBtn}`).pause(200);
     c.click(`${overlaysGroup} ${groupRemove}`).pause(200);
 

--- a/e2e/features/layers/layers-sidebar-test.js
+++ b/e2e/features/layers/layers-sidebar-test.js
@@ -52,9 +52,9 @@ const groupedLayerIdOrder = [
   'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
 ];
 const ungroupedReorderdLayerIdOrder = [
-  'active-Reference_Features_15m',
-  'active-MODIS_Combined_Value_Added_AOD',
   'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
+  'active-MODIS_Combined_Value_Added_AOD',
+  'active-Reference_Features_15m',
   'active-VIIRS_SNPP_Thermal_Anomalies_375m_All',
   'active-VIIRS_NOAA20_Thermal_Anomalies_375m_All',
 ];

--- a/web/js/modules/layers/actions.test.js
+++ b/web/js/modules/layers/actions.test.js
@@ -64,10 +64,10 @@ describe('Layer actions', () => {
   });
 
   test('REMOVE_LAYER action removes layer by id', () => {
-    const def = layers[1];
+    const def = layers[0];
     store.dispatch(removeLayer('aqua-aod'));
     const actionResponse = store.getActions()[0];
-    const responseLayers = [layers[0], layers[2], layers[3]];
+    const responseLayers = [layers[1], layers[2], layers[3]];
 
     const expectedPayload = {
       type: LAYER_CONSTANTS.REMOVE_LAYER,
@@ -92,8 +92,8 @@ describe('Layer actions', () => {
     const expectedPayload = {
       type: LAYER_CONSTANTS.REMOVE_GROUP,
       activeString: 'active',
-      layersToRemove: [layers[1], layers[2]],
-      layers: [layers[0], layers[3]],
+      layersToRemove: [layers[0], layers[1]],
+      layers: [layers[2], layers[3]],
       granuleLayers: {},
     };
     expect(actionResponse).toEqual(expectedPayload);
@@ -106,7 +106,7 @@ describe('Layer actions', () => {
       type: LAYER_CONSTANTS.TOGGLE_OVERLAY_GROUPS,
       activeString: 'active',
       groupOverlays: false,
-      layers: [layers[1], layers[2], layers[0], layers[3]],
+      layers,
       overlayGroups: [],
     };
     expect(actionResponse).toEqual(expectedPayload);
@@ -117,7 +117,7 @@ describe('Layer actions', () => {
     store = mockStore(getState(layers));
     store.dispatch(updateDatesOnProjChange('arctic'));
     const actionResponse = store.getActions()[0];
-    const { startDate, endDate, dateRanges: [firstRange, secondRange] } = actionResponse.layersA[1];
+    const { startDate, endDate, dateRanges: [firstRange, secondRange] } = actionResponse.layersA[0];
 
     expect(startDate).toEqual('2019-07-21T00:36:00Z');
     expect(endDate).toEqual('2019-09-24T22:30:00Z');

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -319,6 +319,9 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
         }
         index += 1;
       });
+      if (lastRefIndex === 0) {
+        return lastRefIndex;
+      }
       return lastRefIndex + 1;
     };
 

--- a/web/js/modules/layers/selectors.test.js
+++ b/web/js/modules/layers/selectors.test.js
@@ -33,7 +33,7 @@ test('adds base layer', () => {
 
   const layerList = getLayers(getState(layers), {}).map((x) => x.id);
 
-  expect(layerList).toEqual(['terra-cr', 'mask', 'terra-aod']);
+  expect(layerList).toEqual(['mask', 'terra-cr', 'terra-aod']);
 });
 
 test('adds overlay layer', () => {

--- a/web/js/modules/layers/util.test.js
+++ b/web/js/modules/layers/util.test.js
@@ -30,37 +30,37 @@ test('Layer parser, retrieves correct number of palette layers from permalink st
 });
 test('Layer parser, gets correct palette layer ID', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.id).toBe('AMSRE_Brightness_Temp_89H_Night');
 });
 test('Layer parser, gets correct custom palette id from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.custom[0]).toBe('red_2');
 });
 test('Layer parser, gets squashed boolean from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.squash[0]).toBe(true);
 });
 test('Layer parser, gets correct min value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.min[0]).toBe(224);
 });
 test('Layer parser, gets correct max value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.max[0]).toBe(294);
 });
 test('Layer parser, gets correct max value from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.opacity).toBe(0.54);
 });
 test('Layer parser, retrieves hidden palette layer from permalink string', () => {
   const layers = layersParse12(PALETTE_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.opacity).toBe(0.54);
 });
 test('Layer parser, retrieves correct number of vector layers from permalink string', () => {
@@ -69,17 +69,17 @@ test('Layer parser, retrieves correct number of vector layers from permalink str
 });
 test('Layer parser, gets correct vector layer ID', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.id).toBe('OrbitTracks_Aqua_Ascending');
 });
 test('Layer parser, gets correct custom vector style id from permalink string', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.custom[0]).toBe('yellow1');
 });
 test('Layer parser, retrieves hidden vector layer from permalink string', () => {
   const layers = layersParse12(VECTOR_LAYER_STRING, config);
-  const layer = layers[1];
+  const layer = layers[0];
   expect(layer.opacity).toBe(0.46);
 });
 test('serialize layers and palettes', () => {

--- a/web/js/modules/palettes/util.test.js
+++ b/web/js/modules/palettes/util.test.js
@@ -90,12 +90,11 @@ describe('permalink 1.1', () => {
 
     const layer1 = stateFromLocation.layers.active.layers[0];
     const layer2 = stateFromLocation.layers.active.layers[1];
+    expect(layer1.id).toBe('terra-aod');
+    expect(layer1.custom).toBe('blue-1');
 
-    expect(layer1.id).toBe('aqua-aod');
-    expect(layer1.custom).toBe('red-1');
-
-    expect(layer2.id).toBe('terra-aod');
-    expect(layer2.custom).toBe('blue-1');
+    expect(layer2.id).toBe('aqua-aod');
+    expect(layer2.custom).toBe('red-1');
   });
 
   test('disregard palettes value if palette assigned to a layer that is not active', () => {


### PR DESCRIPTION
## Description

This fixes the logic for adding layers so that new overlays will be visible above base layers when there are no reference layers selected.

## How To Test

1. Start with either only the top baselayer visible (see link below)
2. Add any overlay (e.g. an Aerosol Optical Depth layer)
3. Observe that the newly added overlay is visible

[(http://localhost:3000/?v=-457.6410612408573,-294.48706705194684,480.0464387591427,457.01293294805316&l=VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11(hidden)&lg=false&t=2022-10-07-T00%3A03%3A00Z)]

