### PR TITLE
WV-2730: Fix measurement instructions location

### DIFF
--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -90,7 +90,7 @@ export default class AlertUtil extends React.Component {
   render() {
     const { noPortal } = this.props;
     const alertContainer = document.getElementById('wv-alert-container');
-    if (noPortal && alertContainer) {
+    if (!noPortal && alertContainer) {
       return createPortal(this.renderAlert(), document.getElementById('wv-alert-container'));
     }
     return this.renderAlert();


### PR DESCRIPTION
## Description

The instructions that appear when creating a measurement are being rendered in the incorrect location in UAT. Fixed the portal logic in the alert util.

To reproduce bug:
1. `https://worldview.uat.earthdata.nasa.gov/`
2. Modify screen size to mobile
3. Start a measurement 
4. Note how the measurement tool is rendering mostly off screen.

## How To Test

1. `git checkout wv-2730`
2. `npm run watch`
3. `http://localhost:3000/`
4. Modify screensize to mobile
5. Start a measurement 
6. Ensure that you can see the entirety of the measurement instructions. 

