### PR TITLE
wv-2579 build process eslint override removal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,10 +14,9 @@
     {
       "files": ["*.js"],
       "rules": {
-        // "no-undef": "off",
         "n/no-unpublished-require": "off",
         "no-unused-expressions": "off",
-        "prefer-regex-literals": "warn"
+        // "prefer-regex-literals": "warn"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     {
       "files": ["*.js"],
       "rules": {
-        "no-undef": "off",
+        // "no-undef": "off",
         "n/no-unpublished-require": "off",
         "no-unused-expressions": "off",
         "prefer-regex-literals": "warn"

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
       "rules": {
         "n/no-unpublished-require": "off",
         "no-unused-expressions": "off",
-        // "prefer-regex-literals": "warn"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,8 +14,7 @@
     {
       "files": ["*.js"],
       "rules": {
-        "n/no-unpublished-require": "off",
-        "no-unused-expressions": "off",
+        "n/no-unpublished-require": "off", // 96 failures across 79 files - many "@playwright/test" related
       }
     }
   ]

--- a/tasks/build-options/extractConfigFromWMTS.js
+++ b/tasks/build-options/extractConfigFromWMTS.js
@@ -75,7 +75,7 @@ class SkipException extends Error {
  * @throws {SkipException}
  */
 async function main () {
-  for (entry of entries) {
+  for (const entry of entries) {
     wv.layers = {}
     wv.sources = {}
     wvMatrixSets = {}
@@ -143,20 +143,21 @@ async function processEntry (entry) {
     } catch (error) {
       if (error instanceof SkipException) {
         warningCount += 1
-        console.warn(`${prog}: WARNING: [${id}] Skipping\n`)
+        console.warn(`${prog}: WARNING: [${gcId}] Skipping\n`)
       } else {
         errorCount += 1
         console.error(error.stack)
-        console.error(`${prog}: ERROR: [${gcId}:${ident}] ${e}\n`)
+        const ident = gcLayer['ows:Identifier']._text
+        console.error(`${prog}: ERROR: [${gcId}:${ident}] ${error}\n`)
       }
     }
   }
 
   if (gcContents.TileMatrixSet === 'Object') {
-    processMatrixSet(gcContents.TileMatrixSet)
+    processMatrixSet(gcContents.TileMatrixSet, entry)
   } else {
     gcContents.TileMatrixSet.forEach(gcMatrixSet => {
-      processMatrixSet(gcMatrixSet)
+      processMatrixSet(gcMatrixSet, entry)
     })
   }
 
@@ -278,7 +279,7 @@ async function processLayer (gcLayer, wvLayers, entry) {
   }
 }
 
-function processMatrixSet (gcMatrixSet) {
+function processMatrixSet (gcMatrixSet, entry) {
   const tileMatrixArr = gcMatrixSet.TileMatrix
   const ident = gcMatrixSet['ows:Identifier']._text
   const zoomLevels = tileMatrixArr.length

--- a/tasks/build-options/fetchPreviewSnapshots.js
+++ b/tasks/build-options/fetchPreviewSnapshots.js
@@ -249,6 +249,7 @@ async function getSnapshots (layer) {
         params,
         responseType: 'stream'
       })
+      let statusText
       if (imageReq.status === 200) {
         statusText = 'SUCCESS'
         totalSuccessCount += 1
@@ -270,7 +271,6 @@ async function getSnapshots (layer) {
       console.warn(`${prog}: URL: ${imageReq.config.url}`)
     } catch (e) {
       totalFailureCount += 1
-      statusText = 'ERROR'
       console.error(`${prog} ERROR: Unable to fetch layer: ${wvLayerId} proj:${projection}`)
       // console.error(`${prog} Error: ${e}`)
     }

--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -61,7 +61,7 @@ const daacMap = metadataConfig.daacMap || {}
 const layerMetadata = {}
 
 // These are alias or otherwise layers that don't exist in GIBS
-skipLayers = [
+const skipLayers = [
   'Land_Water_Map',
   'Land_Mask',
   'World_Database_on_Protected_Areas',
@@ -80,7 +80,7 @@ skipLayers = [
 ]
 
 // NOTE: Only using these properties at this time
-useKeys = [
+const useKeys = [
   'conceptIds',
   'dataCenter',
   'daynight',
@@ -97,7 +97,7 @@ async function main (url) {
   layerOrder = layerOrder.filter(x => !skipLayers.includes(x))
 
   console.warn(`${prog}: Fetching ${layerOrder.length} layer-metadata files`)
-  for (layerId of layerOrder) {
+  for (const layerId of layerOrder) {
     await getMetadata(layerId, url)
   }
 
@@ -117,7 +117,7 @@ async function getDAAC (metadata) {
   if (!Array.isArray(metadata.conceptIds) || !metadata.conceptIds.length) {
     return metadata
   }
-  for (collection of metadata.conceptIds) {
+  for (const collection of metadata.conceptIds) {
     const origDataCenter = collection.dataCenter
     const dataCenter = daacMap[origDataCenter]
     if (!dataCenter) {
@@ -141,11 +141,11 @@ async function getMetadata (layerId, baseUrl, count) {
     responseType: 'json',
     timeout: 10000
   }).then(async (response) => {
-    metadata = response.data
+    const metadata = response.data
     layerMetadata[layerId] = await getDAAC(metadata)
-    metadataKeys = Object.keys(layerMetadata[layerId])
+    let metadataKeys = Object.keys(layerMetadata[layerId])
     metadataKeys = metadataKeys.filter(x => !useKeys.includes(x))
-    for (key of metadataKeys) {
+    for (const key of metadataKeys) {
       delete layerMetadata[layerId][key]
     }
   }).catch((error) => {

--- a/tasks/build-options/mergeConfig.js
+++ b/tasks/build-options/mergeConfig.js
@@ -47,7 +47,7 @@ async function mergeFiles (inputDir) {
         const data = JSON.parse(fs.readFileSync(path.join(inputDir, file), 'utf-8'))
         await dictMerge(conf, data)
       } else if (fs.existsSync(path.join(inputDir, file)) && fs.lstatSync(path.join(inputDir, file)).isDirectory()) {
-        subDir = path.join(inputDir, file)
+        const subDir = path.join(inputDir, file)
         await mergeFiles(subDir)
       }
     } catch (error) {

--- a/tasks/build-options/processTemporalLayer.js
+++ b/tasks/build-options/processTemporalLayer.js
@@ -48,7 +48,7 @@ async function processTemporalLayer (wvLayer, value) {
             endDate = moment.utc(endDate).subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss[Z]')
           }
         }
-        const regex = new RegExp(/\d+/g)
+        const regex = /\d+/g
         const match = regex.exec(interval)
         rangeInterval.push(match)
         if (endDate.endsWith('T00:00:00Z')) {

--- a/tasks/build-options/processTemporalLayer.js
+++ b/tasks/build-options/processTemporalLayer.js
@@ -4,13 +4,6 @@ function toList (val) {
   return val instanceof Array ? val : [val]
 }
 
-class ValueError extends Error {
-  constructor (message) {
-    super(message)
-    this.name = 'ValueError'
-  }
-}
-
 async function processTemporalLayer (wvLayer, value) {
   const dateFormat = 'YYYY-MM-DD'
   const dateTimeFormat = 'YYYY-MM-DD HH:mm:ss'
@@ -89,9 +82,6 @@ async function processTemporalLayer (wvLayer, value) {
       }
     }
   } catch (e) {
-    if (e instanceof ValueError) {
-      throw new Error(`Invalid time: ${range}`)
-    }
     throw new Error(`Error processing temporal layer: ${e}`)
   }
   return wvLayer

--- a/tasks/build-options/validateConfigs.js
+++ b/tasks/build-options/validateConfigs.js
@@ -41,15 +41,14 @@ const schemaRaw = fs.readFileSync(schemaFile)
 const schema = JSON.parse(schemaRaw)
 const validate = ajv.compile(schema)
 
-layerConfigFiles = []
-invalidJsonFiles = []
+const invalidJsonFiles = []
 
 console.warn(`${prog}: Validating layer configs...`)
 
 async function main () {
   let files = globSync(inputDirectory + '/**/*')
   files = files.filter(file => file.endsWith('.json'))
-  for (filePath of files) {
+  for (const filePath of files) {
     validateFile(filePath)
   }
   if (invalidJsonFiles.length) {
@@ -66,7 +65,7 @@ async function validateFile (filePath) {
   const layer = JSON.parse(layerFile)
   const valid = validate(layer)
   if (!valid) {
-    for (error of validate.errors) {
+    for (const error of validate.errors) {
       invalidJsonFiles.push(error)
       console.error(`${prog}: ERROR: ${error.instancePath} ${error.message}`)
       // TOD: Add verbose mode with the full error:

--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -76,20 +76,22 @@
           For rules set to "off": consider setting to "warn" to identify non-compliance in new code
           For rules set to "warn": consider removing to throw errors on existing and future code
         */
+
+        /* Error Counts compiled 8/22/2023 */
+
         // Base rule overrides
-        "no-nested-ternary": "off", // 58 errors
-        "no-shadow": "warn", // 136 errors
-        "max-len": "off",
-        "consistent-return": "off", // 73 errors
-        "no-underscore-dangle": "off",
-        "func-names": "off",
-        "no-param-reassign": [ // 329 errors
+        "no-nested-ternary": "off",    // 164 errors across 40 files
+        "no-shadow": "warn",           // 110 errors across 40 files
+        "max-len": "off",              // 315 errors across 109 files
+        "consistent-return": "off",    // 95 errors across 58 files
+        "no-underscore-dangle": "off", // 40 errors across 7 files
+        "no-param-reassign": [         // 198 errors across 46 files
           "warn",
           {
             "props": false
           }
         ],
-        "no-use-before-define": [
+        "no-use-before-define": [     // 238 errors across 56 files
           "error",
           {
             "functions": false,
@@ -100,21 +102,20 @@
         // Import rules overrides
         "import/no-cycle": "warn",
         // Accesibility rules overrides
-        "jsx-a11y/no-noninteractive-tabindex": "off",
-        "jsx-a11y/no-noninteractive-element-interactions": "off",
-        "jsx-a11y/anchor-has-content": "off",
-        "jsx-a11y/control-has-associated-label": "off",
-        "jsx-a11y/anchor-is-valid": "off",
-        "jsx-a11y/label-has-associated-control": "off",
-        "jsx-a11y/alt-text": "off",
-        "jsx-a11y/mouse-events-have-key-events": "off",
-        "jsx-a11y/tabindex-no-positive": "off",
-        "jsx-a11y/no-static-element-interactions": "off",
-        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/no-noninteractive-tabindex": "off",             // 2 errors across 2 files
+        "jsx-a11y/no-noninteractive-element-interactions": "off", // 5 errors across 5 files
+        "jsx-a11y/anchor-has-content": "off",                     // 1 error across 1 files
+        "jsx-a11y/control-has-associated-label": "off",           // 1 error across 1 files
+        "jsx-a11y/anchor-is-valid": "off",                        // 24 errors across 13 files
+        "jsx-a11y/label-has-associated-control": "off",           // 5 errors across 4 files
+        "jsx-a11y/alt-text": "off",                               // 15 errors across 10 files
+        "jsx-a11y/mouse-events-have-key-events": "off",           // 7 errors across 4 files
+        "jsx-a11y/no-static-element-interactions": "off",         // 71 errors across 39 files
+        "jsx-a11y/click-events-have-key-events": "off",           // 70 errors across 39 files
         // React rules overrides
-        "react/jsx-props-no-spreading": "warn", // 17 errors
-        "react/jsx-filename-extension": "off",
-        "react/jsx-no-bind": "warn",
+        "react/jsx-props-no-spreading": "warn",                   // 6 errors across 2 files
+        "react/jsx-filename-extension": "off",                    // 206 errors across 206 files
+        "react/jsx-no-bind": "warn",                              // 9 errors across 5 files
         "react/sort-comp": [
           "error",
           {
@@ -155,18 +156,18 @@
             }
           }
         ],
-        "react/forbid-prop-types": "off", // 216 errors
-        "react/require-default-props": "off", // 965 errors,
-        "class-methods-use-this": "warn",
-        "react/no-unused-class-component-methods": "warn",
-        "react/no-unknown-property": "warn",
-        "react/jsx-no-useless-fragment": "warn",
-        "react/no-unstable-nested-components": "warn",
-        "react/prop-types": "warn",
-        "react/no-unused-prop-types": "warn",
-        "default-param-last": "warn",
-        "prefer-regex-literals": "warn",
-        "no-promise-executor-return": "warn"
+        "react/forbid-prop-types": "off",                  // 411 errors across 139 files
+        "react/require-default-props": "off",              // 1644 errors across > 80 files
+        "class-methods-use-this": "warn",                  // 15 errors across 13 files
+        "react/no-unused-class-component-methods": "warn", // 8 errors across 7 files
+        "react/no-unknown-property": "warn",               // 2 errors across 2 files
+        "react/jsx-no-useless-fragment": "warn",           // 3 errors across 3 files
+        "react/no-unstable-nested-components": "warn",     // 1 error across 1 file
+        "react/prop-types": "warn",                        // 58 errors across 22 files
+        "react/no-unused-prop-types": "warn",              // 9 errors across 9 files
+        "default-param-last": "warn",                      // 42 errors across 34 files
+        "prefer-regex-literals": "warn",                   // 3 errors across 1 file
+        "no-promise-executor-return": "warn"               // 1 error across 1 file
       }
     }
   ]


### PR DESCRIPTION
## Description
Our .eslintrc files (worldview\.eslintrc & worldview\web\.eslintrc) have a lot of overrides. These rules should be turned back on and the errors/warnings addressed.

This PR addresses most of the eslint overrides for the build process (worldview\.eslintrc).

Fixes # wv-2579

## How To Test
- git checkout wv-2579-eslint-overrides
- npm ci
- npm run build
- Confirm the build process succeeds
- Confirm that WV loads & runs correctly (E2E tests pass, so a quick look around should be sufficient)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
