### PR TITLE
wv-2863: Do not show tour window on mobile devices

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -143,7 +143,7 @@ class App extends React.Component {
         <div id="wv-alert-container" className="wv-alert-container">
           <FeatureAlert />
           <Alerts />
-          {!isMobile && isTourActive ? <Tour /> : null}
+          {(!isMobile && isTourActive) || (isEmbedModeActive && isTourActive) ? <Tour /> : null}
         </div>
         <Sidebar />
         <div id="layer-modal" className="layer-modal" />

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -143,7 +143,7 @@ class App extends React.Component {
         <div id="wv-alert-container" className="wv-alert-container">
           <FeatureAlert />
           <Alerts />
-          {isTourActive ? <Tour /> : null}
+          {!isMobile && isTourActive ? <Tour /> : null}
         </div>
         <Sidebar />
         <div id="layer-modal" className="layer-modal" />


### PR DESCRIPTION
## Description
When you load Worldview (develop branch), the tour stories/Welcome to Worldview window opens when it should be disabled on mobile. This happens whether I open Worldview as PWA, or in the regular browser (tested on Safari and Firefox). You can even launch the tours when you should not be able to.

Fixes # wv-2863

## How To Recreate

- git checkout develop
- npm ci
- npm run watch
- Open a browser window & set it to a mobile view (ie. iPhone SE)
- Open [http://localhost:3000/](http://localhost:3000/) (you may need to clear cookies or load a private window)
- Confirm the tour stories window shows even though you are on mobile

## How To Test
- git checkout wv-2863-mobile-tour
- npm ci
- npm run watch
- Open a browser window & set it to a mobile view (ie. iPhone SE)
- Open [http://localhost:3000/](http://localhost:3000/) (you may need to clear cookies or load a private window)
- Confirm the tour stories window is not displayed

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
