### PR TITLE
Removing distraction free exit button in kiosk mode

### DIFF
--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -394,13 +394,14 @@ class toolbarContainer extends Component {
   }
 
   render() {
+    const { isKioskModeActive } = this.props;
     return (
       <ErrorBoundary>
         <ButtonToolbar
           id="wv-toolbar"
           className="wv-toolbar"
         >
-          {this.renderDistractionFreeExitButton()}
+          {!isKioskModeActive && this.renderDistractionFreeExitButton()}
           {this.renderLocationSearchButtonComponent()}
           {this.renderShareButton()}
           {this.renderProjectionButton()}
@@ -429,7 +430,7 @@ const mapStateToProps = (state) => {
     sidebar,
     ui,
   } = state;
-  const { isDistractionFreeModeActive } = ui;
+  const { isDistractionFreeModeActive, isKioskModeActive } = ui;
   const { number, type } = notifications;
   const { activeString } = compare;
   const activeLayersForProj = getAllActiveLayers(state);
@@ -472,6 +473,7 @@ const mapStateToProps = (state) => {
     visibleLayersForProj,
     isRotated: Boolean(map.rotation !== 0),
     isDistractionFreeModeActive,
+    isKioskModeActive,
   };
 };
 
@@ -565,6 +567,7 @@ toolbarContainer.propTypes = {
   isAboutOpen: PropTypes.bool,
   isCompareActive: PropTypes.bool,
   isDistractionFreeModeActive: PropTypes.bool,
+  isKioskModeActive: PropTypes.bool,
   isLocationSearchExpanded: PropTypes.bool,
   isImageDownloadActive: PropTypes.bool,
   isMobile: PropTypes.bool,


### PR DESCRIPTION
This removes the exit distraction free mode button (eye button) while in kiosk mode. 

To Test:

1. `git checkout removing-df-button-kiosk-mode`
2. `npm run watch`
3. Use this [url](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&l=OrbitTracks_Terra_Descending(opacity=0.9),Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=false) to verify that the button is no longer visible. 