### PR TITLE
WV-2602: Fix accessing links with 0 layers

### DIFF
--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -124,6 +124,9 @@ export const getActiveOverlayGroups = (state) => {
     return getActiveOverlayGroupsEmbed(state);
   }
   const activeLayersMap = getActiveLayersMap(state);
+
+  if (!Object.keys(activeLayersMap).length) return [];
+
   return (overlayGroups || []).filter(
     (group) => group.layers.filter(
       (id) => !!activeLayersMap[id].projections[proj.id],


### PR DESCRIPTION
## Description

Currently when accessing UAT from the test [link perm.in.layers.3](https://worldview.uat.earthdata.nasa.gov/?l=&now=2013-07-01T12 ) which tests the ability to access links with 0 layers, WV will throw an error. This fixes this prevents this error so that you can access these links with 0 layers. 

## How To Test

1. `git checkout wv-2602`
2. `npm run watch`
3. Access this [link](http://localhost:3000/?l=&now=2013-07-01T12)
4. Verify that the map loads without errors and displays without any layers.

