### PR TITLE
Update smart-hand-off end-to-end test

### DIFF
--- a/e2e/features/smart-handoff/smart-handoff-test.spec.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.spec.js
@@ -61,9 +61,9 @@ test('Arriving via permalink, data tab selected and granule count shows', async 
 })
 
 test('Changing collection updates URL', async () => {
-  await page.locator('#C1664741463-PODAAC-GHRSST_L4_MUR_Sea_Surface_Temperature-collection-choice-label').click()
+  await page.getByLabel('Standard - v4.1').check();
   const url = await page.url()
-  expect(url).toContain('&sh=GHRSST_L4_MUR_Sea_Surface_Temperature,C1664741463-PODAAC')
+  expect(url).toContain('&sh=GHRSST_L4_MUR_Sea_Surface_Temperature')
 })
 
 test('Layers outside of their coverage date range are hidden from layers available for download', async () => {

--- a/e2e/features/smart-handoff/smart-handoff-test.spec.js
+++ b/e2e/features/smart-handoff/smart-handoff-test.spec.js
@@ -61,7 +61,7 @@ test('Arriving via permalink, data tab selected and granule count shows', async 
 })
 
 test('Changing collection updates URL', async () => {
-  await page.getByLabel('Standard - v4.1').check();
+  await page.getByLabel('Standard - v4.1').check()
   const url = await page.url()
   expect(url).toContain('&sh=GHRSST_L4_MUR_Sea_Surface_Temperature')
 })


### PR DESCRIPTION
The smart-handoff-test end-to-end test was failing because the PODAC identifier string in the URL was updated since the tests were implemented. This updates the test to be less specific so that it will not rely on the exact identifier string. 
