### PR TITLE
Updated copyright references to 2023

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@
 This code was originally developed at NASA/Goddard Space Flight Center for
 the Earth Science Data and Information System (ESDIS) project.
 
-Copyright © 2013 - 2022 United States Government as represented by the
+Copyright © 2013 - 2023 United States Government as represented by the
 Administrator of the National Aeronautics and Space Administration.
 All Rights Reserved.
 
@@ -131,7 +131,7 @@ customarily used for software exchange.
 **B.** Each Recipient must ensure that the following copyright notice appears
 prominently in the Subject Software:
 
-    Copyright © 2012-2022 United States Government
+    Copyright © 2012-2023 United States Government
     as represented by the Administrator of the
     National Aeronautics and Space Administration.
     All Rights Reserved.

--- a/config/default/common/brand/about/license.md
+++ b/config/default/common/brand/about/license.md
@@ -1,5 +1,5 @@
 <h2>License</h2>
-<p>Copyright © 2013 - 2022 United States Government as represented by the Administrator of the National Aeronautics
+<p>Copyright © 2013 - 2023 United States Government as represented by the Administrator of the National Aeronautics
     and Space Administration. All Rights Reserved. This software is licensed under the <a
         href="https://ti.arc.nasa.gov/opensource/nosa/" target="_blank" rel="noopener noreferrer">NASA Open Source
         Software Agreement, Version 1.3</a>. Source code is available on the <a

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@ NASA Worldview (https://github.com/nasa-gibs/worldview)
 
 This code was originally developed at NASA/Goddard Space Flight Center for the Earth Science Data and Information System (ESDIS) project.
 
-Copyright (C) 2013 - 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+Copyright (C) 2013 - 2023 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
 
 Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.gsfc.nasa.gov/nosa.php)
 -->


### PR DESCRIPTION
## Description
I noticed a few places where the copyright year needed to be updated to reflect 2023.

## How To Test
Confirm copyright information is correct.

@nasa-gibs/worldview
