### PR TITLE
WV-2914: Configuring New EIC Layers

### DIFF
--- a/web/js/mapUI/components/dev-test-mode/dev-test-modal.js
+++ b/web/js/mapUI/components/dev-test-mode/dev-test-modal.js
@@ -11,7 +11,7 @@ function DevTestModal() {
     <div id="dev-block" className="d-flex flex-column justify-content-center align-items-center">
       <ConsoleTestMode />
       <PresetConsoleCommands />
-      {/* <PixelTestMode /> */}
+      <PixelTestMode />
       {/* <FindOrbitTracksTestMode /> */}
     </div>
   );

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -11,6 +11,11 @@ export const layersToMeasure = [
   'GOES-West_ABI_GeoColor',
   'Himawari_AHI_Band3_Red_Visible_1km',
   'AMSRU2_Sea_Ice_Concentration_12km',
+  'OMI_Nitrogen_Dioxide_Tropo_Column',
+  'VIIRS_SNPP_AOT_Dark_Target_Land_Ocean',
+  'VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate',
+  'AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night',
+  'AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day',
 ];
 
 // Object that contains the black pixel % threshold for each layer
@@ -27,6 +32,11 @@ export const layerPixelData = {
   'GOES-West_ABI_GeoColor': { threshold: 0.76 },
   Himawari_AHI_Band3_Red_Visible_1km: { threshold: 0.76 },
   AMSRU2_Sea_Ice_Concentration_12km: { threshold: 0.85 },
+  OMI_Nitrogen_Dioxide_Tropo_Column: { threshold: 0.50 },
+  VIIRS_SNPP_AOT_Dark_Target_Land_Ocean: { threshold: 0.95 },
+  VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate: { threshold: 0.95 },
+  AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night: { threshold: 0.20 },
+  AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day: { threshold: 0.20 },
 };
 
 // Back-up dates for each layer in case no date is found that satisfies the full imagery threshold
@@ -42,4 +52,10 @@ export const bestDates = {
   GHRSST_L4_MUR_Sea_Surface_Temperature: { date: '2023-06-10' },
   MODIS_Aqua_Land_Surface_Temp_Day: { date: '2023-06-10' },
   MODIS_Aqua_CorrectedReflectance_TrueColor: { date: '2023-06-10' },
+  OMI_Nitrogen_Dioxide_Tropo_Column: { date: '2023-10-06' },
+  VIIRS_SNPP_AOT_Dark_Target_Land_Ocean: { date: '2023-10-06' },
+  VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate: { date: '2023-10-06' },
+  AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night: { date: '2023-10-06' },
+  AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day: { date: '2023-10-06' },
+
 };

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -16,6 +16,7 @@ export const layersToMeasure = [
   'VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate',
   'AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night',
   'AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day',
+  'VIIRS_NOAA20_CorrectedReflectance_TrueColor',
 ];
 
 // Object that contains the black pixel % threshold for each layer
@@ -37,6 +38,7 @@ export const layerPixelData = {
   VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate: { threshold: 0.95 },
   AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night: { threshold: 0.20 },
   AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day: { threshold: 0.20 },
+  VIIRS_NOAA20_CorrectedReflectance_TrueColor: { threshold: 0.65 },
 };
 
 // Back-up dates for each layer in case no date is found that satisfies the full imagery threshold
@@ -57,5 +59,5 @@ export const bestDates = {
   VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate: { date: '2023-10-06' },
   AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night: { date: '2023-10-06' },
   AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day: { date: '2023-10-06' },
-
+  VIIRS_NOAA20_CorrectedReflectance_TrueColor: { date: '2023-10-06' },
 };


### PR DESCRIPTION
## Description

Configuring thresholds for new layers in EIC mode.

## How To Test

1. `git checkout wv-2914`
2. `npm run watch`

The following EIC links should initially load with partial or no imagery and move back to a date with full imagery. 

[Nitrogen Dioxide](http://localhost:3000/?v=-194.082009437024,-143.44489787215997,205.93152842215432,136.62994031845756&l=OMI_Nitrogen_Dioxide_Tropo_Column&lg=false&eic=si&kiosk=true&df=true)
[Carbon Monoxide Day](http://localhost:3000/?v=-311.9280291102433,-131.66342294154617,301.84518064288295,142.29680662013567&df=true&kiosk=true&eic=si&l=AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day&lg=false&t=2023-10-08-T16%3A00%3A00Z)
[Carbon Monoxide Night](http://localhost:3000/?v=-311.9280291102433,-131.66342294154617,301.84518064288295,142.29680662013567&df=true&kiosk=true&eic=si&l=AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night&lg=false&t=2023-10-08-T16%3A00%3A00Z)
[Aerosol Optical Depth Deep Blue](http://localhost:3000/?v=-302.79347943061003,-127.58617863141819,292.7106309632497,138.21956231000775&df=true&kiosk=true&eic=si&l=VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate&lg=true)
[Aerosol Optical Depth Dark Target](http://localhost:3000/?v=-302.79347943061003,-127.58617863141819,292.7106309632497,138.21956231000775&l=VIIRS_SNPP_AOT_Dark_Target_Land_Ocean&lg=true&eic=si&kiosk=true&df=true)

@nasa-gibs/worldview
