### PR TITLE
WV-2587: Fixing Layer Order On Start

### DIFF
--- a/e2e/features/layers/layers-sidebar-test.js
+++ b/e2e/features/layers/layers-sidebar-test.js
@@ -52,11 +52,11 @@ const groupedLayerIdOrder = [
   'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
 ];
 const ungroupedReorderdLayerIdOrder = [
-  'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
   'active-MODIS_Combined_Value_Added_AOD',
-  'active-Reference_Features_15m',
+  'active-MODIS_Combined_MAIAC_L2G_AerosolOpticalDepth',
   'active-VIIRS_SNPP_Thermal_Anomalies_375m_All',
   'active-VIIRS_NOAA20_Thermal_Anomalies_375m_All',
+  'active-Reference_Features_15m',
 ];
 
 module.exports = {

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -333,8 +333,8 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
       layers.forEach((layer) => {
         if (layer.layergroup === 'Reference') {
           lastRefIndex = index;
+          index += 1;
         }
-        index += 1;
       });
       if (lastRefIndex === 0) {
         return lastRefIndex;

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -331,7 +331,7 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
       let index = 0;
 
       layers.forEach((layer) => {
-        if (layer.layergroup === 'Reference') {
+        if (layer.layergroup === 'Reference' && layer.group !== 'baselayers') {
           lastRefIndex = index;
           index += 1;
         }


### PR DESCRIPTION
## Description

This fixes an issue where the layer groups were being reordered from the permalink. 

## How To Test

1. `git checkout wv-2587-fixing-layer-order`
2. `npm run watch`
3. Load URL `http://localhost:3000/?v=-153.70528206889688,2.910068263484021,-45.19495277801988,56.85125626166882&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),OrbitTracks_Sentinel-2A_Descending,OrbitTracks_Sentinel-2B_Descending,OrbitTracks_Landsat-8_Descending(hidden),HLS_S30_Nadir_BRDF_Adjusted_Reflectance,HLS_L30_Nadir_BRDF_Adjusted_Reflectance(hidden),Land_Water_Map&lg=true&t=2021-01-15-T18%3A41%3A50Z`
4. Refresh the page
5. Verify that the layer groups have not been reordered
