### PR TITLE
WV-2651: Updating Layer Opacity

### DIFF
--- a/web/js/mapUI/components/update-opacity/updateOpacity.js
+++ b/web/js/mapUI/components/update-opacity/updateOpacity.js
@@ -69,8 +69,13 @@ function UpdateOpacity(props) {
     if (def.type === 'granule') {
       updateGranuleLayerOpacity(def, activeString, opacity, compare);
     } else {
+      // find the layer in each projection
       const layerGroup = findLayer(def, activeString);
-      layerGroup.getLayersArray().forEach((l) => {
+      // get an array of layers from each projection
+      const layerGroupLayers = layerGroup.getLayersArray();
+      // need to set opacity for layerGroup and each individual layer
+      layerGroup.setOpacity(opacity);
+      layerGroupLayers.forEach((l) => {
         l.setOpacity(opacity);
       });
     }


### PR DESCRIPTION
## Description

When updating the opacity for a layer that is present in multiple projections, refreshing the page, and trying to update the opacity back to 100%, the layer would not be able to return to 100% opacity. 

This updates our `updateOpacity` component which is a component of `mapUI` which communicates with the OpenLayers map object to update the opacity value for each layer. Each individual layer's opacity was being updated but not the layer group itself, an array of layers representing the specific layer in each projection. 

## How To Test

1. git checkout `wv-2651-test2`
2. `npm ci`
3. `npm run watch`
4. Update the opacity of the active `corrected reflectance` layer to 50%.
5. Click refresh to load the page.
6. Observe that the layer opacity is still set to 50%.
7. Update the opacity for the active `corrected reflectance` layer back to 100%.
8. Observe that the layer opacity returns to 100%.
9. Switch to the Arctic projection.
10. Update the opacity for the active `corrected reflectance` layer to 50%.
11. Return to the geographic projection.
12. Observe that the layer opacity is still set to 50%.
13. Update the opacity for the active `corrected reflectance` layer back to 100%.
14. Observe that the layer opacity returns to 100%.



