### PR TITLE
wv-2711: Removed underline from Events --> Event Dates

### DIFF
--- a/web/scss/features/events.scss
+++ b/web/scss/features/events.scss
@@ -129,6 +129,7 @@
     font-size: 14px;
     font-family: $wv-monospace-font;
     cursor: pointer;
+    text-decoration: none;
   }
 
   .active {


### PR DESCRIPTION
## Description
Event date URLs in specific events are underlined when they shouldn't be

Fixes # wv-2711

## How To Test
Go to the [production site ](https://worldview.earthdata.nasa.gov/?v=-61.80790217247987,-123.62588641229539,162.15286805862843,63.66376648486104&e=EONET_4133,2023-04-28&efs=true&efa=false&efd=2023-01-04,2023-05-04&efc=dustHaze,manmade,seaLakeIce,severeStorms,snow,volcanoes,waterColor,wildfires&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,BlueMarble_NextGeneration(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2023-04-28-T00%3A00%3A00Z) & notice that the date(s) listed within specific events are underlined.
git checkout wv-2711-event-urls
npm run watch
Go to the [local branch site ](http://localhost:3000/?v=-61.80790217247987,-123.62588641229539,162.15286805862843,63.66376648486104&e=EONET_4133,2023-04-28&efs=true&efa=false&efd=2023-01-04,2023-05-04&efc=dustHaze,manmade,seaLakeIce,severeStorms,snow,volcanoes,waterColor,wildfires&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,BlueMarble_NextGeneration(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2023-04-28-T00%3A00%3A00Z)and confirm that these dates are no longer underlined.


@nasa-gibs/worldview
