### PR TITLE
WV-2845 double encoded bandCombo

### DIFF
--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -843,7 +843,7 @@ export function serializeLayers(layers, state, groupName) {
       const bandComboString = JSON.stringify(def.bandCombo).replaceAll('(', '<').replaceAll(')', '>');
       item.attributes.push({
         id: 'bandCombo',
-        value: encodeURIComponent(bandComboString),
+        value: bandComboString,
       });
     }
     if (def.palette && (def.custom || def.min || def.max || def.squash || def.disabled)) {


### PR DESCRIPTION
## Description

> With the band math/expressions in the latest release, the HLS DDV layers now have very long URL parameter for the bandCombo, for example, this should just be Coastlines and HLS_False_Color_Sentinel Bands 8,4,3, but it's very long now, and possibly double encoded.

## How To Test

1. `git checkout WV-2845-double-encoded`
2. `npm run ci && npm run build`
3. `npm run watch`
4. Go to this [link](http://localhost:3000/?l=Coastlines_15m,HLS_False_Color_Sentinel(bandCombo=%7B%22r%22%3A%22B08%22,%22g%22%3A%22B04%22,%22b%22%3A%22B03%22%7D)&lg=true&t=2023-09-07-T15%3A18%3A17Z)
5. The bandCombo in the address bar should be fairly short and only encoded once.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
