### PR TITLE
wv-2684: Update xml2js to v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
         "webpack-dev-middleware": "^6.0.2",
         "webpack-dev-server": "^4.13.2",
         "xml-js": "^1.6.11",
-        "xml2js": "^0.4.23",
+        "xml2js": "^0.5.0",
         "yargs": "^17.7.1"
       },
       "engines": {
@@ -17477,9 +17477,10 @@
       "license": "CC0-1.0"
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -28666,7 +28667,9 @@
       "version": "1.3.0"
     },
     "xml2js": {
-      "version": "0.4.23",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "webpack-dev-middleware": "^6.0.2",
     "webpack-dev-server": "^4.13.2",
     "xml-js": "^1.6.11",
-    "xml2js": "^0.4.23",
+    "xml2js": "^0.5.0",
     "yargs": "^17.7.1"
   },
   "dependencies": {


### PR DESCRIPTION
## Description
Snyk indicated our version of xml2js (v0.4.23) is vulnerable to prototype pollution. The fix is to upgrade this package to v0.5.0. 

Fixes # WV-2684

## How To Test
- git checkout wv-2684-xml2js-security-alert
- npm install
- npm run build
- Confirm build runs successfully (this package is only used in the Worldview build scripts.)

@nasa-gibs/worldview
