### PR TITLE
WV-2962: Travel Mode Fixes

### DIFF
--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -103,6 +103,6 @@ export const travelModeData = {
     title: 'Aqua/AIRS Carbon Monoxide Day and Night',
   },
   13: {
-    title: 'VIIRS/Suomi NPP Aerosol Optical Depth Dark Target and Deep Blue & True Color Corrected Reflectance',
+    title: 'VIIRS/Suomi NPP Aerosol Optical Depth Dark Target & True Color Corrected Reflectance',
   },
 };

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -94,15 +94,15 @@ export const travelModeData = {
     title: 'Antarctic Sea Ice',
   },
   10: {
-    title: 'VIIRS/Suomi NPP fires & VIIRS True Color Corrected Reflectance',
+    title: 'Active fires detected by Suomi NPP satellite',
   },
   11: {
-    title: 'Aura/OMI Nitrogen Dioxide and VIIRS/NOAA-20 True Color Corrected Reflectance',
+    title: 'Nitrogen Dioxide (NO2) by Aura satellite',
   },
   12: {
-    title: 'Aqua/AIRS Carbon Monoxide Day and Night',
+    title: 'Carbon Monoxide (CO) by Aqua satellite',
   },
   13: {
-    title: 'VIIRS/Suomi NPP Aerosol Optical Depth Dark Target & True Color Corrected Reflectance',
+    title: 'Aerosol Optical Depth (AOD) by Suomi NPP satellite',
   },
 };

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -94,13 +94,13 @@ export const travelModeData = {
     title: 'Antarctic Sea Ice',
   },
   10: {
-    title: 'VIIRS/Suomi NPP fires & VIRRS True Color Corrected Reflectance',
+    title: 'VIIRS/Suomi NPP fires & VIIRS True Color Corrected Reflectance',
   },
   11: {
     title: 'Aura/OMI Nitrogen Dioxide and VIIRS/NOAA-20 True Color Corrected Reflectance',
   },
   12: {
-    title: 'Aqua/AIRS Carbon Monoxide Day and Night + Borders and coastlines',
+    title: 'Aqua/AIRS Carbon Monoxide Day and Night',
   },
   13: {
     title: 'VIIRS/Suomi NPP Aerosol Optical Depth Dark Target and Deep Blue & True Color Corrected Reflectance',

--- a/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
+++ b/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
@@ -11,12 +11,16 @@ function ColorBarRow({ legend, index }) {
     minLabel, maxLabel, units, type, title, colors,
   } = legend;
   const validUnits = units !== undefined;
-  const minimum = `${minLabel} ${units}`;
-  const maximum = `${maxLabel} ${units}`;
+  const minimum = validUnits ? `${minLabel} ${units}`: minLabel;
+  const maximum = validUnits ? `${maxLabel} ${units}`: maxLabel;
 
   // Temporary fix for manually updating title of the colorbar
   let colorbarTitle = title;
-  if (title === 'Nitric Oxide') colorbarTitle = 'Nitrogen Dioxide';
+  if (title === 'Nitric Oxide'){
+    colorbarTitle = 'Nitrogen Dioxide';
+  } else if (title === 'Deep Blue Aerosol Optical Depth'){
+    colorbarTitle = 'Aerosol Optical Depth';
+  }
 
   const drawOnCanvas = () => {
     if (canvasRef.current && legend) {
@@ -43,12 +47,10 @@ function ColorBarRow({ legend, index }) {
         />
       </div>
       <div className="travel-mode-colorbar-label-container">
-        {validUnits && (
         <div className="travel-mode-colorbar-labels">
           <div className="travel-mode-colorbar-min-label">{minimum}</div>
           <div className="travel-mode-colorbar-max-label">{maximum}</div>
         </div>
-        )}
       </div>
     </div>
   );

--- a/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
+++ b/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
@@ -11,14 +11,14 @@ function ColorBarRow({ legend, index }) {
     minLabel, maxLabel, units, type, title, colors,
   } = legend;
   const validUnits = units !== undefined;
-  const minimum = validUnits ? `${minLabel} ${units}`: minLabel;
-  const maximum = validUnits ? `${maxLabel} ${units}`: maxLabel;
+  const minimum = validUnits ? `${minLabel} ${units}` : minLabel;
+  const maximum = validUnits ? `${maxLabel} ${units}` : maxLabel;
 
   // Temporary fix for manually updating title of the colorbar
   let colorbarTitle = title;
-  if (title === 'Nitric Oxide'){
+  if (title === 'Nitric Oxide') {
     colorbarTitle = 'Nitrogen Dioxide';
-  } else if (title === 'Deep Blue Aerosol Optical Depth'){
+  } else if (title === 'Deep Blue Aerosol Optical Depth') {
     colorbarTitle = 'Aerosol Optical Depth';
   }
 

--- a/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
+++ b/web/js/mapUI/components/kiosk/travel-mode/travelModeColorbars.js
@@ -10,8 +10,13 @@ function ColorBarRow({ legend, index }) {
   const {
     minLabel, maxLabel, units, type, title, colors,
   } = legend;
+  const validUnits = units !== undefined;
   const minimum = `${minLabel} ${units}`;
   const maximum = `${maxLabel} ${units}`;
+
+  // Temporary fix for manually updating title of the colorbar
+  let colorbarTitle = title;
+  if (title === 'Nitric Oxide') colorbarTitle = 'Nitrogen Dioxide';
 
   const drawOnCanvas = () => {
     if (canvasRef.current && legend) {
@@ -28,7 +33,7 @@ function ColorBarRow({ legend, index }) {
 
   return (
     <div className="travel-mode-colorbar-row" key={index}>
-      <div className="travel-mode-colorbar-title">{title}</div>
+      <div className="travel-mode-colorbar-title">{colorbarTitle}</div>
       <div className="travel-mode-colorbar-case">
         <canvas
           className="travel-mode-colorbar"
@@ -38,10 +43,12 @@ function ColorBarRow({ legend, index }) {
         />
       </div>
       <div className="travel-mode-colorbar-label-container">
+        {validUnits && (
         <div className="travel-mode-colorbar-labels">
           <div className="travel-mode-colorbar-min-label">{minimum}</div>
           <div className="travel-mode-colorbar-max-label">{maximum}</div>
         </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

1. Fixes VIIRS spelling for [VIIRS/NOAA-20 fires + VIIRS True Color Corrected Reflectance](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,VIIRS_NOAA20_Thermal_Anomalies_375m_All,VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=false&travel=10)
2. Removing units and unit labels for colorbars that use indexes [VIIRS/Suomi NPP Aerosol Optical Depth Dark Target and Deep Blue + True Color Corrected Reflectance](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,VIIRS_SNPP_AOT_Dark_Target_Land_Ocean,VIIRS_SNPP_AOT_Deep_Blue_Best_Estimate,VIIRS_SNPP_CorrectedReflectance_TrueColor&lg=false&travel=13)
3. Removed "+ borders and coastlines" from title for [Aqua/AIRS Carbon Monoxide Day and Night + Borders and coastlines](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Night,AIRS_L3_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Daily_Day&lg=false&travel=12)
4. Updated colorbar title to use "Nitrogen Dioxide" for [Aura/OMI Nitrogen Dioxide and VIIRS/NOAA-20 True Color Corrected Reflectance](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,OMI_Nitrogen_Dioxide_Tropo_Column(palette=divergent_1),VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=false&travel=11)

@nasa-gibs/worldview
