### PR TITLE
WV-2920 flood

### DIFF
--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -158,11 +158,12 @@ async function processEntries (colormap) {
 
       // Force alpha value to 255 always
       const a = 255
+
+      // If entry is served transparent, add it to the disabled array
       if (entry._attributes.transparent !== 'false') {
         initializeDisabled.push(refsList.length)
       }
 
-      // If entry is served transparent, add it to the disabled array
       if (!entry._attributes.ref) {
         throw new Error('No ref in legend')
       }

--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -162,6 +162,7 @@ async function processEntries (colormap) {
         initializeDisabled.push(refsList.length)
       }
 
+      // If entry is served transparent, add it to the disabled array
       if (!entry._attributes.ref) {
         throw new Error('No ref in legend')
       }

--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -114,7 +114,7 @@ async function matchLegend (entry, legends) {
   }
 }
 
-async function processEntries (colormap, id) {
+async function processEntries (colormap) {
   const entries = toList(colormap.Entries.ColorMapEntry)
   let transparentMap = 'true'
 
@@ -324,7 +324,7 @@ async function processFile (id, xml) {
     }
     const maps = []
     for (const colormap of colormaps) {
-      const result = await processEntries(colormap, id)
+      const result = await processEntries(colormap)
       if (result === 'transparent') {
         // There are no visible colors in the colormap so stop processing
         continue

--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -158,21 +158,8 @@ async function processEntries (colormap, id) {
 
       // Force alpha value to 255 always
       const a = 255
-
-      if (id === 'MODIS_Flood') {
-        console.warn('id', id)
-        console.warn(entry)
-      }
-      // If entry is served transparent, add it to the disabled array
       if (entry._attributes.transparent !== 'false') {
-        if (id === 'MODIS_Flood') {
-          console.warn('index', index)
-          console.warn('-*-*-*-*-refsList.length', refsList.length)
-
-          initializeDisabled.push(refsList.length)
-        } else {
-          initializeDisabled.push(index)
-        }
+        initializeDisabled.push(refsList.length)
       }
 
       if (!entry._attributes.ref) {
@@ -280,19 +267,9 @@ async function processEntries (colormap, id) {
       tooltips.push(...disabledTooltipsArr)
 
       const firstDisabledIndex = totalEntries - numDisabled
-      if (id === 'MODIS_Flood') {
-        console.warn('initializeDisabled before', initializeDisabled)
-        console.warn('colors', colors)
-        console.warn('legendColors', legendColors)
-        console.warn('tooltips', tooltips)
-      }
       initializeDisabled = Array.from({
         length: numDisabled
       }, (item, index) => firstDisabledIndex + index)
-
-      if (id === 'MODIS_Flood') {
-        console.warn('initializeDisabled after', initializeDisabled)
-      }
     }
   }
 

--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -114,7 +114,7 @@ async function matchLegend (entry, legends) {
   }
 }
 
-async function processEntries (colormap) {
+async function processEntries (colormap, id) {
   const entries = toList(colormap.Entries.ColorMapEntry)
   let transparentMap = 'true'
 
@@ -159,9 +159,20 @@ async function processEntries (colormap) {
       // Force alpha value to 255 always
       const a = 255
 
+      if (id === 'MODIS_Flood') {
+        console.warn('id', id)
+        console.warn(entry)
+      }
       // If entry is served transparent, add it to the disabled array
       if (entry._attributes.transparent !== 'false') {
-        initializeDisabled.push(index)
+        if (id === 'MODIS_Flood') {
+          console.warn('index', index)
+          console.warn('-*-*-*-*-refsList.length', refsList.length)
+
+          initializeDisabled.push(refsList.length)
+        } else {
+          initializeDisabled.push(index)
+        }
       }
 
       if (!entry._attributes.ref) {
@@ -269,9 +280,19 @@ async function processEntries (colormap) {
       tooltips.push(...disabledTooltipsArr)
 
       const firstDisabledIndex = totalEntries - numDisabled
+      if (id === 'MODIS_Flood') {
+        console.warn('initializeDisabled before', initializeDisabled)
+        console.warn('colors', colors)
+        console.warn('legendColors', legendColors)
+        console.warn('tooltips', tooltips)
+      }
       initializeDisabled = Array.from({
         length: numDisabled
       }, (item, index) => firstDisabledIndex + index)
+
+      if (id === 'MODIS_Flood') {
+        console.warn('initializeDisabled after', initializeDisabled)
+      }
     }
   }
 
@@ -326,7 +347,7 @@ async function processFile (id, xml) {
     }
     const maps = []
     for (const colormap of colormaps) {
-      const result = await processEntries(colormap)
+      const result = await processEntries(colormap, id)
       if (result === 'transparent') {
         // There are no visible colors in the colormap so stop processing
         continue


### PR DESCRIPTION
## Description
GIBS pushed a fix for removing "No Data" color map entry in the Flood color map, but now the incorrect colors are disabled for this layer in Worldview. For MODIS_Combined_Flood_2-Day and MODIS_Combined_Flood_3-Day layers, set the defaults so "Surface Water", "Flood' & "Insufficient Data" are enabled and "No Water" is disabled.

Fixes # wv-2920.

## How To Test

- git checkout wv-2920-flood
- npm ci
- npm run build
- Load WV locally, add MODIS_Combined_Flood_2-Day & confirm the defaults are correct.
- Load WV locally, add MODIS_Combined_Flood_3-Day & confirm the defaults are correct.
- Refer to the [wiki page listing all classification layers](https://wiki.earthdata.nasa.gov/pages/viewpage.action?pageId=319753829) & spot check that these layers load the correct defaults

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
