### PR TITLE
WV-2433 On mobile, "Add Layer" and "Start Comparison Mode" should not stack

### DIFF
--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -359,7 +359,7 @@ footer .compare-toggle-button {
   }
 
   #products-holder footer .product-buttons {
-    height: 120px;
+    height: 70px;
   }
 }
 

--- a/web/scss/mobile.scss
+++ b/web/scss/mobile.scss
@@ -40,13 +40,11 @@
 
     button#layers-add,
     button#compare-toggle-button {
-      width: 100%;
-      position: relative;
-      left: 0;
+      width: 50%;
       height: 50px;
 
       span {
-        font-size: 18px;
+        font-size: 14px;
       }
     }
 


### PR DESCRIPTION
## Description

On mobile, in landscape view "Add Layer" and "Start Comparison Mode" buttons should not stack

These buttons shouldn't stack in landscape view because they end up consuming way too much vertical space.  The layout should change to show them side-by-side.

Fixes # WV-2433

## How To Test

- Open Chrome and turn on developer mode.
- Click the button on the top left of development mode to switch to mobile view.
- Click on the "layers" icon.

<img width="457" alt="Screen Shot 2023-03-06 at 12 30 07 PM" src="https://user-images.githubusercontent.com/5401206/223451713-40a7183b-5bdc-4dd0-b1c2-44761f042c70.png">

@nasa-gibs/worldview
