### PR TITLE
Firefox + EIC Imagery Fix 

### DIFF
--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { containsExtent, isEmpty } from 'ol/extent';
+import lodashCloneDeep from 'lodash/cloneDeep';
 import * as olProj from 'ol/proj';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -24,7 +25,7 @@ function Input({
   const update = () => {
     try {
       const newInputValue = Number(inputValue);
-      const clonedBBoxArray = structuredClone(boundingBoxArray);
+      const clonedBBoxArray = lodashCloneDeep(boundingBoxArray);
       clonedBBoxArray[index] = newInputValue;
       const minX = Math.min(clonedBBoxArray[0], clonedBBoxArray[2]);
       const minY = Math.min(clonedBBoxArray[1], clonedBBoxArray[3]);

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -19,6 +19,7 @@ import Static from 'ol/source/ImageStatic';
 import lodashMerge from 'lodash/merge';
 import lodashEach from 'lodash/each';
 import lodashGet from 'lodash/get';
+import lodashCloneDeep from 'lodash/cloneDeep';
 import util from '../util/util';
 import lookupFactory from '../ol/lookupimagetile';
 import granuleLayerBuilder from './granule/granule-layer-builder';
@@ -828,7 +829,7 @@ export default function mapLayerBuilder(config, cache, store) {
         nextDate,
         previousDate,
       };
-      def = structuredClone(def);
+      def = lodashCloneDeep(def);
       lodashMerge(def, projections[proj.id]);
       if (breakPointLayer) def = mergeBreakpointLayerAttributes(def, proj.id);
       const isDataDownloadTabActive = activeTab === 'download';


### PR DESCRIPTION
Users using older versions of Firefox and EIC were experiencing a bug where imagery was not loading. This was due to the use of `structuredClone` in the layerBuilder.js file. This was fixed by reverting back to using the lodash library. 