### PR TITLE
Set static loopdelay

### DIFF
--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -232,7 +232,7 @@ class PlayQueue extends React.Component {
     const {
       isLoopActive, startDate, togglePlaying, speed,
     } = this.props;
-    const loopDelay = speed === 0.5 ? 2000 : 1000 / speed;
+    const loopDelay = speed === 0.5 ? 2000 : 1500;
 
     if (isLoopActive) {
       this.playingDate = toString(startDate);


### PR DESCRIPTION
## Description
From Slack: 

Set the loop delay to a fixed value when FPS >= 1 . A fixed value of 1500 seemed to work fine, i.e.

const loopDelay = speed === 0.5 ? 2000 : 1500

Let’s just go ahead and make it a static amount.

## How To Test

- git checkout Set_static_loopdelay
- npm run watch
- Start an animation. Notice that with any FPS above 0.5 the amount of time between the last frame of the animation & the start of the next loop remains a constant 1.5 seconds.

@nasa-gibs/worldview
