### PR TITLE
WV-2791: Layer Threshold Max Decreasing Fix

### DIFF
--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -7,7 +7,7 @@ import {
   cloneDeep as lodashCloneDeep,
 } from 'lodash';
 import update from 'immutability-helper';
-import { getMinValue, getMaxValue } from './util';
+import { getMinValue } from './util';
 
 /**
  * Gets a single colormap (entries / legend combo)
@@ -287,18 +287,13 @@ const toggleLookup = function(layerId, palettesObj, state) {
   return update(newPalettes, { [layerId]: { lookup: { $set: lookup } } });
 };
 
-export function findIndex(layerId, type, value, index, groupStr, state) {
+export function findIndex(layerId, value, index, groupStr, state) {
   index = index || 0;
   const { values } = getPalette(layerId, index, groupStr, state).entries;
   let result;
   lodashEach(values, (check, index) => {
     const min = getMinValue(check);
-    const max = getMaxValue(check);
-    if (type === 'min' && value === min) {
-      result = index;
-      return false;
-    }
-    if (type === 'max' && value === max) {
+    if (value === min) {
       result = index;
       return false;
     }

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -250,7 +250,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
       const entryLength = lodashSize(lodashGet(paletteDef, 'entries.values'))
         || lodashSize(lodashGet(paletteDef, 'entries.colors'));
       const maxValue = paletteDef.max
-        ? lodashSplit(paletteDef.entries.values[paletteDef.max || entryLength], ',', 1)
+        ? lodashSplit(paletteDef.entries.values[paletteDef.max || entryLength], ',').slice(-1)
         : undefined;
       const minValue = paletteDef.min
         ? lodashSplit(paletteDef.entries.values[paletteDef.min || 0], ',', 1)

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -250,7 +250,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
       const entryLength = lodashSize(lodashGet(paletteDef, 'entries.values'))
         || lodashSize(lodashGet(paletteDef, 'entries.colors'));
       const maxValue = paletteDef.max
-        ? lodashSplit(paletteDef.entries.values[paletteDef.max || entryLength], ',').slice(-1)
+        ? lodashSplit(paletteDef.entries.values[paletteDef.max || entryLength], ',', 1)
         : undefined;
       const minValue = paletteDef.min
         ? lodashSplit(paletteDef.entries.values[paletteDef.min || 0], ',', 1)
@@ -372,7 +372,6 @@ export function loadPalettes(permlinkState, state) {
               min.push(
                 findPaletteExtremeIndex(
                   layerId,
-                  'min',
                   value,
                   index,
                   stateObj.groupStr,
@@ -390,7 +389,6 @@ export function loadPalettes(permlinkState, state) {
               max.push(
                 findPaletteExtremeIndex(
                   layerId,
-                  'max',
                   value,
                   index,
                   stateObj.groupStr,

--- a/web/scss/components/range.scss
+++ b/web/scss/components/range.scss
@@ -120,6 +120,7 @@
   &.start-range::-moz-range-track {
     height: 4px;
     border: solid 1px #ccc;
+    border-left: none;
     border-right: none;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -148,6 +149,7 @@
     height: 4px;
     border: solid 1px #ccc;
     border-left: none;
+    border-right: none;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     background: linear-gradient(


### PR DESCRIPTION
## Description
This fix prevents the threshold max of a layer decreasing on every page reload. This was done by modifying the value put into the url for the layer's threshold max. Previously, the url contained the low-end of the range label of the max value, and now the url will instead contain the high-end of the range label of the max value. This fix not only prevents the threshold max from decreasing on page reload, but also is a more accurate representation of the threshold maximum, now being the high-end of that max range.

In addition to this fix, also included in this PR is a minor style fix to the threshold range input track, to fix a Firefox-specific style issue with the range input track's border.

## How To Test
1. `git checkout wv-2791-layerthresholdmax`
2. `npm ci`
3. `npm run watch`
4. Click the "Add Layers" button on the main sidebar on the right, and add any layer with a threshold option (for example, the Aerosol Index layer). Then, click the options sliders icon on the layer card to open the layer options window, and locate the thresholds slider.
5. Move the right side of the slider to any point other than the absolute maximum.
6. Verify that reloading the page does not change the threshold you selected in the previous step, and that it correctly persists between page reloads without changing.