### PR TITLE
WV-2763: Updating UI for Tour Stories in Kiosk Mode

### DIFF
--- a/web/js/components/date-selector/date-input-column.js
+++ b/web/js/components/date-selector/date-input-column.js
@@ -280,6 +280,7 @@ class DateInputColumn extends Component {
       isStartDate,
       isEndDate,
       isDisabled,
+      isKioskModeActive,
       type,
     } = this.props;
     const {
@@ -308,6 +309,7 @@ class DateInputColumn extends Component {
           direction="up"
           onClick={isDisabled ? () => {} : () => this.changeDate(1)}
           type={type}
+          isKioskModeActive={isKioskModeActive}
         />
         <input
           id={inputId}
@@ -330,6 +332,7 @@ class DateInputColumn extends Component {
           direction="down"
           onClick={isDisabled ? () => {} : () => this.changeDate(-1)}
           type={type}
+          isKioskModeActive={isKioskModeActive}
         />
       </div>
     );

--- a/web/js/components/date-selector/date-selector.js
+++ b/web/js/components/date-selector/date-selector.js
@@ -306,6 +306,7 @@ class DateSelector extends Component {
       isStartDate,
       isEndDate,
       isDisabled,
+      isKioskModeActive,
     } = this.props;
     const {
       year,
@@ -347,6 +348,7 @@ class DateSelector extends Component {
           value={yearValue}
           isValid={yearValid}
           isDisabled={isDisabled}
+          isKioskModeActive={isKioskModeActive}
         />
         <DateInputColumn
           {...sharedProps}
@@ -354,6 +356,7 @@ class DateSelector extends Component {
           value={monthValue}
           isValid={monthValid}
           isDisabled={isDisabled}
+          isKioskModeActive={isKioskModeActive}
         />
         <DateInputColumn
           {...sharedProps}
@@ -361,6 +364,7 @@ class DateSelector extends Component {
           value={dayValue}
           isValid={dayValid}
           isDisabled={isDisabled}
+          isKioskModeActive={isKioskModeActive}
         />
         { subDailyMode && (
           <>
@@ -370,16 +374,18 @@ class DateSelector extends Component {
               value={hourValue}
               isValid={hourValid}
               isDisabled={isDisabled}
+              isKioskModeActive={isKioskModeActive}
             />
-            <div className="input-time-divider">:</div>
+            <div className={isKioskModeActive ? 'input-time-divider-kiosk' : 'input-time-divider'}>:</div>
             <DateInputColumn
               {...sharedProps}
               type="minute"
               value={minuteValue}
               isValid={minuteValid}
               isDisabled={isDisabled}
+              isKioskModeActive={isKioskModeActive}
             />
-            <div className="input-time-zmark">Z</div>
+            <div className={isKioskModeActive ? 'input-time-zmark-kiosk' : 'input-time-zmark'}>Z</div>
           </>
         )}
       </div>

--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -10,6 +10,7 @@ function AnimationButton(props) {
     clickAnimationButton,
     breakpoints,
     screenWidth,
+    isKioskModeActive,
     isLandscape,
     isPortrait,
     isMobilePhone,
@@ -39,7 +40,7 @@ function AnimationButton(props) {
   return (
     <div
       onClick={clickAnimationButton}
-      className={disabled ? 'wv-disabled-button button-action-group animate-button' : !isMobile ? 'button-action-group animate-button' : `button-action-group mobile-animate-button animate-button-${buttonClass}`}
+      className={isKioskModeActive ? 'd-none' : disabled ? 'wv-disabled-button button-action-group animate-button' : !isMobile ? 'button-action-group animate-button' : `button-action-group mobile-animate-button animate-button-${buttonClass}`}
       aria-label={labelText}
     >
       <div id={buttonId}>
@@ -65,6 +66,7 @@ AnimationButton.propTypes = {
   disabled: PropTypes.bool,
   label: PropTypes.string,
   screenWidth: PropTypes.number,
+  isKioskModeActive: PropTypes.bool,
   isLandscape: PropTypes.bool,
   isPortrait: PropTypes.bool,
   isMobilePhone: PropTypes.bool,

--- a/web/js/components/timeline/timeline-controls/date-change-arrows.js
+++ b/web/js/components/timeline/timeline-controls/date-change-arrows.js
@@ -74,6 +74,7 @@ class DateChangeArrows extends PureComponent {
       rightArrowDisabled,
       arrowDown,
       tilesPreloaded,
+      isKioskModeActive,
     } = this.props;
 
     const leftArrowDown = () => this.onArrowDown('left');
@@ -92,7 +93,7 @@ class DateChangeArrows extends PureComponent {
 
         {/* LEFT ARROW */}
         <div
-          className={`button-action-group${leftArrowDisabled ? ' button-disabled' : ''}`}
+          className={`button-action-group${leftArrowDisabled ? ' button-disabled' : ''} ${isKioskModeActive ? 'd-none' : ''}`}
           id="left-arrow-group"
           onMouseDown={leftArrowDown}
           onMouseUp={leftArrowUp}
@@ -115,7 +116,7 @@ class DateChangeArrows extends PureComponent {
 
         {/* RIGHT ARROW */}
         <div
-          className={`button-action-group${rightArrowDisabled ? ' button-disabled' : ''}`}
+          className={`button-action-group${rightArrowDisabled ? ' button-disabled' : ''} ${isKioskModeActive ? 'd-none' : ''}`}
           id="right-arrow-group"
           onMouseDown={rightArrowDown}
           onMouseUp={rightArrowUp}
@@ -138,7 +139,7 @@ class DateChangeArrows extends PureComponent {
 
         {/* NOW BUTTON */}
         <div
-          className={`button-action-group now-button-group${nowButtonDisabled ? ' button-disabled' : ''}`}
+          className={`button-action-group now-button-group${nowButtonDisabled ? ' button-disabled' : ''} ${isKioskModeActive ? 'd-none' : ''}`}
           id="now-button-group"
           onClick={handleSelectNowButton}
           aria-disabled={nowButtonDisabled}
@@ -163,9 +164,11 @@ class DateChangeArrows extends PureComponent {
 
 const mapStateToProps = (state) => {
   const { date } = state;
+  const { ui: { isKioskModeActive } } = state;
   return {
     tilesPreloaded: date.preloaded,
     arrowDown: date.arrowDown,
+    isKioskModeActive,
   };
 };
 
@@ -183,6 +186,7 @@ DateChangeArrows.propTypes = {
   arrowDown: PropTypes.string,
   leftArrowDisabled: PropTypes.bool,
   leftArrowDown: PropTypes.func,
+  isKioskModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   nowButtonDisabled: PropTypes.bool,
   rightArrowDisabled: PropTypes.bool,

--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -22,9 +22,10 @@ class ModalInProgress extends React.Component {
       totalSteps,
       decreaseStep,
       incrementStep,
+      isKioskModeActive,
     } = this.props;
     const closeBtn = (
-      <button className="end-tour-close-btn" onClick={endTour} type="button">
+      <button className={isKioskModeActive ? 'd-none' : 'end-tour-close-btn'} onClick={endTour} type="button">
         &times;
       </button>
     );
@@ -58,6 +59,7 @@ class ModalInProgress extends React.Component {
               totalSteps={totalSteps}
               decreaseStep={decreaseStep}
               incrementStep={incrementStep}
+              isKioskModeActive={isKioskModeActive}
             />
           </ModalFooter>
         </Modal>
@@ -71,6 +73,7 @@ ModalInProgress.propTypes = {
   currentStory: PropTypes.object.isRequired,
   decreaseStep: PropTypes.func.isRequired,
   endTour: PropTypes.func.isRequired,
+  isKioskModeActive: PropTypes.bool.isRequired,
   incrementStep: PropTypes.func.isRequired,
   modalInProgress: PropTypes.bool.isRequired,
   totalSteps: PropTypes.number.isRequired,

--- a/web/js/components/tour/widget-steps.js
+++ b/web/js/components/tour/widget-steps.js
@@ -7,7 +7,6 @@ function Steps(props) {
     currentStep, decreaseStep, incrementStep, totalSteps, isKioskModeActive,
   } = props;
 
-
   const handleKeyDown = (event) => {
     switch (event.key) {
       case 'q':
@@ -22,6 +21,8 @@ function Steps(props) {
   };
 
   useEffect(() => {
+    if (!isKioskModeActive) return;
+
     document.addEventListener('keydown', handleKeyDown);
 
     return () => {

--- a/web/js/components/tour/widget-steps.js
+++ b/web/js/components/tour/widget-steps.js
@@ -1,15 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function Steps(props) {
   const {
-    currentStep, decreaseStep, incrementStep, totalSteps,
+    currentStep, decreaseStep, incrementStep, totalSteps, isKioskModeActive,
   } = props;
+
+
+  const handleKeyDown = (event) => {
+    switch (event.key) {
+      case 'q':
+        decreaseStep();
+        break;
+      case 'w':
+        incrementStep();
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   return (
     <div className="step-container">
       <a
-        className="step-previous"
+        className={isKioskModeActive ? 'd-none' : 'step-previous'}
         aria-label="Previous"
         onClick={decreaseStep}
       >
@@ -25,7 +48,7 @@ function Steps(props) {
         </p>
       </div>
       <a
-        className="step-next"
+        className={isKioskModeActive ? 'd-none' : 'step-next'}
         aria-label="Next"
         onClick={incrementStep}
       >
@@ -42,6 +65,7 @@ Steps.propTypes = {
   decreaseStep: PropTypes.func.isRequired,
   incrementStep: PropTypes.func.isRequired,
   totalSteps: PropTypes.number.isRequired,
+  isKioskModeActive: PropTypes.bool.isRequired,
 };
 
 export default Steps;

--- a/web/js/components/util/arrow.js
+++ b/web/js/components/util/arrow.js
@@ -4,14 +4,16 @@ import PropTypes from 'prop-types';
 /*
  * @function Arrow Up/Down
  */
-function Arrow({ onClick, type, direction }) {
+function Arrow({
+  onClick, type, direction, isKioskModeActive,
+}) {
   const containerClassName = `date-arrows date-arrow-${direction}`;
   const arrowClassName = `${direction}arrow`;
 
   return (
     <div
       onClick={onClick}
-      className={containerClassName}
+      className={isKioskModeActive ? 'd-none' : containerClassName}
       data-interval={type}
     >
       <svg width="25" height="8">
@@ -25,6 +27,7 @@ Arrow.propTypes = {
   direction: PropTypes.string,
   onClick: PropTypes.func,
   type: PropTypes.string,
+  isKioskModeActive: PropTypes.bool,
 };
 
 export default Arrow;

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -263,6 +263,7 @@ class Sidebar extends React.Component {
       isEmbedModeActive,
       isLoadingEvents,
       isMobile,
+      isKioskModeActive,
       numberOfLayers,
       onTabClick,
       screenHeight,
@@ -354,13 +355,15 @@ class Sidebar extends React.Component {
                   />
                 </TabPane>
                 )}
-
-                <FooterContent
-                  ref={(el) => { this.footerElement = el; }}
-                  tabTypes={tabTypes}
-                  activeTab={activeTab}
-                />
-
+                {
+                  !isKioskModeActive && (
+                    <FooterContent
+                      ref={(el) => { this.footerElement = el; }}
+                      tabTypes={tabTypes}
+                      activeTab={activeTab}
+                    />
+                  )
+                }
               </TabContent>
             </>
             )}
@@ -396,7 +399,7 @@ const mapStateToProps = (state) => {
   const eventsData = getFilteredEvents(state);
   const eventsSources = lodashGet(requestedEventSources, 'response');
   const { screenHeight } = screenSize;
-  const { isDistractionFreeModeActive } = ui;
+  const { isDistractionFreeModeActive, isKioskModeActive } = ui;
   const { isEmbedModeActive } = embed;
   const { activeTab, isCollapsed, mobileCollapsed } = sidebar;
   const { activeString } = compare;
@@ -425,6 +428,7 @@ const mapStateToProps = (state) => {
     isDataDisabled: events.isAnimatingToEvent,
     isDistractionFreeModeActive,
     isEmbedModeActive,
+    isKioskModeActive,
     isLoadingEvents,
     isMobile,
     selectedMap,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1053,6 +1053,7 @@ class Timeline extends React.Component {
       isDataDownload,
       isDistractionFreeModeActive,
       isEmbedModeActive,
+      isKioskModeActive,
       isMobile,
       isTourActive,
       parentOffset,
@@ -1131,7 +1132,7 @@ class Timeline extends React.Component {
                     style={{ marginRight: isTimelineHidden ? '20px' : '0' }}
                   >
                     {/* Date Selector, Interval, Arrow Controls */}
-                    <div id="date-selector-main">
+                    <div id="date-selector-main" className={isKioskModeActive ? 'date-selector-kiosk' : ''}>
                       <DateSelector
                         id={draggerSelected}
                         idSuffix="timeline"
@@ -1140,10 +1141,11 @@ class Timeline extends React.Component {
                         maxDate={new Date(timelineEndDateLimit)}
                         minDate={new Date(timelineStartDateLimit)}
                         subDailyMode={hasSubdailyLayers}
+                        isKioskModeActive={isKioskModeActive}
                         fontSize={24}
                       />
                     </div>
-                    <div id="zoom-buttons-group">
+                    <div id="zoom-buttons-group" className={isKioskModeActive ? 'd-none' : ''}>
 
                       <TimeScaleIntervalChange
                         timeScaleChangeUnit={timeScaleChangeUnit}
@@ -1156,6 +1158,7 @@ class Timeline extends React.Component {
                     <AnimationButton
                       clickAnimationButton={this.clickAnimationButton}
                       disabled={animationDisabled}
+                      isKioskModeActive={isKioskModeActive}
                       screenWidth={screenWidth}
                       breakpoints={breakpoints}
                       label={
@@ -1398,7 +1401,7 @@ function mapStateToProps(state) {
   } = date;
   const { isCompareA } = compare;
   const isCompareModeActive = compare.active;
-  const { isDistractionFreeModeActive } = ui;
+  const { isDistractionFreeModeActive, isKioskModeActive } = ui;
   const { isEmbedModeActive } = embed;
   const isMobile = screenSize.isMobileDevice;
   const {
@@ -1522,6 +1525,7 @@ function mapStateToProps(state) {
     timelineCustomModalOpen,
     isDistractionFreeModeActive,
     isEmbedModeActive,
+    isKioskModeActive,
   };
 }
 
@@ -1617,6 +1621,7 @@ Timeline.propTypes = {
   isDistractionFreeModeActive: PropTypes.bool,
   isEmbedModeActive: PropTypes.bool,
   isGifActive: PropTypes.bool,
+  isKioskModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   isMobilePhone: PropTypes.bool,
   isMobileTablet: PropTypes.bool,

--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -195,6 +195,7 @@ class Tour extends React.Component {
   }
 
   toggleModalInProgress(e) {
+    if (!e) return;
     e.preventDefault();
     this.setState((prevState) => ({
       modalInProgress: !prevState.modalInProgress,
@@ -203,6 +204,7 @@ class Tour extends React.Component {
 
   toggleModalComplete(e) {
     const { currentStoryId } = this.state;
+    if (!e) return;
     e.preventDefault();
     this.setState((prevState) => ({
       modalComplete: !prevState.modalComplete,

--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -358,6 +358,7 @@ class Tour extends React.Component {
     const {
       stories,
       config,
+      isKioskModeActive,
     } = this.props;
     const {
       modalInProgress,
@@ -391,6 +392,7 @@ class Tour extends React.Component {
         metaLoaded={metaLoaded}
         isLoadingMeta={isLoadingMeta}
         description={description}
+        isKioskModeActive={isKioskModeActive}
       />
     );
   }

--- a/web/scss/components/dateselector.scss
+++ b/web/scss/components/dateselector.scss
@@ -278,3 +278,8 @@
     z-index: 0;
   }
 }
+
+.date-selector-kiosk {
+  margin-top: 10px;
+  margin-left: 40px;
+}

--- a/web/scss/features/timeline.scss
+++ b/web/scss/features/timeline.scss
@@ -185,11 +185,26 @@ button:focus {
     margin-top: 23px;
   }
 
+  & .input-time-divider-kiosk {
+    font-family: $wv-monospace-font;
+    color: #fff;
+    font-size: 24px;
+    width: 13px;
+    margin-top: 13px;
+  }
+
   & .input-time-zmark {
     font-family: $wv-monospace-font;
     color: #fff;
     font-size: 24px;
     margin-top: 25px;
+  }
+
+  & .input-time-zmark-kiosk {
+    font-family: $wv-monospace-font;
+    color: #fff;
+    font-size: 24px;
+    margin-top: 15px;
   }
 
   & .date-arrows {


### PR DESCRIPTION
## Description

This updates the UI for tour stories in Kiosk mode so that there are less clickable options. This can be used to record tour stories by simply adding the `kiosk=true` parameter to the URL. The tour story steps can be decremented and incremented with the `q` and `w` respectively. I would suggest clicking on the tour story dialog box first so that your key press actions do not go into the location search bar. 

## How To Test

1. `git checkout wv-2763`
2. `npm ci`
3. `npm run watch`
4. Use this [URL](http://localhost:3000/?v=-251.3105758334586,-119.175605512903,131.2333374082531,109.2168790336659&kiosk=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GMI_Brightness_Temp_Asc,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&tr=geostationary&t=2021-09-30-T00%3A00%3A00Z) to start a story in kiosk mode with limited UI.
5. Click on the tour story dialog and then use the `w` key to progress the story and the `q` key to step back. 
6. Verify that the UI looks similar to the image below. 

![limited-ui](https://github.com/nasa-gibs/worldview/assets/89816230/29ab9395-39ae-4951-8569-86c9d5e60d7e)

