### PR TITLE
WV-2796: Layer Threshold Max Lowers on Squash Palette

### DIFF
--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -36,7 +36,7 @@ class PaletteThreshold extends React.Component {
     setRange(
       layerId,
       parseFloat(palette.entries.refs.indexOf(startIndex)),
-      parseFloat(palette.entries.refs.indexOf(endIndex)),
+      parseFloat(palette.entries.refs.lastIndexOf(endIndex)),
       isSquashed,
       index,
       groupName,


### PR DESCRIPTION
## Description
This fix prevents the threshold max of a layer decreasing when the Squash Palette checkbox is clicked. Clicking the Squash Palette checkbox shouldn't change the threshold min/max.

## How To Test
1. `git checkout wv-2796-squashpalette-thresholdlowering`
2. `npm ci`
3. `npm run watch`
4. Click the "Add Layers" button on the main sidebar on the right, and add any layer with a threshold option (for example, the Aerosol Index layer). Then, click the options sliders icon on the layer card to open the layer options window, and locate the Squash Palette checkbox.
5. Make sure the MAX threshold is set to the highest value.
6. Verify that clicking the Squash Palette checkbox on doesn't lower the MAX threshold.