### PR TITLE
WV-2651: Update Opacity

### DIFF
--- a/web/js/mapUI/components/update-opacity/updateOpacity.js
+++ b/web/js/mapUI/components/update-opacity/updateOpacity.js
@@ -69,15 +69,8 @@ function UpdateOpacity(props) {
     if (def.type === 'granule') {
       updateGranuleLayerOpacity(def, activeString, opacity, compare);
     } else {
-      // find the layer in each projection
-      const layerGroup = findLayer(def, activeString);
-      // get an array of layers from each projection
-      const layerGroupLayers = layerGroup.getLayersArray();
-      // need to set opacity for layerGroup and each individual layer
-      layerGroup.setOpacity(opacity);
-      layerGroupLayers.forEach((l) => {
-        l.setOpacity(opacity);
-      });
+      const layer = findLayer(def, activeString);
+      layer.setOpacity(opacity);
     }
     updateLayerVisibilities();
   };


### PR DESCRIPTION
## Description

The layer opacity was not updating consistently when loading layers from permalink & changing dates.  

## How To Test

1. `git checkout wv-2651-update-opacity`
2. `npm ci`
3. `npm run watch`
4. Lower the opacity on a base layer.
5. Copy the permalink and open the link in a new tab.
6. Observe that the layer opacity is now the same. 


