### PR TITLE
wv-2704 layer info url underlining

### DIFF
--- a/web/scss/components/modal.scss
+++ b/web/scss/components/modal.scss
@@ -16,6 +16,11 @@
 
   a {
     color: #7bf;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
   }
 
   .modal-header {

--- a/web/scss/features/layer-categories.scss
+++ b/web/scss/features/layer-categories.scss
@@ -103,6 +103,10 @@
     }
   }
 
+  & .nav-link:hover {
+    text-decoration: none;
+  }
+
   & .category-breadcrumb {
     height: 30px;
     line-height: 30px;

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1034,11 +1034,13 @@
   justify-content: space-between;
 }
 
-a[rel="noopener noreferrer"] {
+a[rel="noopener noreferrer"],
+a[rel="noreferrer"] {
   text-decoration: none;
 }
 
-a[rel="noopener noreferrer"]:hover {
+a[rel="noopener noreferrer"]:hover,
+a[rel="noreferrer"]:hover {
   text-decoration: underline;
 }
 

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1034,6 +1034,14 @@
   justify-content: space-between;
 }
 
+a[rel="noopener noreferrer"] {
+  text-decoration: none;
+}
+
+a[rel="noopener noreferrer"]:hover {
+  text-decoration: underline;
+}
+
 @media screen and (max-width: $desktop-min-width) and (max-height: $mobile-max-width) and (orientation: landscape),
   (max-width: $mobile-max-width) {
   .instrument-collection {

--- a/web/scss/features/smart-handoff.scss
+++ b/web/scss/features/smart-handoff.scss
@@ -134,6 +134,7 @@ label[for="chk-crop-toggle"] span {
 .help-link,
 a.help-link {
   color: #7bf;
+  text-decoration: none;
 
   &:hover {
     color: #7bf;


### PR DESCRIPTION
## Description
Hyperlinks are underlined in the layer descriptions by default, when they should not be. 

NOTE: This is because the latest bootstrap has a generic `a { text-decoration: underline}` property. This same problem may appear elsewhere so we should keep an eye out.

Fixes # wv-2704

## How To Test
- git checkout wv-2704-url-underline
- npm run watch
- Click on the "info" icon (view description) for any layer
- Confirm the hyperlinks are not underlined by default & are underlined when hovered.

@nasa-gibs/worldview
