### PR TITLE
Wv 2742 investigate bbox coordinate

### DIFF
--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import * as olProj from 'ol/proj';
-import {
-  clone as lodashClone,
-} from 'lodash';
 import { containsExtent, isEmpty } from 'ol/extent';
+import { fromExtent } from 'ol/geom/Polygon';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CRS } from '../../modules/map/constants';
@@ -27,9 +25,12 @@ function Input({
   const update = () => {
     try {
       const newInputValue = Number(inputValue);
-      const newArray = lodashClone(boundingBoxArray);
+      const newArray = structuredClone(boundingBoxArray);
       newArray[index] = newInputValue;
-      const crsCorrectedExtent = olProj.transformExtent(newArray, CRS.GEOGRAPHIC, crs);
+      // Due to a bug (ol v7.4.0) in transformExtent, we need to create a polygon before transforming it.
+      const extentPolygon = fromExtent(newArray);
+      const crsCorrectedExtentPolygon = extentPolygon.transform(CRS.GEOGRAPHIC, crs);
+      const crsCorrectedExtent = crsCorrectedExtentPolygon.getExtent();
 
       if (containsExtent(viewExtent, crsCorrectedExtent)
       && isValidExtent(newArray)

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -26,7 +26,6 @@ function Input({
       const newInputValue = Number(inputValue);
       const newArray = structuredClone(boundingBoxArray);
       newArray[index] = newInputValue;
-      // Due to a bug (ol v7.4.0) in transformExtent, we need to create a polygon before transforming it.
       const extentPolygon = fromExtent(newArray);
       const crsCorrectedExtentPolygon = extentPolygon.transform(CRS.GEOGRAPHIC, crs);
       const crsCorrectedExtent = crsCorrectedExtentPolygon.getExtent();

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import * as olProj from 'ol/proj';
 import { containsExtent, isEmpty } from 'ol/extent';
 import { fromExtent } from 'ol/geom/Polygon';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
## Description

> There seems to be an issue with editing bounding box coordinates for image snapshots in Arctic/Antarctic projections - anytime you try to edit the coordinates in the "Edit coordinates" box, it will state "Not visible" even if you are able to draw the bounding box with those coordinates.

## How To Test

1. `git checkout `
2. `npm ci`
3. `npm run watch`
4. Got to [this url](http://localhost:3000/?v=-7077888,-4075520,7077888,4075520&p=antarctic&l=Coastlines_15m,BlueMarble_ShadedRelief_Bathymetry,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-07-31-T14%3A16%3A47Z)
5. Draw a bounding box (snapshot/camera icon)
6. Try to edit the corner coordinates to a coordinate that is visible on the map
7. It should not say "Not Visible" as long as the edited corner is within the visible extent.
