### PR TITLE
Add acknowledgement for geocoding service

### DIFF
--- a/config/default/common/brand/about/acknowledgements.md
+++ b/config/default/common/brand/about/acknowledgements.md
@@ -110,7 +110,7 @@
                                         Good Colour Maps: How to Design Them</a></li>
                 </ul>
         </li>
-        <li>Location Search feature uses the <a href="https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm" target="_blank" rel="noopener noreferroer">ArcGIS Geocoding service</a>.</li>
+        <li>Location Search feature uses the <a href="https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm" target="_blank" rel="noopener noreferrer">ArcGIS Geocoding service</a>.</li>
         <li>The imagery ingest and serving system (GIBS) is built by NASA/JPL and operated by NASA/GSFC.</li>
         <li>Worldview is built by the NASA/GSFC <a href="https://earthdata.nasa.gov/esdis" target="_blank"
                         rel="noopener noreferrer">Earth Science Data and Information System (ESDIS) Project</a>. We are

--- a/config/default/common/brand/about/acknowledgements.md
+++ b/config/default/common/brand/about/acknowledgements.md
@@ -110,6 +110,7 @@
                                         Good Colour Maps: How to Design Them</a></li>
                 </ul>
         </li>
+        <li>Location Search feature uses the <a href="https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm" target="_blank" rel="noopener noreferroer">ArcGIS Geocoding service</a>.</li>
         <li>The imagery ingest and serving system (GIBS) is built by NASA/JPL and operated by NASA/GSFC.</li>
         <li>Worldview is built by the NASA/GSFC <a href="https://earthdata.nasa.gov/esdis" target="_blank"
                         rel="noopener noreferrer">Earth Science Data and Information System (ESDIS) Project</a>. We are


### PR DESCRIPTION
## Description

Fixes WV-2877

Add acknowledgement for geocoding service to the about page.

## How To Test
1. `git checkout wv-2877-add-esri-acknowledgement`
2. `npm run build && npm start`
3. Open Worldview, click on the "i" button in the upper right corner, and navigate to "About"
4. Scroll down nearly to the bottom of the page and verify that "Location Search feature uses the ArcGIS geocoding service" is listed and that the link works.


@nasa-gibs/worldview
