### PR TITLE
Enable use of left and right arrow keys to iterate the currently displayed date in "Distraction Free" mode

### DIFF
--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -27,11 +27,6 @@ class DateChangeArrows extends PureComponent {
     };
   }
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleKeyDown);
-    document.addEventListener('keyup', this.handleKeyUp);
-  }
-
   componentDidUpdate (prevProps) {
     const { tilesPreloaded, arrowDown } = this.props;
     const notAnimating = !intervals.left && !intervals.right;
@@ -45,34 +40,12 @@ class DateChangeArrows extends PureComponent {
   componentWillUnmount() {
     clearInterval(intervals.left);
     clearInterval(intervals.right);
-    document.removeEventListener('keydown', this.handleKeyDown);
-    document.removeEventListener('keyup', this.handleKeyUp);
   }
 
   clickAndHold = (direction) => {
     const { setArrowDown } = this.props;
     setArrowDown(direction);
     arrowDownCheckTimer = null;
-  };
-
-  handleKeyDown = (e) => {
-    const { arrowDown } = this.props;
-    const direction = e.keyCode === 37 ? 'left' : e.keyCode === 39 ? 'right' : null;
-    if (e.target.tagName === 'INPUT' || e.target.className === 'form-range' || e.ctrlKey || e.metaKey) {
-      return;
-    }
-    if (direction) {
-      e.preventDefault();
-      if (!arrowDown) this.onArrowDown(direction);
-    }
-  };
-
-  handleKeyUp = (e) => {
-    const direction = e.keyCode === 37 ? 'left' : e.keyCode === 39 ? 'right' : null;
-    if (direction) {
-      e.preventDefault();
-      this.onArrowUp(direction);
-    }
   };
 
   onArrowDown = (direction) => {

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -515,17 +515,23 @@ class Timeline extends React.Component {
     if (e.target.tagName !== 'INPUT' && e.target.className !== 'form-range' && !e.ctrlKey && !e.metaKey && !isTimelineDragging) {
       const timeScaleNumber = Number(TIME_SCALE_TO_NUMBER[timeScale]);
       const maxTimeScaleNumber = hasSubdailyLayers ? 5 : 3;
-      if (e.keyCode === 38) {
+      if (e.key === 'ArrowUp') {
         e.preventDefault();
         if (timeScaleNumber > 1) {
           this.changeTimeScale(timeScaleNumber - 1);
         }
       // down arrow
-      } else if (e.keyCode === 40) {
+      } else if (e.key === 'ArrowDown') {
         e.preventDefault();
         if (timeScaleNumber < maxTimeScaleNumber) {
           this.changeTimeScale(timeScaleNumber + 1);
         }
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        this.handleArrowDateChange(-1);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        this.handleArrowDateChange(1);
       }
     }
   };


### PR DESCRIPTION
## Description

While in distraction-free mode, it would be helpful to retain the ability to use keyboard shortcuts to increment and decrement the currently-displayed date using the left and right arrow keys.

## How To Test


1. `git checkout WV-2729-distraction-free-keyboard-shortcuts`
2. `npm ci`
3. `npm run watch`
4. Got to `http://localhost:3000`
5. Click the info button in the top right
6. Select "Distraction Free"
7. Select different imagery dates using the left and right arrow keys.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added the necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
