### PR TITLE
Wv 2980 no entry bug

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -171,6 +171,10 @@ function LayerRow (props) {
     };
   }, []);
 
+  useEffect(() => {
+    setDisabled(isDisabled);
+  }, [isDisabled]);
+
   const toggleDropdownMenuVisible = () => {
     if (showDropdownMenu) {
       setDropdownBtnVisible(false);


### PR DESCRIPTION
## Description

> "no entry sign" layer notices and eye icons in the Layer List for layer temporal availability are not working correctly. Examples below:

>When you go to a time before a default base layer was available.

  >  Load Worldview and change the year to 1984.
    The "eye" icon should turn into a "no entry" sign for all the default base layers and for example, MODIS/Terra should provide the notice that "Data available between 2000 FEB 24 - Present".
    Once you refresh the page, the correct "no entry" sign is back and the correct on hover dates are correct.

>The [Cloud Liquid Water Over Oceans](https://worldview.earthdata.nasa.gov/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Ascending,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-12-20-T22%3A23%3A32Z) should display on the map for the time period 1987 JUL 09 - 1991 DEC 31.

 >   Load the link and change the year to 1989, the Cloud Liquid Water imagery correctly loads on the map, but the "no entry" sign does not become an eye icon for the Cloud Liquid Water layer, so you cannot turn the layer on and off on the map. The 4 Corrected Reflectance base layers also have an eye icon, when they don't actually have imagery available for that date.
    Once you refresh the page, now you can turn on and off the layer using the eye and you get the correct "no entry" signs for all of the base layers which are not available in 1989.
    Change the year to 2004, and the eye is visible for Cloud Liquid Water, but there is no Cloud Liquid Water imagery, and there is a "no entry" sign for Terra/MODIS Corrected Reflectance and Aqua/MODIS, but there is imagery for those layers.
    Refresh the page and things are back to normal again. Cloud Liquid Water. NOAA-20/VIIRS and Suomi NPP/VIIRS have "no entry" signs, and Aqua/MODIS and Terra/MODIS have eye icons.

>The "no entry" sign should only appear when you are on a date that is not within the temporal availability. The eye icon should appear when you are able to view the layer on the map and turn and off the layer.

## How To Test

1. `git checkout WV-2980-no-entry-bug`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?v=-124.28974479981284,-48.32586195981713,45.009862057489755,48.962627397417506&l=SSMI_DMSP_F8_Cloud_Liquid_Water_Over_Oceans_Ascending&lg=true&t=1986-12-22-T15%3A26%3A52Z)
4. The layer should show as "disabled"
5. Navigate to 1988
6. The layer should no longer be "disabled"

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
