### PR TITLE
WV-2397: Update date intervals for date arrows on mobile views

### DIFF
--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -116,8 +116,6 @@ CustomIntervalSelector.propTypes = {
   closeModal: PropTypes.func,
   customDelta: PropTypes.number,
   customInterval: PropTypes.number,
-  customSelected: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
-  interval: PropTypes.number,
   modalOpen: PropTypes.bool,
 };

--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -10,7 +10,6 @@ import {
 } from '../../../modules/date/constants';
 import {
   toggleCustomModal,
-  selectInterval as selectIntervalAction,
   changeCustomInterval as changeCustomIntervalAction,
 } from '../../../modules/date/actions';
 
@@ -23,30 +22,11 @@ import {
 class CustomIntervalSelector extends PureComponent {
   componentDidUpdate(prevProps) {
     const {
-      changeCustomInterval,
-      customInterval,
-      customSelected,
-      hasSubdailyLayers,
-      interval,
-      selectInterval,
       modalOpen,
     } = this.props;
 
     if (modalOpen && !prevProps.modalOpen) {
       this.customIntervalWidget.focus();
-    }
-
-    const subdailyAdded = hasSubdailyLayers && !prevProps.hasSubdailyLayers;
-    const subdailyRemoved = !hasSubdailyLayers && prevProps.hasSubdailyLayers;
-    const subdailyInterval = customInterval > 3 || interval > 3;
-
-    if (subdailyRemoved && subdailyInterval) {
-      changeCustomInterval();
-      selectInterval(1, TIME_SCALE_TO_NUMBER.day, false);
-    }
-
-    if (subdailyAdded && !customSelected) {
-      changeCustomInterval(10, TIME_SCALE_TO_NUMBER.minute);
     }
   }
 
@@ -111,9 +91,6 @@ const mapDispatchToProps = (dispatch) => ({
   changeCustomInterval: (delta, timeScale) => {
     dispatch(changeCustomIntervalAction(delta, timeScale));
   },
-  selectInterval: (delta, timeScale, customSelected) => {
-    dispatch(selectIntervalAction(delta, timeScale, customSelected));
-  },
 });
 
 const mapStateToProps = (state) => {
@@ -142,6 +119,5 @@ CustomIntervalSelector.propTypes = {
   customSelected: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
   interval: PropTypes.number,
-  selectInterval: PropTypes.func,
   modalOpen: PropTypes.bool,
 };

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -43,7 +43,7 @@ import {
   selectDate as selectDateAction,
   changeTimeScale,
   selectInterval,
-  changeCustomInterval,
+  changeCustomInterval as changeCustomIntervalAction,
   updateAppNow,
   toggleCustomModal,
   triggerTodayButton,
@@ -189,14 +189,19 @@ class Timeline extends React.Component {
     const {
       animStartLocationDate,
       animEndLocationDate,
+      changeCustomInterval,
+      customInterval,
+      customSelected,
       dateA,
       dateB,
+      interval,
       isAnimationPlaying,
       isAnimationWidgetOpen,
       isGifActive,
       hasSubdailyLayers,
     } = this.props;
     const { frontDate, draggerTimeState, draggerTimeStateB } = this.state;
+
 
     // handle update animation positioning and local state from play button/gif creation
     const didAnimationTurnOn = !prevProps.isAnimationPlaying && isAnimationPlaying;
@@ -215,6 +220,19 @@ class Timeline extends React.Component {
           this.animationDraggerDateUpdate(animStartLocationDate, animEndLocationDate);
         }
       }
+    }
+
+    const subdailyAdded = hasSubdailyLayers && !prevProps.hasSubdailyLayers;
+    const subdailyRemoved = !hasSubdailyLayers && prevProps.hasSubdailyLayers;
+    const subdailyInterval = customInterval > 3 || interval > 3;
+
+    if (subdailyRemoved && subdailyInterval) {
+      changeCustomInterval();
+      selectInterval(1, TIME_SCALE_TO_NUMBER.day, false);
+    }
+
+    if (subdailyAdded && !customSelected) {
+      changeCustomInterval(10, TIME_SCALE_TO_NUMBER.minute);
     }
 
     // if user adds a subdaily layer (and none were active) change the time scale to hourly
@@ -1344,6 +1362,7 @@ function mapStateToProps(state) {
     customDelta,
     customInterval,
     customSelected,
+    interval,
     selected,
     selectedB,
     selectedZoom,
@@ -1451,6 +1470,8 @@ function mapStateToProps(state) {
     selectedDate,
     timeScale: TIME_SCALE_FROM_NUMBER[updatedSelectedZoom.toString()],
     timeScaleChangeUnit: unit,
+    customInterval: customInterval || interval,
+    interval,
     customIntervalValue: customDelta || 1,
     customIntervalZoomLevel: updatedCustomInterval || 3,
     nowOverride,
@@ -1491,7 +1512,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
   // changes/sets custom delta and timescale interval
   changeCustomInterval: (delta, timeScale) => {
-    dispatch(changeCustomInterval(delta, timeScale));
+    dispatch(changeCustomIntervalAction(delta, timeScale));
   },
   // changes timescale (scale of grids vs. what LEFT/RIGHT arrow do)
   changeTimeScale: (val) => {
@@ -1547,8 +1568,10 @@ Timeline.propTypes = {
   animStartLocationDate: PropTypes.object,
   axisWidth: PropTypes.number,
   breakpoints: PropTypes.object,
+  changeCustomInterval: PropTypes.func,
   changeTimeScale: PropTypes.func,
   closeAnimation: PropTypes.func,
+  customInterval: PropTypes.number,
   customSelected: PropTypes.bool,
   dateA: PropTypes.string,
   dateB: PropTypes.string,
@@ -1557,6 +1580,7 @@ Timeline.propTypes = {
   hasFutureLayers: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
   hideTimeline: PropTypes.bool,
+  interval: PropTypes.number,
   isAnimationPlaying: PropTypes.bool,
   isAnimatingToEvent: PropTypes.bool,
   isAnimationWidgetOpen: PropTypes.bool,


### PR DESCRIPTION
## Description

The date arrows were not updating by custom intervals when adding a geostationary layer while in a mobile view. This update fixes this so that the arrows will increase/decrease time by the custom value determined by the Geostationary layer.

## How To Test

1. Open WV in a mobile view
2. Add any geostationary layer (ex. GeoColor)
3. Press the back arrow on the date arrows and verify that the date is decreasing by 10 minute intervals.
4. Remove the geostationary layer
5. Verify that the date increases/decreases by days again.


