### PR TITLE
Remove .cgi from share link

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -29,7 +29,7 @@ const getShortenRequestString = (mock, permalink) => {
     return 'mock/short_link.json';
   }
   return (
-    `service/link/shorten.cgi${
+    `service/link/shorten${
       mockStr
     }?url=${
       encodeURIComponent(permalink)}`


### PR DESCRIPTION
## Description

Removes .cgi from share link for cloud transition.

## How To Test

Use the share / shorten link feature and ensure the decoded url is the same.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
