### PR TITLE
WV-2858: Sidebar Palette Prevent Min Value Disabling

### DIFF
--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -160,7 +160,7 @@ async function processEntries (colormap) {
       const a = 255
 
       // If entry is served transparent, add it to the disabled array
-      if (entry._attributes.transparent !== 'false') {
+      if (entry._attributes.transparent !== 'false' && mapType === 'classification') {
         initializeDisabled.push(refsList.length)
       }
 


### PR DESCRIPTION
## Description
This fixes some discrete-type layers from having the 0 value disabled when decreasing the maximum value.

## How To Test
1. `git checkout wv-2858-sidebar-palettevalue`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Click the "Add Layers" button on the main sidebar, and add the Sea Ice Concentration AMSR-E layer. Then, click the options sliders icon on the layer card to open the layer options window, and locate the Threshold slider.
6. Decrease the maximum value of the threshold slider, and verify that the 0 value is not visually disabled on the palette on the sidebar.