### PR TITLE
pin trufflehog to v3.23.0 to fix bug with since-commit flag

### DIFF
--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -12,7 +12,7 @@ jobs:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@v3.23.0
         with:
           path: ./
           base: main


### PR DESCRIPTION
## Description

Fixes broken secrets scan test caused by trufflehog v3.23.1 commit
