### PR TITLE
WV-2601: Fix palette error when sidebar is collapsed 

### DIFF
--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -8,6 +8,7 @@ import { getInitialState as getInitialDateState } from './modules/date/reducers'
 import { defaultState as initialAnimationState } from './modules/animation/reducers';
 import { defaultAlertState } from './modules/alerts/reducer';
 import { getInitialEventsState } from './modules/natural-events/reducers';
+import { sidebarState as initialSidebarState } from './modules/sidebar/reducers';
 import util from './util/util';
 
 const mockBaseCmrApi = 'mock.cmr.api/';
@@ -33,6 +34,7 @@ fixtures.getState = function() {
     events: getInitialEventsState(fixtures.config()),
     map: fixtures.map(),
     animation: initialAnimationState,
+    sidebar: initialSidebarState,
     proj: {
       selected: {
         id: 'geographic',

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -42,8 +42,10 @@ export function getPalette(layerId, index, groupStr, state) {
 }
 
 export function getRenderedPalette(layerId, index, state) {
-  const { config, palettes } = state;
+  const { config, palettes, sidebar: { isCollapsed } } = state;
+  if (isCollapsed) return;
   const name = lodashGet(config, `layers['${layerId}'].palette.id`);
+
   let palette = palettes.rendered[name];
   if (!palette) {
     throw new Error(`${name} Is not a rendered palette`);


### PR DESCRIPTION
## Description

This fixes a bug where the `getRenderedPalettes` function was being called when the sidebar was collapsed.  We do not store `renderedPalettes` in the store when the sidebar is collapsed and there is no reason to try to update the color bars in the sidebar if it is collapsed. 

## How To Test

1. `git checkout wv-2601`
2. `npm run watch`
3. Collapse the layer list on the left
4. Open the tour stories and select `Hurricane Maria`
5. Progress to step 3 and move the mouse cursor off of the tour story text box 
6. Verify that no palettes error occurs.
7. Open the layer list on the left and mouse over some of the render palettes on the map
8. Verify that the color bar still updates when mousing over these palettes.