### PR TITLE
WV-2709: Modulate transition times based on kiosk mode

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -123,9 +123,10 @@ class Tour extends React.Component {
 
   selectTour(e, currentStory, currentStoryIndex, currentStoryId) {
     const {
-      config, renderedPalettes, selectTour, processStepLink,
+      config, renderedPalettes, selectTour, processStepLink, isKioskModeActive,
     } = this.props;
     if (e) e.preventDefault();
+    const kioskParam = this.getKioskParam(isKioskModeActive);
     this.setState({
       currentStep: 1,
       currentStoryIndex,
@@ -145,7 +146,7 @@ class Tour extends React.Component {
       currentStoryId,
       1,
       currentStory.steps.length,
-      `${storyStep.stepLink}&tr=${currentStoryId}${transitionParam}`,
+      `${storyStep.stepLink}&tr=${currentStoryId}${transitionParam}${kioskParam}`,
       config,
       renderedPalettes,
     );
@@ -225,9 +226,9 @@ class Tour extends React.Component {
       currentStoryId,
     } = this.state;
     const {
-      config, renderedPalettes, processStepLink,
+      config, renderedPalettes, processStepLink, isKioskModeActive,
     } = this.props;
-
+    const kioskParam = this.getKioskParam(isKioskModeActive);
     if (currentStep + 1 <= totalSteps) {
       const newStep = currentStep + 1;
       this.fetchMetadata(currentStory, currentStep);
@@ -239,7 +240,7 @@ class Tour extends React.Component {
         currentStoryId,
         newStep,
         currentStory.steps.length,
-        `${stepLink}&tr=${currentStoryId}${transitionParam}`,
+        `${stepLink}&tr=${currentStoryId}${transitionParam}${kioskParam}`,
         config,
         renderedPalettes,
       );
@@ -250,13 +251,18 @@ class Tour extends React.Component {
     }
   }
 
+  getKioskParam(isKioskModeActive) {
+    return isKioskModeActive ? '&kiosk=true' : '';
+  }
+
   decreaseStep(e) {
     const {
-      config, renderedPalettes, processStepLink,
+      config, renderedPalettes, processStepLink, isKioskModeActive,
     } = this.props;
     const {
       currentStep, currentStory, currentStoryId,
     } = this.state;
+    const kioskParam = this.getKioskParam(isKioskModeActive);
     if (currentStep - 1 >= 1) {
       const newStep = currentStep - 1;
       this.fetchMetadata(currentStory, newStep - 1);
@@ -268,7 +274,7 @@ class Tour extends React.Component {
         currentStoryId,
         newStep,
         currentStory.steps.length,
-        `${stepLink}&tr=${currentStoryId}${transitionParam}`,
+        `${stepLink}&tr=${currentStoryId}${transitionParam}${kioskParam}`,
         config,
         renderedPalettes,
       );
@@ -519,10 +525,11 @@ const mapStateToProps = (state) => {
     screenSize, config, tour, palettes, models, compare, map,
   } = state;
   const { screenWidth, screenHeight } = screenSize;
-
+  const { isKioskModeActive } = state.ui;
   return {
     config,
     isActive: tour.active,
+    isKioskModeActive,
     map,
     models,
     compareState: compare,
@@ -558,6 +565,7 @@ Tour.propTypes = {
   currentStoryId: PropTypes.string,
   endTour: PropTypes.func,
   isActive: PropTypes.bool,
+  isKioskModeActive: PropTypes.bool,
   processStepLink: PropTypes.func,
   renderedPalettes: PropTypes.object,
   resetProductPicker: PropTypes.func,

--- a/web/js/map/natural-events/natural-events.js
+++ b/web/js/map/natural-events/natural-events.js
@@ -170,7 +170,7 @@ class NaturalEvents extends React.Component {
   }
 
   zoomToEvent = function(event, date, isSameEventID) {
-    const { proj, map } = this.props;
+    const { proj, map, isKioskModeActive } = this.props;
     const { crs } = proj.selected;
     const category = event.categories[0].title;
     const zoom = isSameEventID ? map.getView().getZoom() : zoomLevelReference[category];
@@ -186,7 +186,7 @@ class NaturalEvents extends React.Component {
     } else {
       coordinates = olProj.transform(geometry.coordinates, CRS.GEOGRAPHIC, crs);
     }
-    return fly(map, proj, coordinates, zoom, null);
+    return fly(map, proj, coordinates, zoom, null, isKioskModeActive);
   };
 
   render() {
@@ -203,6 +203,7 @@ const mapStateToProps = (state) => {
   const {
     map, proj, requestedEvents, layers, config,
   } = state;
+  const { isKioskModeActive } = state.ui;
   const { active, selected } = state.events;
   const selectedMap = map.ui.selected;
   return {
@@ -211,6 +212,7 @@ const mapStateToProps = (state) => {
     proj,
     eventsDataIsLoading: requestedEvents.isLoading,
     eventsData: getFilteredEvents(state),
+    isKioskModeActive,
     selectedEvent: selected,
     eventLayers: layers.eventLayers,
     layers: layers.active.layers,
@@ -249,6 +251,7 @@ NaturalEvents.propTypes = {
   eventsData: PropTypes.array,
   eventsDataIsLoading: PropTypes.bool,
   eventLayers: PropTypes.array,
+  isKioskModeActive: PropTypes.bool,
   layers: PropTypes.array,
   selectedEvent: PropTypes.object,
   selectEventFinished: PropTypes.func,

--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -144,7 +144,7 @@ const getBestZoom = function(distance, start, end, view) {
    * @param  {integer} endZoom Ending Zoom Level
    * @return {Promise}         Promise that is fulfilled when animation completes
    */
-export function fly (map, proj, endPoint, endZoom = 5, rotation = 0) {
+export function fly (map, proj, endPoint, endZoom = 5, rotation = 0, isKioskModeActive) {
   const view = map.getView();
   const polarProjectionCheck = proj.selected.id !== 'geographic'; // boolean if current projection is polar
   view.cancelAnimations();
@@ -156,7 +156,9 @@ export function fly (map, proj, endPoint, endZoom = 5, rotation = 0) {
   const line = new OlGeomLineString([startPoint, endPoint]);
   const distance = line.getLength(); // In map units, which is usually degrees
   const distanceDuration = polarProjectionCheck ? distance / 50000 : distance; // limit large polar projection distances from coordinate transforms
-  let duration = Math.max(5000, 2 * Math.floor(distanceDuration * 20 + 1000)); // Minimum 5 seconds, approx 12 seconds to go 360 degrees
+  let duration = isKioskModeActive
+    ? Math.max(5000, 2 * Math.floor(distanceDuration * 20 + 1000)) // Minimum 5 seconds, approx 12 seconds to go 360 degrees
+    : Math.floor(distanceDuration * 20 + 1000); // approx 6 seconds to go 360 degrees
 
   const animationPromise = function(...args) {
     return new Promise((resolve, reject) => {

--- a/web/js/mapUI/components/markers/markers.js
+++ b/web/js/mapUI/components/markers/markers.js
@@ -13,6 +13,7 @@ function Markers(props) {
     activeLayers,
     config,
     coordinates,
+    isKioskModeActive,
     isMobileDevice,
     selectedMap,
     selectedMapMarkers,
@@ -103,7 +104,7 @@ function Markers(props) {
     const latestCoordinates = coordinatesObject && [longitude, latitude];
     const zoom = selectedMap.getView().getZoom();
     const maxZoom = getMaxZoomLevelLayerCollection(activeLayers, zoom, proj.id, sources);
-    animateCoordinates(selectedMap, proj, latestCoordinates, maxZoom);
+    animateCoordinates(selectedMap, proj, latestCoordinates, maxZoom, isKioskModeActive);
   };
 
   /**
@@ -157,6 +158,7 @@ const mapStateToProps = (state) => {
   const {
     locationSearch, proj, screenSize, map,
   } = state;
+  const { isKioskModeActive } = state.ui;
   const { coordinates } = locationSearch;
   const { isMobileDevice } = screenSize;
   const activeLayers = getActiveLayers(state).filter(({ projections }) => projections[proj.id]);
@@ -165,6 +167,7 @@ const mapStateToProps = (state) => {
   return {
     activeLayers,
     coordinates,
+    isKioskModeActive,
     isMobileDevice,
     selectedMap,
     selectedMapMarkers,
@@ -192,6 +195,7 @@ Markers.propTypes = {
   action: PropTypes.object,
   config: PropTypes.object,
   coordinates: PropTypes.array,
+  isKioskModeActive: PropTypes.bool,
   isMobileDevice: PropTypes.bool,
   proj: PropTypes.object,
   removeMarker: PropTypes.func,

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -38,6 +38,7 @@ function UpdateProjection(props) {
     dateCompareState,
     fitToLeadingExtent,
     getGranuleOptions,
+    isKioskModeActive,
     isMobile,
     layerState,
     map,
@@ -124,6 +125,15 @@ function UpdateProjection(props) {
     }
   };
 
+  /**
+ * Collect information required & initiate a "fly" map transition
+ * Used in Tour Stories.
+ * @method flyToNewExtent
+ * @static
+ *
+ * @param {object} extent
+ * @param {number} rotation
+ */
   const flyToNewExtent = function(extent, rotation) {
     const coordinateX = extent[0] + (extent[2] - extent[0]) / 2;
     const coordinateY = extent[1] + (extent[3] - extent[1]) / 2;
@@ -132,7 +142,7 @@ function UpdateProjection(props) {
     const zoom = ui.selected.getView().getZoomForResolution(resolution);
     // Animate to extent, zoom & rotate:
     // Don't animate when an event is selected (Event selection already animates)
-    return fly(ui.selected, proj, coordinates, zoom, rotation);
+    return fly(ui.selected, proj, coordinates, zoom, rotation, isKioskModeActive);
   };
 
   /**
@@ -357,6 +367,7 @@ const mapStateToProps = (state) => {
   const {
     proj, map, screenSize, layers, compare, date,
   } = state;
+  const { isKioskModeActive } = state.ui;
   const layerState = { layers, compare, proj };
   const isMobile = screenSize.isMobileDevice;
   const dateCompareState = { date, compare };
@@ -367,6 +378,7 @@ const mapStateToProps = (state) => {
     compare,
     compareMode,
     dateCompareState,
+    isKioskModeActive,
     isMobile,
     layerState,
     proj,
@@ -401,6 +413,7 @@ UpdateProjection.propTypes = {
   dateCompareState: PropTypes.object,
   fitToLeadingExtent: PropTypes.func,
   getGranuleOptions: PropTypes.func,
+  isKioskModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   layerState: PropTypes.object,
   map: PropTypes.object,

--- a/web/js/modules/location-search/util.js
+++ b/web/js/modules/location-search/util.js
@@ -19,14 +19,14 @@ const { LOCATION_SEARCH_COLLAPSED } = safeLocalStorage.keys;
  * @param {Array} coordinates
  * @param {Number} zoom
  */
-export function animateCoordinates(map, proj, coordinates, zoom) {
+export function animateCoordinates(map, proj, coordinates, zoom, isKioskModeActive) {
   const { crs } = proj.selected;
 
   let [x, y] = coordinates;
   if (proj !== 'geographic') {
     [x, y] = transform(coordinates, CRS.GEOGRAPHIC, crs);
   }
-  fly(map, proj, [x, y], zoom);
+  fly(map, proj, [x, y], zoom, isKioskModeActive);
 }
 
 /**


### PR DESCRIPTION
## Description
We recently did a global speed reduction on transitions for events/tour stories. We would like to restore the original speed if NOT in kiosk mode & retain the longer duration transitions when IN kiosk mode.

Fixes # wv-2709

## How To Test
- git checkout wv-2709
- npm run watch
- Test [NOT in kiosk mode](http://localhost:3000/?lg=false&t=2023-05-03-T14%3A48%3A29Z) - confirm speed of transition is ~50% faster than the production site.
- Test [in kiosk mode ](http://localhost:3000/?kiosk=true&lg=false&t=2023-05-03-T14%3A48%3A29Z) - confirm speed of transition is the same as the production site.

Note: Click the Information ("i") icon on the top right & select "Explore" to bring up the tours.
Also Note: This PR is branched from WV-2669 as that branch has the logic for kiosk mode (which is not yet in develop)

@nasa-gibs/worldview
