### PR TITLE
UAT v4.14.0-1 to Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worldview",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "worldview",
-      "version": "4.13.0",
+      "version": "4.14.0",
       "hasInstallScript": true,
       "license": "NASA-1.3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",


### PR DESCRIPTION
UAT v4.14.0-1 to Release

The previous push to release for v4.14.0 did not captures the updates to the package.json