### PR TITLE
WV-2891: Increment date button disabled incorrectly sometimes during EIC embed mode

### DIFF
--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -106,11 +106,11 @@ const checkRightArrowDisabled = (
   timelineEndDateLimit,
 ) => {
   const nextIncMoment = moment.utc(date).add(delta, timeScaleChangeUnit);
-  const nextIncrementDate = new Date(nextIncMoment.seconds(0).format());
 
-  const nextIncrementDateTime = nextIncrementDate.getTime();
-  const maxPlusDeltaDateTime = new Date(timelineEndDateLimit).getTime();
-  return nextIncrementDateTime > maxPlusDeltaDateTime;
+  const startOfDayNextIncrement = nextIncMoment.startOf('day').valueOf();
+  const startOfDayLimit = moment.utc(timelineEndDateLimit).startOf('day').valueOf();
+
+  return startOfDayNextIncrement > startOfDayLimit;
 };
 
 const checkNowButtonDisabled = (


### PR DESCRIPTION
## Description

The logic for disabling the increment date button was causing the button to be disabled incorrectly at certain times of the day in EIC embed mode. This was mostly occurring during the morning hours EST. Now, whenever the date moves back for EIC mode the button should always be enabled.  

To see this working incorrectly, refer to [live EIC embed test site](https://nasa-gibs.github.io/eic-embed-test/) sometime during EST morning hours, select the VIIRS Nighttime Black Marble scenario and if the date rolls back to the previous date, the increment date button will still be incorrectly disabled. 

## How To Test
1. `git checkout wv-2891`
2. `npm run watch`
3. Open this link to [view the VIIRS black marble EIC scenario](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&em=true&kiosk=true&eic=si&l=Coastlines_15m(opacity=0.63),VIIRS_SNPP_DayNightBand_At_Sensor_Radiance&lg=true)
4. If the date rolls back to the previous date, the increment date button should still be enabled. 

@nasa-gibs/worldview
