### PR TITLE
WV-2841: add satellite number to customizable HLS layers

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
@@ -2,7 +2,7 @@
   "layers": {
     "HLS_Customizable_Landsat": {
       "id": "HLS_Customizable_Landsat",
-      "title": "HLS Customizable Landsat *BETA*",
+      "title": "HLS Customizable Landsat 8 & 9 *BETA*",
       "subtitle": "Landsat 8 & 9 / OLI",
       "description": "multi-mission/hls/HLS_Customizable_Landsat",
       "tags": "corrected surface landsat oli l30",

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
@@ -2,7 +2,7 @@
   "layers": {
     "HLS_Customizable_Sentinel": {
       "id": "HLS_Customizable_Sentinel",
-      "title": "HLS Customizable Sentinel *BETA*",
+      "title": "HLS Customizable Sentinel 2A & 2B *BETA*",
       "subtitle": "Sentinel 2A & 2B / MSI",
       "description": "multi-mission/hls/HLS_Customizable_Sentinel",
       "tags": "corrected surface oli sentinel msi s30",


### PR DESCRIPTION
## Description

Fixes WV-2841. Added satellite number to customizable HLS layers

## How To Test

Load HLS Customizable Layers
Landsat layer is now called: HLS Customizable Landsat 8 & 9 BETA
Sentinel layer is now called: HLS Customizable Sentinel 2A & 2B BETA

@nasa-gibs/worldview
