### PR TITLE
wv-2594: dockerfile upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM centos:7
+FROM almalinux:9.1
 
-RUN yum install -y epel-release && \
-    yum install -y \
+RUN dnf install -y epel-release && \
+    dnf --enablerepo=crb install giflib-devel -y && \
+    dnf install -y \
     "@Development Tools" \
     cairo-devel \
     firefox \
-    giflib-devel \
     httpd \
     libjpeg-turbo-devel \
     java-1.8.0-openjdk \
@@ -18,10 +18,10 @@ RUN yum install -y epel-release && \
     openssl-devel \
     xz
 RUN cd /usr/src && \
-    wget https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz  && \
-    tar xzf Python-3.9.4.tgz && \
-    rm Python-3.9.4.tgz && \
-    cd Python-3.9.4 && \
+    wget https://www.python.org/ftp/python/3.9.16/Python-3.9.16.tgz  && \
+    tar xzf Python-3.9.16.tgz && \
+    rm Python-3.9.16.tgz && \
+    cd Python-3.9.16 && \
     ./configure --enable-optimizations && \
     make altinstall && \
     ln -sf /usr/local/bin/python3.9 /usr/local/bin/python3 && \
@@ -33,8 +33,8 @@ RUN cd /usr/src && \
     pip --version
 RUN mkdir -p /usr/local/nvm
 ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=16.18.0
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+ENV NODE_VERSION=18.14.0
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash && \
     . "$NVM_DIR/nvm.sh" && \
     nvm install v${NODE_VERSION} && \
     nvm use v${NODE_VERSION} && \


### PR DESCRIPTION
## Description

Fixes wv-3594

Upgrades the e2e Dockerfile from RHEL 7 (centos:7) to RHEL 9 (almalinux:9.1)

## How To Test

- Run `npm run docker:image` and ensure the dockerfile builds successfully
- Run `npm run docker:ci` to ensure the e2e tests run.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
