### PR TITLE
wv-2496

### DIFF
--- a/config/default/common/config/wv.json/defaults.json
+++ b/config/default/common/config/wv.json/defaults.json
@@ -3,11 +3,11 @@
         "projection": "geographic",
         "startingLayers": [
             {
-                "id": "MODIS_Terra_CorrectedReflectance_TrueColor",
-                "hidden": "true"
+                "id": "MODIS_Terra_CorrectedReflectance_TrueColor"
             },
             {
-                "id": "MODIS_Aqua_CorrectedReflectance_TrueColor"
+                "id": "MODIS_Aqua_CorrectedReflectance_TrueColor",
+                "hidden": "true"
             },
             {
                 "id": "VIIRS_SNPP_CorrectedReflectance_TrueColor",

--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -92,19 +92,19 @@
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Day",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Night",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Day",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Night",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_Thermal_Anomalies_375m_Day",
@@ -332,19 +332,19 @@
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Day",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Night",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Day",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Night",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_Thermal_Anomalies_375m_Day",
@@ -428,19 +428,19 @@
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Day",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Night",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Day",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Night",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_Thermal_Anomalies_375m_Day",
@@ -714,19 +714,19 @@
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Day",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Night",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Day",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Night",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_Thermal_Anomalies_375m_Day",
@@ -926,11 +926,11 @@
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Day",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_Thermal_Anomalies_Night",
-                        false
+                        true
                     ],
                     [
                         "VIIRS_NOAA20_Thermal_Anomalies_375m_Day",
@@ -942,11 +942,11 @@
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Day",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_Thermal_Anomalies_Night",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_SNPP_Thermal_Anomalies_375m_Day",

--- a/config/default/common/config/wv.json/naturalEvents.json
+++ b/config/default/common/config/wv.json/naturalEvents.json
@@ -56,7 +56,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -64,7 +64,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
@@ -142,11 +142,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -212,11 +212,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -238,11 +238,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -268,7 +268,7 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands367",
@@ -276,7 +276,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -316,11 +316,11 @@
                 "Volcanoes": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -376,7 +376,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -384,7 +384,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
@@ -478,11 +478,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -556,11 +556,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -590,11 +590,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -632,7 +632,7 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands367",
@@ -640,7 +640,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -674,11 +674,11 @@
                 "Volcanoes": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -768,7 +768,7 @@
                 "Manmade": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -784,7 +784,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_SurfaceReflectance_Bands121",
@@ -814,11 +814,11 @@
                 "Dust and Haze": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -890,7 +890,7 @@
                 "Wildfires": [
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_Bands721",
@@ -906,7 +906,7 @@
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_Bands721",
@@ -980,11 +980,11 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_NOAA20_CorrectedReflectance_TrueColor",
@@ -1054,11 +1054,12 @@
                     ],
                     [
                         "MODIS_Terra_CorrectedReflectance_TrueColor",
-                        false
+                        true
                     ],
+
                     [
                         "MODIS_Aqua_CorrectedReflectance_TrueColor",
-                        true
+                        false
                     ],
                     [
                         "VIIRS_SNPP_CorrectedReflectance_TrueColor",

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -112,6 +112,12 @@ export function mapIsExtentValid(extent) {
 /*
  * Set default extent according to time of day:
  *
+ * at 00:00 UTC, start at far eastern edge of
+ * map: "20.6015625,-46.546875,179.9296875,53.015625"
+ *
+ * at 23:00 UTC, start at far western edge of map:
+ * "-179.9296875,-46.546875,-20.6015625,53.015625"
+ *
  * @method getLeadingExtent
  * @static
  * @param {Object} Time
@@ -119,18 +125,21 @@ export function mapIsExtentValid(extent) {
  * @returns {object} Extent Array
  */
 export function getLeadingExtent(loadtime) {
-  const curHour = loadtime.getUTCHours();
+  let curHour = loadtime.getUTCHours();
 
-  // These values are specifically tuned for the Aqua/MODIS default Corrected Reflectance Layer
-  const eastWestOffset = curHour * 0.6;
-  const minLonConst = 10;
-  const maxLongConst = 170;
-  const minLonMultiplier = -200 / 23;
-  const minLon = minLonConst + (curHour - eastWestOffset) * minLonMultiplier;
-  const maxLon = minLon + maxLongConst;
+  // For earlier hours when data is still being filled in, force a far eastern perspective
+  if (curHour < 3) {
+    curHour = 23;
+  } else if (curHour < 9) {
+    curHour = 0;
+  }
 
-  const minLat = -47;
-  const maxLat = 53;
+  // Compute east/west bounds
+  const minLon = 20.6015625 + curHour * (-200.53125 / 23.0);
+  const maxLon = minLon + 159.328125;
+
+  const minLat = -46.546875;
+  const maxLat = 53.015625;
 
   return [minLon, minLat, maxLon, maxLat];
 }


### PR DESCRIPTION
## Description
Revert wv-2448 (reset default layer to Terra/MODIS).

Fixes #
Flip back to having Terra/MODIS as the default layer on load
Also flip back the default events layers that were changed to Aqua/MODIS
Change the map positioning back to the original location based on time.

## How To Test
Clone, build, run WorldView. Confirm that the default layer is TERRA/MODIS. Also check & confirm that natural events are using Terra/MODIS as the layer.