### PR TITLE
wv-2678 markers

### DIFF
--- a/web/js/modules/location-search/actions.js
+++ b/web/js/modules/location-search/actions.js
@@ -90,7 +90,7 @@ export function setPlaceMarker(coord, reverseGeocodeResults, isInputSearch) {
     dispatch({
       type: SET_MARKER,
       coordinates: {
-        id: Math.floor(longitude + latitude),
+        id: Math.floor(longitude * 1000 + latitude * 1000 + Math.random() * 1000),
         longitude,
         latitude,
       },

--- a/web/js/modules/location-search/actions.js
+++ b/web/js/modules/location-search/actions.js
@@ -87,10 +87,11 @@ export function setPlaceMarker(coord, reverseGeocodeResults, isInputSearch) {
       });
     }
 
+    const markerId = Math.floor(longitude * 1000 + latitude * 1000 + Math.random() * 1000);
     dispatch({
       type: SET_MARKER,
       coordinates: {
-        id: Math.floor(longitude * 1000 + latitude * 1000 + Math.random() * 1000),
+        id: markerId,
         longitude,
         latitude,
       },

--- a/web/js/modules/location-search/util.js
+++ b/web/js/modules/location-search/util.js
@@ -120,8 +120,9 @@ export function mapLocationToLocationSearchState(
         .filter((coord) => !lodashIsNaN(parseFloat(coord)))
       : [];
 
+    const markerId = Math.floor(longitude * 1000 + latitude * 1000 + Math.random() * 1000);
     const validatedCoordinates = isValid && {
-      id: Math.floor(longitude + latitude),
+      id: markerId,
       latitude,
       longitude,
     };


### PR DESCRIPTION
## Description
If you set multiple markers on a map, closing a marker will sometimes erroneously close other marker(s).

Fixes WV-2678

## To Reproduce
In production, create a few markers in close proximity. Like this:
https://worldview.earthdata.nasa.gov/?v=-88.17231727834607,40.02004820533372,-87.93501259084607,40.0889874143181&s=-88.0942,40.0555%2B-88.0777,40.052&t=2023-04-11-T19%3A35%3A08Z

Notice that when you close one of these markers, they are **both** deleted. This is because the marker ID generation is computed by the longitude + latitude & then Math.floor() is applied. So markers in close proximity are likely to have matching IDs.

## How To Test

- npm checkout wv-2678-markers
- npm run watch
- Create a few markers in close proximity as explained above
- Delete markers & confirm that only 1 marker is deleted at a time

You can load the same URL parameters as above to test, as well. http://localhost:3000/?v=-88.17231727834607,40.02004820533372,-87.93501259084607,40.0889874143181&s=-88.0942,40.0555%2B-88.0777,40.052&t=2023-04-11-T19%3A35%3A08Z

@nasa-gibs/worldview
