### PR TITLE
WV-2601: Fixing palette error with collapsed sidebar

### DIFF
--- a/web/js/fixtures.js
+++ b/web/js/fixtures.js
@@ -8,6 +8,7 @@ import { getInitialState as getInitialDateState } from './modules/date/reducers'
 import { defaultState as initialAnimationState } from './modules/animation/reducers';
 import { defaultAlertState } from './modules/alerts/reducer';
 import { getInitialEventsState } from './modules/natural-events/reducers';
+import { sidebarState as initialSidebarState } from './modules/sidebar/reducers';
 import util from './util/util';
 
 const mockBaseCmrApi = 'mock.cmr.api/';
@@ -33,6 +34,7 @@ fixtures.getState = function() {
     events: getInitialEventsState(fixtures.config()),
     map: fixtures.map(),
     animation: initialAnimationState,
+    sidebar: initialSidebarState,
     proj: {
       selected: {
         id: 'geographic',

--- a/web/js/map/runningdata.js
+++ b/web/js/map/runningdata.js
@@ -35,6 +35,8 @@ export default function MapRunningData(compareUi, store) {
 
     // Determine if we should do anything with this vector layer
     const shouldNotProcessVectorLayer = (layer) => {
+      const state = store.getState();
+      const { sidebar: { isCollapsed } } = state;
       const def = lodashGet(layer, 'wv.def');
       if (!def) return true;
       const { wrapX, wrapadjacentdays } = def;
@@ -44,7 +46,7 @@ export default function MapRunningData(compareUi, store) {
       const featureOutsideExtent = !olExtent.containsCoordinate(layer.get('extent'), coords);
       const inCompareRegion = isFromActiveCompareRegion(pixel, layer.wv.group, compare, swipeOffset);
       const hasPalette = !lodashIsEmpty(def.palette);
-      return !isRenderedFeature || !inCompareRegion || featureOutsideExtent || !hasPalette;
+      return !isRenderedFeature || !inCompareRegion || featureOutsideExtent || !hasPalette || isCollapsed;
     };
 
     // Running data for vector layers
@@ -76,10 +78,12 @@ export default function MapRunningData(compareUi, store) {
 
     // Determine if we should do anything with this raster layer
     const shouldNotProcessRasterLayer = (layer) => {
+      const state = store.getState();
+      const { sidebar: { isCollapsed } } = state;
       const type = lodashGet(layer, 'wv.def.type');
       const isGranule = type === 'granule' && !layer.get('granuleGroup');
       const hasPalette = !!lodashGet(layer, 'wv.def.palette');
-      return isGranule || layer.isVector || !hasPalette;
+      return isGranule || layer.isVector || !hasPalette || isCollapsed;
     };
 
     // Running data for raster layers


### PR DESCRIPTION
Description
This fixes a bug where the getRenderedPalettes function was being called when the sidebar was collapsed. We do not store renderedPalettes in the store when the sidebar is collapsed and there is no reason to try to update the color bars in the sidebar if it is collapsed.

How To Test
1. `git checkout wv-2601-palette-fix`
2. `npm run watch`
3. Collapse the layer list on the left
4. Open the tour stories and select Hurricane Maria
5. Progress to step 3 and move the mouse cursor off of the tour story text box
6. Verify that no palettes error occurs.
7. Open the layer list on the left and mouse over some of the render palettes on the map
8. Verify that the color bar still updates when mousing over these palettes
9. Load this [URL](http://localhost:3000/?v=-80.8712032570963,35.19828043896156,-73.10401616661336,40.54016491512236&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GRanD_Reservoirs,GRanD_Dams,VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2023-02-27-T19%3A34%3A58Z)
10. Hover over one of the vector palettes and verify that no palette errors occurs
