### PR TITLE
Update preset-options.js HLS False Color (Urban)

### DIFF
--- a/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
+++ b/web/js/components/layer/settings/band-selection/menu-components/preset-options.js
@@ -91,7 +91,7 @@ const sentinelPresets = [
     title: 'False Color (Urban)',
     r: 'B12',
     g: 'B11',
-    b: 'B4',
+    b: 'B04',
     img: 'HLS_False_Color_Urban_Sentinel.jpg',
   },
   {


### PR DESCRIPTION
## Description

Sentinel HLS False Color (Urban) was missing a 0, so it wasn't loading the imagery for the HLS Customizable layer. This is to add the 0 back in for Band 04.

@nasa-gibs/worldview
