### PR TITLE
WV-2797: Dual Colormap Layer Threshold Double-Slider

### DIFF
--- a/web/js/components/layer/settings/palette-threshold.js
+++ b/web/js/components/layer/settings/palette-threshold.js
@@ -6,8 +6,7 @@ import {
   checkTemperatureUnitConversion, convertPaletteValue,
 } from '../../../modules/settings/util';
 
-const sliderWidth = 264;
-const thumbsize = 22;
+const thumbsize = 26;
 
 class PaletteThreshold extends React.Component {
   constructor(props) {
@@ -18,10 +17,19 @@ class PaletteThreshold extends React.Component {
       end,
       squashed,
       avg: Math.round((start + end) / 2),
+      sliderWidth: 264,
     };
     this.debounceSetRange = lodashDebounce(props.setRange, 300);
     this.updateSquash = this.updateSquash.bind(this);
     this.updateThreshold = this.updateThreshold.bind(this);
+    this.slider = React.createRef();
+  }
+
+  componentDidUpdate() {
+    const { sliderWidth } = this.state;
+    if (sliderWidth !== this.slider.current.offsetWidth && this.slider.current.offsetWidth > 0) {
+      this.setState({ sliderWidth: this.slider.current.offsetWidth });
+    }
   }
 
   updateSquash() {
@@ -108,7 +116,7 @@ class PaletteThreshold extends React.Component {
 
   render() {
     const {
-      start, end, squashed, avg,
+      start, end, squashed, avg, sliderWidth,
     } = this.state;
     const {
       index, min, max, legend, globalTemperatureUnit,
@@ -167,6 +175,7 @@ class PaletteThreshold extends React.Component {
         <div
           id={`wv-layer-options-threshold${index}`}
           className="wv-layer-options-threshold"
+          ref={this.slider}
         >
           <input
             className="double-range form-range start-range palette-threshold-range"


### PR DESCRIPTION
## Description
This change correctly formats the 

## How To Test
1. `git checkout wv-2797-dualcolormap-doubleslider`
2. `npm ci`
3. `npm run watch`
4. Click the "Add Layers" button on the main sidebar on the right, and add any layer with dual thresholds (for example, the Cloud Effective Radius layer). Then, click the options sliders icon on the layer card to open the layer options window, and locate the Threshold slider.
5. Verify that the double slider looks correct in both thresholds, and functions properly.
6. Also verify that non-dual colormap layers also still behave normally and correctly.