### PR TITLE
Updating Layer Order

### DIFF
--- a/config/default/common/config/wv.json/layerOrder.json
+++ b/config/default/common/config/wv.json/layerOrder.json
@@ -288,7 +288,6 @@
 		"MODIS_Aqua_L4_Gross_Primary_Productivity_8Day",
 		"MODIS_Terra_L4_Net_Photosynthesis_8Day",
 		"MODIS_Aqua_L4_Net_Photosynthesis_8Day",
-		"MODIS_Combined_MAIAC_L3_IsotropicKernelParameters_8Day",
 		"MODIS_Terra_L3_SST_MidIR_4km_Night_Daily",
 		"MODIS_Terra_L3_SST_MidIR_4km_Night_8Day",
 		"MODIS_Terra_L3_SST_MidIR_4km_Night_Monthly",


### PR DESCRIPTION
Removing the "MODIS_Combined_MAIAC_L3_IsotropicKernelParameters_8Day" layer from the layer order due to layer meta data inconsistency causing build issue.  