### PR TITLE
WV-2491 Fix granule highlight behavior on mobile

### DIFF
--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -153,7 +153,7 @@ export class VectorInteractions extends React.Component {
 
   mouseMove({ pixel }, map, crs) {
     const {
-      isCoordinateSearchActive, measureIsActive, granuleFootprints, isMobile
+      isCoordinateSearchActive, measureIsActive, granuleFootprints, isMobile,
     } = this.props;
     const coord = map.getCoordinateFromPixel(pixel);
     const [lon, lat] = transform(coord, crs, CRS.GEOGRAPHIC);

--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -153,7 +153,7 @@ export class VectorInteractions extends React.Component {
 
   mouseMove({ pixel }, map, crs) {
     const {
-      isCoordinateSearchActive, measureIsActive, granuleFootprints,
+      isCoordinateSearchActive, measureIsActive, granuleFootprints, isMobile
     } = this.props;
     const coord = map.getCoordinateFromPixel(pixel);
     const [lon, lat] = transform(coord, crs, CRS.GEOGRAPHIC);
@@ -164,7 +164,7 @@ export class VectorInteractions extends React.Component {
     if (lon < -250 || lon > 250 || lat < -90 || lat > 90) {
       return;
     }
-    if (granuleFootprints) {
+    if (granuleFootprints && !isMobile) {
       this.handleGranuleHover(pixel, coord);
     }
     this.handleCursorChange(pixel, map, lon, lat);
@@ -194,6 +194,11 @@ export class VectorInteractions extends React.Component {
 
     const mapRes = map.getView().getResolution();
     const hasNonClickableVectorLayerType = hasNonClickableVectorLayer(activeLayers, mapRes, proj.id, isMobile);
+
+    if (isMobile) {
+      const coord = map.getCoordinateFromPixel(pixels);
+      this.handleGranuleHover(pixels, coord);
+    }
 
     if (metaArray.length) {
       if (hasNonClickableVectorLayerType) {


### PR DESCRIPTION
## Description

Currently, some weird behavior exists that causes map rotation.  Granule footprints should show and hide on a tap gesture.

Fixes # WV-2491

Granule selection was set to `onMouseMove`. The weird behavior was caused by the method checking for granule selection only triggering when the mouse was moved or the touch press was dragged.

## How To Test

Steps to recreate:

- Open Worldview on your phone
- Change to a polar projection, Arctic or Antarctic
- Tap on the Layers icon
- Tap on "Add Layers"
- Type in "granule" in the search bar, select the first one "Granule Corrected Reflectance (True Color) Suomi NPP/VIIRS"
- Tap the x in the upper right corner to close the Layer List
- Tap on a section of the map that has imagery, it should show a blue outline with the date and time inside the granule box.
- Tap on a different section of the map with imagery
- See error - it is difficult to select a different granule to highlight and show the blue outline and date and time. It does no always select and highlight a new granule that has been tapped on.

@nasa-gibs/worldview
