### PR TITLE
WV-2728: Breakpoint Layers Opacity Bug

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -289,6 +289,11 @@ export default function mapLayerBuilder(config, cache, store) {
       }
     }
     layer.setOpacity(opacity || 1.0);
+    if (breakPointLayer) {
+      layer.getLayersArray().forEach((l) => {
+        l.setOpacity(opacity || 1.0);
+      });
+    }
     return layer;
   };
 

--- a/web/js/mapUI/components/update-opacity/updateOpacity.js
+++ b/web/js/mapUI/components/update-opacity/updateOpacity.js
@@ -69,8 +69,11 @@ function UpdateOpacity(props) {
     if (def.type === 'granule') {
       updateGranuleLayerOpacity(def, activeString, opacity, compare);
     } else {
-      const layer = findLayer(def, activeString);
-      layer.setOpacity(opacity);
+      const layerGroup = findLayer(def, activeString);
+      layerGroup.setOpacity(opacity);
+      layerGroup.getLayersArray().forEach((l) => {
+        l.setOpacity(opacity);
+      });
     }
     updateLayerVisibilities();
   };


### PR DESCRIPTION
## Description

The vector tile opacity for breakpoint layers was not updating correctly. This fix loops through each breakpoint sublayer and updates the layer opacity on load and when an opacity update is triggered. 

## How To Test

To reproduce in UAT:

1. `https://worldview.uat.earthdata.nasa.gov/?v=-179.53634369997815,-31.790704125436545,43.00149099152358,67.77179587456345&l=GRanD_Dams&lg=true&t=2023-05-31-T19%3A10%3A49Z`
2. Zoom in until the tiles turn from WMS to Vector tiles. (Ex. Zoom in until the state of Florida takes up the whole screen)
3. Attempt to update the opacity.
4. Notice that the opacity does not update until you reach 0%. 

Testing:
1. `git checkout wv-2728-opacity-bug`
2. `npm ci`
3. `npm run watch`
4. `http://localhost:3000/?v=-155.74508122918647,-26.49558406373081,63.624620838274325,71.64950660082587&l=GRanD_Dams&lg=true&t=2023-05-31-T19%3A12%3A42Z`
5. Zoom into the state of Florida.
6. Update the opacity.
7. Confirm that the opacity updates dynamically. 
8. Refresh the page and confirm that the opacity values still carry over with the permalink. 
