### PR TITLE
WV-2969 Layer Classifications Toggle Updating Issue

### DIFF
--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -61,7 +61,7 @@ function UpdateProjection(props) {
   *
   * @returns {void}
   */
-  const clearLayers = function() {
+  const clearLayers = function(saveCache) {
     const activeLayersUI = ui.selected
       .getLayers()
       .getArray()
@@ -69,6 +69,9 @@ function UpdateProjection(props) {
     lodashEach(activeLayersUI, (mapLayer) => {
       ui.selected.removeLayer(mapLayer);
     });
+
+    if (saveCache) return;
+    ui.cache.clear();
   };
 
   /**
@@ -116,7 +119,7 @@ function UpdateProjection(props) {
    *   @param {Boolean} id - layer id
    * @returns {void}
    */
-  async function reloadLayers(granuleOptions) {
+  async function reloadLayers(granuleOptions, saveCache) {
     const mapUI = ui.selected;
     const { createLayer } = ui;
 
@@ -125,7 +128,7 @@ function UpdateProjection(props) {
       if (compareMapDestroyed) {
         compareMapUi.destroy();
       }
-      clearLayers();
+      clearLayers(saveCache);
       const defs = getLayers(layerState, { reverse: true });
       const layerPromises = defs.map((def) => {
         const options = getGranuleOptions(layerState, def, compare.activeString, granuleOptions);
@@ -138,7 +141,7 @@ function UpdateProjection(props) {
       if (compare && !compare.isCompareA && compare.mode === 'spy') {
         stateArray.reverse(); // Set Layer order based on active A|B group
       }
-      clearLayers();
+      clearLayers(saveCache);
       const stateArrayGroups = stateArray.map(async (arr) => getCompareLayerGroup(arr, layerState, granuleOptions));
       const compareLayerGroups = await Promise.all(stateArrayGroups);
       compareLayerGroups.forEach((layerGroup) => mapUI.addLayer(layerGroup));
@@ -222,7 +225,7 @@ function UpdateProjection(props) {
 
     updateMapUI(ui, rotation);
 
-    reloadLayers();
+    reloadLayers(null, !start);
 
     // If the browser was resized, the inactive map was not notified of
     // the event. Force the update no matter what and reposition the center


### PR DESCRIPTION
## Description
This fixes the issue of layers not updating when modified by toggling a classification, while still clearing the cache between steps of a tour story, to eliminate the need for a long loading time for an animation that has already played (and therefore has been cached).

## How To Test
1. `git checkout wv-2969-classifications-toggle-bug`
2. `npm ci`
3. `npm run watch`
4. Add any layer that has classification toggles (like Flood (3-Day Window).
5. Verify that toggling on/off parts of the layer (like 'Insufficient Data' or 'Surface Water') correctly updates the layer itself.

**After verifying the classification toggle itself works, verify that the tour story animation caching also still works:**
1. Open any Tour Story with an animation (for example, 'Geostationary Imagery Every 10 Minutes!').
2. Proceed to the step with an animation and click the play button. Let it determine the buffer size and preload the buffer, and let the animation play out.
3. After the animation is played, go forward a step in the tour story, and then go back again to the previous step and press the play button again to play the animation.
4. Verify that the site doesn't need to determine the buffer size and preload the buffer, and that the animation plays immediately after clicking the play button. Verify that the animation looks correct, too.
5. Without reloading the page, finish the tour story, open a different tour story and go through that one, too. Then open the original tour story, go to the step with the animation, play the animation and verify that it did not need to load and that it looks correct.