### PR TITLE
WV-2773: Modernizing image-download-panel Component

### DIFF
--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -23,13 +23,7 @@ const RESOLUTION_KEY = {
   20: '5km',
   40: '10km',
 };
-/*
- * A react component, Builds a rather specific
- * interactive widget
- *
- * @class resolutionSelection
- * @extends React.Component
- */
+
 function ImageDownloadPanel(props) {
   const {
     fileType,
@@ -77,9 +71,7 @@ function ImageDownloadPanel(props) {
       markerCoordinates,
     );
 
-    if (url) {
-      window.open(dlURL, '_blank');
-    }
+    window.open(dlURL, '_blank');
     googleTagManager.pushEvent({
       event: 'image_download',
       layers: {
@@ -95,14 +87,16 @@ function ImageDownloadPanel(props) {
   };
 
   const handleChange = (type, value) => {
+    let valueIn = value;
     if (type === 'resolution') {
-      setResolution(value);
+      setResolution(valueIn);
     } else if (type === 'worldfile') {
-      setIsWorldfile(Boolean(Number(value)));
+      valueIn = Boolean(Number(value));
+      setIsWorldfile(valueIn);
     } else {
-      setFileType(value);
+      setFileType(valueIn);
     }
-    onPanelChange(type, value);
+    onPanelChange(type, valueIn);
   };
 
   const _renderFileTypeSelect = () => {
@@ -137,8 +131,8 @@ function ImageDownloadPanel(props) {
               value={value}
               onChange={(e) => handleChange('worldfile', e.target.value)}
             >
-              <option value={0}>No</option>
-              <option value={1}>Yes</option>
+              <option value="0">No</option>
+              <option value="1">Yes</option>
             </select>
           )}
           Worldfile (.zip)
@@ -217,7 +211,7 @@ ImageDownloadPanel.defaultProps = {
   fileType: 'image/jpeg',
   fileTypeOptions: true,
   firstLabel: 'Resolution (per pixel)',
-  isWorldfile: 'false',
+  isWorldfile: false,
   maxImageSize: '8200px x 8200px',
   resolution: '1',
   secondLabel: 'Format',


### PR DESCRIPTION
## Description
This converts the image-download-panel component from a React Class component to a function component, per best modern practices for React. This process included replacing the class state with `useState`.

## How To Test
1. `git checkout wv-2773-modernize-imagedownloadpanel-component`
2. `npm ci`
3. `npm run watch`
4. Click the "Take a snapshot" button in the top-right toolbar, then locate the image-download-panel component on the upper-right side of the screen.
5. Verify that the new image-download-panel component functions the same as the existing image-download-panel component.