### PR TITLE
WV-2725: Fix story crashes

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -35,7 +35,7 @@ import {
   startTour as startTourAction,
 } from '../modules/tour/actions';
 import { resetProductPickerState as resetProductPickerStateAction } from '../modules/product-picker/actions';
-
+import { changeTab as changeTabAction } from '../modules/sidebar/actions';
 import ErrorBoundary from './error-boundary';
 import history from '../main';
 import util from '../util/util';
@@ -226,9 +226,12 @@ class Tour extends React.Component {
       currentStoryId,
     } = this.state;
     const {
-      config, renderedPalettes, processStepLink, isKioskModeActive,
+      config, renderedPalettes, processStepLink, isKioskModeActive, activeTab, changeTab,
     } = this.props;
     const kioskParam = this.getKioskParam(isKioskModeActive);
+
+    if (activeTab === 'events') changeTab('layers');
+
     if (currentStep + 1 <= totalSteps) {
       const newStep = currentStep + 1;
       this.fetchMetadata(currentStory, currentStep);
@@ -257,12 +260,15 @@ class Tour extends React.Component {
 
   decreaseStep(e) {
     const {
-      config, renderedPalettes, processStepLink, isKioskModeActive,
+      config, renderedPalettes, processStepLink, isKioskModeActive, activeTab, changeTab,
     } = this.props;
     const {
       currentStep, currentStory, currentStoryId,
     } = this.state;
     const kioskParam = this.getKioskParam(isKioskModeActive);
+
+    if (activeTab === 'events') changeTab('layers');
+
     if (currentStep - 1 >= 1) {
       const newStep = currentStep - 1;
       this.fetchMetadata(currentStory, newStep - 1);
@@ -518,11 +524,14 @@ const mapDispatchToProps = (dispatch) => ({
   resetProductPicker: () => {
     dispatch(resetProductPickerStateAction());
   },
+  changeTab: (str) => {
+    dispatch(changeTabAction(str));
+  },
 });
 
 const mapStateToProps = (state) => {
   const {
-    screenSize, config, tour, palettes, models, compare, map,
+    screenSize, config, tour, palettes, models, compare, map, sidebar,
   } = state;
   const { screenWidth, screenHeight } = screenSize;
   const { isKioskModeActive } = state.ui;
@@ -539,6 +548,7 @@ const mapStateToProps = (state) => {
     screenWidth,
     screenHeight,
     renderedPalettes: palettes.rendered,
+    activeTab: sidebar.activeTab,
   };
 };
 
@@ -557,6 +567,8 @@ export default connect(
 )(Tour);
 
 Tour.propTypes = {
+  activeTab: PropTypes.string,
+  changeTab: PropTypes.func,
   config: PropTypes.object.isRequired,
   map: PropTypes.object,
   selectTour: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description

When stepping through a story we allow users to enter & exit the events tab. When incrementing or decrementing into a step of a story that uses compare mode, the app would crash if the events tab was still open. This updates the tour logic to check each incremental or decremental step to see if the events tab is active, and if so, switch back to the layers tab. 


## How To Test

1. `git checkout `wv-2725-story-compare-mode`
2. `npm ci`
3. `npm run watch`
4. Start the flood tour story
5. Increment to step 2.
6. Activate the events tab
7. Increment to step 3.
8. Verify that A. The app has not crashed. B. The events tab is no longer active C. Compare mode is working. 
9. Increment to step 4.
10. Activate the events tab.
11. Decrement to step 3.
12. Verify that A. The app has not crashed. B. The events tab is no longer active C. Compare mode is working. 
