### PR TITLE
Update HLS Sentinel band combo; change title of EIC NOAA-20 fires

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
@@ -16,8 +16,8 @@
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],
       "bandCombo": {
-        "r": "B07",
-        "g": "B05",
+        "r": "B12",
+        "g": "B8A",
         "b": "B04"
       },
       "wrapX": false,

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -67,7 +67,7 @@ export const bestDates = {
 
 export const travelModeData = {
   1: {
-    title: 'True Color Imagery from Terra Satellite',
+    title: 'True Color Imagery from Terra satellite',
   },
   2: {
     title: 'Geostationary imagery from NOAA and JAXA satellites',
@@ -76,7 +76,7 @@ export const travelModeData = {
     title: 'Active fires detected by Suomi NPP satellite',
   },
   4: {
-    title: 'Black Marble Night Time Imaging from Suomi NPP Satellite',
+    title: 'Black Marble Night Time Imaging from Suomi NPP satellite',
   },
   5: {
     title: 'Rain and Snow',
@@ -94,7 +94,7 @@ export const travelModeData = {
     title: 'Antarctic Sea Ice',
   },
   10: {
-    title: 'Active fires detected by Suomi NPP satellite',
+    title: 'Active fires detected by NOAA-20 satellite',
   },
   11: {
     title: 'Nitrogen Dioxide (NO2) by Aura satellite',


### PR DESCRIPTION
## Description

Fixes WV-2966 and WV-2971

## How To Test
- `git checkout wv-2966-EIC-title-wv2971-hls-combo`
- `npm ci`
- `npm run build && npm start`
- WV-2966: Updated title to NOAA-20 for EIC travel Mode, compare [localhost](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,VIIRS_NOAA20_Thermal_Anomalies_375m_All,VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=false&travel=10) to [prod](https://worldview.earthdata.nasa.gov/?v=-215.83066343026118,-98.53068072538338,216.8955207443781,106.52986177528524&df=true&kiosk=true&eic=si&l=Coastlines_15m,VIIRS_NOAA20_Thermal_Anomalies_375m_All,VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=false&t=2023-12-19-T17%3A00%3A00Z&travel=10)
- WV-2971: Load HLS Customizable Landsat and Customizable Sentinel layers - visually check to make sure they are displaying the same band combinations. Sentinel should be set to B12, B8A and B4; Landsat set to B7, B5 and B4.


