### PR TITLE
WV-2879: Removing Dynamic HLS layers from the "Always Available" facet

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Landsat.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Sentinel.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Sentinel.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Sentinel.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Landsat.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Sentinel.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Landsat.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Sentinel.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Landsat.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Sentinel.json
@@ -26,7 +26,8 @@
             "source": "DDV",
             "matrixSet": "31.25m"
           }
-        }
+        },
+        "startDate": "2022-01-01T00:00:00Z"
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Sentinel.json
@@ -25,7 +25,8 @@
           "source": "DDV",
           "matrixSet": "31.25m"
         }
-      }
+      },
+      "startDate": "2022-01-01T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Description

The new Dynamic HLS layers are appearing under the "Always Available" facet in the layer picker. These layers should not be listed under this facet. To fix this, a startDate was added to the DDV layer config files. 

## How To Test

1. `git checkout wv-2879`
2. `npm run build`
3. `npm ci`
4. `npm run watch`
5. Open Layer Picker Modal
6. Select "Always Available" under "Coverage"
7. Ensure that none of the DDV layers are listed

@nasa-gibs/worldview
