### PR TITLE
Added tough-cookie to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "simplebar-react": "^3.2.4",
         "stackblur": "^1.0.0",
         "supercluster": "^8.0.1",
+        "tough-cookie": "^4.1.3",
         "upng-js": "^2.1.0",
         "url-template": "^3.1.0",
         "what-input": "^5.2.12"
@@ -14603,7 +14604,6 @@
     },
     "node_modules/psl": {
       "version": "1.9.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -14653,7 +14653,6 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -15634,7 +15633,6 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/reselect": {
@@ -17370,9 +17368,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -17665,7 +17663,6 @@
     },
     "node_modules/universalify": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -17725,7 +17722,6 @@
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -28599,8 +28595,7 @@
       "version": "1.1.0"
     },
     "psl": {
-      "version": "1.9.0",
-      "dev": true
+      "version": "1.9.0"
     },
     "punycode": {
       "version": "2.3.0"
@@ -28624,8 +28619,7 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.2.0",
-      "dev": true
+      "version": "2.2.0"
     },
     "queue-microtask": {
       "version": "1.2.3"
@@ -29340,8 +29334,7 @@
       "dev": true
     },
     "requires-port": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "reselect": {
       "version": "4.1.8",
@@ -30541,8 +30534,9 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "dev": true,
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -30737,8 +30731,7 @@
       "dev": true
     },
     "universalify": {
-      "version": "0.2.0",
-      "dev": true
+      "version": "0.2.0"
     },
     "unpipe": {
       "version": "1.0.0",
@@ -30769,7 +30762,6 @@
     },
     "url-parse": {
       "version": "1.5.10",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "simplebar-react": "^3.2.4",
     "stackblur": "^1.0.0",
     "supercluster": "^8.0.1",
+    "tough-cookie": "^4.1.3",
     "upng-js": "^2.1.0",
     "url-template": "^3.1.0",
     "what-input": "^5.2.12"


### PR DESCRIPTION
## Description
The 'tough-cookie' package is failing an `npm audit`. Upgrade to version 4.1.3 or later to address the vulnerability.

Fixes # wv-2921

## How To Test
- git checkout wv-2921-tough-cookie
- npm install
- Run `npm audit` & confirm that tough-cookie is no longer a vulnerability

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
