### PR TITLE
Wv 2837 display currently selected preset

### DIFF
--- a/web/js/components/layer/settings/band-selection/band-selection-menu.js
+++ b/web/js/components/layer/settings/band-selection/band-selection-menu.js
@@ -8,6 +8,7 @@ import PresetOptions from './menu-components/preset-options';
 import {
   updateBandCombination as updateBandCombinationAction,
   removeLayer as removeLayerAction,
+  updateSelectedPreset as updateSelectedPresetAction,
 } from '../../../../modules/layers/actions';
 import { getActiveLayers } from '../../../../modules/layers/selectors';
 import { onClose } from '../../../../modules/modal/actions';
@@ -18,14 +19,16 @@ export default function BandSelection({ layer }) {
     activeLayers: getActiveLayers(state, state.compare.activeString).map((layer) => layer),
   }));
   const layerIndex = activeLayers.findIndex((activeLayer) => activeLayer.id === layer.id);
+  const currentSelectedPreset = useSelector((state) => state.layers.active.layers[layerIndex].selectedPreset);
   const updateBandCombination = (id, bandCombo) => {
-    dispatch(updateBandCombinationAction(id, bandCombo, layerIndex));
+    dispatch(updateBandCombinationAction(id, bandCombo, layerIndex, selectedPreset));
   };
+
   const removeLayer = (id) => { dispatch(removeLayerAction(id)); };
   const closeModal = () => { dispatch(onClose()); };
 
 
-  const [selectedPreset, setSelectedPreset] = useState(null);
+  const [selectedPreset, setSelectedPreset] = useState(currentSelectedPreset);
   const [bandSelection, setBandSelection] = useState({
     r: layer.bandCombo.r,
     g: layer.bandCombo.g,
@@ -50,6 +53,8 @@ export default function BandSelection({ layer }) {
   const presetOptions = layer.id === 'HLS_Customizable_Landsat' ? 'landsat' : 'sentinel';
 
   const isValidBandSelection = () => (bandSelection.r !== 'undefined' && bandSelection.r !== undefined) && (bandSelection.g !== 'undefined' && bandSelection.g !== undefined) && (bandSelection.b !== 'undefined' && bandSelection.b !== undefined);
+
+  console.log({ selectedPreset });
 
   return (
     <div className="customize-bands-container">

--- a/web/js/components/layer/settings/band-selection/band-selection-menu.js
+++ b/web/js/components/layer/settings/band-selection/band-selection-menu.js
@@ -53,8 +53,6 @@ export default function BandSelection({ layer }) {
 
   const isValidBandSelection = () => (bandSelection.r !== 'undefined' && bandSelection.r !== undefined) && (bandSelection.g !== 'undefined' && bandSelection.g !== undefined) && (bandSelection.b !== 'undefined' && bandSelection.b !== undefined);
 
-  console.log({ selectedPreset });
-
   return (
     <div className="customize-bands-container">
       <PresetOptions

--- a/web/js/components/layer/settings/band-selection/band-selection-menu.js
+++ b/web/js/components/layer/settings/band-selection/band-selection-menu.js
@@ -8,7 +8,6 @@ import PresetOptions from './menu-components/preset-options';
 import {
   updateBandCombination as updateBandCombinationAction,
   removeLayer as removeLayerAction,
-  updateSelectedPreset as updateSelectedPresetAction,
 } from '../../../../modules/layers/actions';
 import { getActiveLayers } from '../../../../modules/layers/selectors';
 import { onClose } from '../../../../modules/modal/actions';
@@ -20,6 +19,7 @@ export default function BandSelection({ layer }) {
   }));
   const layerIndex = activeLayers.findIndex((activeLayer) => activeLayer.id === layer.id);
   const currentSelectedPreset = useSelector((state) => state.layers.active.layers[layerIndex].selectedPreset);
+  const [selectedPreset, setSelectedPreset] = useState(currentSelectedPreset);
   const updateBandCombination = (id, bandCombo) => {
     dispatch(updateBandCombinationAction(id, bandCombo, layerIndex, selectedPreset));
   };
@@ -28,7 +28,6 @@ export default function BandSelection({ layer }) {
   const closeModal = () => { dispatch(onClose()); };
 
 
-  const [selectedPreset, setSelectedPreset] = useState(currentSelectedPreset);
   const [bandSelection, setBandSelection] = useState({
     r: layer.bandCombo.r,
     g: layer.bandCombo.g,

--- a/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
+++ b/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
@@ -172,6 +172,8 @@ export default function PresetOptions(props) {
 
   const presets = presetOptions === 'landsat' ? landsatPresets : sentinelPresets;
 
+  const currentlySelectedPreset = selectedPreset || presets[0];
+
   return (
     <div className="band-selection-presets-container">
       <div className="band-selection-presets-title-row">
@@ -182,7 +184,7 @@ export default function PresetOptions(props) {
           <Card
             key={preset.id}
             onClick={() => handlePresetSelect(preset)}
-            className={`band-selection-preset-card ${preset.id === selectedPreset?.id ? 'selected-preset' : ''}`}
+            className={`band-selection-preset-card ${preset.id === currentlySelectedPreset?.id ? 'selected-preset' : ''}`}
           >
             <CardImg top className="band-selection-preset-image" src={imgPath + preset.img} alt={preset.title} />
             <CardBody>

--- a/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
+++ b/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
@@ -172,8 +172,6 @@ export default function PresetOptions(props) {
 
   const presets = presetOptions === 'landsat' ? landsatPresets : sentinelPresets;
 
-  const currentlySelectedPreset = selectedPreset || presets[0];
-
   return (
     <div className="band-selection-presets-container">
       <div className="band-selection-presets-title-row">
@@ -184,7 +182,7 @@ export default function PresetOptions(props) {
           <Card
             key={preset.id}
             onClick={() => handlePresetSelect(preset)}
-            className={`band-selection-preset-card ${preset.id === currentlySelectedPreset?.id ? 'selected-preset' : ''}`}
+            className={`band-selection-preset-card ${preset.id === selectedPreset?.id ? 'selected-preset' : ''}`}
           >
             <CardImg top className="band-selection-preset-image" src={imgPath + preset.img} alt={preset.title} />
             <CardBody>

--- a/web/js/modules/layers/actions.js
+++ b/web/js/modules/layers/actions.js
@@ -416,7 +416,7 @@ export function updateLayerDateCollection(layerInfo) {
   };
 }
 
-export function updateBandCombination(id, bandCombo, layerIndex) {
+export function updateBandCombination(id, bandCombo, layerIndex, selectedPreset) {
   return (dispatch, getState) => {
     const state = getState();
     const {
@@ -435,6 +435,7 @@ export function updateBandCombination(id, bandCombo, layerIndex) {
       proj.id,
       groupOverlays,
       bandCombo,
+      selectedPreset,
     );
     const projections = Object.keys(config.projections);
     updateRecentLayers(layerObj, projections);

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -21,7 +21,7 @@ const getLayerState = ({ layers }) => layers;
 const getConfig = ({ config }) => config;
 const getLayerId = (state, { layer }) => layer && layer.id;
 
-export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection, groupOverlays, bandComboParam) {
+export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection, groupOverlays, bandComboParam, selectedPresetParam) {
   let layers = lodashCloneDeep(layersParam);
   if (projection) {
     layers = layers.filter((layer) => layer.projections[projection]);
@@ -51,6 +51,10 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
     };
   } else if (bandComboParam) {
     def.bandCombo = bandComboParam;
+  }
+
+  if (selectedPresetParam) {
+    def.selectedPreset = selectedPresetParam;
   }
 
   if (!lodashIsUndefined(spec.visible)) {


### PR DESCRIPTION
## Description

> In the "Customize" menu for DDV layers, make it so that the currently selected preset is in a "selected" or "clicked" state.

## How To Test

1. `git checkout WV-2837-display-currently-selected-preset`
2. `npm ci && npm run watch`
3. Open this [link](http://localhost:3000/?v=-76.37172809794721,39.305032656143176,-74.86300080168131,40.17377319999999&l=Reference_Labels_15m,Reference_Features_15m,Coastlines_15m,OrbitTracks_Sentinel-2B_Descending,OrbitTracks_Sentinel-2A_Descending,HLS_Customizable_Sentinel(bandCombo=%257B%2522r%2522%253A%2522B07%2522%252C%2522g%2522%253A%2522B05%2522%252C%2522b%2522%253A%2522B04%2522%257D),HLS_Customizable_Landsat(hidden,bandCombo=%257B%2522r%2522%253A%2522B07%2522%252C%2522g%2522%253A%2522B05%2522%252C%2522b%2522%253A%2522B04%2522%257D),VIIRS_NOAA20_CorrectedReflectance_TrueColor,VIIRS_SNPP_CorrectedReflectance_TrueColor,MODIS_Aqua_CorrectedReflectance_TrueColor,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-09-02-T23%3A02%3A13Z)
4. Click on layer settings
5. Click Customize
6. Select a preset and click Confirm Band Selection
7. Open the customize menu again
8. Verify that the preset you selected is still selected.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
