### PR TITLE
WV-2717 Remove underline from tour stories

### DIFF
--- a/web/scss/features/tour.scss
+++ b/web/scss/features/tour.scss
@@ -560,6 +560,7 @@
   .wildfire .modal-body a {
     color: #7bf;
     font-weight: 400;
+    text-decoration: none;
   }
 
   .default .modal-body a:hover,


### PR DESCRIPTION
## Description
Some tour stories have hyperlinks & currently these links are underlined by default. They should not be underlined. 

Fixes # WV-2717

## How To Reproduce

- Load [Prod Worldview](https://worldview.earthdata.nasa.gov/?lg=false&t=2023-05-15-T18%3A42%3A15Z)
- Load the "Satellite Detections of Fire (2021 update)" tour story & navigate to slide 9. Notice underlined links in the blurb
- Load the "Night Lights from NASA's Black Marble" tour story & navigate to slide 5. Notice underlined links in the blurb

## How To Test

- git checkout wv-2717_underline_tour
- npm run watch
- Load local Worldview
- Load the "Satellite Detections of Fire (2021 update)" tour story & navigate to slide 9. Confirm links in the blurb are no longer underlined.
- Load the "Night Lights from NASA's Black Marble" tour story & navigate to slide 5. Confirm links in the blurb are no longer underlined.
- Check other tour(s) and confirm there are no underlined links in any of the text content.

@nasa-gibs/worldview
