### PR TITLE
WV-2913: Multiple Tracks Incorrectly Highlighted Simultaneously FIX

### DIFF
--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -161,19 +161,24 @@ function EventTrack () {
     return overlayMapping;
   };
 
+  const removeTrackById = (mapArg, overlayMapping, track) => {
+    const id = track?.id;
+    if (overlayMapping[id]) {
+      overlayMapping[id].forEach((subTrack) => {
+        mapArg.removeOverlay(subTrack);
+      });
+    } else {
+      mapArg.removeOverlay(track);
+    }
+  };
+
   const removeAllTracks = (mapArg) => {
     if (!mapArg) return;
     const overlayMapping = createOverlayMapping(mapArg);
     allTrackDetailsRef.current?.forEach((trackDetail) => {
       const { pointsAndArrows } = trackDetail.newTrackDetails;
       const { track } = trackDetail.newTrackDetails;
-      if (overlayMapping[track.id]) {
-        overlayMapping[track.id].forEach((subTrack) => {
-          mapArg.removeOverlay(subTrack);
-        });
-      } else {
-        mapArg.removeOverlay(track);
-      }
+      removeTrackById(mapArg, overlayMapping, track);
       removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
     });
   };
@@ -182,13 +187,7 @@ function EventTrack () {
     if (!mapArg) return;
     const overlayMapping = createOverlayMapping(mapArg);
     const { track, pointsAndArrows } = trackDetailsRef.current;
-    if (overlayMapping[track?.id]) {
-      overlayMapping[track.id].forEach((subTrack) => {
-        mapArg.removeOverlay(subTrack);
-      });
-    } else {
-      mapArg.removeOverlay(track);
-    }
+    removeTrackById(mapArg, overlayMapping, track);
     removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
 
     return {};

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -143,12 +143,17 @@ function EventTrack () {
     showAllTracksRef.current = showAllTracks;
   }, [showAllTracks]);
 
-  const removeAllTracks = (mapArg) => {
+  const createOverlayMapping = (mapArg) => {
     const overlayMapping = {};
-    mapArg?.getOverlays().forEach((overlay) => {
+    mapArg.getOverlays().forEach((overlay) => {
       overlayMapping[overlay.getId()] = overlay;
     });
+    return overlayMapping;
+  };
 
+  const removeAllTracks = (mapArg) => {
+    if (!mapArg) return;
+    const overlayMapping = createOverlayMapping(mapArg);
     allTrackDetailsRef.current?.forEach((trackDetail) => {
       const { pointsAndArrows } = trackDetail.newTrackDetails;
       const { track } = trackDetail.newTrackDetails;
@@ -159,9 +164,10 @@ function EventTrack () {
 
   const removeTrack = (mapArg) => {
     if (!mapArg) return;
+    const overlayMapping = createOverlayMapping(mapArg);
     const { track, pointsAndArrows } = trackDetailsRef.current;
-    mapArg.removeOverlay(track);
-    removePointOverlays(mapArg, pointsAndArrows);
+    mapArg.removeOverlay(overlayMapping[track?.id] || track);
+    removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
 
     return {};
   };
@@ -331,7 +337,7 @@ function EventTrack () {
         if (prevMap) {
           update(null);
           removeTrack(prevMap);
-          removePointOverlays(prevMap, trackDetailsRef.current.pointsAndArrows);
+          removePointOverlays(prevMap, trackDetailsRef.current.pointsAndArrows, createOverlayMapping(prevMap));
           if (showAllTracksRef.current) {
             removeAllTracks(prevMap);
           }

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -26,7 +26,13 @@ import {
 const removePointOverlays = (map, pointsAndArrows, overlayMapping) => {
   lodashEach(pointsAndArrows, (pointOverlay) => {
     if (map.getOverlayById(pointOverlay.getId())) {
-      map.removeOverlay(overlayMapping[pointOverlay.getId()] || pointsAndArrows);
+      if (overlayMapping[pointOverlay.getId()]) {
+        overlayMapping[pointOverlay.getId()].forEach((subPointsAndArrows) => {
+          map.removeOverlay(subPointsAndArrows);
+        });
+      } else {
+        map.removeOverlay(pointsAndArrows);
+      }
     }
   });
 };
@@ -146,7 +152,11 @@ function EventTrack () {
   const createOverlayMapping = (mapArg) => {
     const overlayMapping = {};
     mapArg.getOverlays().forEach((overlay) => {
-      overlayMapping[overlay.getId()] = overlay;
+      if (!overlay.getId()) return;
+      if (!overlayMapping[overlay.getId()]) {
+        overlayMapping[overlay.getId()] = [];
+      }
+      overlayMapping[overlay.getId()].push(overlay);
     });
     return overlayMapping;
   };
@@ -157,7 +167,13 @@ function EventTrack () {
     allTrackDetailsRef.current?.forEach((trackDetail) => {
       const { pointsAndArrows } = trackDetail.newTrackDetails;
       const { track } = trackDetail.newTrackDetails;
-      mapArg.removeOverlay(overlayMapping[track.id] || track);
+      if (overlayMapping[track.id]) {
+        overlayMapping[track.id].forEach((subTrack) => {
+          mapArg.removeOverlay(subTrack);
+        });
+      } else {
+        mapArg.removeOverlay(track);
+      }
       removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
     });
   };
@@ -166,7 +182,13 @@ function EventTrack () {
     if (!mapArg) return;
     const overlayMapping = createOverlayMapping(mapArg);
     const { track, pointsAndArrows } = trackDetailsRef.current;
-    mapArg.removeOverlay(overlayMapping[track?.id] || track);
+    if (overlayMapping[track?.id]) {
+      overlayMapping[track.id].forEach((subTrack) => {
+        mapArg.removeOverlay(subTrack);
+      });
+    } else {
+      mapArg.removeOverlay(track);
+    }
     removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
 
     return {};

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -23,10 +23,10 @@ import {
   getTrackLines, getTrackPoint, getArrows, getClusterPointEl,
 } from './util';
 
-const removePointOverlays = (map, pointsAndArrows) => {
+const removePointOverlays = (map, pointsAndArrows, overlayMapping) => {
   lodashEach(pointsAndArrows, (pointOverlay) => {
     if (map.getOverlayById(pointOverlay.getId())) {
-      map.removeOverlay(pointOverlay);
+      map.removeOverlay(overlayMapping[pointOverlay.getId()]);
     }
   });
 };
@@ -144,11 +144,16 @@ function EventTrack () {
   }, [showAllTracks]);
 
   const removeAllTracks = (mapArg) => {
+    const overlayMapping = {};
+    mapArg.getOverlays().forEach((overlay) => {
+      overlayMapping[overlay.getId()] = overlay;
+    });
+
     allTrackDetailsRef.current?.forEach((trackDetail) => {
       const { pointsAndArrows } = trackDetail.newTrackDetails;
       const { track } = trackDetail.newTrackDetails;
-      mapArg.removeOverlay(track);
-      removePointOverlays(mapArg, pointsAndArrows);
+      mapArg.removeOverlay(overlayMapping[track.id]);
+      removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
     });
   };
 

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -26,7 +26,7 @@ import {
 const removePointOverlays = (map, pointsAndArrows, overlayMapping) => {
   lodashEach(pointsAndArrows, (pointOverlay) => {
     if (map.getOverlayById(pointOverlay.getId())) {
-      map.removeOverlay(overlayMapping[pointOverlay.getId()]);
+      map.removeOverlay(overlayMapping[pointOverlay.getId()] || pointsAndArrows);
     }
   });
 };
@@ -145,14 +145,14 @@ function EventTrack () {
 
   const removeAllTracks = (mapArg) => {
     const overlayMapping = {};
-    mapArg.getOverlays().forEach((overlay) => {
+    mapArg?.getOverlays().forEach((overlay) => {
       overlayMapping[overlay.getId()] = overlay;
     });
 
     allTrackDetailsRef.current?.forEach((trackDetail) => {
       const { pointsAndArrows } = trackDetail.newTrackDetails;
       const { track } = trackDetail.newTrackDetails;
-      mapArg.removeOverlay(overlayMapping[track.id]);
+      mapArg.removeOverlay(overlayMapping[track.id] || track);
       removePointOverlays(mapArg, pointsAndArrows, overlayMapping);
     });
   };

--- a/web/js/map/natural-events/event-track.js
+++ b/web/js/map/natural-events/event-track.js
@@ -160,7 +160,7 @@ function EventTrack () {
     });
     return overlayMapping;
   };
-  
+
   const removeTrackById = (mapArg, overlayMapping, track) => {
     const id = track?.id;
     if (overlayMapping[id]) {
@@ -171,7 +171,7 @@ function EventTrack () {
       mapArg.removeOverlay(track);
     }
   };
-  
+
   const removeAllTracks = (mapArg) => {
     if (!mapArg) return;
     const overlayMapping = createOverlayMapping(mapArg);

--- a/web/js/map/natural-events/util.js
+++ b/web/js/map/natural-events/util.js
@@ -219,7 +219,7 @@ export const getTrackLines = function(map, trackCoords, eventID, date, callback,
     insertFirst: true,
     stopEvent: false,
     element: svgEl,
-    id: 'event-track',
+    id: `event-track-${eventID}`,
   });
 };
 


### PR DESCRIPTION
## Description
This fix makes it so multiple event tracks can't be highlighted at the same time incorrectly. This prevents tracks from being stuck 'on' or highlighted after mousing over other tracks.

## How To Test
1. `git checkout wv-2913-highlight-tracks`
2. `npm ci`
3. `npm run watch`
4. Open the Events tab in the sidebar, then click the filter icon to open the Filter Events window. Enable the option for "Show tracks for all events", then click the Apply button to apply the changes.
5. Hover over an event track and verify that the track becomes highlighted (change in line color, line thickness, arrow size, appears above other track lines).
6. Attempt to quickly hover over multiple event tracks by quickly moving your cursor back and forth between multiple tracks, and confirm that no track ever becomes permanently 'stuck' highlighted.
7. Ensure that the event tracks or arrows have correct behavior in other cases as well, by zooming in and out, selecting and unselecting events, and switching to and from the Events tab.