### PR TITLE
WV-2649 Modernize Measure Menu

### DIFF
--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Form } from 'reactstrap';
 

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -48,7 +48,7 @@ const MeasureMenu = memo(() => {
   const dispatch = useDispatch();
 
   const {
-    isMobile, isTouchDevice, unitOfMeasure, measurementsInProj
+    isMobile, isTouchDevice, unitOfMeasure, measurementsInProj,
   } = useSelector((state) => ({
     isMobile: state.screenSize.isMobileDevice,
     isTouchDevice: state.modal.customProps.touchDevice,

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -44,7 +44,7 @@ const OPTIONS_ARRAY = [
   DOWNLOAD_GEOJSON,
 ];
 
-const MeasureMenu = memo(() => {
+const MeasureMenu = function () {
   const dispatch = useDispatch();
 
   const {
@@ -95,6 +95,6 @@ const MeasureMenu = memo(() => {
       />
     </>
   );
-});
+};
 
 export default MeasureMenu;

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Form } from 'reactstrap';
 
 import { onToggle as onToggleAction } from '../../modules/modal/actions';
-import { changeUnits } from '../../modules/measure/actions';
+import { changeUnits as changeUnitsAction } from '../../modules/measure/actions';
 import IconList from '../util/icon-list';
 import util from '../../util/util';
 
@@ -47,6 +47,7 @@ const OPTIONS_ARRAY = [
 const MeasureMenu = function () {
   const dispatch = useDispatch();
   const onToggle = () => { dispatch(onToggleAction()); };
+  const changeUnits = (units) => { dispatch(changeUnitsAction(units)); };
 
   const {
     isMobile, isTouchDevice, unitOfMeasure, measurementsInProj,
@@ -70,7 +71,7 @@ const MeasureMenu = function () {
   const unitToggle = (evt) => {
     const { checked } = evt.target;
     const units = checked ? 'mi' : 'km';
-    dispatch(changeUnits(units));
+    changeUnits(units);
   };
 
   return (

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Form } from 'reactstrap';
 
-import { onToggle } from '../../modules/modal/actions';
+import { onToggle as onToggleAction } from '../../modules/modal/actions';
 import { changeUnits } from '../../modules/measure/actions';
 import IconList from '../util/icon-list';
 import util from '../../util/util';
@@ -46,6 +46,7 @@ const OPTIONS_ARRAY = [
 
 const MeasureMenu = function () {
   const dispatch = useDispatch();
+  const onToggle = () => { dispatch(onToggleAction()) }
 
   const {
     isMobile, isTouchDevice, unitOfMeasure, measurementsInProj,
@@ -58,7 +59,7 @@ const MeasureMenu = function () {
 
   const triggerEvent = (eventName) => {
     events.trigger(eventName);
-    dispatch(onToggle());
+    onToggle();
   };
 
   const unitToggle = (evt) => {

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -57,6 +57,11 @@ const MeasureMenu = function () {
     measurementsInProj: !!Object.keys(state.measure.allMeasurements[state.proj.selected.crs]).length,
   }), shallowEqual);
 
+  const listSize = isTouchDevice ? 'large' : 'small';
+  DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
+  const getRemoveOptionIndex = OPTIONS_ARRAY.findIndex((item) => item.text === 'Remove Measurements');
+  OPTIONS_ARRAY[getRemoveOptionIndex].hidden = !measurementsInProj;
+
   const triggerEvent = (eventName) => {
     events.trigger(eventName);
     onToggle();
@@ -67,11 +72,6 @@ const MeasureMenu = function () {
     const units = checked ? 'mi' : 'km';
     dispatch(changeUnits(units));
   };
-
-  const listSize = isTouchDevice ? 'large' : 'small';
-  DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
-  const getRemoveOptionIndex = OPTIONS_ARRAY.findIndex((item) => item.text === 'Remove Measurements');
-  OPTIONS_ARRAY[getRemoveOptionIndex].hidden = !measurementsInProj;
 
   return (
     <>

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -47,7 +47,9 @@ const OPTIONS_ARRAY = [
 const MeasureMenu = memo(() => {
   const dispatch = useDispatch();
 
-  const { isMobile, isTouchDevice, unitOfMeasure, measurementsInProj } = useSelector((state) => ({
+  const {
+    isMobile, isTouchDevice, unitOfMeasure, measurementsInProj
+  } = useSelector((state) => ({
     isMobile: state.screenSize.isMobileDevice,
     isTouchDevice: state.modal.customProps.touchDevice,
     unitOfMeasure: state.measure.unitOfMeasure,

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -45,18 +45,18 @@ const OPTIONS_ARRAY = [
 ];
 
 const MeasureMenu = function () {
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
 
   const triggerEvent = (eventName) => {
     events.trigger(eventName);
-    dispatch(onToggle())
-  }
+    dispatch(onToggle());
+  };
 
   const unitToggle = (evt) => {
     const { checked } = evt.target;
     const units = checked ? 'mi' : 'km';
-    dispatch(changeUnits(units))
-  }
+    dispatch(changeUnits(units));
+  };
 
   const [isMobile, isTouchDevice, unitOfMeasure, measurementsInProj] = useSelector((state) => [
     state.screenSize.isMobileDevice,

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -46,7 +46,7 @@ const OPTIONS_ARRAY = [
 
 const MeasureMenu = function () {
   const dispatch = useDispatch();
-  const onToggle = () => { dispatch(onToggleAction()) }
+  const onToggle = () => { dispatch(onToggleAction()); };
 
   const {
     isMobile, isTouchDevice, unitOfMeasure, measurementsInProj,

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React, { memo } from 'react';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Form } from 'reactstrap';
 
 import { onToggle } from '../../modules/modal/actions';
@@ -44,8 +44,15 @@ const OPTIONS_ARRAY = [
   DOWNLOAD_GEOJSON,
 ];
 
-const MeasureMenu = function () {
+const MeasureMenu = memo(() => {
   const dispatch = useDispatch();
+
+  const { isMobile, isTouchDevice, unitOfMeasure, measurementsInProj } = useSelector((state) => ({
+    isMobile: state.screenSize.isMobileDevice,
+    isTouchDevice: state.modal.customProps.touchDevice,
+    unitOfMeasure: state.measure.unitOfMeasure,
+    measurementsInProj: !!Object.keys(state.measure.allMeasurements[state.proj.selected.crs]).length,
+  }), shallowEqual);
 
   const triggerEvent = (eventName) => {
     events.trigger(eventName);
@@ -57,13 +64,6 @@ const MeasureMenu = function () {
     const units = checked ? 'mi' : 'km';
     dispatch(changeUnits(units));
   };
-
-  const [isMobile, isTouchDevice, unitOfMeasure, measurementsInProj] = useSelector((state) => [
-    state.screenSize.isMobileDevice,
-    state.modal.customProps.touchDevice,
-    state.measure.unitOfMeasure,
-    !!Object.keys(state.measure.allMeasurements[state.proj.selected.crs]).length,
-  ]);
 
   const listSize = isTouchDevice ? 'large' : 'small';
   DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
@@ -93,6 +93,6 @@ const MeasureMenu = function () {
       />
     </>
   );
-};
+});
 
 export default MeasureMenu;

--- a/web/js/components/measure-tool/measure-menu.js
+++ b/web/js/components/measure-tool/measure-menu.js
@@ -1,11 +1,10 @@
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import React, { Component } from 'react';
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import { Form } from 'reactstrap';
 
 import { onToggle } from '../../modules/modal/actions';
-import IconList from '../util/icon-list';
 import { changeUnits } from '../../modules/measure/actions';
+import IconList from '../util/icon-list';
 import util from '../../util/util';
 
 const { events } = util;
@@ -18,13 +17,7 @@ const DOWNLOAD_GEOJSON = {
   key: 'measure:download-geojson',
   className: 'measure-download',
 };
-// const DOWNLOAD_SHAPEFILE = {
-//   text: 'Download as Shapefiles',
-//   iconClass: 'ui-icon icon-large',
-//   iconName: 'download',
-//   id: 'download-shapefiles-button',
-//   key: 'measure:download-shapefile',
-// };
+
 const OPTIONS_ARRAY = [
   {
     text: 'Measure distance',
@@ -49,109 +42,57 @@ const OPTIONS_ARRAY = [
     hidden: true,
   },
   DOWNLOAD_GEOJSON,
-  // DOWNLOAD_SHAPEFILE,
 ];
 
-class MeasureMenu extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      tooltipOpen: false,
-    };
-    this.tooltipToggle = this.tooltipToggle.bind(this);
-    this.triggerEvent = this.triggerEvent.bind(this);
-    this.unitToggle = this.unitToggle.bind(this);
-  }
+const MeasureMenu = function () {
+  const dispatch = useDispatch()
 
-  triggerEvent(eventName) {
-    const { onCloseModal } = this.props;
+  const triggerEvent = (eventName) => {
     events.trigger(eventName);
-    onCloseModal();
+    dispatch(onToggle())
   }
 
-  unitToggle(evt) {
-    const { onToggleUnits } = this.props;
+  const unitToggle = (evt) => {
     const { checked } = evt.target;
     const units = checked ? 'mi' : 'km';
-    onToggleUnits(units);
+    dispatch(changeUnits(units))
   }
 
-  tooltipToggle() {
-    this.setState((prevState) => ({
-      tooltipOpen: !prevState.tooltipOpen,
-    }));
-  }
+  const [isMobile, isTouchDevice, unitOfMeasure, measurementsInProj] = useSelector((state) => [
+    state.screenSize.isMobileDevice,
+    state.modal.customProps.touchDevice,
+    state.measure.unitOfMeasure,
+    !!Object.keys(state.measure.allMeasurements[state.proj.selected.crs]).length,
+  ]);
 
-  render() {
-    const {
-      isTouchDevice, unitOfMeasure, measurementsInProj, isMobile,
-    } = this.props;
-    const listSize = isTouchDevice ? 'large' : 'small';
-    // DOWNLOAD_SHAPEFILE.hidden = !measurementsInProj || isMobile;
-    DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
-    const getRemoveOptionIndex = OPTIONS_ARRAY.findIndex((item) => item.text === 'Remove Measurements');
-    OPTIONS_ARRAY[getRemoveOptionIndex].hidden = !measurementsInProj;
-    return (
-      <>
-        <Form>
-          <div className="measure-unit-toggle custom-control custom-switch">
-            <input
-              id="unit-toggle"
-              className="custom-control-input"
-              type="checkbox"
-              onChange={this.unitToggle}
-              defaultChecked={unitOfMeasure === 'mi'}
-            />
-            <label className="custom-control-label" htmlFor="unit-toggle">
-              {unitOfMeasure}
-            </label>
-          </div>
-        </Form>
-        <IconList
-          list={OPTIONS_ARRAY}
-          onClick={this.triggerEvent}
-          size={listSize}
-        />
-      </>
-    );
-  }
-}
+  const listSize = isTouchDevice ? 'large' : 'small';
+  DOWNLOAD_GEOJSON.hidden = !measurementsInProj || isMobile;
+  const getRemoveOptionIndex = OPTIONS_ARRAY.findIndex((item) => item.text === 'Remove Measurements');
+  OPTIONS_ARRAY[getRemoveOptionIndex].hidden = !measurementsInProj;
 
-const mapStateToProps = (state) => {
-  const {
-    modal, map, measure, proj, screenSize,
-  } = state;
-  const { unitOfMeasure, allMeasurements } = measure;
-  const { crs } = proj.selected;
-  const measurementsInProj = !!Object.keys(allMeasurements[crs]).length;
-  return {
-    isMobile: screenSize.isMobileDevice,
-    isTouchDevice: modal.customProps.touchDevice,
-    map,
-    unitOfMeasure,
-    measurementsInProj,
-  };
+  return (
+    <>
+      <Form>
+        <div className="measure-unit-toggle custom-control custom-switch">
+          <input
+            id="unit-toggle"
+            className="custom-control-input"
+            type="checkbox"
+            onChange={unitToggle}
+            defaultChecked={unitOfMeasure === 'mi'}
+          />
+          <label className="custom-control-label" htmlFor="unit-toggle">
+            {unitOfMeasure}
+          </label>
+        </div>
+      </Form>
+      <IconList
+        list={OPTIONS_ARRAY}
+        onClick={triggerEvent}
+        size={listSize}
+      />
+    </>
+  );
 };
 
-const mapDispatchToProps = (dispatch) => ({
-  onToggleUnits: (unitOfMeasure) => {
-    dispatch(changeUnits(unitOfMeasure));
-  },
-  onCloseModal: (eventName) => {
-    dispatch(onToggle());
-  },
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MeasureMenu);
-
-MeasureMenu.propTypes = {
-  isMobile: PropTypes.bool,
-  isTouchDevice: PropTypes.bool,
-  measurementsInProj: PropTypes.bool,
-  onCloseModal: PropTypes.func,
-  onToggleUnits: PropTypes.func,
-  unitOfMeasure: PropTypes.string,
-};
+export default MeasureMenu;


### PR DESCRIPTION
## Description

The MeasureMenu component is currently written as a React Class component. Today's best practices for React suggest we should be using functional components whenever possible. Using the modern best practices for React, convert the MeasureMenu component into a functional component.

Study the current behavior of the component so you know exactly what needs to be replicated.
Research [the differences between class & functional components and how to replace lifecycle hooks with useEffect hooks](https://www.scaler.com/topics/react/react-functional-vs-class-components/).
Use the [React docs](https://react.dev/reference/react) to find the best practices for updating state, using hooks & props.
Use other components from the WV repo that are currently written as functional components for reference.
If there are obvious opportunities to refactor code to be more concise or easier to read do so.
After refactoring into a functional component, test the component to make sure the behavior is still the same.

Fixes # WV-2649

## Changes
- Converted component from class based to functional
- Use of Redux hooks and shallowEquals

## How To Test
- `git fetch --all`
- `git checkout wv-2649-modernize-measure-menu`
- `npm ci`
- `go to http://localhost:3000`
- On the bottom right corner of the app, click on the measure button
- Select measure distance. Click on a location on the map, then drag the mouse to a different location and double click to complete.
- The measure menu should update with an option to `Remove Measurements` and to `Download as GeoJSON`
- Clicking on `Remove Measurements` should delete the measured distance drawn on the map.
- Clicking on `Download as GeoJSON` should start a download
- The same behavior should occur when clicking `Measure Menu`

@nasa-gibs/worldview
