### PR TITLE
Wv 2780 invalid bbox coords

### DIFF
--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { containsExtent, isEmpty } from 'ol/extent';
-import { fromExtent } from 'ol/geom/Polygon';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CRS } from '../../modules/map/constants';
+import * as olProj from 'ol/proj';
 
 const isValidExtent = (extent) => {
   if (extent.length !== 4) return false;
@@ -24,11 +24,15 @@ function Input({
   const update = () => {
     try {
       const newInputValue = Number(inputValue);
-      const newArray = structuredClone(boundingBoxArray);
+      const newArray = structuredClone(boundingBoxArray)
       newArray[index] = newInputValue;
-      const extentPolygon = fromExtent(newArray);
-      const crsCorrectedExtentPolygon = extentPolygon.transform(CRS.GEOGRAPHIC, crs);
-      const crsCorrectedExtent = crsCorrectedExtentPolygon.getExtent();
+      const minX = Math.min(newArray[0], newArray[2]);
+      const minY = Math.min(newArray[1], newArray[3]);
+      const maxX = Math.max(newArray[0], newArray[2]);
+      const maxY = Math.max(newArray[1], newArray[3]);  
+      const validExtent = [minX, minY, maxX, maxY];
+
+      const crsCorrectedExtent = olProj.transformExtent(validExtent, CRS.GEOGRAPHIC, crs)
 
       if (containsExtent(viewExtent, crsCorrectedExtent)
       && isValidExtent(newArray)

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -24,12 +24,12 @@ function Input({
   const update = () => {
     try {
       const newInputValue = Number(inputValue);
-      const newArray = structuredClone(boundingBoxArray);
-      newArray[index] = newInputValue;
-      const minX = Math.min(newArray[0], newArray[2]);
-      const minY = Math.min(newArray[1], newArray[3]);
-      const maxX = Math.max(newArray[0], newArray[2]);
-      const maxY = Math.max(newArray[1], newArray[3]);
+      const clonedBBoxArray = structuredClone(boundingBoxArray);
+      clonedBBoxArray[index] = newInputValue;
+      const minX = Math.min(clonedBBoxArray[0], clonedBBoxArray[2]);
+      const minY = Math.min(clonedBBoxArray[1], clonedBBoxArray[3]);
+      const maxX = Math.max(clonedBBoxArray[0], clonedBBoxArray[2]);
+      const maxY = Math.max(clonedBBoxArray[1], clonedBBoxArray[3]);
       const validExtent = [minX, minY, maxX, maxY];
 
       const crsCorrectedExtent = olProj.transformExtent(validExtent, CRS.GEOGRAPHIC, crs);

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -35,10 +35,10 @@ function Input({
       const crsCorrectedExtent = olProj.transformExtent(validExtent, CRS.GEOGRAPHIC, crs);
 
       if (containsExtent(viewExtent, crsCorrectedExtent)
-      && isValidExtent(newArray)
+      && isValidExtent(clonedBBoxArray)
       && !isEmpty(crsCorrectedExtent)
       && !Number.isNaN(newInputValue)) {
-        onLatLongChange(newArray);
+        onLatLongChange(clonedBBoxArray);
         setInputInvalid(false);
       } else {
         setInputValue(boundingBoxArray[index].toFixed(4));

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -120,7 +120,7 @@ function LatLongSelect(props) {
                     boundingBoxArray={boundingBoxArray}
                     onLatLongChange={onLatLongChange}
                     index={3}
-                    title="max Latitude"
+                    title="Latitude"
                   />
                   <Input
                     crs={crs}
@@ -129,7 +129,7 @@ function LatLongSelect(props) {
                     boundingBoxArray={boundingBoxArray}
                     onLatLongChange={onLatLongChange}
                     index={2}
-                    title="max Longitude"
+                    title="Longitude"
                   />
                 </div>
               </div>
@@ -147,7 +147,7 @@ function LatLongSelect(props) {
                     boundingBoxArray={boundingBoxArray}
                     onLatLongChange={onLatLongChange}
                     index={1}
-                    title="min Latitude"
+                    title="Latitude"
                   />
                   <Input
                     crs={crs}
@@ -156,7 +156,7 @@ function LatLongSelect(props) {
                     boundingBoxArray={boundingBoxArray}
                     onLatLongChange={onLatLongChange}
                     index={0}
-                    title="min Longitude"
+                    title="Longitude"
                   />
                 </div>
               </div>

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { containsExtent, isEmpty } from 'ol/extent';
+import * as olProj from 'ol/proj';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CRS } from '../../modules/map/constants';
-import * as olProj from 'ol/proj';
 
 const isValidExtent = (extent) => {
   if (extent.length !== 4) return false;
@@ -24,15 +24,15 @@ function Input({
   const update = () => {
     try {
       const newInputValue = Number(inputValue);
-      const newArray = structuredClone(boundingBoxArray)
+      const newArray = structuredClone(boundingBoxArray);
       newArray[index] = newInputValue;
       const minX = Math.min(newArray[0], newArray[2]);
       const minY = Math.min(newArray[1], newArray[3]);
       const maxX = Math.max(newArray[0], newArray[2]);
-      const maxY = Math.max(newArray[1], newArray[3]);  
+      const maxY = Math.max(newArray[1], newArray[3]);
       const validExtent = [minX, minY, maxX, maxY];
 
-      const crsCorrectedExtent = olProj.transformExtent(validExtent, CRS.GEOGRAPHIC, crs)
+      const crsCorrectedExtent = olProj.transformExtent(validExtent, CRS.GEOGRAPHIC, crs);
 
       if (containsExtent(viewExtent, crsCorrectedExtent)
       && isValidExtent(newArray)


### PR DESCRIPTION
## Description

>Image snapshot bounding box selection generates invalid coordinates. The bounding box coordinates can be invalid with the minimum/maximum latitude/longitude appearing out of order, i.e. the minimum can be greater than the maximum. It is possible that the bounding box generation logic is not properly accounting for the polar coordinate system.

## How To Test

1. `git clone WV-2780-invalid-bbox-coords`
2. `npm ci`
3. `npm run watch`
4. Go to this [link](http://localhost:3000/?v=-7077888,-4075520,7077888,4075520&p=antarctic&l=Coastlines_15m,BlueMarble_ShadedRelief_Bathymetry,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-08-06-T04%3A00%3A00Z)
5. Click the "Take a snapshot" button that looks like a camera.
6. Expand the "Edit Coordinates" section.
7. Verify that the min/max labels for each coordinate are gone.

<img width="221" alt="Screenshot 2023-08-28 at 11 05 34 AM" src="https://github.com/nasa-gibs/worldview/assets/4834892/77aa2960-a0cd-4c6d-b69d-a6709d5f41ad">
