### PR TITLE
wv-2710: CSS adjustments to fix compare mode hover palette

### DIFF
--- a/web/scss/features/compare.scss
+++ b/web/scss/features/compare.scss
@@ -165,6 +165,25 @@
   span {
     padding-bottom: 2px;
   }
+
+  &.nav-link {
+    &.first-tab, &.second-tab {
+      background-color: #28292a;
+    }
+
+    &.active {
+      background-color: #fff;
+
+      // Toggle layer icon color on hover by repositioning the SVG
+      &:hover > i {
+        background-position: 0 -10px;
+      }
+    }
+
+    &:hover {
+      background-color: #404542;
+    }
+  }
 }
 
 /* Mobile */
@@ -198,7 +217,7 @@
     border-bottom-right-radius: 5px;
   }
 
-  &:hover:not(.compare-btn-selected) {
+  .active.nav-link:not(.compare-btn-selected) {
     border-color: #fff;
   }
 }

--- a/web/scss/features/compare.scss
+++ b/web/scss/features/compare.scss
@@ -173,14 +173,14 @@
 
     &.active {
       background-color: #fff;
-
-      // Toggle layer icon color on hover by repositioning the SVG
-      &:hover > i {
-        background-position: 0 -10px;
-      }
     }
 
-    &:hover {
+    // Toggle layer icon color on hover by repositioning the SVG
+    &:not(.active):hover > i {
+      background-position: 0 -10px;
+    }
+
+    &:not(.active):hover {
       background-color: #404542;
     }
   }

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -593,7 +593,7 @@ footer .compare-toggle-button {
     }
 
     &:hover {
-      border: 1px solid #555;
+      border: 1px solid #eee;
     }
 
     a.nav-link {

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -593,7 +593,7 @@ footer .compare-toggle-button {
     }
 
     &:hover {
-      border: 1px solid #eee;
+      border: 1px solid #555;
     }
 
     a.nav-link {

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -88,6 +88,7 @@
 
   .tab-content .nav-tabs {
     border-bottom: 3px solid #dee2e6;
+    padding-bottom: 4px;
   }
 
   .nav-item {
@@ -175,6 +176,13 @@
   }
 }
 
+// .ab-tabs-case > .nav-tabs > .nav-item {
+//   width: 100%;
+// }
+
+// .ab-tabs-case > .nav-tabs > .nav-item > .ab-tab {
+//   width: unset;
+// }
 /**
  * IE Scrollbar hack
  * For strange ui when

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -176,13 +176,6 @@
   }
 }
 
-// .ab-tabs-case > .nav-tabs > .nav-item {
-//   width: 100%;
-// }
-
-// .ab-tabs-case > .nav-tabs > .nav-item > .ab-tab {
-//   width: unset;
-// }
 /**
  * IE Scrollbar hack
  * For strange ui when

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -78,7 +78,7 @@
     height: 32px;
   }
 
-  .nav-item a:hover {
+  .nav-item a:not(.active):hover {
     color: #fff !important;
   }
 


### PR DESCRIPTION
## Description
The text for the active tab in compare mode should be a contrasting color when the cursor hovers over it. Currently it's white on white when you hover over the text with the cursor. 

Fixes # wv-2710

## How To Test

- git checkout wv-2710-hover-color
- npm run watch
- Enter Compare Mode
- Hover over the active tab and notice (in production) that it is white on white
- Hover over the active tab and notice (in this branch) that it is white on a contrasting gray. The icon also swaps colors & the bottom border is more cohesive with these changes.

@nasa-gibs/worldview
