### PR TITLE
WV-27798: Update dois to v2 for Suomi NPP/VIIRS Deep Blue atmosphere products

### DIFF
--- a/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate.md
+++ b/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate.md
@@ -4,4 +4,4 @@ This layer is the combined Aerosol Optical Depth at 550 nm, only populated for t
 
 The VIIRS Deep Blue Aerosol Optical Thickness layer is available from the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite (AERDB_L2_VIIRS_SNPP) for the daytime overpass. The sensor/algorithm resolution is 6 km at nadir, imagery resolution is 2 km at nadir, and the temporal resolution is daily. Resolution is much coarser out toward the edge of the swath.
 
-References: AERDB_L2_VIIRS_SNPP_NRT [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.011](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.011); AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011)
+References: AERDB_L2_VIIRS_SNPP_NRT [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002); AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002)

--- a/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_Aerosol_Type_Deep_Blue_Best_Estimate.md
+++ b/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_Aerosol_Type_Deep_Blue_Best_Estimate.md
@@ -4,4 +4,4 @@ The Deep Blue (DB) algorithm is employed for over-land use and the Satellite Oce
 
 The VIIRS Deep Blue Aerosol Type layer is available from the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite (AERDB_L2_VIIRS_SNPP) for the daytime overpass. The sensor/algorithm resolution is 6 km at nadir, imagery resolution is 2 km at nadir, and the temporal resolution is daily. Resolution is much coarser out toward the edge of the swath.
 
-References: AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011)
+References: AERDB_L2_VIIRS_SNPP_NRT [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002); AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002)

--- a/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_Angstrom_Exponent_Deep_Blue_Best_Estimate.md
+++ b/config/default/common/config/metadata/layers/viirs/snpp/VIIRS_SNPP_Angstrom_Exponent_Deep_Blue_Best_Estimate.md
@@ -4,4 +4,4 @@ The VIIRS Deep Blue Aerosol Angstrom Exponent layer can be used to provide addit
 
 The VIIRS Deep Blue Aerosol Ångström Exponent layer is available from the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite (AERDB_L2_VIIRS_SNPP) for the daytime overpass. The sensor/algorithm resolution is 6 km at nadir, imagery resolution is 2 km at nadir, and the temporal resolution is daily. Resolution is much coarser out toward the edge of the swath.
 
-References: AERDB_L2_VIIRS_SNPP_NRT [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.011](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.011); AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.011)
+References: AERDB_L2_VIIRS_SNPP_NRT [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP_NRT.002); AERDB_L2_VIIRS_SNPP [doi:10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002](https://doi.org/10.5067/VIIRS/AERDB_L2_VIIRS_SNPP.002)


### PR DESCRIPTION
## Description

Fixes #WV-2778.

Updated dois for 3 Suomi NPP/VIIRS Deep Blue products - Deep Blue Aerosol Optical Thickness, Deep Blue Aerosol Angstrom Exponent and Deep Blue Aerosol Type.

## How To Test

1. Open with[ these URL parameters](http://localhost:3000/?v=-468.11671722885535,-168.17442112139904,206.30643500597884,152.32928255120194&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate,VIIRS_SNPP_Angstrom_Exponent_Deep_Blue_Best_Estimate,VIIRS_SNPP_Aerosol_Type_Deep_Blue_Best_Estimate,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-09-12-T19%3A28%3A28Z)
2. Check to make sure the layer descriptions are pointing to version 2 dois
