### PR TITLE
WV-2726 "Running data value" feature breaks under certain circumstances

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -146,7 +146,7 @@ class PaletteLegend extends React.Component {
         if (this[ctxStr]) {
           const newWidth = this[ctxStr].current.getBoundingClientRect().width;
           // eslint-disable-next-line react/destructuring-assignment
-          if (newWidth !== this.state.width) {
+          if (newWidth && newWidth !== this.state.width) {
             // If scrollbar appears canvas width changes.
             // This value is needed for calculating running data offsets
             this.setState({ width: newWidth });


### PR DESCRIPTION
## Description

Fixes bug where the "Running data value" feature breaks under certain circumstances

## How To Test

1. Select the Events tab
2. Select a cyclone event
3. Select the Layers tab
4. Expand the "Precipitation Rate" layer group
5. Hover over the map where there is precipitation rate imagery; the running data value indicators should appear in the legend

All other functionality should remain the same.

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
