### PR TITLE
WV-2844: Autoplay Animations 

### DIFF
--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -119,7 +119,7 @@ function AnimationWidget (props) {
       setWidgetPosition({ x: 10, y: 0 });
       toggleCollapse();
     }
-    if (!isPlaying && autoplay && !isKioskModeActive) {
+    if (!isPlaying && autoplay) {
       onPushPlay();
       toggleAutoplay();
     }

--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -35,7 +35,6 @@ import {
   changeEndDate,
   changeStartAndEndDate,
   toggleAnimationCollapse,
-  toggleAnimationAutoplay,
 } from '../../modules/animation/actions';
 import usePrevious from '../../util/customHooks';
 import DesktopAnimationWidget from './desktop-animation-widget';
@@ -76,7 +75,6 @@ function AnimationWidget (props) {
     onPushPause,
     onPushPlay,
     onSlide,
-    onToggleAnimationAutoplay,
     onToggleAnimationCollapse,
     onUpdateEndDate,
     onUpdateStartDate,
@@ -109,10 +107,6 @@ function AnimationWidget (props) {
     onToggleAnimationCollapse();
   };
 
-  const toggleAutoplay = () => {
-    onToggleAnimationAutoplay();
-  };
-
   // component did mount
   useEffect(() => {
     if (isEmbedModeActive) {
@@ -121,7 +115,6 @@ function AnimationWidget (props) {
     }
     if (!isPlaying && autoplay) {
       onPushPlay();
-      toggleAutoplay();
     }
   }, []);
 
@@ -313,6 +306,7 @@ function AnimationWidget (props) {
         : (
           <DesktopAnimationWidget
             animationCustomModalOpen={animationCustomModalOpen}
+            autoplay={autoplay}
             customModalType={customModalType}
             isDistractionFreeModeActive={isDistractionFreeModeActive}
             endDate={endDate}
@@ -517,9 +511,6 @@ const mapDispatchToProps = (dispatch) => ({
   onToggleAnimationCollapse: () => {
     dispatch(toggleAnimationCollapse());
   },
-  onToggleAnimationAutoplay: () => {
-    dispatch(toggleAnimationAutoplay());
-  },
 });
 
 AnimationWidget.propTypes = {
@@ -551,7 +542,6 @@ AnimationWidget.propTypes = {
   minDate: PropTypes.object,
   numberOfFrames: PropTypes.number,
   onToggleAnimationCollapse: PropTypes.func,
-  onToggleAnimationAutoplay: PropTypes.func,
   onClose: PropTypes.func,
   onPushLoop: PropTypes.func,
   onPushPause: PropTypes.func,

--- a/web/js/containers/animation-widget/desktop-animation-widget.js
+++ b/web/js/containers/animation-widget/desktop-animation-widget.js
@@ -12,11 +12,13 @@ import CustomIntervalSelector from '../../components/timeline/custom-interval-se
 function DesktopAnimationWidget(props) {
   const {
     animationCustomModalOpen,
+    autoplay,
     customModalType,
     endDate,
     handleDragStart,
     hasSubdailyLayers,
     interval,
+    isDistractionFreeModeActive,
     isPlaying,
     looping,
     maxDate,
@@ -47,6 +49,8 @@ function DesktopAnimationWidget(props) {
     onSlide(speed);
   };
 
+  const hideWidget = autoplay || isDistractionFreeModeActive ? 'd-none' : '';
+
   return (
     <Draggable
       bounds="body"
@@ -56,7 +60,7 @@ function DesktopAnimationWidget(props) {
       onDrag={onExpandedDrag}
       onStart={handleDragStart}
     >
-      <div className="wv-animation-widget-wrapper">
+      <div className={`wv-animation-widget-wrapper ${hideWidget}`}>
         <div
           id="wv-animation-widget"
           className={`wv-animation-widget${subDailyMode ? ' subdaily' : ''}`}
@@ -101,7 +105,6 @@ function DesktopAnimationWidget(props) {
               />
             </div>
             <span className="wv-slider-label mt-1">
-
               {speed}
               {' '}
               {sliderLabel}
@@ -122,7 +125,6 @@ function DesktopAnimationWidget(props) {
             subDailyMode={subDailyMode}
             isDisabled={isPlaying}
           />
-
           <FontAwesomeIcon icon="chevron-down" className="wv-minimize" onClick={toggleCollapse} />
           <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} />
         </div>
@@ -133,11 +135,13 @@ function DesktopAnimationWidget(props) {
 
 DesktopAnimationWidget.propTypes = {
   animationCustomModalOpen: PropTypes.bool,
+  autoplay: PropTypes.bool,
   customModalType: PropTypes.object,
   endDate: PropTypes.object,
   handleDragStart: PropTypes.func,
   hasSubdailyLayers: PropTypes.bool,
   interval: PropTypes.string,
+  isDistractionFreeModeActive: PropTypes.bool,
   isPlaying: PropTypes.bool,
   looping: PropTypes.bool,
   maxDate: PropTypes.object,


### PR DESCRIPTION
## Description

Add the ability to autoplay animations when included as a permalink parameter. 

To autoplay animations open the animations widget and configure an animation, then add the `aa=true` parameter to a permalink. This can be used with distraction free mode and kiosk mode as well. In both kiosk mode and distraction free mode, the animation widget will be hidden during an autoplay. 

## How To Test

1. `git checkout wv-2844`
2. `npm ci`
3. `npm run watch`
4. Use this [link](http://localhost:3000/?v=-133.6865143897777,-1.883687133234421,-11.986559735470792,52.465901787422695&z=4&i=4&ics=true&ici=4&icd=1&as=2023-08-30-T06%3A00%3A00Z&ae=2023-08-31-T04%3A00%3A00Z&df=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GOES-East_ABI_GeoColor,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&al=true&ab=on&aa=true) to autoplay an animation in distraction free mode. 
5. Use this [link](http://localhost:3000/?v=-133.6865143897777,-1.883687133234421,-11.986559735470792,52.465901787422695&z=4&i=4&ics=true&ici=4&icd=1&as=2023-08-30-T06%3A00%3A00Z&ae=2023-08-31-T04%3A00%3A00Z&df=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GOES-East_ABI_GeoColor,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&al=true&ab=on&aa=true&kiosk=true) to autoplay an animation in kiosk & distraction free mode. Note* kiosk mode will hide the buffering bar so it may seem like the animation is not playing at first. 

@nasa-gibs/worldview
