### PR TITLE
WV-2562: Filter GITC Relevant Headers

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -119,16 +119,19 @@ export default function mapLayerBuilder(config, cache, store) {
 
     const updateCollections = (headers) => {
       const actualId = headers.get('layer-identifier-actual');
+
       if (!actualId) return;
 
+      const parts = actualId.split('_');
+      const type = parts[parts.length - 1];
+      const version = parts[parts.length - 2];
+
+      if (type !== 'NRT' && type !== 'STD') return;
+
       const { layers } = state;
-      const collectionCheck = getCollections(layers, date, layer);
       // check if the collection & dates already exist for layer so we don't dispatch actions
-      if (!collectionCheck) {
+      if (!getCollections(layers, date, layer)) {
         updateStoreCollections(layer.id);
-        const parts = actualId.split('_');
-        const version = parts[parts.length - 2];
-        const type = parts[parts.length - 1];
         updateStoreCollectionDates(layer.id, version, type, date);
       }
     };


### PR DESCRIPTION
## Description

Currently we are pulling in some irrelevant headers in the layer sidebar for some specific layers. An example of this is the `Ground Elevation Standard Deviation (L3, v2, 2019 APR - 2022 JAN)` layer which pulls in a header of `Mode 201904`. We only want to show headers relevant to the NRT or STD version types. This adds a filter to the layerBuilder file to only include the relevant headers.

## Testing

1. `git checkout wv-2562`
2. `npm run watch`
3. Open a local instance of WV with this [link](http://localhost:3000/?l=VIIRS_SNPP_DayNightBand_At_Sensor_Radiance,GEDI_ISS_L3_Elevation_StdDev_Lowest_Mode_201904-202201&lg=true&t=2023-07-05-T14%3A14%3A14Z)
4. Ensure that the `Black Marble Nighttime at Sensor Radiance (Day/Night Band)` layers has the header of `v1.0 NRT` and ensure that the layer `Ground Elevation Standard Deviation (L3, v2, 2019 APR - 2022 JAN)` has no header. 

@nasa-gibs/worldview
