### PR TITLE
WV-2642 On mobile, the version/NRT/STD chip is too close to the kebab/three dots

### DIFF
--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1018,6 +1018,10 @@
   margin-top: 3px;
   display: flex;
   justify-content: space-between;
+
+  h6 {
+    margin-right: 20px;
+  }
 }
 
 /** React-Swipe-To-Delete Overrides */

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1018,9 +1018,14 @@
   margin-top: 3px;
   display: flex;
   justify-content: space-between;
+}
 
-  h6 {
-    margin-right: 20px;
+@media screen and (max-width: $desktop-min-width) and (max-height: $mobile-max-width) and (orientation: landscape),
+(max-width: $mobile-max-width) {
+  .instrument-collection {
+    h6 {
+      margin-right: 20px;
+    }
   }
 }
 

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1021,7 +1021,7 @@
 }
 
 @media screen and (max-width: $desktop-min-width) and (max-height: $mobile-max-width) and (orientation: landscape),
-(max-width: $mobile-max-width) {
+  (max-width: $mobile-max-width) {
   .instrument-collection {
     h6 {
       margin-right: 20px;


### PR DESCRIPTION
## Description

On mobile, in portrait and landscape modes, the version/NRT/STD chip is too close to the kebab/three dots.
Move the version/NRT/STD chip over so it does not overlap.

Fixes # WV-2642

## How To Test

- `git fetch --all`
- `git checkout wv-2642`
- `npm ci`
- `npm run watch`
- Go to http://localhost:3000 in Chrome
- Open the developer console
- Switch to mobile view
- Click add layer
- Search for `Clear Sky Confidence` and add the layer
- The version/NRT/STD chip should be farther away from the kebab/three dots
<img width="274" alt="Screen Shot 2023-03-27 at 11 01 29 AM" src="https://user-images.githubusercontent.com/5401206/228027460-8ea18596-5391-4a95-9a4a-8789b9fdf8cc.png">

@nasa-gibs/worldview
