### PR TITLE
WV 2826 embed mode layer list is wider than the logo in narrow window

### DIFF
--- a/web/js/components/sidebar/collapsed-button.js
+++ b/web/js/components/sidebar/collapsed-button.js
@@ -6,14 +6,13 @@ import { UncontrolledTooltip } from 'reactstrap';
 class CollapsedButton extends PureComponent {
   render() {
     const {
-      isEmbed,
       isMobile,
       numberOfLayers,
       onclick,
     } = this.props;
     const buttonId = 'accordion-toggler-button';
     const labelText = 'Expand sidebar';
-    const classes = `sidebar-expand ${isMobile && !isEmbed ? 'mobile' : ''}`;
+    const classes = `sidebar-expand ${isMobile ? 'mobile' : ''}`;
 
     return (
       <div
@@ -47,7 +46,6 @@ class CollapsedButton extends PureComponent {
   }
 }
 CollapsedButton.propTypes = {
-  isEmbed: PropTypes.bool,
   isMobile: PropTypes.bool,
   numberOfLayers: PropTypes.number,
   onclick: PropTypes.func,


### PR DESCRIPTION
## Description
When you're in embed mode and on a narrow screen, the collapsed layer list is very wide in comparison to the NASA logo. We should make the collapsed layer list look like the mobile layer icon. Check the ticket for images of the problem.

Fixes # wv-2826.

## How To Test

- git checkout wv-2826-embed-mode-layer-list
- npm ci
- npm run watch
- Load the page 
- Click the "Share this page" icon
- Switch to the embed tab
- Copy the embed code (something like <iframe src="http://localhost:3000/?t=2023-08-25-T15%3A43%3A07Z&em=true" role="application" sandbox="allow-modals allow-scripts allow-same-origin allow-forms allow-popups" width="100%" height="100%" allow="fullscreen; autoplay;" loading="lazy"></iframe>)
- Create an html page locally & paste the embed code onto that page
- Load your local html page in the browser & observe the layer list & logo resizing as the screen width changes

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
