### PR TITLE
WV-2536 Fixing granule layers getting stuck

### DIFF
--- a/web/js/mapUI/components/layers/addLayer.js
+++ b/web/js/mapUI/components/layers/addLayer.js
@@ -27,7 +27,7 @@ const AddLayer = (props) => {
     if (action.type === layerConstants.ADD_LAYER) {
       const def = lodashFind(action.layers, { id: action.id });
       if (def.type === 'granule') {
-        granuleLayerAdd(def);
+        return granuleLayerAdd(def);
       }
       clearPreload();
       addLayer(def);
@@ -38,7 +38,6 @@ const AddLayer = (props) => {
     ui.processingPromise = new Promise((resolve) => {
       resolve(addLayer(def));
     });
-    return addLayer(def);
   };
 
   /**


### PR DESCRIPTION
## Description

This fixes a bug that was causing the initial granule layer that gets added to the map when you add a granule layer to stay on the map after you changed dates. So there would be multiple granule layers visible at one time (one would be with incorrect dates). 

1. `git checkout wv-2536-fixing-granules`
2. `npm run watch`
3. Add any granule layer
4. Move the date backwards by one day. 
5. Verify that the map rerenders and removes the previous layer granule layer. 

This is an image of what it would look like after adding a granule layer and changing the date. It should no longer appear like this.
<img width="800" alt="stuck-granules-example" src="https://user-images.githubusercontent.com/89816230/209882511-0791b213-8f78-475c-a3cb-08881464acc8.png">
