### PR TITLE
WV-2436: "Categories" breadcrumb element should not show in Recent Layers

### DIFF
--- a/web/js/components/layer/product-picker/header.js
+++ b/web/js/components/layer/product-picker/header.js
@@ -80,36 +80,19 @@ class ProductPickerHeader extends React.Component {
   renderBreadCrumb() {
     const { category } = this.props;
     return (
-      <>
-        <Button
-          id="layer-back-button"
-          className="back-button"
-          color="secondary"
+      <Breadcrumb tag="nav" className="layer-bread-crumb">
+        <BreadcrumbItem
+          tag="a"
+          title="Back to Layer Categories"
+          href="#"
           onClick={this.revertToInitialScreen}
         >
-          <UncontrolledTooltip
-            id="center-align-tooltip"
-            placement="right"
-            target="layer-back-button"
-          >
-            Return to category view
-          </UncontrolledTooltip>
-          <FontAwesomeIcon icon="arrow-left" />
-        </Button>
-        <Breadcrumb tag="nav" className="layer-bread-crumb">
-          <BreadcrumbItem
-            tag="a"
-            title="Back to Layer Categories"
-            href="#"
-            onClick={this.revertToInitialScreen}
-          >
-            Categories
-          </BreadcrumbItem>
-          <BreadcrumbItem active tag="span">
-            {category && category.title}
-          </BreadcrumbItem>
-        </Breadcrumb>
-      </>
+          Categories
+        </BreadcrumbItem>
+        <BreadcrumbItem active tag="span">
+          {category && category.title}
+        </BreadcrumbItem>
+      </Breadcrumb>
     );
   }
 
@@ -151,11 +134,12 @@ class ProductPickerHeader extends React.Component {
     } = this.props;
     const searchMode = mode === 'search';
     const categoryId = category && category.id;
+    const recentLayersMode = categoryType === 'recent';
     const showBackButton = searchMode
       || (categoryId !== 'featured-all'
       && selectedProjection === 'geographic'
-      && mode !== 'category');
-    const recentLayersMode = categoryType === 'recent';
+      && mode !== 'category'
+      && !recentLayersMode);
     const isBreadCrumb = showBackButton && !searchMode && width > 650 && !recentLayersMode;
     const showReset = !!(filters.length || searchTerm.length) && mode === 'search';
     const showFilterBtnMobile = recentLayersMode
@@ -171,6 +155,21 @@ class ProductPickerHeader extends React.Component {
         <InputGroup id="layer-search" className="layer-search">
           {showBackButton && (
             <>
+              <Button
+                id="layer-back-button"
+                className="back-button"
+                color="secondary"
+                onClick={this.revertToInitialScreen}
+              >
+                <UncontrolledTooltip
+                  id="center-align-tooltip"
+                  placement="right"
+                  target="layer-back-button"
+                >
+                  Return to category view
+                </UncontrolledTooltip>
+                <FontAwesomeIcon icon="arrow-left" />
+              </Button>
               {isBreadCrumb && this.renderBreadCrumb()}
             </>
           )}

--- a/web/js/components/layer/product-picker/header.js
+++ b/web/js/components/layer/product-picker/header.js
@@ -80,19 +80,36 @@ class ProductPickerHeader extends React.Component {
   renderBreadCrumb() {
     const { category } = this.props;
     return (
-      <Breadcrumb tag="nav" className="layer-bread-crumb">
-        <BreadcrumbItem
-          tag="a"
-          title="Back to Layer Categories"
-          href="#"
+      <>
+        <Button
+          id="layer-back-button"
+          className="back-button"
+          color="secondary"
           onClick={this.revertToInitialScreen}
         >
-          Categories
-        </BreadcrumbItem>
-        <BreadcrumbItem active tag="span">
-          {category && category.title}
-        </BreadcrumbItem>
-      </Breadcrumb>
+          <UncontrolledTooltip
+            id="center-align-tooltip"
+            placement="right"
+            target="layer-back-button"
+          >
+            Return to category view
+          </UncontrolledTooltip>
+          <FontAwesomeIcon icon="arrow-left" />
+        </Button>
+        <Breadcrumb tag="nav" className="layer-bread-crumb">
+          <BreadcrumbItem
+            tag="a"
+            title="Back to Layer Categories"
+            href="#"
+            onClick={this.revertToInitialScreen}
+          >
+            Categories
+          </BreadcrumbItem>
+          <BreadcrumbItem active tag="span">
+            {category && category.title}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </>
     );
   }
 
@@ -139,7 +156,7 @@ class ProductPickerHeader extends React.Component {
       && selectedProjection === 'geographic'
       && mode !== 'category');
     const recentLayersMode = categoryType === 'recent';
-    const isBreadCrumb = showBackButton && !searchMode && width > 650;
+    const isBreadCrumb = showBackButton && !searchMode && width > 650 && !recentLayersMode;
     const showReset = !!(filters.length || searchTerm.length) && mode === 'search';
     const showFilterBtnMobile = recentLayersMode
       || (searchMode ? !showMobileFacets : !selectedLayer);
@@ -154,21 +171,6 @@ class ProductPickerHeader extends React.Component {
         <InputGroup id="layer-search" className="layer-search">
           {showBackButton && (
             <>
-              <Button
-                id="layer-back-button"
-                className="back-button"
-                color="secondary"
-                onClick={this.revertToInitialScreen}
-              >
-                <UncontrolledTooltip
-                  id="center-align-tooltip"
-                  placement="right"
-                  target="layer-back-button"
-                >
-                  Return to category view
-                </UncontrolledTooltip>
-                <FontAwesomeIcon icon="arrow-left" />
-              </Button>
               {isBreadCrumb && this.renderBreadCrumb()}
             </>
           )}


### PR DESCRIPTION
## Description

"Categories" breadcrumb element should not show in Recent Layers

Fixes # WV-2436

## How To Test

- Open the product picker
- Select the "Featured" tab first
- Now select the "Recent" tab

Result: The "Categories" breadcrumb UI element should no longer show up under the "Recent" tab.

https://user-images.githubusercontent.com/5401206/223852186-615ab997-295d-48e7-9e89-124404132e7e.mov

@nasa-gibs/worldview
