### PR TITLE
WV-2829 outage adjustments

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -70,7 +70,7 @@ class App extends React.Component {
     const { numberOutagesUnseen, object } = this.props;
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
       if (numberOutagesUnseen > 0) {
-        this.openNotification(object, numberOutagesUnseen);
+        this.openNotification(object.outages, numberOutagesUnseen);
       }
     }
   }
@@ -215,10 +215,14 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setScreenInfo());
   },
   notificationClick: (obj, numberOutagesUnseen) => {
+    Notifications.alerts = {};
+    Notifications.layernotices = {};
+    Notifications.messages = {};
     dispatch(
       openCustomContent('NOTIFICATION_LIST_MODAL', {
         headerText: 'Notifications',
         bodyComponent: Notifications,
+        source: 'outage-alert',
         onClose: () => {
           if (numberOutagesUnseen > 0) {
             dispatch(outageNotificationsSeenAction());

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -67,9 +67,9 @@ class App extends React.Component {
 
   componentDidUpdate(prevProps) {
     // Check if the numberUnseen prop has changed
-    const { eicModeEnabled, numberOutagesUnseen, object } = this.props;
+    const { kioskModeEnabled, numberOutagesUnseen, object } = this.props;
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
-      if (numberOutagesUnseen > 0 && !eicModeEnabled) {
+      if (numberOutagesUnseen > 0 && !kioskModeEnabled) {
         this.openNotification(object.outages, numberOutagesUnseen);
       }
     }
@@ -190,10 +190,10 @@ function mapStateToProps(state) {
   const {
     numberOutagesUnseen, numberUnseen, type, object,
   } = notifications;
-  const eicModeEnabled = state.ui.eic !== null && state.ui.eic !== '';
+  const kioskModeEnabled = (state.ui.eic !== null && state.ui.eic !== '') || state.ui.isKioskModeActive;
   return {
     state,
-    eicModeEnabled,
+    kioskModeEnabled,
     isAnimationWidgetActive: state.animation.isActive,
     isEmbedModeActive: state.embed.isEmbedModeActive,
     isMobile: state.screenSize.isMobileDevice,
@@ -239,7 +239,7 @@ export default connect(
 
 App.propTypes = {
   isAnimationWidgetActive: PropTypes.bool,
-  eicModeEnabled: PropTypes.bool,
+  kioskModeEnabled: PropTypes.bool,
   isEmbedModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   isTourActive: PropTypes.bool,

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -217,9 +217,6 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setScreenInfo());
   },
   notificationClick: (obj, numberOutagesUnseen) => {
-    Notifications.alerts = {};
-    Notifications.layernotices = {};
-    Notifications.messages = {};
     dispatch(
       openCustomContent('NOTIFICATION_LIST_MODAL', {
         headerText: 'Notifications',

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -67,9 +67,9 @@ class App extends React.Component {
 
   componentDidUpdate(prevProps) {
     // Check if the numberUnseen prop has changed
-    const { numberOutagesUnseen, object } = this.props;
+    const { eicModeEnabled, numberOutagesUnseen, object } = this.props;
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
-      if (numberOutagesUnseen > 0) {
+      if (numberOutagesUnseen > 0 && !eicModeEnabled) {
         this.openNotification(object.outages, numberOutagesUnseen);
       }
     }
@@ -190,8 +190,10 @@ function mapStateToProps(state) {
   const {
     numberOutagesUnseen, numberUnseen, type, object,
   } = notifications;
+  const eicModeEnabled = state.ui.eic !== null && state.ui.eic !== '';
   return {
     state,
+    eicModeEnabled,
     isAnimationWidgetActive: state.animation.isActive,
     isEmbedModeActive: state.embed.isEmbedModeActive,
     isMobile: state.screenSize.isMobileDevice,
@@ -240,6 +242,7 @@ export default connect(
 
 App.propTypes = {
   isAnimationWidgetActive: PropTypes.bool,
+  eicModeEnabled: PropTypes.bool,
   isEmbedModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   isTourActive: PropTypes.bool,

--- a/web/js/containers/notifications.js
+++ b/web/js/containers/notifications.js
@@ -5,12 +5,12 @@ import NotificationBlock from '../components/notifications/notification-block';
 import { getNumberOfTypeNotSeen } from '../modules/notifications/util';
 
 function Notifications(props) {
-  const { eicModeEnabled, numberOutagesUnseen, object } = props;
+  const { kioskModeEnabled, numberOutagesUnseen, object } = props;
   const {
     messages, outages, alerts,
   } = object;
 
-  if (numberOutagesUnseen > 0 && !eicModeEnabled) {
+  if (numberOutagesUnseen > 0 && !kioskModeEnabled) {
     return (
       <div className="wv-notify-modal">
         <NotificationBlock
@@ -43,10 +43,9 @@ function Notifications(props) {
 }
 function mapStateToProps(state) {
   const { object, numberOutagesUnseen } = state.notifications;
-  const eicModeEnabled = state.ui.eic !== null && state.ui.eic !== '';
-
+  const kioskModeEnabled = (state.ui.eic !== null && state.ui.eic !== '') || state.ui.isKioskModeActive;
   return {
-    eicModeEnabled,
+    kioskModeEnabled,
     numberOutagesUnseen,
     object,
   };

--- a/web/js/containers/notifications.js
+++ b/web/js/containers/notifications.js
@@ -5,12 +5,12 @@ import NotificationBlock from '../components/notifications/notification-block';
 import { getNumberOfTypeNotSeen } from '../modules/notifications/util';
 
 function Notifications(props) {
-  const { object, numberOutagesUnseen } = props;
+  const { eicModeEnabled, numberOutagesUnseen, object } = props;
   const {
     messages, outages, alerts,
   } = object;
 
-  if (numberOutagesUnseen > 0) {
+  if (numberOutagesUnseen > 0 && !eicModeEnabled) {
     return (
       <div className="wv-notify-modal">
         <NotificationBlock
@@ -43,10 +43,12 @@ function Notifications(props) {
 }
 function mapStateToProps(state) {
   const { object, numberOutagesUnseen } = state.notifications;
+  const eicModeEnabled = state.ui.eic !== null && state.ui.eic !== '';
 
   return {
-    object,
+    eicModeEnabled,
     numberOutagesUnseen,
+    object,
   };
 }
 

--- a/web/js/containers/notifications.js
+++ b/web/js/containers/notifications.js
@@ -5,10 +5,22 @@ import NotificationBlock from '../components/notifications/notification-block';
 import { getNumberOfTypeNotSeen } from '../modules/notifications/util';
 
 function Notifications(props) {
-  const { object } = props;
+  const { object, numberOutagesUnseen } = props;
   const {
     messages, outages, alerts,
   } = object;
+
+  if (numberOutagesUnseen > 0) {
+    return (
+      <div className="wv-notify-modal">
+        <NotificationBlock
+          arr={outages}
+          type="outage"
+          numberNotSeen={getNumberOfTypeNotSeen('outage', outages)}
+        />
+      </div>
+    );
+  }
   return (
     <div className="wv-notify-modal">
       <NotificationBlock
@@ -30,10 +42,11 @@ function Notifications(props) {
   );
 }
 function mapStateToProps(state) {
-  const { object } = state.notifications;
+  const { object, numberOutagesUnseen } = state.notifications;
 
   return {
     object,
+    numberOutagesUnseen,
   };
 }
 
@@ -44,4 +57,5 @@ export default connect(
 
 Notifications.propTypes = {
   object: PropTypes.object,
+  numberOutagesUnseen: PropTypes.number,
 };


### PR DESCRIPTION
## Description
The recent Notification/Outage alert required some additional adjustments. This is now disabled when EIC mode is active & the list of events that were being notified has been reduced to strictly OUTAGES.

Fixes #wv-2829 

## How To Test
- git checkout wv-2829-outage-adjustments
- npm ci
- npm run watch

Test in normal mode with [this link](http://localhost:3000/)
- Confirm that on page load the notifications window pops up with OUTAGES listed only 
- Click Info Icon --> Notifications & confirm that all notifications are listed (not just the outages)

Test in EIC mode with [this link](http://localhost:3000/?eic=si)
- Confirm that on page load you are NOT shown any notifications
- Click Info Icon --> Notifications & confirm that all notifications are listed (not just the outages)
 
Test in KIOSK mode with [this link](http://localhost:3000/?kiosk=true)
- Confirm that on page load you are NOT shown any notifications
- Click Info Icon --> Notifications & confirm that all notifications are listed (not just the outages)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
