### PR TITLE
WV-2438 On mobile, categories layout landscape could be improved

### DIFF
--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -210,7 +210,7 @@ function BrowseLayers (props) {
               <CategoryGrid width={width} />
             </div>
           ) : renderContent()
-        }
+      }
     </>
   );
 }

--- a/web/js/components/layer/product-picker/browse/category-grid.js
+++ b/web/js/components/layer/product-picker/browse/category-grid.js
@@ -27,13 +27,9 @@ function CategoryGrid(props) {
     width,
   } = props;
   const setColumnWidth = (width) => {
-    console.log(width)
-    if (width >= 656) {
-      return 310;
-    } else {
-      return 0;
-    }
-  }
+    if (width >= 656) return 310;
+    return 0;
+  };
   const masonryOptions = {
     transitionDuration: '0.6s',
     columnWidth: setColumnWidth(width),

--- a/web/js/components/layer/product-picker/browse/category-grid.js
+++ b/web/js/components/layer/product-picker/browse/category-grid.js
@@ -26,9 +26,17 @@ function CategoryGrid(props) {
     categoryType,
     width,
   } = props;
+  const setColumnWidth = (width) => {
+    console.log(width)
+    if (width >= 656) {
+      return 310;
+    } else {
+      return 0;
+    }
+  }
   const masonryOptions = {
     transitionDuration: '0.6s',
-    columnWidth: width >= 630 ? 310 : width - 26,
+    columnWidth: setColumnWidth(width),
     gutter: 10,
   };
   categories.forEach((item) => {

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -853,10 +853,6 @@
     }
   }
 
-  .category-masonry-case .layer-category {
-    width: 100%;
-  }
-
   .category-background-cover {
     background-size: cover;
   }
@@ -882,6 +878,16 @@
       height: 30px;
       width: 30px;
     }
+  }
+}
+
+@media (max-width: 768px) {
+  .category-masonry-case {
+    width: 100%;
+  }
+
+  .layer-category {
+    width: 48.5%;
   }
 }
 
@@ -963,8 +969,12 @@
     }
   }
 
-  .category-masonry-case .layer-category {
+  .category-masonry-case {
     width: 100%;
+  }
+
+  .layer-category {
+    width: 310px;
   }
 
   .category-background-cover {


### PR DESCRIPTION
## Description

Now that we support mobile landscape view for larger devices, the categories layout could be updated to show two categories side by side since there appears to be plenty of horizontal real estate to support this.  Currently a single category takes up an entire row.

Fixes # WV-2438

[Description of the bug or feature]

The solution provided effects the styling of the `react-masonry-component`. The specific class that was modified was `.layer-category`. The CSS was changed so that the width of a category containing box resizes with the width of its container.

The main difference here between mobile view and desktop view is that the category modal is set to the width of screen on mobile, while the width in desktop is static except for breakpoints > 768 and > 1024

## How To Test

1. Open Chrome and turn on the developer console.
2. Set the developer console to mobile view.
3. Set the mobile device rotation to landscape.
4. Change the width of the device to <= 768px.
5. Category Items should be side-by-side.

@nasa-gibs/worldview
