### PR TITLE
WV-2847: Fix animate button embed mode positioning

### DIFF
--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -31,7 +31,7 @@ function AnimationButton(props) {
       return `phone-portrait${subdailyID}`;
     } if (isMobilePhone && isLandscape) {
       return `phone-landscape${subdailyID}`;
-    } if (((isMobileTablet && isPortrait) || (!isMobilePhone && screenWidth < breakpoints.small)) && isEmbedModeActive) {
+    } if (((isMobileTablet && isPortrait) || !isMobile || (!isMobilePhone && screenWidth < breakpoints.small)) && isEmbedModeActive) {
       return `tablet-portrait${subdailyID}-embed`;
     } if ((isMobileTablet && isPortrait) || (!isMobilePhone && screenWidth < breakpoints.small)) {
       return `tablet-portrait${subdailyID}`;
@@ -45,7 +45,7 @@ function AnimationButton(props) {
   return (
     <div
       onClick={clickAnimationButton}
-      className={isKioskModeActive ? 'd-none' : disabled ? 'wv-disabled-button button-action-group animate-button' : !isMobile ? 'button-action-group animate-button' : `button-action-group mobile-animate-button animate-button-${buttonClass}`}
+      className={isKioskModeActive ? 'd-none' : disabled ? 'wv-disabled-button button-action-group animate-button' : !isMobile && !isEmbedModeActive ? 'button-action-group animate-button' : `button-action-group mobile-animate-button animate-button-${buttonClass}`}
       aria-label={labelText}
     >
       <div id={buttonId}>
@@ -78,6 +78,7 @@ AnimationButton.propTypes = {
   isMobileTablet: PropTypes.bool,
   isMobile: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
+  isEmbedModeActive: PropTypes.bool,
 };
 
 export default React.memo(AnimationButton);


### PR DESCRIPTION
## Description

The animate button was being rendered out of position when embed mode was active but the screen size was not registered as a mobile view. 

## How To Test

1. `git checkout wv-2847`
2. `npm ci`
3. `npm run watch`
4. Open up WV in [embed mode](http://localhost:3000/?v=-155.79966375628877,-10.30306333330288,-22.98882468634008,72.23420213656371&z=4&i=4&ics=true&ici=5&icd=10&em=true&l=GOES-East_ABI_GeoColor&lg=true&t=2021-08-30-T08%3A40%3A00Z)
5. Use the dev tools to change the screen size to a width of just less than 970px
6. Confirm that the animate button still appears at the bottom of the page

@nasa-gibs/worldview
