### PR TITLE
WV 2725 App crashes when tour story and events tab are used together

### DIFF
--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -280,7 +280,8 @@ function UpdateProjection(props) {
  * @returns {void}
  */
   function showMap(map) {
-    document.getElementById(`${map.getTarget()}`).style.display = 'block';
+    const el = document.getElementById(`${map.getTarget()}`);
+    if (el) el.style.display = 'block';
   }
 
   /**
@@ -294,7 +295,8 @@ function UpdateProjection(props) {
  * @returns {void}
  */
   function hideMap(map) {
-    document.getElementById(`${map.getTarget()}`).style.display = 'none';
+    const el = document.getElementById(`${map.getTarget()}`);
+    if (el) el.style.display = 'none';
   }
 
 

--- a/web/js/modules/layers/reducers.js
+++ b/web/js/modules/layers/reducers.js
@@ -159,12 +159,14 @@ export function layerReducer(state = initialState, action) {
       };
 
     case TOGGLE_LAYER_VISIBILITY:
+      const index = getLayerIndex();
+      if (index === -1) return state;
       return update(state, {
         [compareState]: {
           layers: {
-            [getLayerIndex()]: {
+            [index]: {
               visible: {
-                $set: action.visible,
+                $set: action?.visible,
               },
             },
           },

--- a/web/js/modules/layers/reducers.js
+++ b/web/js/modules/layers/reducers.js
@@ -159,12 +159,11 @@ export function layerReducer(state = initialState, action) {
       };
 
     case TOGGLE_LAYER_VISIBILITY:
-      const index = getLayerIndex();
-      if (index === -1) return state;
+      if (getLayerIndex() === -1) return state;
       return update(state, {
         [compareState]: {
           layers: {
-            [index]: {
+            [getLayerIndex()]: {
               visible: {
                 $set: action?.visible,
               },


### PR DESCRIPTION
## Description

Fixes bug where the app crashes when tour story and events tab are used together

## How To Test

1. `git checkout WV-2679-layer-picker-menu-header-bug`
2. `npm ci`
3. `npm run watch`
4. Got to `http://localhost:3000`
5. Click on the "Events" tab
6. Click on the "Information" button
7. Click on "Explore"
8. Click on one of the tour stories
9. The app should not crash

@nasa-gibs/worldview
