### PR TITLE
WV-2790 sidebar buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,8 +4834,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -4904,7 +4903,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
       "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5940,7 +5938,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6941,7 +6938,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8724,7 +8720,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8769,7 +8764,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -14904,8 +14898,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isMobileOnly, isTablet } from 'react-device-detect';
 import { connect } from 'react-redux';
 import {
   UncontrolledTooltip,
@@ -17,9 +18,11 @@ import {
 import { openCustomContent } from '../../modules/modal/actions';
 import { getFilteredEvents } from '../../modules/natural-events/selectors';
 import { LIMIT_EVENT_REQUEST_COUNT } from '../../modules/natural-events/constants';
+import SearchUiProvider from '../../components/layer/product-picker/search-ui-provider';
 import {
   toggleOverlayGroups as toggleOverlayGroupsAction,
 } from '../../modules/layers/actions';
+import { stop as stopAnimationAction } from '../../modules/animation/actions';
 
 const FooterContent = React.forwardRef((props, ref) => {
   const {
@@ -36,6 +39,10 @@ const FooterContent = React.forwardRef((props, ref) => {
     openChartingInfoModal,
     toggleCharting,
     toggleCompare,
+    breakpoints,
+    screenWidth,
+    isPlaying,
+    addLayers,
   } = props;
 
   const compareBtnText = !isCompareActive
@@ -60,19 +67,34 @@ const FooterContent = React.forwardRef((props, ref) => {
     googleTagManager.pushEvent({ event: 'charting_mode' });
   };
 
+  const onClickAddLayers = (e) => {
+    e.stopPropagation();
+    addLayers(isPlaying, isMobile, breakpoints, screenWidth);
+    googleTagManager.pushEvent({ event: 'add_layers' });
+  };
+
   const renderLayersFooter = () => (
-    <div className="product-buttons">
-      <CompareModeOptions
-        isActive={isCompareActive}
-        isMobile={isMobile}
-        selected={compareMode}
-        onclick={changeCompareMode}
-      />
-      <ChartingModeOptions
-        isChartingActive={isChartingActive}
-        isMobile={isMobile}
-      />
-      <div className="compare-chart-container">
+    <>
+      <div>
+        <CompareModeOptions
+          isActive={isCompareActive}
+          isMobile={isMobile}
+          selected={compareMode}
+          onclick={changeCompareMode}
+        />
+        <ChartingModeOptions
+          isChartingActive={isChartingActive}
+          isMobile={isMobile}
+        />
+      </div>
+      <div className="product-buttons">
+        <Button
+          id="layers-add"
+          aria-label="Add layers"
+          className="layers-add red"
+          text="+ Add Layers"
+          onClick={onClickAddLayers}
+        />
         {!isCompareActive && chartFeature
           && (
           <Button
@@ -96,7 +118,7 @@ const FooterContent = React.forwardRef((props, ref) => {
           />
           )}
       </div>
-    </div>
+    </>
   );
 
   const renderEventsFooter = () => {
@@ -196,6 +218,21 @@ const mapDispatchToProps = (dispatch) => ({
       }),
     );
   },
+  addLayers: (isPlaying) => {
+    const modalClassName = isMobileOnly || isTablet ? 'custom-layer-dialog-mobile custom-layer-dialog light' : 'custom-layer-dialog light';
+    if (isPlaying) {
+      dispatch(stopAnimationAction());
+    }
+    dispatch(
+      openCustomContent('LAYER_PICKER_COMPONENT', {
+        headerText: null,
+        modalClassName,
+        backdrop: true,
+        CompletelyCustomModal: SearchUiProvider,
+        wrapClassName: '',
+      }),
+    );
+  },
 });
 
 export default connect(
@@ -219,4 +256,8 @@ FooterContent.propTypes = {
   openChartingInfoModal: PropTypes.func,
   toggleCompare: PropTypes.func,
   toggleCharting: PropTypes.func,
+  breakpoints: PropTypes.object,
+  isPlaying: PropTypes.bool,
+  screenWidth: PropTypes.number,
+  addLayers: PropTypes.func,
 };

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -88,6 +88,8 @@ const FooterContent = React.forwardRef((props, ref) => {
         />
       </div>
       <div className="product-buttons">
+        {!isChartingActive
+        && (
         <Button
           id="layers-add"
           aria-label="Add layers"
@@ -95,17 +97,7 @@ const FooterContent = React.forwardRef((props, ref) => {
           text="+ Add Layers"
           onClick={onClickAddLayers}
         />
-        {!isCompareActive && chartFeature
-          && (
-          <Button
-            id="chart-toggle-button"
-            aria-label={chartBtnText}
-            className={!isCompareActive && chartingModeAccessible ? 'chart-toggle-button btn' : 'chart-toggle-button btn disabled'}
-            style={!chartFeature ? { display: 'none' } : null}
-            onClick={!isCompareActive && chartingModeAccessible ? onClickToggleCharting : null}
-            text={chartBtnText}
-          />
-          )}
+        )}
         {!isChartingActive
           && (
           <Button
@@ -115,6 +107,19 @@ const FooterContent = React.forwardRef((props, ref) => {
             style={!compareFeature ? { display: 'none' } : null}
             onClick={!isChartingActive ? onClickToggleCompare : null}
             text={compareBtnText}
+          />
+          )}
+      </div>
+      <div className="charting-button">
+        {!isMobile && !isCompareActive && chartFeature
+          && (
+          <Button
+            id="chart-toggle-button"
+            aria-label={chartBtnText}
+            className={!isCompareActive && chartingModeAccessible ? 'chart-toggle-button btn' : 'chart-toggle-button btn disabled'}
+            style={!chartFeature ? { display: 'none' } : null}
+            onClick={!isCompareActive && chartingModeAccessible ? onClickToggleCharting : null}
+            text={chartBtnText}
           />
           )}
       </div>

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -165,13 +165,6 @@ function LayersContainer (props) {
       { !isEmbedModeActive && (
         <div className="product-buttons">
           <div className="layers-add-container">
-            {/* <Button
-              id="layers-add"
-              aria-label="Add layers"
-              className="layers-add red"
-              text="+ Add Layers"
-              onClick={onClickAddLayers}
-            /> */}
             <Checkbox
               id="group-overlays-checkbox"
               checked={groupOverlays}

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -177,19 +177,19 @@ function LayersContainer (props) {
       </div>
       <div className="product-buttons">
         <div className="layers-add-container">
-          <Button
-            id="layers-add"
-            aria-label="Add layers"
-            className="layers-add red"
-            text="+ Add Layers"
-            onClick={onClickAddLayers}
-          />
           <Checkbox
             id="group-overlays-checkbox"
             checked={groupOverlays}
             onCheck={toggleOverlayGroups}
             label="Group Similar Layers"
           />
+          {/* <Button
+            id="layers-add"
+            aria-label="Add layers"
+            className="layers-add red"
+            text="+ Add Layers"
+            onClick={onClickAddLayers}
+          /> */}
         </div>
       </div>
     </>

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Draggable, Droppable, DragDropContext } from 'react-beautiful-dnd';
 import PropTypes from 'prop-types';
 import { isMobileOnly, isTablet } from 'react-device-detect';
-import googleTagManager from 'googleTagManager';
 import LayerList from './layer-list';
 import {
   getAllActiveOverlaysBaselayers,
@@ -19,7 +18,6 @@ import {
 } from '../../modules/layers/actions';
 import Checkbox from '../../components/util/checkbox';
 import util from '../../util/util';
-import Button from '../../components/util/button';
 import SearchUiProvider from '../../components/layer/product-picker/search-ui-provider';
 import { openCustomContent } from '../../modules/modal/actions';
 import { stop as stopAnimationAction } from '../../modules/animation/actions';
@@ -39,11 +37,6 @@ function LayersContainer (props) {
     reorderOverlayGroups,
     toggleCollapse,
     toggleOverlayGroups,
-    isMobile,
-    breakpoints,
-    screenWidth,
-    isPlaying,
-    addLayers,
   } = props;
 
   const [overlaysCollapsed, toggleOverlaysCollapsed] = useState(false);
@@ -98,12 +91,6 @@ function LayersContainer (props) {
         )}
       </Draggable>
     );
-  };
-
-  const onClickAddLayers = (e) => {
-    e.stopPropagation();
-    addLayers(isPlaying, isMobile, breakpoints, screenWidth);
-    googleTagManager.pushEvent({ event: 'add_layers' });
   };
 
   const renderOverlayGroups = () => (
@@ -183,13 +170,6 @@ function LayersContainer (props) {
             onCheck={toggleOverlayGroups}
             label="Group Similar Layers"
           />
-          {/* <Button
-            id="layers-add"
-            aria-label="Add layers"
-            className="layers-add red"
-            text="+ Add Layers"
-            onClick={onClickAddLayers}
-          /> */}
         </div>
       </div>
     </>

--- a/web/scss/components/button.scss
+++ b/web/scss/components/button.scss
@@ -14,9 +14,15 @@
 }
 
 .wv-button span {
-  padding: 3px 6px;
+  padding: 6px 13px 7px;
   display: block;
   font-size: 13px;
+}
+
+#compare-toggle-button.wv-button > span.button-text{
+    display: block;
+    font-size: 13px;
+    padding: 3px 13px 4px;
 }
 
 .wv-button.red {
@@ -28,7 +34,8 @@
   background: #212121;
 }
 
-.wv-button:hover {
+.wv-button:hover,
+#compare-toggle-button:hover {
   border-color: #eee;
   background-color: #eee;
   transition: background 0.4s ease, border-color 0.4s ease, color 0.4s ease;

--- a/web/scss/components/button.scss
+++ b/web/scss/components/button.scss
@@ -19,7 +19,8 @@
   font-size: 13px;
 }
 
-#compare-toggle-button.wv-button > span.button-text{
+#compare-toggle-button.wv-button > span.button-text,
+#chart-toggle-button.wv-button > span.button-text{
     display: block;
     font-size: 13px;
     padding: 3px 13px 4px;

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -203,7 +203,7 @@ footer .product-buttons {
   background-image: linear-gradient(#555,#666);
   border: 1px solid #666;
   color: #eee;
-  font-family: Open Sans Bold,sans-serif;
+  font-family: "Open Sans Bold",sans-serif;
   font-size: 1em;
   font-weight: 700;
   padding: 0;
@@ -224,7 +224,7 @@ footer .product-buttons {
   background-image: linear-gradient(#555,#666);
   border: 1px solid #666;
   color: #eee;
-  font-family: Open Sans Bold,sans-serif;
+  font-family: "Open Sans Bold",sans-serif;
   font-size: 1em;
   font-weight: 700;
   padding: 0;

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -193,11 +193,20 @@
   margin-bottom: 10px;
 }
 
-footer .product-buttons .layers-add-container {
+footer .product-buttons {
   height: 47px;
-  display: flex;
+  width: auto;
   padding: 10px;
-  justify-content: space-around;
+}
+
+.wv-button {
+  background-image: linear-gradient(#555,#666);
+  border: 1px solid #666;
+  color: #eee;
+  font-family: Open Sans Bold,sans-serif;
+  font-size: 1em;
+  font-weight: 700;
+  padding: 0;
 }
 
 .compare-chart-container {
@@ -205,10 +214,30 @@ footer .product-buttons .layers-add-container {
   justify-content: space-around;
 }
 
-.layers-add-container {
+.product-buttons {
   display: flex;
-  justify-content: space-around;
-  margin: 10px 0;
+  width: auto;
+}
+
+#compare-toggle-button {
+  background-image: linear-gradient(#555,#666);
+  border: 1px solid #666;
+  color: #eee;
+  font-family: Open Sans Bold,sans-serif;
+  font-size: 1em;
+  font-weight: 700;
+  padding: 0;
+  border-radius: 0;
+}
+
+footer .compare-toggle-button {
+  border-bottom: none;
+  position: absolute;
+  right: 10px;
+}
+
+div#group-overlays-checkbox-case {
+  margin: 4px 0 0 4px;
 }
 
 .layer-group-baselayers {

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -214,10 +214,10 @@ footer .product-buttons {
   justify-content: space-around;
 }
 
-.product-buttons {
-  display: flex;
-  width: auto;
-}
+// .product-buttons {
+//   display: flex;
+//   width: auto;
+// }
 
 #compare-toggle-button {
   background-image: linear-gradient(#555,#666);

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -207,6 +207,7 @@ footer .product-buttons {
   font-size: 1em;
   font-weight: 700;
   padding: 0;
+  border-radius: 0;
 }
 
 .compare-chart-container {
@@ -214,10 +215,10 @@ footer .product-buttons {
   justify-content: space-around;
 }
 
-// .product-buttons {
-//   display: flex;
-//   width: auto;
-// }
+.charting-button {
+  display: flex;
+  justify-content: space-around;
+}
 
 #compare-toggle-button {
   background-image: linear-gradient(#555,#666);
@@ -227,7 +228,6 @@ footer .product-buttons {
   font-size: 1em;
   font-weight: 700;
   padding: 0;
-  border-radius: 0;
 }
 
 footer .compare-toggle-button {


### PR DESCRIPTION
## Description
Charting Mode was pushed towards production, but we would like to retain the pre-charting mode styling of the buttons at the bottom of the sidebar. This PR returns the Add Layers & Start Comparison buttons to their original locations & tucks the Start Charting button below them (when charting mode is enabled).

Fixes #wv-2790

## How To Test
Testing with Charting Mode DISABLED:
- git checkout wv-2790-sidebar-buttons
- npm install
- npm run watch
- In a desktop browser, compare this PR to the production site. Confirm that the sidebar button location(s) are correct.
- On a mobile browser, compare this PR to the production site. Confirm that the sidebar button location(s) are correct.

Testing with Charting Mode ENABLED:
- Modify `config\default\common\features.json` to set `"charting": true,`
- npm run build
- npm run watch
- In a desktop browser, compare this PR to the production site. Confirm that the sidebar button location(s) are correct. Only the `Start Charting` button should be different.
- On a mobile browser, compare this PR to the production site. Confirm that the sidebar button location(s) are correct. Note that `Charting mode` is disabled on mobile.

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
