### PR TITLE
WV-2506: Fix build paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "3.38.0",
+  "version": "3.39.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -92,6 +92,7 @@
         "css-hot-loader": "^1.4.1",
         "css-loader": "^3.5.2",
         "css-minimizer-webpack-plugin": "^4.1.0",
+        "css-url-relative-plugin": "^1.1.0",
         "cssnano": "^5.1.13",
         "eslint": "^7.5.0",
         "eslint-config-airbnb": "^18.0.1",
@@ -126,6 +127,7 @@
         "react-refresh": "^0.14.0",
         "react-test-renderer": "^16.12.0",
         "redux-mock-store": "^1.5.3",
+        "resolve-url-loader": "^5.0.0",
         "run-script-os": "^1.1.5",
         "sass": "^1.49.7",
         "sass-loader": "^10.1.0",
@@ -3773,6 +3775,19 @@
         "object-assign": "4.x"
       }
     },
+    "node_modules/adjust-sourcemap-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      },
+      "engines": {
+        "node": ">=8.9"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
@@ -6881,6 +6896,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/css-url-relative-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-url-relative-plugin/-/css-url-relative-plugin-1.1.0.tgz",
+      "integrity": "sha512-dr7cF4Fwy4B4t642LjrSQmGRDJT8pNs8YmtO4wT+PSXkuAFtKR4nO70+8qkLK6EmGtu+r3xQHQl1QWXlNyhKnA==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "parse-import": "^2.0.0",
+        "webpack-sources": "^1.1.0"
+      }
+    },
+    "node_modules/css-url-relative-plugin/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/css-url-relative-plugin/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/css-url-relative-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-url-relative-plugin/node_modules/webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "dev": true,
+      "dependencies": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "dev": true,
@@ -9793,6 +9864,19 @@
         "node": "*"
       }
     },
+    "node_modules/get-imports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-imports/-/get-imports-1.0.0.tgz",
+      "integrity": "sha512-9FjKG2Os+o/EuOIh3B/LNMbU2FWPGHVy/gs9TJpytK95IPl7lLqiu+VAU7JX6VZimqdmpLemgsGMdQWdKvqYGQ==",
+      "dev": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1",
+        "import-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -10873,6 +10957,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/import-regex/-/import-regex-1.1.0.tgz",
+      "integrity": "sha512-EblpleIyIdATUKj8ovFojUHyToxgjeKXQgTHZBGZ4cEkbtV21BlO1PSrzZQ6Fei2fgk7uhDeEx656yvPhlRGeA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -16173,6 +16266,18 @@
       "version": "2.0.5",
       "license": "MIT"
     },
+    "node_modules/parse-import": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-import/-/parse-import-2.0.0.tgz",
+      "integrity": "sha512-c59vdx1LiQT+majNKMyfFLrNMAVS9U1bychTv3CEuxbKspgnVTrzLRtgtfCWyAmTuFAxQVSJFasVv8svJLksIg==",
+      "dev": true,
+      "dependencies": {
+        "get-imports": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "4.0.0",
       "dev": true,
@@ -18467,6 +18572,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+      "dev": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "license": "MIT",
@@ -18741,6 +18852,31 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-url-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+      "dev": true,
+      "dependencies": {
+        "adjust-sourcemap-loader": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.14",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/resolve-url-loader/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -20386,6 +20522,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -25941,6 +26083,16 @@
         "object-assign": "4.x"
       }
     },
+    "adjust-sourcemap-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
+      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      }
+    },
     "adm-zip": {
       "version": "0.5.9",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
@@ -28113,6 +28265,55 @@
         }
       }
     },
+    "css-url-relative-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-url-relative-plugin/-/css-url-relative-plugin-1.1.0.tgz",
+      "integrity": "sha512-dr7cF4Fwy4B4t642LjrSQmGRDJT8pNs8YmtO4wT+PSXkuAFtKR4nO70+8qkLK6EmGtu+r3xQHQl1QWXlNyhKnA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "parse-import": "^2.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
+    },
     "css-what": {
       "version": "6.1.0",
       "dev": true
@@ -30099,6 +30300,16 @@
       "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
+    "get-imports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-imports/-/get-imports-1.0.0.tgz",
+      "integrity": "sha512-9FjKG2Os+o/EuOIh3B/LNMbU2FWPGHVy/gs9TJpytK95IPl7lLqiu+VAU7JX6VZimqdmpLemgsGMdQWdKvqYGQ==",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1",
+        "import-regex": "^1.1.0"
+      }
+    },
     "get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -30810,6 +31021,12 @@
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
       }
+    },
+    "import-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/import-regex/-/import-regex-1.1.0.tgz",
+      "integrity": "sha512-EblpleIyIdATUKj8ovFojUHyToxgjeKXQgTHZBGZ4cEkbtV21BlO1PSrzZQ6Fei2fgk7uhDeEx656yvPhlRGeA==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -34430,6 +34647,15 @@
     "parse-headers": {
       "version": "2.0.5"
     },
+    "parse-import": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-import/-/parse-import-2.0.0.tgz",
+      "integrity": "sha512-c59vdx1LiQT+majNKMyfFLrNMAVS9U1bychTv3CEuxbKspgnVTrzLRtgtfCWyAmTuFAxQVSJFasVv8svJLksIg==",
+      "dev": true,
+      "requires": {
+        "get-imports": "^1.0.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "dev": true,
@@ -35934,6 +36160,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
+      "dev": true
+    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "requires": {
@@ -36122,6 +36354,27 @@
     "resolve-url": {
       "version": "0.2.1",
       "dev": true
+    },
+    "resolve-url-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
+      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
+      "dev": true,
+      "requires": {
+        "adjust-sourcemap-loader": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.14",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "responselike": {
       "version": "2.0.1",
@@ -37269,6 +37522,12 @@
         "sort-asc": "^0.1.0",
         "sort-desc": "^0.1.1"
       }
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+      "dev": true
     },
     "source-map": {
       "version": "0.5.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
         "react-refresh": "^0.14.0",
         "react-test-renderer": "^16.12.0",
         "redux-mock-store": "^1.5.3",
-        "resolve-url-loader": "^5.0.0",
         "run-script-os": "^1.1.5",
         "sass": "^1.49.7",
         "sass-loader": "^10.1.0",
@@ -3773,19 +3772,6 @@
       "license": "MIT",
       "dependencies": {
         "object-assign": "4.x"
-      }
-    },
-    "node_modules/adjust-sourcemap-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "regex-parser": "^2.2.11"
-      },
-      "engines": {
-        "node": ">=8.9"
       }
     },
     "node_modules/adm-zip": {
@@ -18572,12 +18558,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/regex-parser": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
-      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
-      "dev": true
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "license": "MIT",
@@ -18852,31 +18832,6 @@
       "version": "0.2.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/resolve-url-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
-      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
-      "dev": true,
-      "dependencies": {
-        "adjust-sourcemap-loader": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "loader-utils": "^2.0.0",
-        "postcss": "^8.2.14",
-        "source-map": "0.6.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -26081,16 +26036,6 @@
       "version": "1.1.0",
       "requires": {
         "object-assign": "4.x"
-      }
-    },
-    "adjust-sourcemap-loader": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
-      "integrity": "sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "regex-parser": "^2.2.11"
       }
     },
     "adm-zip": {
@@ -36160,12 +36105,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regex-parser": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
-      "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
-      "dev": true
-    },
     "regexp.prototype.flags": {
       "version": "1.4.3",
       "requires": {
@@ -36354,27 +36293,6 @@
     "resolve-url": {
       "version": "0.2.1",
       "dev": true
-    },
-    "resolve-url-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
-      "integrity": "sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==",
-      "dev": true,
-      "requires": {
-        "adjust-sourcemap-loader": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "loader-utils": "^2.0.0",
-        "postcss": "^8.2.14",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
     },
     "responselike": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "css-hot-loader": "^1.4.1",
     "css-loader": "^3.5.2",
     "css-minimizer-webpack-plugin": "^4.1.0",
+    "css-url-relative-plugin": "^1.1.0",
     "cssnano": "^5.1.13",
     "eslint": "^7.5.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/tasks/start.js
+++ b/tasks/start.js
@@ -6,7 +6,8 @@ const port = process.env.PORT || 3000;
 
 const app = express();
 app.use(compression());
-app.use(express.static(path.join(__dirname, '../web')));
+// app.use(express.static(path.join(__dirname, '../web')));
+app.use('/test', express.static(path.join(__dirname, '../build/worldview'))); // test dist in a "test" sub directory
 app.set('port', port);
 app.listen(port, () => {
   console.log(`Worldview is available at http://localhost:${port}`);

--- a/tasks/start.js
+++ b/tasks/start.js
@@ -6,8 +6,8 @@ const port = process.env.PORT || 3000;
 
 const app = express();
 app.use(compression());
-// app.use(express.static(path.join(__dirname, '../web')));
-app.use('/test', express.static(path.join(__dirname, '../build/worldview'))); // test dist in a "test" sub directory
+app.use(express.static(path.join(__dirname, '../web')));
+// app.use('/test', express.static(path.join(__dirname, '../build/worldview'))); // test dist in a "test" sub directory
 app.set('port', port);
 app.listen(port, () => {
   console.log(`Worldview is available at http://localhost:${port}`);

--- a/web/index.html
+++ b/web/index.html
@@ -61,7 +61,7 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@NASAEarth">
 
-  <link type="text/css" rel="Stylesheet" href="/build/wv.css?v=@BUILD_NONCE@">
+  <link type="text/css" rel="Stylesheet" href="build/wv.css?v=@BUILD_NONCE@">
   <script type="text/javascript" src="build/wv.js?v=@BUILD_NONCE@"></script>
 
   <link rel="apple-touch-icon" href="images/wv-logo-apple-icon.png">

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -199,8 +199,8 @@ class Sidebar extends React.Component {
       ? 'Click to Open This @NAME@ Map in a New Tab'
       : 'Click to Reset @NAME@ to Defaults';
     const embedWVLogoLink = isEmbedModeActive ? permalink : '/';
-    const mobileImgURL = '../../../brand/images/wv-logo-mobile.svg?v=@BUILD_NONCE@';
-    const desktopImgURL = '../../../brand/images/wv-logo.svg?v=@BUILD_NONCE@';
+    const mobileImgURL = 'brand/images/wv-logo-mobile.svg?v=@BUILD_NONCE@';
+    const desktopImgURL = 'brand/images/wv-logo.svg?v=@BUILD_NONCE@';
 
     const sidebarStyle = isMobile ? {
       background: `url(${mobileImgURL}) no-repeat center rgb(40 40 40 / 85%)`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,11 +6,13 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const CssUrlRelativePlugin = require('css-url-relative-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 
 const pluginSystem = [
   new MomentLocalesPlugin(),
+  new CssUrlRelativePlugin(),
   new MiniCssExtractPlugin({
     filename: 'wv.css',
   }),
@@ -60,7 +62,7 @@ module.exports = {
   output: {
     filename: 'wv.js',
     path: path.resolve(__dirname, 'web/build/'),
-    publicPath: '/build/',
+    publicPath: './',
     pathinfo: false,
     clean: true,
   },


### PR DESCRIPTION
## Description

Changes absolute paths in css files and throughout the app to relative paths.

## How To Test

1. build a dist version of worldview (`npm i`, `npm run dist`)
2. modify tasks/start.js:9 to serve the dist files locally through express (../build/worldview). And set express to use a sub-directory (/test)
 ```
 // app.use(express.static(path.join(__dirname, '../web')));
app.use('/test', express.static(path.join(__dirname, '../build/worldview'))); 
```
3. run `npm start` and navigate to http://localhost:3000/test

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
