### PR TITLE
fix unrelated zots

### DIFF
--- a/web/js/containers/sidebar/zot.js
+++ b/web/js/containers/sidebar/zot.js
@@ -21,7 +21,7 @@ export default function Zot (props) {
     } else if (underZoomValue > 0) {
       className = 'zot underzoom';
       tooltipString += `Layer is underzoomed by ${zot.underZoomValue.toString()}x its minimum zoom level; zoom in to see imagery <br/>`;
-    } else if (!hasGranules) {
+    } else if (Object.hasOwn(zot, 'hasGranules') && !hasGranules) {
       className = 'zot no-granules';
       tooltipString += 'No visible imagery on this date and/or location. <br/> Try moving the map or select a different date in the layer\'s settings. <br/>';
     }


### PR DESCRIPTION
## Description

> [Layers that have exclamation mark zots](https://worldview.earthdata.nasa.gov/?v=-176.21602231386993,-100.31634323855491,181.7964546986356,65.97053871761929&z=4&ics=true&ici=5&icd=10&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,MOPITT_CO_Monthly_Surface_Mixing_Ratio_Night,MOPITT_CO_Monthly_Surface_Mixing_Ratio_Day,MOPITT_CO_Monthly_Total_Column_Night,MOPITT_CO_Monthly_Total_Column_Day,MOPITT_CO_Daily_Surface_Mixing_Ratio_Night(hidden),MOPITT_CO_Daily_Surface_Mixing_Ratio_Day(hidden),MOPITT_CO_Daily_Total_Column_Night(hidden),MOPITT_CO_Daily_Total_Column_Day(hidden),VIIRS_SNPP_DayNightBand_ENCC(hidden),MODIS_Combined_Flood_3-Day(hidden,disabled=3),MODIS_Combined_Flood_2-Day(hidden,disabled=3),LIS_ISS_Flash_Radiance,LIS_ISS_Flash_Count,MISR_Aerosol_Optical_Depth_Avg_Green_Monthly(hidden),MISR_Cloud_Stereo_Height_Histogram_Bin_1.5-2.0km_Monthly(hidden),MISR_Cloud_Stereo_Height_Histogram_Bin_0.5km_Monthly(hidden),MISR_TOA_Albedo_Average_Red_Monthly(hidden),MODIS_Terra_NDVI_8Day(hidden),MISR_Land_NDVI_Average_Monthly(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_DF(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_DA(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_CF(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_CA(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_BF(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_BA(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_AN(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_AF(hidden),MISR_AM1_Ellipsoid_Radiance_NGB_AA(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_DF(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_DA(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_CF(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_CA(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_BF(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_BA(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_AN(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_AF(hidden),MISR_AM1_Ellipsoid_Radiance_RGB_AA(hidden),VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule(hidden,count=10),VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule(hidden,count=10),VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(hidden,count=10),VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule(hidden,count=10),VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule(hidden,count=10),VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule(hidden,count=10),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2023-12-22-T15%3A47%3A39Z) that are not he HLS DDV layers are showing the HLS DDV specific notifications: "No visible imagery on this date and/or location" and "Try moving the map or select a different date in the layer's settings". These layers get their layer specific notifications from the Status app (status.earthdata.nasa.gov) and is specified in the status app using the following example path "/layer-notice/MODIS_Terra_EVI_8Day/MODIS_Terra_NDVI_8Day". We should not be showing the HLS DDV specific notifications for layers that get notifications via the status app.

## How To Test

1. `git clone WV-2983-unrelated-zots`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-191.18900160255873,-115.80774341723811,166.8234754099468,89.925120977101&l=HLS_Customizable_Sentinel(bandCombo=%7B%22r%22%3A%22B07%22;%22g%22%3A%22B05%22;%22b%22%3A%22B04%22%7D),HLS_Customizable_Landsat(bandCombo=%7B%22r%22%3A%22B07%22;%22g%22%3A%22B05%22;%22b%22%3A%22B04%22%7D),HLS_L30_Nadir_BRDF_Adjusted_Reflectance,HLS_S30_Nadir_BRDF_Adjusted_Reflectance,MISR_Aerosol_Optical_Depth_Avg_Green_Monthly(hidden),Land_Water_Map&lg=true&t=2023-12-22-T07%3A08%3A34Z)
4. Zots should display correctly.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
