### PR TITLE
EIC mode UI & Performance Improvements

### DIFF
--- a/web/js/components/animation-widget/loading-indicator.js
+++ b/web/js/components/animation-widget/loading-indicator.js
@@ -6,7 +6,7 @@ import {
 
 export default function LoadingIndicator(props) {
   const {
-    onClose, title, bodyMsg, loadedItems, totalItems,
+    onClose, title, bodyMsg, loadedItems, totalItems, isKioskModeActive,
   } = props;
 
   const msgStyle = {
@@ -31,7 +31,7 @@ export default function LoadingIndicator(props) {
     </button>
   );
 
-  return (
+  return !isKioskModeActive && (
     <Modal
       isOpen
       toggle={onClose}
@@ -56,4 +56,5 @@ LoadingIndicator.propTypes = {
   bodyMsg: PropTypes.string,
   loadedItems: PropTypes.number,
   totalItems: PropTypes.number,
+  isKioskModeActive: PropTypes.bool,
 };

--- a/web/js/components/animation-widget/play-queue.js
+++ b/web/js/components/animation-widget/play-queue.js
@@ -435,7 +435,7 @@ class PlayQueue extends React.Component {
 
   render() {
     const { isAnimating } = this.state;
-    const { onClose, isMobile } = this.props;
+    const { onClose, isMobile, isKioskModeActive } = this.props;
     const loadedItems = util.objectLength(this.bufferObject);
     const title = !this.minBufferLength ? 'Determining buffer size...' : 'Preloading buffer...';
     const mobileProgressStyle = {
@@ -459,6 +459,7 @@ class PlayQueue extends React.Component {
           onClose={onClose}
           loadedItems={loadedItems}
           totalItems={this.minBufferLength || 100}
+          isKioskModeActive={isKioskModeActive}
         />
       );
   }
@@ -480,6 +481,7 @@ PlayQueue.propTypes = {
   onClose: PropTypes.func,
   numberOfFrames: PropTypes.number,
   snappedCurrentDate: PropTypes.object,
+  isKioskModeActive: PropTypes.bool,
 };
 
 export default PlayQueue;

--- a/web/js/components/map/loading-spinner.js
+++ b/web/js/components/map/loading-spinner.js
@@ -1,9 +1,18 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 import { Spinner } from 'reactstrap';
+import { useSelector } from 'react-redux';
 
-function LoadingIndicator({ msg, isLoading, isMobile }) {
+function LoadingIndicator() {
+  const {
+    msg,
+    shouldSpinnerShow,
+    isMobile,
+  } = useSelector((state) => ({
+    msg: state.loading.msg,
+    shouldSpinnerShow: state.loading.isLoading && !state.ui.isKioskModeActive,
+    isMobile: state.screenSize.isMobileDevice,
+  }));
+
   const spinnerStyle = isMobile ? {
     position: 'absolute',
     top: 10,
@@ -17,26 +26,12 @@ function LoadingIndicator({ msg, isLoading, isMobile }) {
       zIndex: 999,
     };
 
-  return isLoading && (
+  return shouldSpinnerShow && (
     <div style={spinnerStyle}>
       <Spinner color="light" size="sm" />
       {msg}
     </div>
   );
 }
-LoadingIndicator.propTypes = {
-  msg: PropTypes.string,
-  isLoading: PropTypes.bool,
-  isMobile: PropTypes.bool,
-};
 
-const mapStateToProps = (state) => {
-  const { screenSize, loading } = state;
-  const { msg, isLoading } = loading;
-  return {
-    isLoading,
-    isMobile: screenSize.isMobileDevice,
-    msg,
-  };
-};
-export default connect(mapStateToProps)(LoadingIndicator);
+export default LoadingIndicator;

--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -246,6 +246,7 @@ function AnimationWidget (props) {
             startDate={startDate}
             endDate={endDate}
             interval={interval}
+            isKioskModeActive={isKioskModeActive}
             delta={delta}
             speed={speed}
             selectDate={selectDate}

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/date-util.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/date-util.js
@@ -42,7 +42,11 @@ function getSubdailyDates (selectedDate) {
   // Get the date as a string in UTC
   const utcDateString = selectedDate.toLocaleString('en-US', { timeZone: 'UTC' });
   // Convert the UTC string back to a Date object
-  const currentDate = new Date(utcDateString);
+  let currentDate = new Date(utcDateString);
+
+  // Subtract 30 minutes to start half an hour before the selectedDate
+  // This is a performance improvement for EIC mode since most of the time, no full imagery is found in the first 30 minutes
+  currentDate = new Date(currentDate.getTime() - 30 * 60 * 1000);
 
   // Round minutes down to nearest ten and seconds and milliseconds to zero
   currentDate.setMinutes(Math.floor(currentDate.getMinutes() / 10) * 10, 0, 0);

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -284,8 +284,8 @@ function promiseLayerGroup(layerGroup, map) {
  * @return {object} Promise
  */
 export async function promiseImageryForTime(state, date, activeString) {
-  const { map, ui: { eic } } = state;
-  if (!map.ui.proj || eic === 'si') return;
+  const { map } = state;
+  if (!map.ui.proj) return;
   const {
     cache, selected, createLayer, layerKey,
   } = map.ui;


### PR DESCRIPTION
## Description

Small updates to the UI & performance of EIC mode after on site testing.

1. The spinning loading indicator was removed from `kiosk-mode`
2. The animation buffering indicator was removed from `kiosk-mode`
3. The tile testing process for subdaily layers in `eic-mode` was updated to begin tile search - 30 minutes before app date. This is to improve the performance on load for panels with these layers. Most of the time, there is not usable imagery in this timeframe, so skipping this part of the search greatly improves loading times.

## How To Test

1. `git checkout improvements-eic-mode`
2. `npm ci`
3. `npm run watch`
4. Use this [link](http://localhost:3000/?v=-4171187.01916682,-4238559.180936186,4142545.3786389525,4188800.5389352706&p=arctic&df=true&kiosk=true&eic=da&l=Land_Mask,AMSRU2_Sea_Ice_Concentration_12km(palette=blue_6)&lg=true) to open the Arctic animation scenario.
5. Verify that the animation plays and does not include the spinner at the top of the screen nor the buffering animation indicator. 
6. Use this [link](http://localhost:3000/?v=-218.05641352247375,-98.53068072538338,146.49566203427042,106.52986177528524&ics=true&ici=5&icd=10&df=true&kiosk=true&eic=si&l=Coastlines_15m(opacity=0.77),GOES-East_ABI_GeoColor,GOES-West_ABI_GeoColor,Himawari_AHI_Band3_Red_Visible_1km&lg=false) to load the subdaily geostationary scenario.
7. Verify that this scenario loads full imagery.