### PR TITLE
Reintegrating WV-2642

### DIFF
--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1019,3 +1019,12 @@
   display: flex;
   justify-content: space-between;
 }
+
+@media screen and (max-width: $desktop-min-width) and (max-height: $mobile-max-width) and (orientation: landscape),
+  (max-width: $mobile-max-width) {
+  .instrument-collection {
+    h6 {
+      margin-right: 20px;
+    }
+  }
+}


### PR DESCRIPTION
It looks like WV-2642 got wiped out by another branch when resolving merge conflicts. This reintegrates the CSS changes back into `layers.scss`. 