### PR TITLE
Removing dual GTM logic in index.html

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,12 +21,6 @@ Licensed under the NASA Open Source Agreement, Version 1.3 (https://opensource.g
         j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
           'https://www.googletagmanager.com/.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
       })(window,document,'script','dataLayer','GTM-WNP7MLF');
-
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-88182106-1');
     }
   </script>
   <!-- End Google Tag Manager -->


### PR DESCRIPTION
Removing extra GTM function that was causing analytics to be tracked twice. 