### PR TITLE
WV-2801 palette chunked classification

### DIFF
--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -201,7 +201,7 @@ const updateLookup = function(layerId, palettesObj, state) {
           }
         } else {
           sourcePercent = index / sourceCount;
-          targetIndex = Math.floor(sourcePercent * targetCount);
+          targetIndex = Math.round(sourcePercent * targetCount);
         }
         targetColor = target[targetIndex];
       }


### PR DESCRIPTION
## Description
When you adjust the threshold for more chunked classifications (discrete colormaps), sometimes the middle colors get merged into one in the layer legend.

Fixes #wv-2801

## How To Reproduce
- Load "Cloud Fraction Terra/Modis" layer
- Adjust either the max or min threshold from the default
- Notice that in the left layer legend, the yellow color becomes green. If you remove thresholds entirely the yellow will return.

## How To Test

- git checkout wv-2801-chunks
- npm ci
- npm run watch
- Follow steps above & confirm that the yellow (and all other colors) remain in place as the thresholds are adjusted

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
