### PR TITLE
Change to async fetch in getCapabilities.js

### DIFF
--- a/tasks/build-options/getCapabilities.js
+++ b/tasks/build-options/getCapabilities.js
@@ -74,7 +74,6 @@ async function getCapabilities () {
   }
 }
 
-// convert to superagent and use promises
 async function fetchConfigs (inputFile, outputFile) {
   const writer = await fs.createWriteStream(outputFile)
   return axios({
@@ -173,9 +172,9 @@ async function gatherProcess (type, typeStr, dir, ext) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)
   }
-  Object.values(type).forEach(async (link) => {
+  for (const link of Object.values(type)) {
     await processMetadata(link, dir, ext)
-  })
+  }
 }
 
 main().catch((err) => {

--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -258,10 +258,9 @@ async function readFileAsync (file) {
 }
 
 async function processFile (id, xml) {
-  let document
   let colormaps = []
   try {
-    document = JSON.parse(convert.xml2json(xml, { compact: true, spaces: 2 }))
+    const document = JSON.parse(convert.xml2json(xml, { compact: true, spaces: 2 }))
     if (document && document.ColorMaps && document.ColorMaps.ColorMap) {
       colormaps = await toList(document.ColorMaps.ColorMap)
     }


### PR DESCRIPTION
## Description

Fixes fetch errors in getCapabilities.json when fetching colormaps, vector styles and vector data synchronously.
Fixes TypeError: Converting circular structure to JSON

## How To Test

- `npm i`
- `npm run build`
- check that there are no circular json errors occuring

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview
