### PR TITLE
WV-2643 Change text "Loading MetaData" to "Loading Layer Description"

### DIFF
--- a/web/js/components/layer/info/info.js
+++ b/web/js/components/layer/info/info.js
@@ -87,7 +87,7 @@ export default function LayerInfo ({ layer, measurementDescriptionPath }) {
         />
       ) : (
         <div id="layer-metadata" className="layer-metadata">
-          <p>Loading MetaData...</p>
+          <p>Loading Layer Description...</p>
         </div>
       )}
 


### PR DESCRIPTION
## Description

Change text "Loading MetaData" to "Loading Layer Description"

Fixes # WV-2643

When you click "View Description", sometimes you get the text "Loading MetaData..." if the connection is slow. Since it's misspelled, we should just go ahead and change it to "Loading Layer Description..." or "Loading Description..."

This happens on mobile and desktop, I just happened to notice it on mobile.

## How To Test

- `git fetch --all`
- `git checkout wv-2643`
- `npm ci`
- Go to the file `web/js/components/layer/info/info.js`
- add `await new Promise(r => setTimeout(r, 2000));` to line 27 and save.
- `npm run watch`
- Add a layer or use a layer that's already in the sidebar
- Select the info icon
- "Loading Layer Description..." should show up for 2 seconds before displaying the layer description.
<img width="610" alt="Screen Shot 2023-03-27 at 11 05 03 AM" src="https://user-images.githubusercontent.com/5401206/228028183-97e2539f-de72-4aa3-a281-c89fbf1a707f.png">


@nasa-gibs/worldview
