### PR TITLE
WV-2750: Measure imagery pixels within visible extent of map for EIC Mode

### DIFF
--- a/web/js/mapUI/components/kiosk/tile-measurement/tile-measurement.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/tile-measurement.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { transformExtent } from 'ol/proj';
 import { getActiveLayers } from '../../../../modules/layers/selectors';
 import { selectDate as selectDateAction } from '../../../../modules/date/actions';
 import {
@@ -26,10 +27,12 @@ function TileMeasurement({ ui }) {
   const {
     activeString,
     activeLayers,
+    map,
     eic,
     realTime,
   } = useSelector((state) => ({
     activeLayers: getActiveLayers(state, state.compare.activeString).map((layer) => layer),
+    map: state.map,
     eic: state.ui.eic,
     realTime: state.date.appNow,
     activeString: state.compare.activeString,
@@ -39,7 +42,7 @@ function TileMeasurement({ ui }) {
   const [measurementsStarted, setMeasurementsStarted] = useState(false);
 
   useEffect(() => {
-    if (!measurementsStarted && activeLayers && eic) {
+    if (!measurementsStarted && activeLayers && eic && map.ui.selected) {
       calculateMeasurements();
     }
   });
@@ -67,7 +70,9 @@ function TileMeasurement({ ui }) {
       console.log(`-----Loop #${i + 1} for date ${dates[i]}-----`);
       for (let j = 0; j < layers.length; j += 1) {
         try {
-          const wmsImage = await fetchWMSImage(layers[j].id, dates[i]);
+          const currentExtent = map.ui.selected.getView().calculateExtent(map.ui.selected.getSize());
+          const mercatorExtent = transformExtent(currentExtent, 'EPSG:4326', 'EPSG:3857');
+          const wmsImage = await fetchWMSImage(layers[j].id, dates[i], mercatorExtent);
           const blackPixelRatio = await calculatePixels(wmsImage);
           const { threshold } = layerPixelData[layers[j].id];
           if (blackPixelRatio < threshold) {

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/image-api-request.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/image-api-request.js
@@ -2,15 +2,25 @@
 import axios from 'axios';
 import { saveAs } from 'file-saver';
 
-export default async function fetchWMSImage(layer, date, testMode) {
+export default async function fetchWMSImage(layer, date, extent, testMode) {
   const baseUrl = 'https://gibs.earthdata.nasa.gov/wms/epsg4326/best/wms.cgi';
+  const boundingBox = `${extent[0]},${extent[1]},${extent[2]},${extent[3]}`;
+  const fullExtentBBox = '-20037508.34,-20048966.1,20037508.34,20048966.1';
+  let bbox;
+  // when we are zoomed out too far, the bounding box will include NaN
+  if (boundingBox.includes('NaN')) {
+    bbox = fullExtentBBox;
+  } else {
+    bbox = boundingBox;
+  }
+
   const params = {
     version: '1.3.0',
     service: 'WMS',
     request: 'GetMap',
     format: 'image/png',
     STYLE: 'default',
-    bbox: '-20037508.34,-20048966.1,20037508.34,20048966.1',
+    bbox,
     CRS: 'EPSG:3857',
     HEIGHT: '256',
     WIDTH: '256',


### PR DESCRIPTION
## Description

Currently, the logic in EIC mode can only measure the imagery based on the full extent of the map. This updates the logic so that it can use the visible extent of the map when the map is zoomed to a certain level. 

## How To Test

1. `git checkout wv-2750`
2. `npm ci`
3. `npm run watch`
4. Use this [test URL](http://localhost:3000/?v=-86.3812902525358,24.53642695144682,-75.78868584000408,30.868068403397686&df=true&kiosk=true&eic=si&l=OrbitTracks_Terra_Descending(opacity=0.9),Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2023-06-27-T12%3A35%3A07Z) which shows imagery over the state Florida. 
5. Check the logs and verify that you can see the imagery fall back logic being logged. Depending on what time of day you test this, you may or may not see additional loops in the log. 
6. If you want to see and verify the exact image that is being checked follow these additional steps
     A. Open the file `tile-measurement.js`
     B. Add the parameter `true` to the end of the `wmsImage` variable on line 75. This will engage the test mode for the `fetchWMSImage` that it calls. This should look like this `const wmsImage = await fetchWMSImage(layers[j].id, dates[i], mercatorExtent, true);`
     C. Now that test mode is engaged, when you use the [test URL](http://localhost:3000/?v=-86.3812902525358,24.53642695144682,-75.78868584000408,30.868068403397686&df=true&kiosk=true&eic=si&l=OrbitTracks_Terra_Descending(opacity=0.9),Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2023-06-27-T12%3A35%3A07Z) your browser should prompt you to open the exact image that was tested as a downloaded file. Depending on if you have ad blocking on your browser, you may need to accept the download. 


