### PR TITLE
WV-2775: Layer Threshold Combined Slider

### DIFF
--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -57,23 +57,24 @@ class PaletteThreshold extends React.Component {
     const newEnd = parseInt(thresholdArray[1], 10);
     const startRef = legend.refs[newStart];
     const endRef = legend.refs[newEnd];
+    const newAvg = Math.round((newStart + newEnd) / 2);
 
     // Update local state on every range-selector change but debounce threshold model update
     if (newStart !== start && newEnd !== end) {
       this.setState({
         start: newStart,
         end: newEnd,
-        avg: Math.round((newStart + newEnd) / 2),
+        avg: newAvg,
       });
     } else if (newStart !== start) {
       this.setState({
         start: newStart,
-        avg: Math.round((newStart + end) / 2),
+        avg: newAvg,
       });
     } else if (newEnd !== end) {
       this.setState({
         end: newEnd,
-        avg: Math.round((start + newEnd) / 2),
+        avg: newAvg,
       });
     } else {
       return;

--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -24,17 +24,6 @@ class PaletteThreshold extends React.Component {
     this.updateThreshold = this.updateThreshold.bind(this);
   }
 
-  componentDidUpdate() {
-    const {
-      start, end, avg,
-    } = this.state;
-    if (avg !== Math.round((start + end) / 2)) {
-      this.setState({
-        avg: Math.round((start + end) / 2),
-      });
-    }
-  }
-
   updateSquash() {
     const {
       setRange, layerId, index, groupName, palette, legend,
@@ -74,14 +63,17 @@ class PaletteThreshold extends React.Component {
       this.setState({
         start: newStart,
         end: newEnd,
+        avg: Math.round((newStart + newEnd) / 2),
       });
     } else if (newStart !== start) {
       this.setState({
         start: newStart,
+        avg: Math.round((newStart + end) / 2),
       });
     } else if (newEnd !== end) {
       this.setState({
         end: newEnd,
+        avg: Math.round((start + newEnd) / 2),
       });
     } else {
       return;

--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -17,7 +17,7 @@ class PaletteThreshold extends React.Component {
       start,
       end,
       squashed,
-      avg: 0,
+      avg: Math.round((start + end) / 2),
     };
     this.debounceSetRange = lodashDebounce(props.setRange, 300);
     this.updateSquash = this.updateSquash.bind(this);

--- a/web/scss/components/range.scss
+++ b/web/scss/components/range.scss
@@ -50,7 +50,7 @@
       );
     }
 
-    &::-moz-range-progress {
+    &:not(.double-range)::-moz-range-progress {
       height: 4px;
       background-color: $wv-dark-blue;
     }
@@ -117,6 +117,21 @@
     );
   }
 
+  &.start-range::-moz-range-track {
+    height: 4px;
+    border: solid 1px #ccc;
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    background: linear-gradient(
+      to right,
+      #ccc 0%,
+      #ccc var(--min-range-percent),
+      $wv-dark-blue var(--min-range-percent),
+      $wv-dark-blue 100%
+    );
+  }
+
   &.end-range::-webkit-slider-runnable-track {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
@@ -124,6 +139,21 @@
       to right,
       #ABE2FB 0%,
       #ABE2FB var(--max-range-percent),
+      #ccc var(--max-range-percent),
+      #ccc 100%
+    );
+  }
+
+  &.end-range::-moz-range-track {
+    height: 4px;
+    border: solid 1px #ccc;
+    border-left: none;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    background: linear-gradient(
+      to right,
+      $wv-dark-blue 0%,
+      $wv-dark-blue var(--max-range-percent),
       #ccc var(--max-range-percent),
       #ccc 100%
     );

--- a/web/scss/components/range.scss
+++ b/web/scss/components/range.scss
@@ -103,3 +103,29 @@
     width: 85% ;
     padding-top: 8px;
   }
+
+.double-range {
+  &.start-range::-webkit-slider-runnable-track {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    background: linear-gradient(
+      to right,
+      #ccc 0%,
+      #ccc var(--min-range-percent),
+      #ABE2FB var(--min-range-percent),
+      #ABE2FB 100%
+    );
+  }
+
+  &.end-range::-webkit-slider-runnable-track {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    background: linear-gradient(
+      to right,
+      #ABE2FB 0%,
+      #ABE2FB var(--max-range-percent),
+      #ccc var(--max-range-percent),
+      #ccc 100%
+    );
+  }
+}


### PR DESCRIPTION
## Description
This converts the the two MIN and MAX sliders for Threshold in a layer's options to a single, two-sided slider instead.

## How To Test
1. `git checkout wv-2775-update-layerthresholdslider`
2. `npm ci`
3. `npm run watch`
4. Click the "Add Layers" button on the main sidebar on the right, and add any layer with a threshold option (for example, the Aerosol Index layer). Then, click the options sliders icon on the layer card to open the layer options window, and locate the thresholds slider.
5. Verify that the two-sided threshold slider functions the same as the existing two MIN and MAX threshold sliders do, by changing the low and high ends of the threshold and verifying that the correct change is seen on the layer.