### PR TITLE
WV-2857 Additional Properties GITC

### DIFF
--- a/tasks/build-options/validateConfigs.js
+++ b/tasks/build-options/validateConfigs.js
@@ -40,22 +40,21 @@ const { inputDirectory, schemaFile } = argv
 const schemaRaw = fs.readFileSync(schemaFile)
 const schema = JSON.parse(schemaRaw)
 // check if build is gitc
-const gitcEnv = process.env.CONFIG_ENV && process.env.CONFIG_ENV.includes("gitc")
+const gitcEnv = process.env.CONFIG_ENV && process.env.CONFIG_ENV.includes('gitc')
 // setting the additionalProperties to true for gitc builds
 if (gitcEnv) {
-  schema.definitions.layer.additionalProperties = true;
+  schema.definitions.layer.additionalProperties = true
 }
 const validate = ajv.compile(schema)
 
-layerConfigFiles = []
-invalidJsonFiles = []
+const invalidJsonFiles = []
 
 console.warn(`${prog}: Validating layer configs...`)
 
 async function main () {
   let files = globSync(inputDirectory + '/**/*')
   files = files.filter(file => file.endsWith('.json'))
-  for (filePath of files) {
+  for (const filePath of files) {
     validateFile(filePath)
   }
   if (invalidJsonFiles.length) {
@@ -72,7 +71,7 @@ async function validateFile (filePath) {
   const layer = JSON.parse(layerFile)
   const valid = validate(layer)
   if (!valid) {
-    for (error of validate.errors) {
+    for (const error of validate.errors) {
       invalidJsonFiles.push(error)
       console.error(`${prog}: ERROR: ${error.instancePath} ${error.message}`)
       // TOD: Add verbose mode with the full error:

--- a/tasks/build-options/validateConfigs.js
+++ b/tasks/build-options/validateConfigs.js
@@ -74,8 +74,6 @@ async function validateFile (filePath) {
     for (const error of validate.errors) {
       invalidJsonFiles.push(error)
       console.error(`${prog}: ERROR: ${error.instancePath} ${error.message}`)
-      // TOD: Add verbose mode with the full error:
-      // console.error(error)
     }
   }
 }

--- a/tasks/build-options/validateConfigs.js
+++ b/tasks/build-options/validateConfigs.js
@@ -39,16 +39,23 @@ const { inputDirectory, schemaFile } = argv
 
 const schemaRaw = fs.readFileSync(schemaFile)
 const schema = JSON.parse(schemaRaw)
+// check if build is gitc
+const gitcEnv = process.env.CONFIG_ENV && process.env.CONFIG_ENV.includes("gitc")
+// setting the additionalProperties to true for gitc builds
+if (gitcEnv) {
+  schema.definitions.layer.additionalProperties = true;
+}
 const validate = ajv.compile(schema)
 
-const invalidJsonFiles = []
+layerConfigFiles = []
+invalidJsonFiles = []
 
 console.warn(`${prog}: Validating layer configs...`)
 
 async function main () {
   let files = globSync(inputDirectory + '/**/*')
   files = files.filter(file => file.endsWith('.json'))
-  for (const filePath of files) {
+  for (filePath of files) {
     validateFile(filePath)
   }
   if (invalidJsonFiles.length) {
@@ -65,10 +72,11 @@ async function validateFile (filePath) {
   const layer = JSON.parse(layerFile)
   const valid = validate(layer)
   if (!valid) {
-    for (const error of validate.errors) {
+    for (error of validate.errors) {
       invalidJsonFiles.push(error)
       console.error(`${prog}: ERROR: ${error.instancePath} ${error.message}`)
-      if (argv.mode === 'verbose') console.error(error)
+      // TOD: Add verbose mode with the full error:
+      // console.error(error)
     }
   }
 }


### PR DESCRIPTION
## Description

Updates the validateConfigs build file to set the `additionalProperties` property to true for GITC builds.

## How To Test

1. `git checkout wv-2857-additional-properties-gitc`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Verify that WV still built correctly.

@nasa-gibs/worldview
