### PR TITLE
wv-2702 orbit tracks

### DIFF
--- a/web/js/components/layer/settings/associated-layers-toggle.js
+++ b/web/js/components/layer/settings/associated-layers-toggle.js
@@ -32,6 +32,7 @@ function AssociatedLayersToggle(props) {
       <h2 className="wv-header"> Associated Layers </h2>
       { associatedLayers.map((layer) => {
         const { id } = layer;
+        const satelliteName = layer.title.split(' - ')[0];
         const isEnabled = !!activeLayers[id];
         const onCheck = () => (isEnabled ? removeLayer(id) : addLayer(id));
         return (
@@ -41,7 +42,7 @@ function AssociatedLayersToggle(props) {
             title="Enable/disable this layer"
             checked={isEnabled}
             onCheck={onCheck}
-            label={getTitle(layer)}
+            label={`${getTitle(layer)} (${satelliteName})`}
           />
         );
       }) }

--- a/web/js/containers/sidebar/orbit-track.js
+++ b/web/js/containers/sidebar/orbit-track.js
@@ -27,6 +27,7 @@ function OrbitTrack(props) {
 
   const containerClasses = `wv-orbit-track ${!trackLayer.visible ? 'not-visible' : ''}`;
   const [palette, setPalette] = useState();
+  const satelliteName = trackLayer.title.split(' - ')[0];
 
   useEffect(() => {
     if (hasPalette && !isLoading && !renderedPalette) {
@@ -50,7 +51,7 @@ function OrbitTrack(props) {
       {palette}
       <FontAwesomeIcon icon="satellite" />
       <span className="wv-orbit-track-label">
-        {getOrbitTrackTitle(trackLayer)}
+        {`${getOrbitTrackTitle(trackLayer)} (${satelliteName})`}
       </span>
     </div>
   );

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -25,11 +25,8 @@ import util from '../../util/util';
 import { parseDate } from '../date/util';
 
 export function getOrbitTrackTitle(def) {
-  console.log('getOrbitTrackTitle');
   const { track } = def;
   const daynightValue = lodashGet(def, 'daynight[0]');
-  console.log(`track: ${track}`);
-  console.log(`daynightValue: ${daynightValue}`);
   if (track && daynightValue) {
     return `${lodashStartCase(track)}/${lodashStartCase(daynightValue)}`;
   } if (track) {

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -25,8 +25,11 @@ import util from '../../util/util';
 import { parseDate } from '../date/util';
 
 export function getOrbitTrackTitle(def) {
+  console.log('getOrbitTrackTitle');
   const { track } = def;
   const daynightValue = lodashGet(def, 'daynight[0]');
+  console.log(`track: ${track}`);
+  console.log(`daynightValue: ${daynightValue}`);
   if (track && daynightValue) {
     return `${lodashStartCase(track)}/${lodashStartCase(daynightValue)}`;
   } if (track) {

--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -838,6 +838,8 @@ p.recharts-tooltip-label {
 
   .layer-orbit-tracks .wv-checkbox {
     margin: 10px 0 10px 10px;
+    display: flex;
+    align-items: center;
 
     & label {
       display: inline;


### PR DESCRIPTION
## Description
We developed the associated layers section for orbit tracks before we had layers that were created from multiple satellites traveling in the same orbit direction and time of day. Now that we have a few layers like that, HLS Sentinel-2A & B and Landsat 8 & 9 and OPERA Surface Water Extent, we should consider including the satellite name as well so you can discern which orbit track is for what satellite.

Fixes # wv-2702.

## How To Test

- git checkout wv-2702-orbit-tracks
- npm ci
- npm run watch
- Load a layer with multiple satellites (such as "OPERA Dynamic Surface Water Extent Provisional (L3)" or "Reflectance (Nadir BRDF-Adjusted)") and a layer with a single satellite (such as 'Deep Blue Aerosol Type')
- Click the 'View Options' icon to open the options menu
- Confirm under "Associated Layers" section the text label includes the satellite name
- Enable an orbit track by clicking on the checkbox(es) in "Associated Layers"
- Confirm that the associated orbit track is listed within the layer row & that this text also includes the satellite name

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
