### PR TITLE
Updating package-lock.json from previous kiosk mode commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15911,15 +15911,15 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "4.4.0",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz",
+      "integrity": "sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0"
+        "postcss-selector-parser": "^6.0.11",
+        "postcss-value-parser": "^4.2.0"
       },
       "peerDependencies": {
         "stylelint": "^14.5.1 || ^15.0.0"
@@ -27822,14 +27822,15 @@
       }
     },
     "stylelint-scss": {
-      "version": "4.4.0",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz",
+      "integrity": "sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0"
+        "postcss-selector-parser": "^6.0.11",
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "stylis": {


### PR DESCRIPTION
The package-lock.json file was not updated from the previous kiosk mode commit. This puts it up to date. 