### PR TITLE
WV-2597: Removing Measurement Tooltip after projection change

### DIFF
--- a/web/js/components/map/ol-measure-tool.js
+++ b/web/js/components/map/ol-measure-tool.js
@@ -124,6 +124,9 @@ function OlMeasureTool (props) {
 
   useEffect(recalculateAllMeasurements, [crs]);
 
+  // we need this to make sure we have the latest version of olMap in renderToolTip()
+  useEffect(recalculateAllMeasurements, [olMap]);
+
   const areaBgFill = new OlStyleFill({
     color: 'rgba(213, 78, 33, 0.1)',
   });


### PR DESCRIPTION
## Description

After making a measurement, switching the projection, switching back to the previous projection and removing the measurement, the measurement tooltip was not being removed. I have updated the `ol-measure-tool.js` component to recalculate all of the measurements when the OpenLayers map object variable is updated. The issue was that the function `renderToolTip` which renders the DOM node for the tooltip was using an out dated version of the OL Map object at the time you would click the close button. 


## How To Test

To see the bug in production:

1. Create a measurement in Geographic projection.
2. Switch to Arctic projection.
3. Switch back to Geographic projection.
4. Remove the measurement with the X on its tooltip.
5. Observe how the measurement line was removed but not the tooltip itself. 

Test feature fix branch:
1. `git checkout wv-2597`
2. `npm run watch`
3. Follow steps 1-4 above.
4. Verify that the measurement tool tip is no longer displayed on the map. 





