### PR TITLE
Fix npm audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
         "regenerator-runtime": "^0.13.3",
         "reselect": "^4.0.0",
         "rgbcolor": "^0.0.4",
-        "shp-write": "^0.3.2",
         "simplebar-react": "^2.1.0",
         "stackblur": "^1.0.0",
         "supercluster": "7.0.0",
@@ -6584,9 +6583,10 @@
       }
     },
     "node_modules/css-hot-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -6638,9 +6638,10 @@
       }
     },
     "node_modules/css-loader/node_modules/loader-utils": {
-      "version": "1.4.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -7085,13 +7086,6 @@
       "version": "1.30.1",
       "license": "MIT"
     },
-    "node_modules/dbf": {
-      "version": "0.1.4",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "jdataview": "~2.5.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "dev": true,
@@ -7142,9 +7136,10 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -11656,9 +11651,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jdataview": {
-      "version": "2.5.0"
-    },
     "node_modules/jest": {
       "version": "26.6.3",
       "dev": true,
@@ -13375,15 +13367,16 @@
       }
     },
     "node_modules/jszip": {
-      "version": "2.5.0",
-      "license": "MIT or GPLv3",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
       "dependencies": {
-        "pako": "~0.2.5"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
-    },
-    "node_modules/jszip/node_modules/pako": {
-      "version": "0.2.9",
-      "license": "MIT"
     },
     "node_modules/kdbush": {
       "version": "3.0.0",
@@ -13525,9 +13518,10 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -19520,18 +19514,6 @@
         "node": ">= 10.15.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
     "node_modules/selenium-webdriver/node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -20032,14 +20014,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/shp-write": {
-      "version": "0.3.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dbf": "0.1.4",
-        "jszip": "2.5.0"
       }
     },
     "node_modules/side-channel": {
@@ -27961,7 +27935,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -27998,7 +27974,9 @@
           }
         },
         "loader-utils": {
-          "version": "1.4.0",
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -28295,12 +28273,6 @@
     "date-fns": {
       "version": "1.30.1"
     },
-    "dbf": {
-      "version": "0.1.4",
-      "requires": {
-        "jdataview": "~2.5.0"
-      }
-    },
     "debug": {
       "version": "4.3.4",
       "dev": true,
@@ -28331,7 +28303,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "decompress-response": {
@@ -31345,9 +31319,6 @@
         }
       }
     },
-    "jdataview": {
-      "version": "2.5.0"
-    },
     "jest": {
       "version": "26.6.3",
       "dev": true,
@@ -32477,14 +32448,15 @@
       }
     },
     "jszip": {
-      "version": "2.5.0",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
       "requires": {
-        "pako": "~0.2.5"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "0.2.9"
-        }
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "kdbush": {
@@ -32588,7 +32560,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -36698,18 +36672,6 @@
         "ws": ">=8.7.0"
       },
       "dependencies": {
-        "jszip": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-          "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-          "dev": true,
-          "requires": {
-            "lie": "~3.3.0",
-            "pako": "~1.0.2",
-            "readable-stream": "~2.3.6",
-            "setimmediate": "^1.0.5"
-          }
-        },
         "tmp": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -37063,13 +37025,6 @@
             "decamelize": "^1.2.0"
           }
         }
-      }
-    },
-    "shp-write": {
-      "version": "0.3.2",
-      "requires": {
-        "dbf": "0.1.4",
-        "jszip": "2.5.0"
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -216,7 +216,6 @@
     "regenerator-runtime": "^0.13.3",
     "reselect": "^4.0.0",
     "rgbcolor": "^0.0.4",
-    "shp-write": "^0.3.2",
     "simplebar-react": "^2.1.0",
     "stackblur": "^1.0.0",
     "supercluster": "7.0.0",

--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -102,7 +102,6 @@ function OlMeasureTool (props) {
   }, [projections]);
 
   useEffect(() => {
-    // const dlShapeFiles = () => downloadShapefiles(allMeasurements[crs], crs);
     const dlGeoJSON = () => downloadGeoJSON(allMeasurements[crs], crs);
 
     if (map && map.rendered) {

--- a/web/js/components/measure-tool/util.js
+++ b/web/js/components/measure-tool/util.js
@@ -3,7 +3,6 @@ import {
   Polygon as OlGeomPolygon,
 } from 'ol/geom';
 import geographiclib from 'geographiclib';
-import shpWrite from 'shp-write';
 import FileSaver from 'file-saver';
 import { CRS } from '../../modules/map/constants';
 
@@ -151,19 +150,6 @@ function getFeatureJSON(measurements, crs) {
       };
     }),
   };
-}
-
-export function downloadShapefiles(measurements, crs) {
-  // Set names for feature types and zipped folder
-  const options = {
-    folder: 'worldviewMeasurements',
-    types: {
-      polygon: 'areaMeasurements',
-      polyline: 'distanceMeasurements',
-    },
-  };
-  const json = getFeatureJSON(measurements, crs);
-  shpWrite.download(json, options);
 }
 
 export function downloadGeoJSON(measurements, crs) {


### PR DESCRIPTION
## Description

- Fixes vulnerabilities found in npm audit. 
- Removes the shp-write package and the unused `downloadShapefiles` function. 
- Updates some dependencies in package-lock.json 

## How To Test

- `git checkout wv-2452`
- `npm ci`
- `npm run build`
- `npm run watch`
- Ensure the app builds and there are no issues with the app.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
