### PR TITLE
WV-2782: Reimplement embed mode and associated documentation

### DIFF
--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -94,7 +94,6 @@ function InfoList (props) {
       ? { href: 'mailto:@MAIL@?subject=Feedback for @LONG_NAME@ tool' }
       : {
         onClick: () => {
-          console.log('feedbackIsInititated: ', feedbackIsInitiated);
           sendFeedback(feedbackIsInitiated, isMobile);
         },
       };

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -94,6 +94,7 @@ function InfoList (props) {
       ? { href: 'mailto:@MAIL@?subject=Feedback for @LONG_NAME@ tool' }
       : {
         onClick: () => {
+          console.log('feedbackIsInititated: ', feedbackIsInitiated);
           sendFeedback(feedbackIsInitiated, isMobile);
         },
       };

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -19,6 +19,7 @@ import {
   getPermalink, getShareLink, wrapWithIframe,
 } from '../modules/link/util';
 import onClickFeedback from '../modules/feedback/util';
+import initFeedback from '../modules/feedback/actions';
 import { getSelectedDate } from '../modules/date/selectors';
 import Checkbox from '../components/util/checkbox';
 import HoverTooltip from '../components/util/hover-tooltip';
@@ -167,10 +168,11 @@ class ShareLinkContainer extends Component {
   openFeedback = () => {
     const {
       isMobile,
-      isInitiated,
+      feedbackIsInitiated,
       feedbackEnabled,
+      sendFeedback,
     } = this.props;
-    if (feedbackEnabled) onClickFeedback(isInitiated, isMobile);
+    if (feedbackEnabled) sendFeedback(feedbackIsInitiated, isMobile);
   };
 
   renderNavTabs = () => {
@@ -377,6 +379,12 @@ const mapDispatchToProps = (dispatch) => ({
   requestShortLinkAction: (location, options) => dispatch(
     requestShortLink(location, 'application/json', null, options),
   ),
+  sendFeedback: (isInitiated, isMobile) => {
+    onClickFeedback(isInitiated, isMobile);
+    if (!isInitiated) {
+      dispatch(initFeedback());
+    }
+  },
 });
 
 export default connect(
@@ -386,12 +394,13 @@ export default connect(
 
 ShareLinkContainer.propTypes = {
   embedDisableNavLink: PropTypes.bool,
-  isInitiated: PropTypes.bool,
+  feedbackIsInitiated: PropTypes.bool,
   feedbackEnabled: PropTypes.bool,
   isMobile: PropTypes.bool,
   mock: PropTypes.string,
   requestShortLinkAction: PropTypes.func,
   selectedDate: PropTypes.object,
+  sendFeedback: PropTypes.func,
   shortLink: PropTypes.object,
   urlShortening: PropTypes.bool,
 };

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -291,7 +291,7 @@ class ShareLinkContainer extends Component {
             <p>
               Please
               {' '}
-              <a onClick={this.openFeedback} id="feedback-link">contact us</a>
+              <a onClick={this.openFeedback} id="feedback-url">contact us</a>
               {' '}
               to enable Worldview embedding on your website.
             </p>

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -19,7 +19,6 @@ import {
   getPermalink, getShareLink, wrapWithIframe,
 } from '../modules/link/util';
 import onClickFeedback from '../modules/feedback/util';
-import initFeedback from '../modules/feedback/actions';
 import { getSelectedDate } from '../modules/date/selectors';
 import Checkbox from '../components/util/checkbox';
 import HoverTooltip from '../components/util/hover-tooltip';
@@ -169,9 +168,9 @@ class ShareLinkContainer extends Component {
     const {
       isMobile,
       isInitiated,
-      feedbackEnabled
+      feedbackEnabled,
     } = this.props;
-    if (feedbackEnabled) onClickFeedback(isInitiated, isMobile)
+    if (feedbackEnabled) onClickFeedback(isInitiated, isMobile);
   };
 
   renderNavTabs = () => {
@@ -288,7 +287,11 @@ class ShareLinkContainer extends Component {
           <>
             {this.renderInputGroup(embedIframeHTMLCode, 'embed')}
             <p>
-              Please <a onClick={this.openFeedback} style={{cursor: 'pointer', textDecoration: 'underline', color: 'lightblue'}}>contact us</a> to enable Worldview embedding on your website.
+              Please
+              {' '}
+              <a onClick={this.openFeedback} style={{ cursor: 'pointer', textDecoration: 'underline', color: 'lightblue' }}>contact us</a>
+              {' '}
+              to enable Worldview embedding on your website.
             </p>
           </>
         )}
@@ -374,12 +377,6 @@ const mapDispatchToProps = (dispatch) => ({
   requestShortLinkAction: (location, options) => dispatch(
     requestShortLink(location, 'application/json', null, options),
   ),
-  sendFeedback: (isInitiated, isMobile) => {
-    onClickFeedback(isInitiated, isMobile);
-    if (!isInitiated) {
-      dispatch(initFeedback());
-    }
-  },
 });
 
 export default connect(
@@ -389,6 +386,8 @@ export default connect(
 
 ShareLinkContainer.propTypes = {
   embedDisableNavLink: PropTypes.bool,
+  isInitiated: PropTypes.bool,
+  feedbackEnabled: PropTypes.bool,
   isMobile: PropTypes.bool,
   mock: PropTypes.string,
   requestShortLinkAction: PropTypes.func,

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -18,6 +18,8 @@ import ShareToolTips from '../components/toolbar/share/tooltips';
 import {
   getPermalink, getShareLink, wrapWithIframe,
 } from '../modules/link/util';
+import onClickFeedback from '../modules/feedback/util';
+import initFeedback from '../modules/feedback/actions';
 import { getSelectedDate } from '../modules/date/selectors';
 import Checkbox from '../components/util/checkbox';
 import HoverTooltip from '../components/util/hover-tooltip';
@@ -37,7 +39,7 @@ const getShortenRequestString = (mock, permalink) => {
   );
 };
 
-const SOCIAL_SHARE_TABS = ['link', 'social'];
+const SOCIAL_SHARE_TABS = ['link', 'embed', 'social'];
 
 class ShareLinkContainer extends Component {
   constructor(props) {
@@ -163,6 +165,15 @@ class ShareLinkContainer extends Component {
     this.setState({ activeTab });
   };
 
+  openFeedback = () => {
+    const {
+      isMobile,
+      isInitiated,
+      feedbackEnabled
+    } = this.props;
+    if (feedbackEnabled) onClickFeedback(isInitiated, isMobile)
+  };
+
   renderNavTabs = () => {
     const { embedDisableNavLink, isMobile } = this.props;
     const { activeTab } = this.state;
@@ -277,11 +288,7 @@ class ShareLinkContainer extends Component {
           <>
             {this.renderInputGroup(embedIframeHTMLCode, 'embed')}
             <p>
-              Embed @NAME@ in your website. See our
-              {' '}
-              <a id="share-embed-doc-link" className="share-embed-doc-link" href="https://github.com/nasa-gibs/worldview/blob/main/doc/embed.md" target="_blank" rel="noopener noreferrer">documentation</a>
-              {' '}
-              for a guide.
+              Please <a onClick={this.openFeedback} style={{cursor: 'pointer', textDecoration: 'underline', color: 'lightblue'}}>contact us</a> to enable Worldview embedding on your website.
             </p>
           </>
         )}
@@ -330,7 +337,7 @@ class ShareLinkContainer extends Component {
           {this.renderNavTabs()}
           <TabContent activeTab={activeTab}>
             {this.renderLinkTab()}
-            {/* {this.renderEmbedTab()} */}
+            {this.renderEmbedTab()}
             {this.renderSocialTab()}
           </TabContent>
         </div>
@@ -341,14 +348,17 @@ class ShareLinkContainer extends Component {
 
 function mapStateToProps(state) {
   const {
-    screenSize, config, shortLink, sidebar, tour,
+    screenSize, config, shortLink, sidebar, tour, feedback,
   } = state;
 
   const { features: { urlShortening } } = config;
   const isMobile = screenSize.isMobileDevice;
   const embedDisableNavLink = sidebar.activeTab === 'download' || tour.active;
+  const { features: { feedback: feedbackEnabled } } = config;
 
   return {
+    feedbackEnabled,
+    feedbackIsInitiated: feedback.isInitiated,
     urlShortening,
     embedDisableNavLink,
     isMobile,
@@ -364,6 +374,12 @@ const mapDispatchToProps = (dispatch) => ({
   requestShortLinkAction: (location, options) => dispatch(
     requestShortLink(location, 'application/json', null, options),
   ),
+  sendFeedback: (isInitiated, isMobile) => {
+    onClickFeedback(isInitiated, isMobile);
+    if (!isInitiated) {
+      dispatch(initFeedback());
+    }
+  },
 });
 
 export default connect(

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -289,7 +289,7 @@ class ShareLinkContainer extends Component {
             <p>
               Please
               {' '}
-              <a onClick={this.openFeedback} style={{ cursor: 'pointer', textDecoration: 'underline', color: 'lightblue' }}>contact us</a>
+              <a onClick={this.openFeedback} id="feedback-link">contact us</a>
               {' '}
               to enable Worldview embedding on your website.
             </p>

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -107,3 +107,14 @@
     bottom: 14px;
   }
 }
+
+#feedback-link {
+  cursor: pointer;
+  text-decoration: none;
+  color: #7bf;
+}
+
+#feedback-link:hover {
+  text-decoration: underline;
+  color: #7bf !important;
+}

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -108,13 +108,13 @@
   }
 }
 
-#feedback-link {
+#feedback-url {
   cursor: pointer;
   text-decoration: none;
   color: #7bf;
 }
 
-#feedback-link:hover {
+#feedback-url:hover {
   text-decoration: underline;
   color: #7bf !important;
 }


### PR DESCRIPTION
## Description

Reimplement the embed mode tab in the share menu. Link this tab to the contact page and display iframe info. Bring back the embed documentation. 

## How To Test

1. `git checkout wv-2782`
2. `npm ci`
3. `npm run watch`
4. Click the `Share` button in the top right
5. Click the `Embed` tab in the share menu
6. Click on the `contact us` link in the description and verify that it opens the feedback modal. (You will not be able to see the contents locally)

@nasa-gibs/worldview
