### PR TITLE
Make sure we are pointing to EONET v3 API

### DIFF
--- a/tasks/link-check/html-url-extract.js
+++ b/tasks/link-check/html-url-extract.js
@@ -49,7 +49,7 @@ const getUrls = (htmlArray) => {
 
 // get URLS from HTML files
 // scraped URLs are saved in an array of objects with a key value pair of link text and href:
-// 'Wildfire MB-CE042, Manitoba, Canada': 'https://eonet.gsfc.nasa.gov/api/v2.1/events/EONET_3518'
+// 'Wildfire MB-CE042, Manitoba, Canada': 'https://eonet.gsfc.nasa.gov/api/v3/events/EONET_3518'
 const initExtractor = async () => {
   // any html file with a url will be scraped and added
   const htmlFiles = await walk('./build/options')

--- a/tasks/link-check/natural-event-url-extract.js
+++ b/tasks/link-check/natural-event-url-extract.js
@@ -62,12 +62,12 @@ const scrapeLinks = async (htmlLinks) => {
 
 // get URLs from natural events EONET
 // scraped URLs are saved in an array of objects with a key value pair of link text and href:
-// 'Wildfire MB-CE042, Manitoba, Canada': 'https://eonet.gsfc.nasa.gov/api/v2.1/events/EONET_3518'
+// 'Wildfire MB-CE042, Manitoba, Canada': 'https://eonet.gsfc.nasa.gov/api/v3/events/EONET_3518'
 const initExtractor = async () => {
   // target EONET sources from natural events
-  const links = ['https://eonet.gsfc.nasa.gov/api/v2.1/sources',
-    'https://eonet.gsfc.nasa.gov/api/v2.1/events',
-    'https://eonet.gsfc.nasa.gov/api/v2.1/categories']
+  const links = ['https://eonet.gsfc.nasa.gov/api/v3/sources',
+    'https://eonet.gsfc.nasa.gov/api/v3/events',
+    'https://eonet.gsfc.nasa.gov/api/v3/categories']
   const results = await scrapeLinks(links)
   return results
 }

--- a/web/mock/events_data.json
+++ b/web/mock/events_data.json
@@ -2,13 +2,13 @@
 {
 	"title": "EONET Events",
 	"description": "Natural events from EONET.",
-	"link": "https://eonet.gsfc.nasa.gov/api/v2/events",
+	"link": "https://eonet.gsfc.nasa.gov/api/v3/events",
 	"events": [
 		{
 			"id": "EONET_2793",
 			"title": "Elm Fire, California",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2793",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2793",
 			"categories": [
 				{
 					"id": "wildfires",
@@ -38,7 +38,7 @@
 			"id": "EONET_2792",
 			"title": "Santiago, Chile Flooding",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2792",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2792",
 			"categories": [
 				{
 					"id": "floods",
@@ -68,7 +68,7 @@
 			"id": "EONET_2781",
 			"title": "Langila Volcano, Papua New Guinea",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2781",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2781",
 			"categories": [
 				{
 					"id": "volcanoes",
@@ -98,7 +98,7 @@
 			"id": "EONET_2733",
 			"title": "Iceberg B30",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2733",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2733",
 			"categories": [
 				{
 					"id": "seaLakeIce",
@@ -239,7 +239,7 @@
 			"id": "EONET_2733",
 			"title": "Iceberg B30-TEST",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2733",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2733",
 			"categories": [
 				{
 					"id": "seaLakeIce",
@@ -385,7 +385,7 @@
 			"id": "EONET_0001",
 			"title": "Example id 1",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_0001",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_0001",
 			"categories": [
 				{
 					"id": "seaLakeIce",

--- a/web/mock/events_data.json-20170530
+++ b/web/mock/events_data.json-20170530
@@ -2,7 +2,7 @@
 {
 	"title": "EONET Events",
 	"description": "Natural events from EONET.",
-	"link": "https://eonet.gsfc.nasa.gov/api/v2/events",
+	"link": "https://eonet.gsfc.nasa.gov/api/v3/events",
 	"events": [
 		{
 			"id": "EONET_99999",
@@ -78,7 +78,7 @@
 			"id": "EONET_2804",
 			"title": "Tropical Storm Mora",
             "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2804",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2804",
 			"categories": [
 				{
 					"id": "severeStorms",
@@ -135,7 +135,7 @@
 			"id": "EONET_2777",
 			"title": "Tropical Worldview Storm",
             "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2804",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2804",
 			"categories": [
 				{
 					"id": "severeStorms",
@@ -172,7 +172,7 @@
       "id": "EONET_3931",
       "title": "Rattlesnake Fire",
       "description": "",
-      "link": "https://eonet.gsfc.nasa.gov/api/v2/events/EONET_3931",
+      "link": "https://eonet.gsfc.nasa.gov/api/v3/events/EONET_3931",
       "categories": [
         {
           "id": "wildfires",
@@ -197,7 +197,7 @@
 			"id": "EONET_2781",
 			"title": "Langila Volcano, Papua New Guinea",
             "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2781",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2781",
 			"categories": [
 				{
 					"id": "volcanoes",
@@ -227,7 +227,7 @@
 			"id": "EONET_2703",
 			"title": "Iceberg B30",
             "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2733",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2733",
 			"categories": [
 				{
 					"id": "seaLakeIce",
@@ -369,7 +369,7 @@
 			"id": "EONET_2733",
 			"title": "Iceberg B30-TEST",
       "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_2733",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_2733",
 			"categories": [
 				{
 					"id": "seaLakeIce",
@@ -515,7 +515,7 @@
 			"id": "EONET_0001",
 			"title": "Example id 1",
             "description": "",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events/EONET_0001",
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events/EONET_0001",
 			"categories": [
 				{
 					"id": "seaLakeIce",

--- a/web/mock/sources_data.json-20170530
+++ b/web/mock/sources_data.json-20170530
@@ -2,127 +2,127 @@
 {
 	"title": "EONET Event Sources",
 	"description": "List of all the available event sources in the EONET system",
-	"link": "http://eonet.gsfc.nasa.gov/api/v2/sources",
+	"link": "http://eonet.gsfc.nasa.gov/api/v3/sources",
 	"sources": [
 		{
 			"id": "TEST",
 			"title": "Test Source",
 			"source": "http://www.example.com/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=TEST"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=TEST"
 		},
 		{
 			"id": "AU_BOM",
 			"title": "Australia Bureau of Meteorology",
 			"source": "http://www.bom.gov.au/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=AU_BOM"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=AU_BOM"
 		},
 		{
 			"id": "BCWILDFIRE",
 			"title": "British Columbia Wildfire Service",
 			"source": "http://bcwildfire.ca/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=BCWILDFIRE"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=BCWILDFIRE"
 		},
 		{
 			"id": "CALFIRE",
 			"title": "California Department of Forestry and Fire Protection",
 			"source": "http://www.calfire.ca.gov/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=CALFIRE"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=CALFIRE"
 		},
 		{
 			"id": "CEMS",
 			"title": "Copernicus Emergency Management Service",
 			"source": "http://emergency.copernicus.eu/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=CEMS"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=CEMS"
 		},
 		{
 			"id": "EO",
 			"title": "Earth Observatory",
 			"source": "http://earthobservatory.nasa.gov/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=EO"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=EO"
 		},
 		{
 			"id": "GDACS",
 			"title": "Global Disaster Alert and Coordination System",
 			"source": "http://www.gdacs.org/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=GDACS"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=GDACS"
 		},
 		{
 			"id": "GLIDE",
 			"title": "GLobal IDEntifier Number (GLIDE)",
 			"source": "http://www.glidenumber.net/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=GLIDE"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=GLIDE"
 		},
 		{
 			"id": "InciWeb",
 			"title": "InciWeb",
 			"source": "http://inciweb.nwcg.gov/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=InciWeb"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=InciWeb"
 		},
 		{
 			"id": "IDC",
 			"title": "International Charter on Space and Major Disasters",
 			"source": "https://www.disasterscharter.org/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=IDC"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=IDC"
 		},
 		{
 			"id": "MRR",
 			"title": "LANCE Rapid Response",
 			"source": "https://lance.modaps.eosdis.nasa.gov/cgi-bin/imagery/gallery.cgi",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=MRR"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=MRR"
 		},
 		{
 			"id": "NASA_ESRS",
 			"title": "NASA Earth Science and Remote Sensing Unit",
 			"source": "https://eol.jsc.nasa.gov/ESRS/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=NASA_ESRS"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=NASA_ESRS"
 		},
 		{
 			"id": "PDC",
 			"title": "Pacific Disaster Center",
 			"source": "http://www.pdc.org/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=PDC"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=PDC"
 		},
 		{
 			"id": "ReliefWeb",
 			"title": "ReliefWeb",
 			"source": "http://reliefweb.int/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=ReliefWeb"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=ReliefWeb"
 		},
 		{
 			"id": "SIVolcano",
 			"title": "Smithsonian Institution Global Volcanism Program",
 			"source": "http://www.volcano.si.edu/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=SIVolcano"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=SIVolcano"
 		},
 		{
 			"id": "NATICE",
 			"title": "U.S. National Ice Center",
 			"source": "http://www.natice.noaa.gov/Main_Products.htm",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=NATICE"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=NATICE"
 		},
 		{
 			"id": "UNISYS",
 			"title": "Unisys Weather",
 			"source": "http://weather.unisys.com/hurricane/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=UNISYS"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=UNISYS"
 		},
 		{
 			"id": "USGS_CMT",
 			"title": "USGS Emergency Operations Collection Management Tool",
 			"source": "https://cmt.usgs.gov/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=USGS_CMT"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=USGS_CMT"
 		},
 		{
 			"id": "HDDS",
 			"title": "USGS Hazards Data Distribution System",
 			"source": "https://hddsexplorer.usgs.gov/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=HDDS"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=HDDS"
 		},
 		{
 			"id": "DFES_WA",
 			"title": "Western Australia Department of Fire and Emergency Services",
 			"source": "https://www.dfes.wa.gov.au/",
-			"link": "http://eonet.gsfc.nasa.gov/api/v2/events?source=DFES_WA"
+			"link": "http://eonet.gsfc.nasa.gov/api/v3/events?source=DFES_WA"
 		}
 	]
 }


### PR DESCRIPTION
## Description

WV-2732: The EONET v2.1 API which powers the Events will be deprecated soon and we need to update to v3. We should check to see if we need to update to the v3 API (https://eonet.gsfc.nasa.gov/api/v3/) across the board to be consistent. 