### PR TITLE
WV-2605: Fixing layer ordering in compare mode after removing layers

### DIFF
--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -18,7 +18,7 @@ import {
 } from '../../modules/layers/selectors';
 import {
   reorderLayers as reorderLayersAction,
-  removeLayer as removeLayerAction,
+  removeGroup as removeGroupAction,
   toggleGroupVisibility as toggleGroupVisibilityAction,
 } from '../../modules/layers/actions';
 
@@ -43,7 +43,7 @@ function LayerList(props) {
     available,
     groupId,
     title,
-    removeLayers,
+    removeGroup,
     toggleVisibility,
     toggleCollapse,
     isMobile,
@@ -132,7 +132,7 @@ function LayerList(props) {
         <DropdownItem id="hide-all" onClick={() => toggleVisibility(groupLayerIds, false)}>
           Hide All Layers
         </DropdownItem>
-        <DropdownItem id="remove-group" onClick={() => removeLayers(groupLayerIds)}>
+        <DropdownItem id="remove-group" onClick={() => removeGroup(groupLayerIds)}>
           Remove Group
         </DropdownItem>
       </DropdownMenu>
@@ -244,10 +244,8 @@ const mapDispatchToProps = (dispatch) => ({
   reorderLayers: (newLayerArray) => {
     dispatch(reorderLayersAction(newLayerArray));
   },
-  removeLayers: (layerIds) => {
-    layerIds.forEach((id) => {
-      dispatch(removeLayerAction(id));
-    });
+  removeGroup: (layerIds) => {
+    dispatch(removeGroupAction(layerIds));
   },
   toggleVisibility: (layerIds, visible) => {
     dispatch(toggleGroupVisibilityAction(layerIds, visible));

--- a/web/js/mapUI/components/layers/addLayer.js
+++ b/web/js/mapUI/components/layers/addLayer.js
@@ -15,10 +15,10 @@ function AddLayer(props) {
     action,
     activeLayersState,
     activeString,
+    compareDate,
     compareMapUi,
     mode,
     preloadNextTiles,
-    selected,
     updateLayerVisibilities,
     ui,
   } = props;
@@ -47,7 +47,7 @@ function AddLayer(props) {
  */
   const addLayer = async function(def, layerDate, activeLayersParam) {
     const { createLayer } = ui;
-    const date = layerDate || selected;
+    const date = layerDate || compareDate;
     const activeLayers = activeLayersParam || activeLayersState;
     const reverseLayers = lodashCloneDeep(activeLayers).reverse();
     const index = lodashFindIndex(reverseLayers, { id: def.id });
@@ -78,13 +78,14 @@ function AddLayer(props) {
 const mapStateToProps = (state) => {
   const { compare, date } = state;
   const { activeString, mode } = compare;
-  const { selected } = date;
+  const { selected, selectedB } = date;
   const activeLayersState = getActiveLayers(state);
+  const compareDate = compare.active && activeString === 'activeB' ? selectedB : selected;
   return {
     activeLayersState,
+    compareDate,
     activeString,
     mode,
-    selected,
   };
 };
 

--- a/web/js/mapUI/components/layers/removeLayer.js
+++ b/web/js/mapUI/components/layers/removeLayer.js
@@ -1,12 +1,14 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getActiveLayerGroup } from '../../../modules/layers/selectors';
 
 function RemoveLayer(props) {
   const {
     action,
     compare,
     findLayer,
+    map,
     ui,
     updateLayerVisibilities,
   } = props;
@@ -21,7 +23,8 @@ function RemoveLayer(props) {
     layersToRemove.forEach((def) => {
       const layer = findLayer(def, compare.activeString);
       if (compare && compare.active) {
-        if (ui.selected) ui.selected.getLayers().remove(layer);
+        const layerGroup = getActiveLayerGroup({ map, compare });
+        if (layerGroup) layerGroup.getLayers().remove(layer);
       } else {
         ui.selected.removeLayer(layer);
       }
@@ -33,12 +36,14 @@ function RemoveLayer(props) {
 }
 
 const mapStateToProps = (state) => {
-  const { compare } = state;
+  const { compare, map } = state;
 
   return {
     compare,
+    map,
   };
 };
+
 export default React.memo(
   connect(
     mapStateToProps,
@@ -49,6 +54,7 @@ RemoveLayer.propTypes = {
   action: PropTypes.any,
   compare: PropTypes.object,
   findLayer: PropTypes.func,
+  map: PropTypes.object,
   ui: PropTypes.object,
   updateLayerVisibilities: PropTypes.func,
 };

--- a/web/js/mapUI/mapUI.js
+++ b/web/js/mapUI/mapUI.js
@@ -359,7 +359,6 @@ function MapUI(props) {
       />
       <RemoveLayer
         action={removeLayersAction}
-        compareMapUi={compareMapUi}
         updateLayerVisibilities={updateLayerVisibilities}
         findLayer={findLayer}
         ui={ui}


### PR DESCRIPTION
## Description

This fixes a bug that was causing layers to be added out of order when they were removed while compare mode was active and added again.

## How To Test

1. `git checkout wv-2605` 
2. `npm run watch`
3. Start compare mode
4. Remove all of the layer groups with the `Remove Group` button. 
5.  Add the Aerosol Optical Depth MODIS/Terra layer.
6. Add the Corrected Reflectance MODIS/Terra layer.
7. Click on the B side tab.
8. Remove all of the layer groups with the `Remove Group` button. 
9. Add the Aerosol Optical Depth MODIS/Aqua layer.
10. Add the Corrected Reflectance MODIS/Aqua layer.
11. Verify that the layers are shown in the correct order and you can still perform the swipe compare action. 

