### PR TITLE
WV-2437: On mobile, category label should not show on "Featured" tab

### DIFF
--- a/web/js/components/layer/product-picker/header.js
+++ b/web/js/components/layer/product-picker/header.js
@@ -134,11 +134,13 @@ class ProductPickerHeader extends React.Component {
     } = this.props;
     const searchMode = mode === 'search';
     const categoryId = category && category.id;
+    const recentLayersMode = categoryType === 'recent';
+    const featuredLayersMode = categoryType === 'featured';
     const showBackButton = searchMode
       || (categoryId !== 'featured-all'
       && selectedProjection === 'geographic'
-      && mode !== 'category');
-    const recentLayersMode = categoryType === 'recent';
+      && mode !== 'category'
+      && !featuredLayersMode);
     const isBreadCrumb = showBackButton && !searchMode && width > 650;
     const showReset = !!(filters.length || searchTerm.length) && mode === 'search';
     const showFilterBtnMobile = recentLayersMode

--- a/web/js/modules/product-picker/reducers.js
+++ b/web/js/modules/product-picker/reducers.js
@@ -1,4 +1,5 @@
 import googleTagManager from 'googleTagManager';
+import { get as lodashGet } from 'lodash';
 
 import {
   SAVE_SEARCH_STATE,
@@ -158,13 +159,18 @@ export function productPickerReducer(state = productPickerState, action) {
     }
 
     case TOGGLE_FEATURED_TAB: {
+      const { config } = action;
+      const category = lodashGet(config, 'categories.featured.All');
+      const selectedMeasurement = lodashGet(category, 'measurements[0]');
+      const selectedMeasurementId = lodashGet(config, `measurements[${selectedMeasurement}].id`);
       return {
         ...state,
         categoryType: 'featured',
+        // category,
         category: null,
         mode: 'measurements',
         selectedLayer: null,
-        selectedMeasurement: null,
+        selectedMeasurement: selectedMeasurementId,
         selectedMeasurementSourceIndex: 0,
       };
     }

--- a/web/js/modules/product-picker/reducers.js
+++ b/web/js/modules/product-picker/reducers.js
@@ -1,5 +1,4 @@
 import googleTagManager from 'googleTagManager';
-import { get as lodashGet } from 'lodash';
 
 import {
   SAVE_SEARCH_STATE,

--- a/web/js/modules/product-picker/reducers.js
+++ b/web/js/modules/product-picker/reducers.js
@@ -159,17 +159,13 @@ export function productPickerReducer(state = productPickerState, action) {
     }
 
     case TOGGLE_FEATURED_TAB: {
-      const { config } = action;
-      const category = lodashGet(config, 'categories.featured.All');
-      const selectedMeasurement = lodashGet(category, 'measurements[0]');
-      const selectedMeasurementId = lodashGet(config, `measurements[${selectedMeasurement}].id`);
       return {
         ...state,
         categoryType: 'featured',
-        category,
+        category: null,
         mode: 'measurements',
         selectedLayer: null,
-        selectedMeasurement: selectedMeasurementId,
+        selectedMeasurement: null,
         selectedMeasurementSourceIndex: 0,
       };
     }

--- a/web/js/modules/product-picker/reducers.js
+++ b/web/js/modules/product-picker/reducers.js
@@ -166,7 +166,6 @@ export function productPickerReducer(state = productPickerState, action) {
       return {
         ...state,
         categoryType: 'featured',
-        // category,
         category: null,
         mode: 'measurements',
         selectedLayer: null,

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -424,7 +424,7 @@
 
     & .product-outter-list-case {
       width: 100%;
-      padding: 6px 4px;
+      padding: 0 4px;
     }
   }
 


### PR DESCRIPTION
## Description

When the "Featured" tab is chosen in a mobile layout, the header element which would display the category title in other tabs (e.g. Air Quality seen below under Hazards and Disasters tab) should not be visible.  Right now it just shows "All"

Fixes # WV-2437

## How To Test

- Click on "Add Layers"
- Click the header dropdown and selected "Featured"
- "All" should no longer be there.

<img width="516" alt="Screen Shot 2023-03-08 at 2 12 35 PM" src="https://user-images.githubusercontent.com/5401206/223863014-a974a948-e220-4f11-a0ad-81e83db7da62.png">

@nasa-gibs/worldview
