### PR TITLE
WV-2719 Error if mapped moved while sharing

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -69,6 +69,7 @@ class ShareLinkContainer extends Component {
     this.unlisten = history.listen((location, action) => {
       const newString = location.search;
       const { queryString } = this.state;
+      if (newString === undefined) { return; }
       if (queryString !== newString) {
         this.setState({
           queryString: newString,


### PR DESCRIPTION
## Description
On initial page load, if the user clicks the Share button & then moves the map with the Share window open an error occurs.

Fixes # wv-2719

## How to reproduce
- Open [worldview with fresh URL ](https://worldview.earthdata.nasa.gov/)
- Close the tour but don’t move page
- Click share
- Move map
- Observe error

## How To Test
- git checkout wv-2719-share-error
- npm run watch
- Follow steps above at [localhost address](http://localhost:3000/)
- Confirm error no longer occurs

@nasa-gibs/worldview
