### PR TITLE
WV-2671 slow down tour animations

### DIFF
--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -156,7 +156,7 @@ export function fly (map, proj, endPoint, endZoom = 5, rotation = 0) {
   const line = new OlGeomLineString([startPoint, endPoint]);
   const distance = line.getLength(); // In map units, which is usually degrees
   const distanceDuration = polarProjectionCheck ? distance / 50000 : distance; // limit large polar projection distances from coordinate transforms
-  let duration = Math.floor(distanceDuration * 20 + 1000); // approx 6 seconds to go 360 degrees
+  let duration = Math.max(5000, 2 * Math.floor(distanceDuration * 20 + 1000)); // Minimum 5 seconds, approx 12 seconds to go 360 degrees
 
   const animationPromise = function(...args) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description
Make a global edit to slow down transition time in tour story map transitions.

Fixes #WV-2671

## Notes
The production code does a calculation using the distance from one point to the next when determining the duration of the transition. This PR alters the calculation in 2 ways:

- Doubles the length of transitions relative to the production code
- Set a minimum of 5 seconds on any transition

It is simple to tweak the values based on the opinions of the team to get this dialed in.

## How To Test
- git checkout wv-2671-slow-down-tour-animations
- npm run watch
- Load any tour story
- Proceed through the story & confirm the transitions are running slower relative to production

@nasa-gibs/worldview
