### PR TITLE
WV-2685: Disable Snapshots for OPERA Layer

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/opera/OPERA_L3_Dynamic_Surface_Water_Extent-HLS_Provisional.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/opera/OPERA_L3_Dynamic_Surface_Water_Extent-HLS_Provisional.json
@@ -5,7 +5,8 @@
       "description": "multi-mission/opera/OPERA_L3_Dynamic_Surface_Water_Extent-HLS_Provisional",
       "tags": "podaac PO.DAAC DSWx flood",
       "group": "overlays",
-      "layergroup": "Surface Water Extent"
+      "layergroup": "Surface Water Extent",
+      "disableSnapshot": true
     }
   }
 }


### PR DESCRIPTION
## Description

Disabling snapshots for new OPERA water layer.

## How To Test

1. `git checkout wv-2685`
2. `npm run build`
3. `npm run watch`
4. Add OPERA water layer.
5. Try to take a snapshot with the water layer visible.
6. Verify notification message. 
