### PR TITLE
WV-2651 Layer Opacity Refresh Bug

### DIFF
--- a/web/js/components/layer/settings/opacity.js
+++ b/web/js/components/layer/settings/opacity.js
@@ -1,35 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Slider from 'rc-slider';
 
-class OpacitySelect extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: props.start,
-    };
-  }
-
-  render() {
-    const { layer, setOpacity, start } = this.props;
-    const { value } = this.state;
-    return (
-      <div className="layer-opacity-select settings-component">
-        <h2 className="wv-header">Opacity</h2>
-        <Slider
-          defaultValue={start}
-          onChange={(val) => {
-            setOpacity(layer.id, (val / 100).toFixed(2));
-            this.setState({ value: val });
-          }}
-        />
-        <div className="wv-label wv-label-opacity">
-          {`${value}%`}
-        </div>
+const OpacitySelect = function ({ layer, setOpacity, start }) {
+  const [value, setValue] = useState(start)
+  return (
+    <div className="layer-opacity-select settings-component">
+      <h2 className="wv-header">Opacity</h2>
+      <Slider
+        defaultValue={start}
+        onChange={(val) => {
+          setOpacity(layer.id, (val / 100).toFixed(2));
+          setValue(val)
+        }}
+      />
+      <div className="wv-label wv-label-opacity">
+        {`${value}%`}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
 OpacitySelect.defaultProps = {
   start: 100,
 };

--- a/web/js/components/layer/settings/opacity.js
+++ b/web/js/components/layer/settings/opacity.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Slider from 'rc-slider';
 
 const OpacitySelect = function ({ layer, setOpacity, start }) {
-  const [value, setValue] = useState(start)
+  const [value, setValue] = useState(start);
   return (
     <div className="layer-opacity-select settings-component">
       <h2 className="wv-header">Opacity</h2>
@@ -11,7 +11,7 @@ const OpacitySelect = function ({ layer, setOpacity, start }) {
         defaultValue={start}
         onChange={(val) => {
           setOpacity(layer.id, (val / 100).toFixed(2));
-          setValue(val)
+          setValue(val);
         }}
       />
       <div className="wv-label wv-label-opacity">

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -44,7 +44,7 @@ import {
 
 export default function mapLayerBuilder(config, cache, store) {
   const { getGranuleLayer } = granuleLayerBuilder(cache, store, createLayerWMTS);
-  let layer_set_opacity_count = 0
+  let layerSetOpacityCount = 0;
 
   /**
    * Return a layer, or layergroup, created with the supplied function
@@ -212,10 +212,10 @@ export default function mapLayerBuilder(config, cache, store) {
         layer = await getGranuleLayer(def, attributes, options);
       }
     }
-    if (layer_set_opacity_count === 0) {
+    if (layerSetOpacityCount === 0) {
       await layer.setOpacity(opacity || 1.0);
     }
-    layer_set_opacity_count++
+    layerSetOpacityCount += 1;
     return layer;
   };
 

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -44,6 +44,7 @@ import {
 
 export default function mapLayerBuilder(config, cache, store) {
   const { getGranuleLayer } = granuleLayerBuilder(cache, store, createLayerWMTS);
+  let layer_set_opacity_count = 0
 
   /**
    * Return a layer, or layergroup, created with the supplied function
@@ -211,7 +212,10 @@ export default function mapLayerBuilder(config, cache, store) {
         layer = await getGranuleLayer(def, attributes, options);
       }
     }
-    layer.setOpacity(opacity || 1.0);
+    if (layer_set_opacity_count === 0) {
+      await layer.setOpacity(opacity || 1.0);
+    }
+    layer_set_opacity_count++
     return layer;
   };
 

--- a/web/js/mapUI/components/update-opacity/updateOpacity.js
+++ b/web/js/mapUI/components/update-opacity/updateOpacity.js
@@ -71,7 +71,7 @@ function UpdateOpacity(props) {
     } else {
       const layerGroup = findLayer(def, activeString);
       layerGroup.getLayersArray().forEach((l) => {
-        l.setOpacity(opacity);
+        l.setOpacity(parseFloat(opacity));
       });
     }
     updateLayerVisibilities();


### PR DESCRIPTION
## Description

When changing the opacity of a layer in the layer options and then reloading the page, worldview will remember the opacity that was selected for this layer. Right now, a side effect of this feature is that the values in the OpacitySelect component are being incorrectly calculated upon reloading the page. If you change the value of opacity below 100% and reload the page, you will not be able to set the opacity back to 100%. 

Investigation of this ticket can begin in the OpacitySelect component but you may need to track the start prop back to the parent components and possibly look into some redux actions.

To recreate:

1. Open Worldview in production
2. Open the layer options for the Corrected Reflectance base layer.
3. Change the opacity to 40%.
4. Reload the page.
5. Try to set the opacity back to 100%. 
6. Note that the opacity is still far less than 100%.

Fixes # wv-2651

## How To Test
- `git fetch --all`
- `git checkout wv-2651-opacity-refresh`
- `npm ci`
- Open the layer options for the Corrected Reflectance base layer.
- Change the opacity to 40%.
- Reload the page.
- Try to set the opacity back to 100%. 

@nasa-gibs/worldview
