### PR TITLE
WV-2683: Layer Picker shows individual measurements under category grid

### DIFF
--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -203,15 +203,14 @@ function BrowseLayers (props) {
   return (
     <>
       { isMobile ? renderMobileDropdown() : renderDesktopTabs() }
-      <div
-        className="product-outter-list-case"
-        style={
-          isCategoryDisplay ? { display: 'block', visibility: 'visible' } : { display: 'none', visibility: 'hidden' }
-        }
-      >
-        <CategoryGrid width={width} />
-      </div>
-      { renderContent() }
+      {
+      isCategoryDisplay
+        ? (
+          <div className="product-outter-list-case">
+            <CategoryGrid width={width} />
+          </div>
+        ) : renderContent()
+      }
     </>
   );
 }


### PR DESCRIPTION
## Description

This fixes a bug where the individual measurements were displaying below the category cards in the layer picker.

TO REPRODUCE:
1. Open WV
2. Click Add Layer
3. Scroll down past categories to see measurements

## How To Test

1. `git checkout wv-2683`
2. `npm run watch`
3. Click Add Layer
4. Scroll to bottom and verify measurements are not visible.
5. The same fixes for [wv-2438](https://github.com/nasa-gibs/worldview/pull/4147) should still work as well. (e.g, 2 category columns on ipad mini & iphone 12 pro landscape...)
