### PR TITLE
WV-2981: Dynamically update subdomains for collection updates feature for GITC deployments

### DIFF
--- a/web/js/mapUI/components/dev-test-mode/dev-console-test.js
+++ b/web/js/mapUI/components/dev-test-mode/dev-console-test.js
@@ -6,11 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 function ConsoleTest () {
   // eslint-disable-next-line no-unused-vars
   const dispatch = useDispatch();
-  const {
-    map,
-  } = useSelector((state) => ({
-    map: state.map.ui.selected,
-  }));
+  const map = useSelector((state) => state.map.ui.selected);
 
   const consoleResponse = () => {
     console.log(map);

--- a/web/js/mapUI/components/update-collections/updateCollections.js
+++ b/web/js/mapUI/components/update-collections/updateCollections.js
@@ -17,18 +17,10 @@ function UpdateCollections () {
 
   // Finds the correct subdomain to query headers from based on the layer source and GIBS/GITC env
   const lookupLayerSource = (layerId) => {
-    const crs = `epsg${proj.selected.epsg}`;
-    let sourceDomain = '';
-    // ex. GIBS:geographic or GITC:geographic
     const { source } = layerConfig[layerId].projections[proj.id];
-    // ex. GIBS or GITC
-    const splitSource = source.split(':')[0];
-    // This is necessary because GIBS source URL structure uses {a-c}. We can pull GITC srcs straight from the config
-    if (splitSource === 'GIBS') {
-      sourceDomain = `https://gibs-a.earthdata.nasa.gov/wmts/${crs}/best/wmts.cgi?`;
-    } else {
-      sourceDomain = sources[source].url;
-    }
+    const subRegex = /-{[a-z]{1}-[a-z]{1}}/i;
+    const sourceDomain = sources[source].url.replace(subRegex, '-a');
+
     return sourceDomain;
   };
 
@@ -41,7 +33,6 @@ function UpdateCollections () {
     const sourceDomain = lookupLayerSource(id);
 
     const sourceUrl = `${sourceDomain}?TIME=${isoStringDate}&layer=${id}&style=default&tilematrixset=${matrixSet}&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2F${imageType}&TileMatrix=0&TileCol=0&TileRow=0`;
-
     try {
       const response = await fetch(sourceUrl);
 

--- a/web/js/mapUI/mapUI.js
+++ b/web/js/mapUI/mapUI.js
@@ -101,7 +101,7 @@ function MapUI(props) {
   const [preloadAction, setPreloadAction] = useState({});
 
   // eslint-disable-next-line no-unused-vars
-  const [tileImageTestMode, setTileImageTestMode] = useState(false);
+  const [devTestMode, setDevTestMode] = useState(false);
 
   const subscribeToStore = function(action) {
     switch (action.type) {
@@ -416,7 +416,7 @@ function MapUI(props) {
         { (isTravelModeActive && !isStaticMapActive) && <TravelMode /> }
       </>
       )}
-      {tileImageTestMode && <DevTestButton />}
+      {devTestMode && <DevTestButton />}
 
     </>
   );


### PR DESCRIPTION
## Description
This will require a GITC setup to test.

Currently, the collections feature in Worldview is set to always query the GIBS subdomain for layer headers. This updates the feature to dynamically query the correct subdomain based on the current layer sources (Ex. GIBS/GITC-SIT/GITC-UAT/GITC-PROD). 

## How To Test
1. Source GITC with your develop env.
2. In the worldview directory of the terraform directory, update the `WORLDVIEW_BRANCH` variable in the version script to point to `wv-2981`. 
3. Update the build-release script so that the CONFIG_ENV variable in the else block of the env conditional now points to `gitc-prod`. 
4. Disconnect from the VPN and in the root directory, run the `worldview:build-download` command. 
5. Reconnect to the VPN and in the root directory, run the `worldview:build-release` command.
6. From the `src` directory of Worldview which you just built, run the `npm run watch` command.
7. Use this [WV Link](http://localhost:3000/?v=-410.765625,-229.921875,332.296875,236.390625&ics=true&ici=3&icd=5&l=AMSRU2_Snow_Water_Equivalent_Monthly,AMSRU2_Snow_Water_Equivalent_5Day_vB02_STD,AMSRU2_Snow_Water_Equivalent_Daily,AMSRU2_Snow_Water_Equivalent_5Day&lg=false&t=2016-02-15-T00%3A00%3A00Z) and verify that each of the layers have a collections badge.
8. Move the date forward a few times and verify that each layer still has a collection badge.

@nasa-gibs/worldview
