### PR TITLE
wv-2706: restore collapsed layer list styles

### DIFF
--- a/web/js/components/sidebar/collapsed-button.js
+++ b/web/js/components/sidebar/collapsed-button.js
@@ -23,6 +23,7 @@ class CollapsedButton extends PureComponent {
           id={buttonId}
           aria-label={labelText}
           onClick={onclick}
+          className="sidebar-anchor"
         >
           <UncontrolledTooltip id="center-align-tooltip" placement="right" target={buttonId}>
             {labelText}

--- a/web/scss/features/sidebar-panel.scss
+++ b/web/scss/features/sidebar-panel.scss
@@ -19,6 +19,7 @@
     color: #fff;
     overflow: hidden;
     z-index: 1;
+    text-decoration: none;
 
     & .layer-count {
       margin: 0 5px;


### PR DESCRIPTION
## Description
When the layer list is collapsed the font is black instead of white, making it hard to read.
This was caused by the recent bootstrap update. You can read more here: https://github.com/twbs/bootstrap/issues/24140

Fixes # wv-2706

## How To Test
- git checkout wv-2706-layer-list-font-color
- npm run watch
- Load worldview & click the up arrow/triangle to the right of the Data tab to collapse the layers
- Confirm that the styles are correct (white font on dark gray background, black font on gray background when hovered)

@nasa-gibs/worldview
