### PR TITLE
WV-2952 Tour Story Textbox Width

### DIFF
--- a/web/scss/overrides/react-joyride.scss
+++ b/web/scss/overrides/react-joyride.scss
@@ -3,4 +3,5 @@
 }
 .react-joyride__tooltip div {
   line-height: 16px;
+  max-width: 360px;
 }


### PR DESCRIPTION
## Description
This changes the max-width of the text boxes in tour stories. The change is mostly for the Intro to Worldview tour story.

## How To Test
1. `git checkout wv-2952-tourstory-textbox`
2. `npm ci`
3. `npm run watch`
4. Open the 'Intro to Worldview' tour story.
5. Proceed through each step and verify the text box is an appropriate width.