### PR TITLE
Updating content length thresholds for Sea Ice animation

### DIFF
--- a/web/js/components/kiosk/animation-tile-check/date-range-tile-check.js
+++ b/web/js/components/kiosk/animation-tile-check/date-range-tile-check.js
@@ -24,7 +24,7 @@ import {
 const contentLengthThresholds = {
   'GOES-East_ABI_GeoColor': 160000,
   'GOES-West_ABI_GeoColor': 160000,
-  'AMSRU2_Sea_Ice_Concentration_12km': 50000,
+  'AMSRU2_Sea_Ice_Concentration_12km': 10000,
 };
 
 function DateRangeTileCheck(props) {


### PR DESCRIPTION
## Description

The content length threshold for the `AMSRU2_Sea_Ice_Concentration_12km` that is being used to measure empty tiles in EIC animations was too high, causing this animation to not play. This lowers the threshold value. 


## How To Test

1. `git checkout eic-antarctic-animations`
2. `npm ci`
3. `npm run watch`
4. localhost:3000/?v=-4171187.01916682,-4238559.180936186,4142545.3786389525,4188800.5389352706&p=antarctic&df=true&kiosk=true&eic=da&l=Land_Mask,AMSRU2_Sea_Ice_Concentration_12km(palette=blue_6)&lg=true
5. Verify that animation plays

