### PR TITLE
WV-2648 Modernize Measure Button

### DIFF
--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, memo, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
@@ -20,7 +20,7 @@ const MEASURE_MENU_PROPS = {
 const mobileHelpMsg = 'Tap to add a point. Double-tap to complete.';
 const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete. ';
 
-const MeasureButton = function () {
+const MeasureButton = memo(function () {
   const dispatch = useDispatch();
   const [showAlert, setShowAlert] = useState(true);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -42,18 +42,24 @@ const MeasureButton = function () {
     setShowAlert(false);
   };
 
-  const [isActive, isDistractionFreeModeActive, isMobile] = useSelector((state) => [
-    state.measure.isActive,
-    state.ui.isDistractionFreeModeActive,
-    state.screenSize.isMobileDevice,
-  ]);
+  const isActive = useSelector((state) => state.measure.isActive);
+  const isDistractionFreeModeActive = useSelector((state) => state.ui.isDistractionFreeModeActive);
+  const isMobile = useSelector((state) => state.screenSize.isMobileDevice);
 
-  const faSize = isMobile ? '2x' : '1x';
-  const shouldShowAlert = isActive && showAlert;
-  const message = isTouchDevice ? mobileHelpMsg : helpMsg;
+  const memoizedSelectors = useMemo(() => {
+    return {
+      isActive,
+      isDistractionFreeModeActive,
+      isMobile,
+    };
+  }, [isActive, isDistractionFreeModeActive, isMobile]);
+
   const buttonId = 'wv-measure-button';
   const labelText = 'Measure distances & areas';
-  const mobileMeasureButtonStyle = isMobile ? {
+  const faSize = memoizedSelectors.isMobile ? '2x' : '1x';
+  const shouldShowAlert = memoizedSelectors.isActive && showAlert;
+  const message = isTouchDevice ? mobileHelpMsg : helpMsg;
+  const mobileMeasureButtonStyle = memoizedSelectors.isMobile ? {
     bottom: '20px',
     fontSize: '14.3px',
     height: '44px',
@@ -74,14 +80,14 @@ const MeasureButton = function () {
       />
       )}
 
-      {!isDistractionFreeModeActive && (
+      {!memoizedSelectors.isDistractionFreeModeActive && (
       <Button
         id={buttonId}
         className="wv-measure-button wv-toolbar-button"
         aria-label={labelText}
         onTouchEnd={onButtonClick}
         onMouseDown={onButtonClick}
-        disabled={isActive}
+        disabled={memoizedSelectors.isActive}
         style={mobileMeasureButtonStyle}
       >
         <UncontrolledTooltip
@@ -96,6 +102,6 @@ const MeasureButton = function () {
       )}
     </>
   );
-};
+});
 
 export default MeasureButton;

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -1,5 +1,5 @@
 import React, { useState, memo, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Button, UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -23,11 +23,11 @@ const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to comple
 const MeasureButton = memo(() => {
   const dispatch = useDispatch();
 
-  const { isActive, isDistractionFreeModeActive, isMobile } = useSelector((state) => useMemo(() => ({
+  const { isActive, isDistractionFreeModeActive, isMobile } = useSelector((state) => ({
     isActive: state.measure.isActive,
     isDistractionFreeModeActive: state.ui.isDistractionFreeModeActive,
     isMobile: state.screenSize.isMobileDevice,
-  }), [state.measure.isActive, state.ui.isDistractionFreeModeActive, state.screenSize.isMobileDevice]));
+  }), shallowEqual);
 
   const [showAlert, setShowAlert] = useState(true);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -59,6 +59,8 @@ const MeasureButton = memo(() => {
     margin: '0 0 0 4px',
     padding: '5.72px 9.1px',
   } : null;
+
+  console.log('render')
 
   return (
     <>

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -22,6 +22,13 @@ const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to comple
 
 const MeasureButton = memo(() => {
   const dispatch = useDispatch();
+
+  const { isActive, isDistractionFreeModeActive, isMobile } = useSelector((state) => useMemo(() => ({
+    isActive: state.measure.isActive,
+    isDistractionFreeModeActive: state.ui.isDistractionFreeModeActive,
+    isMobile: state.screenSize.isMobileDevice,
+  }), [state.measure.isActive, state.ui.isDistractionFreeModeActive, state.screenSize.isMobileDevice]));
+
   const [showAlert, setShowAlert] = useState(true);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
 
@@ -40,22 +47,12 @@ const MeasureButton = memo(() => {
     });
   };
 
-  const isActive = useSelector((state) => state.measure.isActive);
-  const isDistractionFreeModeActive = useSelector((state) => state.ui.isDistractionFreeModeActive);
-  const isMobile = useSelector((state) => state.screenSize.isMobileDevice);
-
-  const memoizedSelectors = useMemo(() => ({
-    isActive,
-    isDistractionFreeModeActive,
-    isMobile,
-  }), [isActive, isDistractionFreeModeActive, isMobile]);
-
   const buttonId = 'wv-measure-button';
   const labelText = 'Measure distances & areas';
-  const faSize = memoizedSelectors.isMobile ? '2x' : '1x';
-  const shouldShowAlert = memoizedSelectors.isActive && showAlert;
+  const faSize = isMobile ? '2x' : '1x';
+  const shouldShowAlert = isActive && showAlert;
   const message = isTouchDevice ? mobileHelpMsg : helpMsg;
-  const mobileMeasureButtonStyle = memoizedSelectors.isMobile ? {
+  const mobileMeasureButtonStyle = isMobile ? {
     bottom: '20px',
     fontSize: '14.3px',
     height: '44px',
@@ -76,14 +73,14 @@ const MeasureButton = memo(() => {
       />
       )}
 
-      {!memoizedSelectors.isDistractionFreeModeActive && (
+      {!isDistractionFreeModeActive && (
       <Button
         id={buttonId}
         className="wv-measure-button wv-toolbar-button"
         aria-label={labelText}
         onTouchEnd={onButtonClick}
         onMouseDown={onButtonClick}
-        disabled={memoizedSelectors.isActive}
+        disabled={isActive}
         style={mobileMeasureButtonStyle}
       >
         <UncontrolledTooltip

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -1,6 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Button, UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -21,110 +20,82 @@ const MEASURE_MENU_PROPS = {
 const mobileHelpMsg = 'Tap to add a point. Double-tap to complete.';
 const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete. ';
 
-class MeasureButton extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showAlert: true,
-      isTouchDevice: false,
-    };
-    this.onButtonClick = this.onButtonClick.bind(this);
-    this.dismissAlert = this.dismissAlert.bind(this);
-  }
+const MeasureButton = () => {
+  const dispatch = useDispatch();
+  const [showAlert, setShowAlert] = useState(true);
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
 
-  onButtonClick(evt) {
-    const { openModal } = this.props;
-    const isTouchDevice = evt.type === 'touchend';
+  const onButtonClick = (evt) => {
+    const touchDevice = evt.type === 'touchend';
     evt.stopPropagation();
     evt.preventDefault();
-    MEASURE_MENU_PROPS.touchDevice = isTouchDevice;
-    openModal('MEASURE_MENU', MEASURE_MENU_PROPS);
-    this.setState({
-      isTouchDevice,
-      showAlert: true,
-    });
+    MEASURE_MENU_PROPS.touchDevice = touchDevice;
+    dispatch(openCustomContent('MEASURE_MENU', MEASURE_MENU_PROPS));
+    setIsTouchDevice(touchDevice)
+    setShowAlert(true)
     googleTagManager.pushEvent({
       event: 'measure_tool_activated',
     });
   }
 
-  dismissAlert() {
-    this.setState({ showAlert: false });
+  const dismissAlert = () => {
+    setShowAlert(false)
   }
 
-  render() {
-    const { isActive, isDistractionFreeModeActive, isMobile } = this.props;
-    const { showAlert, isTouchDevice } = this.state;
-    const faSize = isMobile ? '2x' : '1x';
-    const shouldShowAlert = isActive && showAlert;
-    const message = isTouchDevice ? mobileHelpMsg : helpMsg;
-    const buttonId = 'wv-measure-button';
-    const labelText = 'Measure distances & areas';
-    const mobileMeasureButtonStyle = isMobile ? {
-      bottom: '20px',
-      fontSize: '14.3px',
-      height: '44px',
-      margin: '0 0 0 4px',
-      padding: '5.72px 9.1px',
-    } : null;
+  const [isActive, isDistractionFreeModeActive, isMobile] = useSelector((state) => [
+    state.measure.isActive,
+    state.ui.isDistractionFreeModeActive,
+    state.screenSize.isMobileDevice,
+  ]);
 
-    return (
-      <>
-        {shouldShowAlert && (
-        <AlertUtil
-          id="measurement-alert"
-          isOpen
-          icon="ruler"
-          title="Measure Tool"
-          message={message}
-          onDismiss={this.dismissAlert}
-        />
-        )}
+  const faSize = isMobile ? '2x' : '1x';
+  const shouldShowAlert = isActive && showAlert;
+  const message = isTouchDevice ? mobileHelpMsg : helpMsg;
+  const buttonId = 'wv-measure-button';
+  const labelText = 'Measure distances & areas';
+  const mobileMeasureButtonStyle = isMobile ? {
+    bottom: '20px',
+    fontSize: '14.3px',
+    height: '44px',
+    margin: '0 0 0 4px',
+    padding: '5.72px 9.1px',
+  } : null;
 
-        {!isDistractionFreeModeActive && (
-        <Button
-          id={buttonId}
-          className="wv-measure-button wv-toolbar-button"
-          aria-label={labelText}
-          onTouchEnd={this.onButtonClick}
-          onMouseDown={this.onButtonClick}
-          disabled={isActive}
-          style={mobileMeasureButtonStyle}
+  return (
+    <>
+      {shouldShowAlert && (
+      <AlertUtil
+        id="measurement-alert"
+        isOpen
+        icon="ruler"
+        title="Measure Tool"
+        message={message}
+        onDismiss={dismissAlert}
+      />
+      )}
+
+      {!isDistractionFreeModeActive && (
+      <Button
+        id={buttonId}
+        className="wv-measure-button wv-toolbar-button"
+        aria-label={labelText}
+        onTouchEnd={onButtonClick}
+        onMouseDown={onButtonClick}
+        disabled={isActive}
+        style={mobileMeasureButtonStyle}
+      >
+        <UncontrolledTooltip
+          id="center-align-tooltip"
+          placement="top"
+          target={buttonId}
         >
-          <UncontrolledTooltip
-            id="center-align-tooltip"
-            placement="top"
-            target={buttonId}
-          >
-            {labelText}
-          </UncontrolledTooltip>
-          <FontAwesomeIcon icon="ruler" size={faSize} />
-        </Button>
-        )}
-      </>
-    );
-  }
+          {labelText}
+        </UncontrolledTooltip>
+        <FontAwesomeIcon icon="ruler" size={faSize} />
+      </Button>
+      )}
+    </>
+  )
 }
 
-const mapStateToProps = (state) => ({
-  isActive: state.measure.isActive,
-  isDistractionFreeModeActive: state.ui.isDistractionFreeModeActive,
-  isMobile: state.screenSize.isMobileDevice,
-});
-const mapDispatchToProps = (dispatch) => ({
-  openModal: (key, customParams) => {
-    dispatch(openCustomContent(key, customParams));
-  },
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MeasureButton);
-
-MeasureButton.propTypes = {
-  isActive: PropTypes.bool,
-  isDistractionFreeModeActive: PropTypes.bool,
-  isMobile: PropTypes.bool,
-  openModal: PropTypes.func,
-};
+export default MeasureButton;

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -1,4 +1,4 @@
-import React, { useState, memo, useMemo } from 'react';
+import React, { useState, memo } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Button, UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
@@ -59,8 +59,6 @@ const MeasureButton = memo(() => {
     margin: '0 0 0 4px',
     padding: '5.72px 9.1px',
   } : null;
-
-  console.log('render')
 
   return (
     <>

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -20,7 +20,7 @@ const MEASURE_MENU_PROPS = {
 const mobileHelpMsg = 'Tap to add a point. Double-tap to complete.';
 const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete. ';
 
-const MeasureButton = () => {
+const MeasureButton = function () {
   const dispatch = useDispatch();
   const [showAlert, setShowAlert] = useState(true);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -31,16 +31,16 @@ const MeasureButton = () => {
     evt.preventDefault();
     MEASURE_MENU_PROPS.touchDevice = touchDevice;
     dispatch(openCustomContent('MEASURE_MENU', MEASURE_MENU_PROPS));
-    setIsTouchDevice(touchDevice)
-    setShowAlert(true)
+    setIsTouchDevice(touchDevice);
+    setShowAlert(true);
     googleTagManager.pushEvent({
       event: 'measure_tool_activated',
     });
-  }
+  };
 
   const dismissAlert = () => {
-    setShowAlert(false)
-  }
+    setShowAlert(false);
+  };
 
   const [isActive, isDistractionFreeModeActive, isMobile] = useSelector((state) => [
     state.measure.isActive,
@@ -95,7 +95,7 @@ const MeasureButton = () => {
       </Button>
       )}
     </>
-  )
-}
+  );
+};
 
 export default MeasureButton;

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -20,10 +20,12 @@ const MEASURE_MENU_PROPS = {
 const mobileHelpMsg = 'Tap to add a point. Double-tap to complete.';
 const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete. ';
 
-const MeasureButton = memo(function () {
+const MeasureButton = memo(() => {
   const dispatch = useDispatch();
   const [showAlert, setShowAlert] = useState(true);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  const dismissAlert = () => setShowAlert(false);
 
   const onButtonClick = (evt) => {
     const touchDevice = evt.type === 'touchend';
@@ -38,21 +40,15 @@ const MeasureButton = memo(function () {
     });
   };
 
-  const dismissAlert = () => {
-    setShowAlert(false);
-  };
-
   const isActive = useSelector((state) => state.measure.isActive);
   const isDistractionFreeModeActive = useSelector((state) => state.ui.isDistractionFreeModeActive);
   const isMobile = useSelector((state) => state.screenSize.isMobileDevice);
 
-  const memoizedSelectors = useMemo(() => {
-    return {
-      isActive,
-      isDistractionFreeModeActive,
-      isMobile,
-    };
-  }, [isActive, isDistractionFreeModeActive, isMobile]);
+  const memoizedSelectors = useMemo(() => ({
+    isActive,
+    isDistractionFreeModeActive,
+    isMobile,
+  }), [isActive, isDistractionFreeModeActive, isMobile]);
 
   const buttonId = 'wv-measure-button';
   const labelText = 'Measure distances & areas';

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -1,4 +1,4 @@
-import React, { useState, memo } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Button, UncontrolledTooltip } from 'reactstrap';
 import googleTagManager from 'googleTagManager';
@@ -18,9 +18,9 @@ const MEASURE_MENU_PROPS = {
 };
 
 const mobileHelpMsg = 'Tap to add a point. Double-tap to complete.';
-const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete. ';
+const helpMsg = 'Click: Add a point. Right-click: Cancel. Double-click to complete.';
 
-const MeasureButton = memo(() => {
+const MeasureButton = function () {
   const dispatch = useDispatch();
 
   const { isActive, isDistractionFreeModeActive, isMobile } = useSelector((state) => ({
@@ -35,9 +35,9 @@ const MeasureButton = memo(() => {
   const dismissAlert = () => setShowAlert(false);
 
   const onButtonClick = (evt) => {
-    const touchDevice = evt.type === 'touchend';
     evt.stopPropagation();
     evt.preventDefault();
+    const touchDevice = evt.type === 'touchend';
     MEASURE_MENU_PROPS.touchDevice = touchDevice;
     dispatch(openCustomContent('MEASURE_MENU', MEASURE_MENU_PROPS));
     setIsTouchDevice(touchDevice);
@@ -95,6 +95,6 @@ const MeasureButton = memo(() => {
       )}
     </>
   );
-});
+};
 
 export default MeasureButton;


### PR DESCRIPTION
## Description

The MeasureButton component is currently written as a React Class component. Today's best practices for React suggest we should be using functional components whenever possible. Using the modern best practices for React, convert the MeasureButton component into a functional component.

1. Study the current behavior of the component so you know exactly what needs to be replicated.
2. Research [the differences between class & functional components and how to replace lifecycle hooks with useEffect hooks](https://www.scaler.com/topics/react/react-functional-vs-class-components/).
3. Use the [React docs](https://react.dev/reference/react) to find the best practices for updating state, using hooks & props.
4. Use other components from the WV repo that are currently written as functional components for reference.
5. If there are obvious opportunities to refactor code to be more concise or easier to read do so.
6. After refactoring into a functional component, test the component to make sure the behavior is still the same.

Fixes # wv-2648

## Changes
- Class based component was converted into a functional component
- Using redux hooks instead of redux function to map dispatch and props.

## How To Test

- `git fetch --all`
- `git checkout wv-2648-modernize-measure-button`
- `npm ci`
- `npm run watch`
- Click the measure button on the bottom left
- Click measure distance. Click on the map to create the first point. Click on the map again in a different location to create another point.
- Right click to cancel
- Click on the measure button
- Click on measure area. Click on the map to create the first point. Click on the map again in a different location to create another point.
- Right click to cancel
- Click on the measure button.
- Click the toggle from km to mi. Repeat steps for measuring distance and measuring area.
- Open Chrome developer console. Change to mobile view and select Iphone 12 pro.
- Follow the same steps as above but using touch input instead of mouse clicks.
- An alert should open explaining how to control each measure tool in mobile.

@nasa-gibs/worldview
