### PR TITLE
WV-2607 Granule zoom issues on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">= 18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -303,7 +303,6 @@ const mapDispatchToProps = (dispatch) => ({
   activateVectorExceededResultsAlert: () => dispatch({ type: ACTIVATE_VECTOR_EXCEEDED_ALERT }),
   clearVectorExceededResultsAlert: () => dispatch({ type: DISABLE_VECTOR_EXCEEDED_ALERT }),
   openVectorDialog: (dialogId, metaArray, offsetLeft, offsetTop, screenSize, isEmbedModeActive) => {
-    console.log('openVectorDialog');
     const { screenHeight, screenWidth } = screenSize;
     const isMobile = screenSize.isMobileDevice;
     const dialogKey = new Date().getUTCMilliseconds();

--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -303,6 +303,7 @@ const mapDispatchToProps = (dispatch) => ({
   activateVectorExceededResultsAlert: () => dispatch({ type: ACTIVATE_VECTOR_EXCEEDED_ALERT }),
   clearVectorExceededResultsAlert: () => dispatch({ type: DISABLE_VECTOR_EXCEEDED_ALERT }),
   openVectorDialog: (dialogId, metaArray, offsetLeft, offsetTop, screenSize, isEmbedModeActive) => {
+    console.log('openVectorDialog');
     const { screenHeight, screenWidth } = screenSize;
     const isMobile = screenSize.isMobileDevice;
     const dialogKey = new Date().getUTCMilliseconds();

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -400,6 +400,7 @@ export const granuleFootprint = (map) => {
   };
 
   const drawFootprint = (points, date) => {
+    console.log('drawFootprint');
     const geometry = new OlGeomPolygon([points]);
     const featureFootprint = new OlFeature({ geometry });
     const newVectorLayer = getVectorLayer(date);

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -366,7 +366,6 @@ export const areCoordinatesAndPolygonExtentValid = (points, coords, maxExtent) =
  * @returns
  */
 export const granuleFootprint = (map, initialIsMobile) => {
-  console.log(`initialIsMobile: ${initialIsMobile}`);
   let currentGranule = {};
   let vectorLayer = {};
   const vectorSource = new OlVectorSource({

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -409,7 +409,7 @@ export const granuleFootprint = (map, initialIsMobile) => {
     map.addLayer(vectorLayer);
   };
 
-  const debouncedDrawFootprint = debounce(drawFootprint, 2000);
+  const debouncedDrawFootprint = debounce(drawFootprint, 850);
 
   const addFootprint = (points, date) => {
     if (currentGranule[date]) {

--- a/web/js/mapUI/components/create-map/createMap.js
+++ b/web/js/mapUI/components/create-map/createMap.js
@@ -54,7 +54,7 @@ function CreateMap(props) {
     updateRotation,
   } = props;
 
-  const { projections } = config;
+  const { initialIsMobile, projections } = config;
   let granuleFootprintsObj = {};
   const animationDuration = 250;
   const doubleClickZoom = new OlInteractionDoubleClickZoom({
@@ -219,7 +219,7 @@ function CreateMap(props) {
     });
     map.on('rendercomplete', onRenderComplete);
 
-    granuleFootprintsObj = { ...granuleFootprintsObj, [proj.crs]: granuleFootprint(map) };
+    granuleFootprintsObj = { ...granuleFootprintsObj, [proj.crs]: granuleFootprint(map, initialIsMobile) };
 
     window.addEventListener('resize', () => {
       map.getView().changed();


### PR DESCRIPTION
## Description
With granules loaded, zooming in on the map will sometimes result in incorrect pinch/swipe behavior. For instance, if a user tries to pan by swiping left-right with their finger the app will instead zoom. This behavior is most noticeable on my iPhone; Android seemed to work OK prior to the fix.

Steps to recreate: 

- Load a granule layer
- Turn off any other baselayer
- Two finger pinch and zoom FAR into the granules
- Two finger pinch to zoom and moving one finger to pan behave incorrectly.

Fixes WV-2607.

## How To Test

- git checkout wv-2607_granule_zoom_issues
- Connect your iPhone to access localhost ([for Windows](https://stackoverflow.com/questions/3132105/how-do-you-access-a-website-running-on-localhost-from-iphone-browser))
- Follow the steps to recreate above & confirm that the pinch/pan behavior is improved

@nasa-gibs/worldview
