### PR TITLE
WV-2735: Remove Menu border styling

### DIFF
--- a/web/scss/components/list.scss
+++ b/web/scss/components/list.scss
@@ -2,6 +2,7 @@
   background: #282828;
   color: #eee;
   text-align: left;
+  border: none;
 }
 
 .list-group-item.active {


### PR DESCRIPTION
## Description
Through an update to bootstrap, the `ListGroup` classes acquired a border color through the default styling. This removes that styling. 

To recreate bug, open UAT and select the `information` button and view the menu that opens.

## How To Test

1. `git checkout wv-2735`
2. `npm run watch`
3. Click on the `information` button
4. Verify that the menu that opens has no border styling
