### PR TITLE
WV-2764: Modernizing custom-interval-selector component

### DIFF
--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import usePrevious from '../../../util/customHooks';
 import DeltaInput from './delta-input';
 import IntervalSelect from './interval-select';
 import {
@@ -28,17 +27,15 @@ function CustomIntervalSelector(props) {
 
   let customIntervalWidget;
 
-  const prevModalOpen = usePrevious(modalOpen);
-
   const customDelta = useSelector((state) => state.date.customDelta || 1);
   const customInterval = useSelector((state) => state.date.customInterval || state.date.interval);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (modalOpen && !prevModalOpen) {
+    if (modalOpen) {
       customIntervalWidget.focus();
     }
-  });
+  }, [modalOpen]);
 
   const changeDelta = (value) => {
     if (value >= 0 && value <= 1000) {

--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -29,7 +29,10 @@ function CustomIntervalSelector(props) {
 
   const customDelta = useSelector((state) => state.date.customDelta || 1);
   const customInterval = useSelector((state) => state.date.customInterval || state.date.interval);
+
   const dispatch = useDispatch();
+  const closeModal = () => dispatch(toggleCustomModal(false, undefined));
+  const changeCustomInterval = (delta, timeScale) => dispatch(changeCustomIntervalAction(delta, timeScale));
 
   useEffect(() => {
     if (modalOpen) {
@@ -51,14 +54,6 @@ function CustomIntervalSelector(props) {
     if (e.key === 'Escape') {
       closeModal();
     }
-  };
-
-  const closeModal = () => {
-    dispatch(toggleCustomModal(false, undefined));
-  };
-
-  const changeCustomInterval = (delta, timeScale) => {
-    dispatch(changeCustomIntervalAction(delta, timeScale));
   };
 
   return modalOpen && (

--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -1,7 +1,8 @@
-import React, { PureComponent } from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import usePrevious from '../../../util/customHooks';
 import DeltaInput from './delta-input';
 import IntervalSelect from './interval-select';
 import {
@@ -19,103 +20,77 @@ import {
  *
  * @class CustomIntervalSelector
  */
-class CustomIntervalSelector extends PureComponent {
-  componentDidUpdate(prevProps) {
-    const {
-      modalOpen,
-    } = this.props;
+function CustomIntervalSelector(props) {
+  const {
+    modalOpen,
+    hasSubdailyLayers,
+  } = props;
 
-    if (modalOpen && !prevProps.modalOpen) {
-      this.customIntervalWidget.focus();
+  let customIntervalWidget;
+
+  const prevModalOpen = usePrevious(modalOpen);
+
+  const customDelta = useSelector((state) => state.date.customDelta || 1);
+  const customInterval = useSelector((state) => state.date.customInterval || state.date.interval);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (modalOpen && !prevModalOpen) {
+      customIntervalWidget.focus();
     }
-  }
+  });
 
-  changeDelta = (value) => {
-    const {
-      changeCustomInterval, customInterval,
-    } = this.props;
+  const changeDelta = (value) => {
     if (value >= 0 && value <= 1000) {
       changeCustomInterval(value, customInterval);
     }
   };
 
-  changeZoomLevel = (zoomLevel) => {
-    const { changeCustomInterval, customDelta } = this.props;
+  const changeZoomLevel = (zoomLevel) => {
     changeCustomInterval(customDelta, TIME_SCALE_TO_NUMBER[zoomLevel]);
   };
 
-  handleKeyPress = (e) => {
-    const { closeModal } = this.props;
+  const handleKeyPress = (e) => {
     if (e.key === 'Escape') {
       closeModal();
     }
   };
 
-  render() {
-    const {
-      modalOpen,
-      hasSubdailyLayers,
-      customDelta,
-      customInterval,
-      closeModal,
-    } = this.props;
-    return modalOpen && (
-      <div
-        onKeyDown={this.handleKeyPress}
-        className={`custom-interval-widget ${hasSubdailyLayers ? 'subdaily' : ''}`}
-        tabIndex={0}
-        ref={(customIntervalWidget) => { this.customIntervalWidget = customIntervalWidget; }}
-      >
-        <h3 className="custom-interval-widget-header">Custom Interval Selector</h3>
-        <div className="custom-interval-widget-controls-container">
-          <DeltaInput
-            deltaValue={customDelta}
-            changeDelta={this.changeDelta}
-          />
-          <IntervalSelect
-            hasSubdailyLayers={hasSubdailyLayers}
-            zoomLevel={TIME_SCALE_FROM_NUMBER[customInterval]}
-            changeZoomLevel={this.changeZoomLevel}
-          />
-        </div>
-        <FontAwesomeIcon icon="times" className="wv-close" onClick={closeModal} />
+  const closeModal = () => {
+    dispatch(toggleCustomModal(false, undefined));
+  };
+
+  const changeCustomInterval = (delta, timeScale) => {
+    dispatch(changeCustomIntervalAction(delta, timeScale));
+  };
+
+  return modalOpen && (
+    <div
+      onKeyDown={handleKeyPress}
+      className={`custom-interval-widget ${hasSubdailyLayers ? 'subdaily' : ''}`}
+      tabIndex={0}
+      ref={(widget) => { customIntervalWidget = widget; }}
+    >
+      <h3 className="custom-interval-widget-header">Custom Interval Selector</h3>
+      <div className="custom-interval-widget-controls-container">
+        <DeltaInput
+          deltaValue={customDelta}
+          changeDelta={changeDelta}
+        />
+        <IntervalSelect
+          hasSubdailyLayers={hasSubdailyLayers}
+          zoomLevel={TIME_SCALE_FROM_NUMBER[customInterval]}
+          changeZoomLevel={changeZoomLevel}
+        />
       </div>
-    );
-  }
+      <FontAwesomeIcon icon="times" className="wv-close" onClick={closeModal} />
+    </div>
+  );
 }
 
-const mapDispatchToProps = (dispatch) => ({
-  closeModal: () => {
-    dispatch(toggleCustomModal(false, undefined));
-  },
-  changeCustomInterval: (delta, timeScale) => {
-    dispatch(changeCustomIntervalAction(delta, timeScale));
-  },
-});
-
-const mapStateToProps = (state) => {
-  const { date } = state;
-  const {
-    interval, customInterval, customDelta, customSelected,
-  } = date;
-  return {
-    customDelta: customDelta || 1,
-    customInterval: customInterval || interval,
-    customSelected,
-    interval,
-  };
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(CustomIntervalSelector);
-
 CustomIntervalSelector.propTypes = {
-  changeCustomInterval: PropTypes.func,
-  closeModal: PropTypes.func,
-  customDelta: PropTypes.number,
-  customInterval: PropTypes.number,
   hasSubdailyLayers: PropTypes.bool,
   modalOpen: PropTypes.bool,
 };
+
+export default CustomIntervalSelector;


### PR DESCRIPTION
## Description
This converts the custom-interval-selector component from a React Class component to a function component, per best modern practices for React. This process included replacing the lifecycle hooks with `useEffect`, and replacing Redux's `connect` with `useSelector` and `useDispatch`.

## How To Test
1. `git checkout wv-2764-modernize-customintervalselector-component`
2. `npm ci`
3. `npm run watch`
4. Locate the custom-interval-selector component in the bottom-left of the screen, as part of the Timeline component.
5. Verify that the new custom-interval-selector component functions the same as the existing custom-interval-selector component.