### PR TITLE
WV-2606 Fix typo

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -48,7 +48,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
   );
 
   function dispathCMRErrorDialog (title) {
-    const bodyText = `The Common Metadata Repository(CMR) service that
+    const bodyText = `The Common Metadata Repository (CMR) service that
                       provides metadata for this granule layer, ${title}, is currently unavailable.
                       Please try again later.`;
     const modalHeader = 'Granules unavailable at this time.';


### PR DESCRIPTION
## Description
Added space between 'Common Metadata Repository' & '(CMR)' in granule error dialog.

Fixes WV-2606

@nasa-gibs/worldview
