### PR TITLE
WV-2875 hydrate and dehydrate bandCombo objects

### DIFF
--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -43,13 +43,17 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
   def.disabled = spec.disabled || undefined;
   def.count = spec.count || undefined;
 
-  if (spec.bandCombo) {
+  if (Array.isArray(spec.bandCombo)) {
     def.bandCombo = {
       r: spec.bandCombo[0],
       g: spec.bandCombo[1],
       b: spec.bandCombo[2],
     };
-  } else if (bandComboParam) {
+  } else if (spec.bandCombo) {
+    def.bandCombo = spec.bandCombo;
+  }
+
+  if (bandComboParam) {
     def.bandCombo = bandComboParam;
   }
 

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -840,7 +840,7 @@ export function serializeLayers(layers, state, groupName) {
       });
     }
     if (def.bandCombo) {
-      const bandComboString = JSON.stringify(def.bandCombo).replaceAll('(', '<').replaceAll(')', '>');
+      const bandComboString = JSON.stringify(def.bandCombo).replaceAll('(', '<').replaceAll(')', '>').replaceAll(',', ';');
       item.attributes.push({
         id: 'bandCombo',
         value: bandComboString,
@@ -981,6 +981,11 @@ const getLayerSpec = (attributes) => {
     if (attr.id === 'bands') {
       const values = util.toArray(attr.value.split(';'));
       bandCombo = values;
+    }
+
+    if (attr.id === 'bandCombo') {
+      const formattedString = attr.value.replaceAll(';', ',').replaceAll('<', '(').replaceAll('>', ')');
+      bandCombo = JSON.parse(formattedString);
     }
 
     if (attr.id === 'palette') {


### PR DESCRIPTION
## Description

>If you change the band combinations for a customizable HLS layer, the new band combination should be retained in the URL, so that when you copy the URL, you will get the same new band combination. It currently appears to load the default band combination instead of the newly set combination.

## How To Test

1. `git checkout WV-2875-rehydrate-custom-hls`
2. `npm ci && npm run watch`
3. open this [link](http://localhost:3000/?v=-98.38051930362946,34.406160096287906,-98.14321461612946,34.54280255234259&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,HLS_Customizable_Landsat(bandCombo=%7B%22assets%22%3A%5B%22B05%22;%22B04%22%5D;%22expression%22%3A%22%3CB05-B04%3E%2F%3CB05%2BB04%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22greens%22%7D),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-09-03-T04%3A08%3A07Z)
4. verify that the layer loads with the NDVI band expression
5. change the band combo/expression
6. reload the page and verify that your changes persist

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
