### PR TITLE
WV-2727 invalid tour parameters failure 

### DIFF
--- a/config/default/common/config/wv.json/storyOrder.json
+++ b/config/default/common/config/wv.json/storyOrder.json
@@ -5,7 +5,6 @@
         "geostationary",
         "fires_overview_2019",
         "worldview_intro",
-        "hls_intro",
         "clouds",
         "australia_fires_2019_2020",
         "dust_storms_overview_2019",

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -143,9 +143,9 @@ class App extends React.Component {
         <div id="wv-alert-container" className="wv-alert-container">
           <FeatureAlert />
           <Alerts />
+          {isTourActive ? <Tour /> : null}
         </div>
         <Sidebar />
-        {isTourActive ? <Tour /> : null}
         <div id="layer-modal" className="layer-modal" />
         <div id="layer-settings-modal" />
         <div id="eventsHolder" />

--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -89,6 +89,7 @@ export default class AlertUtil extends React.Component {
 
   render() {
     const { noPortal } = this.props;
+    console.log(`noportal: ${noPortal}`);
     return noPortal
       ? this.renderAlert()
       : createPortal(this.renderAlert(), document.getElementById('wv-alert-container'));

--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -89,18 +89,9 @@ export default class AlertUtil extends React.Component {
 
   render() {
     const { noPortal } = this.props;
-    console.log(`noportal: ${noPortal}`);
-    // This was the working code prior to commit df8e5a4944 which updated many dependencies
-    // It also eliminated the Portal component...
-    // return noPortal
-    // : (
-    //   <Portal node={document && document.getElementById('wv-alert-container')}>
-    //     {this.renderAlert()}
-    //   </Portal>
-    // );
     return noPortal
-      ? this.renderAlert()
-      : createPortal(this.renderAlert(), document.getElementById('wv-alert-container'));
+      ? createPortal(this.renderAlert(), document.getElementById('wv-alert-container'))
+      : this.renderAlert();
   }
 }
 

--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -90,6 +90,14 @@ export default class AlertUtil extends React.Component {
   render() {
     const { noPortal } = this.props;
     console.log(`noportal: ${noPortal}`);
+    // This was the working code prior to commit df8e5a4944 which updated many dependencies
+    // It also eliminated the Portal component...
+    // return noPortal
+    // : (
+    //   <Portal node={document && document.getElementById('wv-alert-container')}>
+    //     {this.renderAlert()}
+    //   </Portal>
+    // );
     return noPortal
       ? this.renderAlert()
       : createPortal(this.renderAlert(), document.getElementById('wv-alert-container'));


### PR DESCRIPTION
## Description
Worldview should fail gracefully if a tour story is no longer present. Current production/UAT/SIT crash with a black screen. We should present a warning message to users as specified in the test plan.

This PR also removes the "hls_intro" Tour Story. This is a temporary measure because the imagery is being reprocessed & causing some issues.

Fixes # WV-2727

## How To Reproduce
Click [https://worldview.earthdata.nasa.gov/?tr=testing](https://worldview.earthdata.nasa.gov/?tr=testing)

## How To Test
- git checkout wv-2727_invalid_tour
- npm ci
- npm run build (required for the HLS Tour Story adjustment)
- npm run watch
- Click [http://localhost:3000/?tr=testing](http://localhost:3000/?tr=testing)

@nasa-gibs/worldview
