### PR TITLE
WV-2793 Embed Examples

### DIFF
--- a/web/js/components/timeline/mobile-date-picker.js
+++ b/web/js/components/timeline/mobile-date-picker.js
@@ -122,13 +122,11 @@ function MobileDatePicker(props) {
   const displayDate = getDisplayDate(date, hasSubdailyLayers);
   const headerTime = getHeaderTime(time, hasSubdailyLayers);
 
-  console.log(isEmbedModeActive)
-
   return (
     time && (
       <>
         <div
-          className={"mobile-date-picker-select-btn"}
+          className="mobile-date-picker-select-btn"
           onClick={handleClickDateButton}
         >
           <div className="mobile-date-picker-select-btn-text">

--- a/web/js/components/timeline/mobile-date-picker.js
+++ b/web/js/components/timeline/mobile-date-picker.js
@@ -68,6 +68,7 @@ const convertToLocalDateObject = (date) => {
 function MobileDatePicker(props) {
   const {
     date,
+    isEmbedModeActive,
     startDateLimit,
     endDateLimit,
     onDateChange,
@@ -83,7 +84,9 @@ function MobileDatePicker(props) {
   }, [endDateLimit, date]);
 
   const handleClickDateButton = () => {
-    setIsOpen(true);
+    if (!isEmbedModeActive) {
+      setIsOpen(true);
+    }
   };
 
   const handleCancel = () => {
@@ -119,11 +122,13 @@ function MobileDatePicker(props) {
   const displayDate = getDisplayDate(date, hasSubdailyLayers);
   const headerTime = getHeaderTime(time, hasSubdailyLayers);
 
+  console.log(isEmbedModeActive)
+
   return (
     time && (
       <>
         <div
-          className="mobile-date-picker-select-btn"
+          className={"mobile-date-picker-select-btn"}
           onClick={handleClickDateButton}
         >
           <div className="mobile-date-picker-select-btn-text">

--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -17,6 +17,7 @@ function AnimationButton(props) {
     isMobileTablet,
     isMobile,
     hasSubdailyLayers,
+    isEmbedModeActive,
   } = props;
 
   const subdailyID = hasSubdailyLayers ? '-subdaily' : '';
@@ -24,10 +25,14 @@ function AnimationButton(props) {
   const labelText = label || 'Set up animation';
 
   const getButtonClassName = () => {
-    if ((isMobilePhone && isPortrait) || (!isMobileTablet && screenWidth < 670 && hasSubdailyLayers) || (!isMobileTablet && screenWidth < 575 && !hasSubdailyLayers)) {
+    if (((isMobilePhone && isPortrait) || (!isMobileTablet && screenWidth < 670 && hasSubdailyLayers) || (!isMobileTablet && screenWidth < 575 && !hasSubdailyLayers)) && isEmbedModeActive) {
+      return 'phone-portrait-embed';
+    } if ((isMobilePhone && isPortrait) || (!isMobileTablet && screenWidth < 670 && hasSubdailyLayers) || (!isMobileTablet && screenWidth < 575 && !hasSubdailyLayers)) {
       return `phone-portrait${subdailyID}`;
     } if (isMobilePhone && isLandscape) {
       return `phone-landscape${subdailyID}`;
+    } if (((isMobileTablet && isPortrait) || (!isMobilePhone && screenWidth < breakpoints.small)) && isEmbedModeActive) {
+      return `tablet-portrait${subdailyID}-embed`;
     } if ((isMobileTablet && isPortrait) || (!isMobilePhone && screenWidth < breakpoints.small)) {
       return `tablet-portrait${subdailyID}`;
     } if (isMobileTablet && isLandscape) {

--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -109,6 +109,7 @@ function AnimationWidget (props) {
   useEffect(() => {
     if (isEmbedModeActive) {
       setWidgetPosition({ x: 10, y: 0 });
+      toggleCollapse();
     }
     if (!isPlaying && autoplay && !isKioskModeActive) {
       onPushPlay();

--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -282,6 +282,7 @@ function AnimationWidget (props) {
           breakpoints={breakpoints}
           endDate={endDate}
           hasSubdailyLayers={hasSubdailyLayers}
+          isEmbedModeActive={isEmbedModeActive}
           isLandscape={isLandscape}
           isMobile={isMobile}
           isMobilePhone={isMobilePhone}

--- a/web/js/containers/animation-widget/mobile-animation-widget.js
+++ b/web/js/containers/animation-widget/mobile-animation-widget.js
@@ -88,7 +88,7 @@ function MobileAnimationWidget (props) {
           aria-label="Close"
           onClick={toggleCollapse}
           id="mobile-animation-close"
-          >
+        >
           <FontAwesomeIcon icon="times" className="collapse-icon" style={collapseIconMobile} />
         </span>
       </div>

--- a/web/js/containers/animation-widget/mobile-animation-widget.js
+++ b/web/js/containers/animation-widget/mobile-animation-widget.js
@@ -14,6 +14,7 @@ function MobileAnimationWidget (props) {
     breakpoints,
     endDate,
     hasSubdailyLayers,
+    isEmbedModeActive,
     isLandscape,
     isMobile,
     isMobilePhone,
@@ -82,8 +83,12 @@ function MobileAnimationWidget (props) {
 
   return (
     <div className="wv-animation-widget-wrapper-mobile" id={`mobile-animation-widget-${mobileID}`}>
-      <div className="mobile-animation-header">
-        <span aria-label="Close" onClick={toggleCollapse} id="mobile-animation-close">
+      <div className="mobile-animation-header" style={{ justifyContent: isEmbedModeActive ? 'flex-start' : 'flex-end' }}>
+        <span
+          aria-label="Close"
+          onClick={toggleCollapse}
+          id="mobile-animation-close"
+          >
           <FontAwesomeIcon icon="times" className="collapse-icon" style={collapseIconMobile} />
         </span>
       </div>
@@ -175,6 +180,7 @@ MobileAnimationWidget.propTypes = {
   breakpoints: PropTypes.object,
   endDate: PropTypes.object,
   hasSubdailyLayers: PropTypes.bool,
+  isEmbedModeActive: PropTypes.bool,
   isLandscape: PropTypes.bool,
   isMobile: PropTypes.bool,
   isMobilePhone: PropTypes.bool,

--- a/web/js/containers/embed.js
+++ b/web/js/containers/embed.js
@@ -9,15 +9,16 @@ import { getSelectedDate } from '../modules/date/selectors';
 import HoverTooltip from '../components/util/hover-tooltip';
 import history from '../main';
 
-function Embed (props) {
-  const {
-    isEmbedModeActive,
-  } = props;
+function Embed ({ isEmbedModeActive, selectedDate, isMobile }) {
+  const [showClickToInteractMessage, setShowClickToInteractMessage] = useState(false);
+  const [hasClicked, setHasClicked] = useState(false);
 
-  const [showOverlay, clickOverlay] = useState(true);
+  const handleOverlayClick = () => {
+    setShowClickToInteractMessage(false);
+    setHasClicked(true);
+  };
 
   const newTabLink = function() {
-    const { selectedDate } = props;
     const queryString = history.location.search || '';
     const permalink = getPermalink(queryString, selectedDate);
     googleTagManager.pushEvent({
@@ -27,7 +28,6 @@ function Embed (props) {
   };
 
   const renderEmbedLinkBtn = function() {
-    const { isMobile } = props;
     const buttonId = 'wv-embed-link-button';
     const labelText = 'Open this @NAME@ map in a new tab';
     return (
@@ -49,10 +49,14 @@ function Embed (props) {
 
   return (
     isEmbedModeActive && (
-      <>
-        {showOverlay && (
+      <div
+        id={!hasClicked ? 'embed-mode-wrapper' : ''}
+        onMouseEnter={() => !hasClicked && setShowClickToInteractMessage(true)}
+        onMouseLeave={() => !hasClicked && setShowClickToInteractMessage(false)}
+      >
+        {showClickToInteractMessage && (
           <>
-            <div onClick={() => clickOverlay(false)} className="embed-overlay-bg" />
+            <div onClick={handleOverlayClick} className="embed-overlay-bg" />
             <div className="embed-overlay-btn">
               <FontAwesomeIcon icon="hand-pointer" size="2x" fixedWidth />
               <p>Click anywhere to interact</p>
@@ -60,7 +64,7 @@ function Embed (props) {
           </>
         )}
         {renderEmbedLinkBtn()}
-      </>
+      </div>
     )
   );
 }

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -85,7 +85,7 @@ function Events(props) {
       </div>
       <Button
         id="event-filter-button"
-        className="filter-button"
+        className={isEmbedModeActive ? 'filter-button-hidden' : 'filter-button'}
         aria-label="Filtered layer search"
         onClick={openFilterModal}
         color="primary"

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -973,6 +973,8 @@ class Timeline extends React.Component {
       hasSubdailyLayers,
       isCompareModeActive,
       isDataDownload,
+      isEmbedModeActive,
+      isKioskModeActive,
       isMobile,
       isMobilePhone,
       isMobileTablet,
@@ -983,7 +985,6 @@ class Timeline extends React.Component {
       selectedDate,
       timelineEndDateLimit,
       timelineStartDateLimit,
-      isKioskModeActive,
     } = this.props;
 
     return (
@@ -995,6 +996,7 @@ class Timeline extends React.Component {
           onDateChange={this.onDateChange}
           hasSubdailyLayers={hasSubdailyLayers}
           isMobile={isMobile}
+          isEmbedModeActive={isEmbedModeActive}
         />
         <MobileComparisonToggle />
         <div

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1020,6 +1020,7 @@ class Timeline extends React.Component {
             clickAnimationButton={this.clickAnimationButton}
             hasSubdailyLayers={hasSubdailyLayers}
             isKioskModeActive={isKioskModeActive}
+            isEmbedModeActive={isEmbedModeActive}
             disabled={animationDisabled}
             label={
                     isCompareModeActive

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -928,7 +928,7 @@ class Timeline extends React.Component {
       mobileBottom = 75;
       if (isEmbedModeActive) {
         mobileLeft = isCompareModeActive ? 90 : 10;
-        mobileBottom = 60;
+        mobileBottom = 56;
       }
     }
 

--- a/web/scss/features/anim-widget.scss
+++ b/web/scss/features/anim-widget.scss
@@ -530,6 +530,7 @@ a .wv-animation-widget-icon {
         display: flex;
         justify-content: center;
         align-items: center;
+        margin-left: 40px;
 
         & .mobile-date-picker-select-btn-text {
           display: flex;

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -80,6 +80,7 @@
 
   #wv-sidebar {
     transform: scale(0.75);
+    transform-origin: left center;
 
     #download-sidebar-tab {
       display: none;

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -154,7 +154,7 @@
   .comparison-mobile-select-toggle {
     transform-origin: bottom left;
     transform: scale(0.75);
-    bottom: 50px;
+    bottom: 60px;
   }
 
   .ab-swipe-dragger {

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -155,7 +155,7 @@
   .comparison-mobile-select-toggle {
     transform-origin: bottom left;
     transform: scale(0.75);
-    bottom: 60px;
+    bottom: 56px;
   }
 
   .ab-swipe-dragger {

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -1,3 +1,10 @@
+#embed-mode-wrapper {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: all;
+}
+
 .embed-overlay-bg {
   position: absolute;
   top: 0;

--- a/web/scss/features/event-filter.scss
+++ b/web/scss/features/event-filter.scss
@@ -37,6 +37,10 @@
     display: inline-block;
     vertical-align: top;
   }
+
+  .filter-button-hidden {
+    display: none !important;
+  }
 }
 
 .event-filter-modal {

--- a/web/scss/features/timeline.scss
+++ b/web/scss/features/timeline.scss
@@ -909,6 +909,12 @@ button:focus {
   bottom: 75px;
 }
 
+.animate-button-phone-portrait-embed {
+  left: 100px;
+  bottom: 52px;
+  transform: scale(.75);
+}
+
 .animate-button-phone-portrait-subdaily {
   left: 140px;
   bottom: 75px;
@@ -927,6 +933,18 @@ button:focus {
 .animate-button-tablet-portrait {
   left: 325px;
   bottom: 20px;
+}
+
+.animate-button-tablet-portrait-embed {
+  left: 235px;
+  bottom: 15px;
+  transform: scale(.75);
+}
+
+.animate-button-tablet-portrait-subdaily-embed {
+  left: 315px;
+  bottom: 15px;
+  transform: scale(.75);
 }
 
 .animate-button-tablet-portrait-subdaily {


### PR DESCRIPTION
## Description

Now that the embed feature is returning in a limited capacity, this ticket required us to test each of the previous embed examples. The only UI change that I had to make was to adjust the A|B compare toggle in embed mode that was slightly covering the date.

## How To Test

1. `git checkout wv-2793-embed-exps`
2. `npm ci`
3. `npm run watch`
4. **Comparing Different Dates**: Use this [link](http://localhost:3000/?v=-126.09514147857739,40.3056245406739,-116.48361945209307,44.575743440981775&em=true&l=Reference_Labels_15m,Reference_Features_15m,Coastlines_15m,MODIS_Aqua_CorrectedReflectance_Bands721,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&l1=Reference_Labels_15m,Reference_Features_15m,Coastlines_15m,MODIS_Aqua_CorrectedReflectance_Bands721,MODIS_Terra_CorrectedReflectance_TrueColor&lg1=true&ca=false&cv=54&t=2021-07-09-T14%3A52%3A15Z&t1=2021-07-18-T14%3A52%3A15Z) and verify that embed mode works correctly when comparing 2 different dates.
5. **Comparing the Same Date**: Use this [link](http://localhost:3000/?v=-74.23084688598335,40.62878329893921,-73.61265211672084,40.903429204241775&em=true&l=MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&l1=HLS_S30_Nadir_BRDF_Adjusted_Reflectance,Land_Water_Map(opacity=0.6)&lg1=false&ca=false&cv=49&t=2020-10-09-T16%3A46%3A06Z&t1=2020-10-09-T16%3A46%3A06Z) to verify that compare mode works when comparing the same dates. 
6. **Playing Animations**: Use this [link](http://localhost:3000/?v=-128.513507532474,37.36002303473546,-114.6517154141861,43.51841297062066&z=4&ics=true&ici=5&icd=10&as=2021-07-21-T00%3A30%3A00Z&ae=2021-07-21-T02%3A20%3A00Z&em=true&l=Coastlines_15m,GOES-West_ABI_GeoColor&lg=true&al=true&ab=on&t=2021-07-21-T00%3A40%3A00Z) and verify that the animation plays.
7. **Vector Points**: Use this [link](http://localhost:3000/?v=-123.528375,38.8818662109375,-119.309625,40.7561337890625&em=true&e=EONET_5653,2021-07-13&efs=false&efa=false&efd=2021-07-13,2021-07-22&efc=wildfires&l=Reference_Labels_15m,Reference_Features_15m,MODIS_Terra_Thermal_Anomalies_Night,MODIS_Terra_Thermal_Anomalies_Day,BlueMarble_NextGeneration,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-07-21-T19%3A34%3A25Z) and click on the vector points to verify their functionality.
8. **Events** Use this [link](https://worldview.earthdata.nasa.gov/?v=-103.50028271122204,10.26847172967436,-14.979785444452538,49.5955468174631&em=true&e=true&efs=false&efa=false&efd=2020-06-01,2020-11-30&efc=severeStorms&l=Coastlines_15m,BlueMarble_NextGeneration,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2021-07-20-T15%3A00%3A46Z) and click on map events to verify functionality. 


## Updates

- [x] Animation should load as _collapsed_
- [x] Disable the mobile date picker
- [x] Disable the event filter
- [x] Fix open mobile animation widget 
- [x] Don't show _click screen_ prompt until mouse hover