### PR TITLE
WV-2912 notification

### DIFF
--- a/e2e/features/notifications/notify-test.spec.js
+++ b/e2e/features/notifications/notify-test.spec.js
@@ -20,7 +20,7 @@ test.beforeAll(async ({ browser }) => {
   selectors = createSelectors(page)
   infoButtonIcon = page.locator('#wv-info-button svg.svg-inline--fa')
   infoMenu = page.locator('#toolbar_info')
-  notificationsListItem = page.locator('#notifications_info_item .fa-circle-exclamation')
+  notificationsListItem = page.locator('#notifications_info_item')
   tooltipSelector = page.locator('.tooltip-inner div')
 })
 
@@ -39,30 +39,21 @@ test('No visible notifications with mockAlert parameter set to no_types', async 
   await expect(boltListItem).not.toBeVisible()
 })
 
-test('Outage takes precedence when all three notifications are present', async () => {
+test('Verify that layer notices don\'t show up in the notification list or contribute to the count', async () => {
   const { modalCloseButton } = selectors
   const url = `${layerNoticesQuery}&mockAlerts=all_types`
-  const statusOutage = await page.locator('#wv-info-button.wv-status-outage')
   await page.goto(url)
   await modalCloseButton.click()
-  await expect(statusOutage).toBeVisible()
   await infoButtonIcon.click()
-  await expect(infoMenu).toContainText('Notifications')
-  await expect(notificationsListItem).toBeVisible()
-})
-
-test('Verify that layer notices don\'t show up in the notification list or contribute to the count', async () => {
   const badge = await page.locator('span.badge')
   await expect(badge).toBeVisible()
   await expect(badge).toContainText('2')
 })
 
-test('Alert, outage, and message content is highlighted and found in modal', async () => {
-  const outageContentHighlighted = await page.locator('#notification_list_modal .outage-notification-item span')
+test('Alert and message content is highlighted and found in modal', async () => {
   const alertContentHighlighted = await page.locator('#notification_list_modal .alert-notification-item p')
   const messageContentHighlighted = await page.locator('#notification_list_modal .message-notification-item p')
   await notificationsListItem.click()
-  await expect(outageContentHighlighted).toContainText('Posted 20 May 2018')
   await expect(alertContentHighlighted).toContainText('learn how to visualize global satellite imagery')
   await expect(messageContentHighlighted).toContainText('This is a message test')
 })

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -36,6 +36,7 @@ import Debug from './components/util/debug';
 import keyPress from './modules/key-press/actions';
 import setScreenInfo from './modules/screen-size/actions';
 // Notifications
+import { addToLocalStorage } from './modules/notifications/util';
 import Notifications from './containers/notifications';
 import { outageNotificationsSeenAction } from './modules/notifications/actions';
 // Dependency CSS
@@ -67,10 +68,12 @@ class App extends React.Component {
 
   componentDidUpdate(prevProps) {
     // Check if the numberUnseen prop has changed
-    const { kioskModeEnabled, numberOutagesUnseen, object } = this.props;
+    const {
+      kioskModeEnabled, notifications, numberOutagesUnseen,
+    } = this.props;
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
       if (numberOutagesUnseen > 0 && !kioskModeEnabled) {
-        this.openNotification(object.outages, numberOutagesUnseen);
+        this.openNotification(notifications, numberOutagesUnseen);
       }
     }
   }
@@ -198,6 +201,7 @@ function mapStateToProps(state) {
     isEmbedModeActive: state.embed.isEmbedModeActive,
     isMobile: state.screenSize.isMobileDevice,
     isTourActive: state.tour.active,
+    notifications,
     numberOutagesUnseen,
     numberUnseen,
     object,
@@ -217,6 +221,14 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(setScreenInfo());
   },
   notificationClick: (obj, numberOutagesUnseen) => {
+    // Used to update local storage to reflect OUTAGES have been seen
+    const notificationsSeenObj = {
+      alerts: [],
+      layerNotices: [],
+      messages: [],
+      outages: obj.object.outages,
+    };
+
     dispatch(
       openCustomContent('NOTIFICATION_LIST_MODAL', {
         headerText: 'Notifications',
@@ -225,6 +237,7 @@ const mapDispatchToProps = (dispatch) => ({
         onClose: () => {
           if (numberOutagesUnseen > 0) {
             dispatch(outageNotificationsSeenAction());
+            addToLocalStorage(notificationsSeenObj);
           }
         },
       }),
@@ -247,6 +260,7 @@ App.propTypes = {
   locationKey: PropTypes.string,
   modalId: PropTypes.string,
   notificationClick: PropTypes.func,
+  notifications: PropTypes.object,
   numberOutagesUnseen: PropTypes.number,
   parameters: PropTypes.object,
   setScreenInfoAction: PropTypes.func,

--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -50,7 +50,7 @@ function InfoList (props) {
           ? 'exclamation-circle'
           : ['fas', 'bolt'],
       id: 'notifications_info_item',
-      badge: numberUnseen,
+      badge: type ? numberUnseen : 0,
       className: type ? `${type}-notification` : '',
       onClick: () => {
         notificationClick(object, numberUnseen);

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -102,7 +102,9 @@ class toolbarContainer extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { isAboutOpen, openAboutModal, modalIsOpen } = this.props;
+    const {
+      isAboutOpen, openAboutModal, modalIsOpen,
+    } = this.props;
     if (modalIsOpen !== prevProps.modalIsOpen) {
       if (isAboutOpen) {
         openAboutModal();
@@ -439,7 +441,7 @@ const mapStateToProps = (state) => {
     ui,
   } = state;
   const { isDistractionFreeModeActive, isKioskModeActive } = ui;
-  const { number, type } = notifications;
+  const { numberUnseen, type } = notifications;
   const { activeString } = compare;
   const activeLayersForProj = getAllActiveLayers(state);
   const isMobile = screenSize.isMobileDevice;
@@ -479,7 +481,7 @@ const mapStateToProps = (state) => {
     ),
     modalIsOpen,
     notificationType: type,
-    notificationContentNumber: number,
+    notificationContentNumber: numberUnseen,
     proj,
     rotation: map.rotation,
     shouldBeCollapsed,

--- a/web/js/modules/notifications/reducers.js
+++ b/web/js/modules/notifications/reducers.js
@@ -32,7 +32,7 @@ export function notificationsReducer(state = notificationReducerState, action) {
         return {
           ...state,
           number: getCount(notificationsByType),
-          numberUnseen: getCount(notificationsByType, true),
+          numberUnseen: getCount(notificationsByType),
           numberOutagesUnseen,
           type: getPriority(notificationsByType),
           isActive: true,

--- a/web/js/modules/notifications/reducers.js
+++ b/web/js/modules/notifications/reducers.js
@@ -48,11 +48,25 @@ export function notificationsReducer(state = notificationReducerState, action) {
         type: '',
         isActive: true,
       };
-    case OUTAGE_NOTIFICATIONS_SEEN:
+    case OUTAGE_NOTIFICATIONS_SEEN: {
+      const notificationObj = {
+        alerts: state.object.alerts,
+        messages: state.object.messages,
+        layerNotices: state.object.layerNotices,
+        outages: [],
+      };
       return {
         ...state,
+        numberUnseen: state.number - state.numberOutagesUnseen >= 0
+          ? state.number - state.numberOutagesUnseen
+          : 0,
+        number: state.number - state.numberOutagesUnseen >= 0
+          ? state.number - state.numberOutagesUnseen
+          : 0,
         numberOutagesUnseen: 0,
+        type: getPriority(notificationObj),
       };
+    }
     default:
       return state;
   }

--- a/web/js/modules/notifications/reducers.test.js
+++ b/web/js/modules/notifications/reducers.test.js
@@ -54,7 +54,7 @@ describe('notificationsReducer', () => {
       ).toEqual({
         number: 1,
         numberOutagesUnseen: 1,
-        numberUnseen: 0,
+        numberUnseen: 1,
         type: 'outage',
         isActive: true,
         object: constants.MOCK_SORTED_NOTIFICATIONS,

--- a/web/js/modules/notifications/util.js
+++ b/web/js/modules/notifications/util.js
@@ -153,13 +153,6 @@ export function getCount(notifications, unseenOnly) {
     messages, outages, alerts,
   } = notifications;
 
-  if (unseenOnly) {
-    const messageCount = getNumberOfTypeNotSeen(NOTIFICATION_MSG, notifications.layerNotices.filter((obj) => obj.notification_type === 'message'));
-    const alertCount = getNumberOfTypeNotSeen(NOTIFICATION_ALERT, notifications.layerNotices.filter((obj) => obj.notification_type === 'alert'));
-    const outageCount = getNumberOfTypeNotSeen(NOTIFICATION_OUTAGE, notifications.layerNotices.filter((obj) => obj.notification_type === 'outage'));
-
-    return messageCount + outageCount + alertCount;
-  }
   return messages.length + alerts.length + outages.length;
 }
 

--- a/web/scss/features/vectorMeta.scss
+++ b/web/scss/features/vectorMeta.scss
@@ -16,6 +16,7 @@
 }
 
 .vector-modal .modal-body {
+  /* stylelint-disable declaration-block-no-redundant-longhand-properties */
   overflow-x: scroll;
   overflow-y: visible;
   padding: 0;


### PR DESCRIPTION
## Description
After some recent updates to the Notification system, the number of notifications is not correctly reflected in the "i" menu. For example, I posted 6 messages, and the "i" menu only says there are 4 messages. I also tried this with 3 and 5 notifications, and each time the "i" menu stated there were 4 notifications. (Images are in the ticket).

The primary cause of this issue is that with the Outage Notifications displaying on page load, SOME notifications are "seen" while others were not. This PR better manage these values so they remain in sync until all notifications have been seen by the user.

Fixes # wv-2912.

## How To Test
- git fetch --all
- git checkout wv-2912-notification-count
- npm run watch
- Either clear your cookies or open a private browser & navigate to http://localhost:3000/
- Notice the red number next to the info button (reflecting the total number of notifications - should be 5 currently)
- Dismiss the Outage Notification window & note the info button badge number is now 3 (because you saw & dismissed the 2 outages). Further, the badge should be yellow now, indicating ALERTS but not OUTAGES.
- Click the Info button & confirm that there is also a "3' next to the Notifications menu item
- Click Notifications to view notifications.
- Dismiss the Notifications window & confirm the yellow badge & the number in the sub menu are now gone because you saw & dismissed all notifications

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
