### PR TITLE
Wv 2977 comparison available imagery

### DIFF
--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -19,13 +19,20 @@ export default function ImagerySearch({ layer }) {
   const endRef = useRef(null);
   const dispatch = useDispatch();
   const selectDate = (date) => { dispatch(selectDateAction(date)); };
-  const selectedDate = useSelector((state) => state.date.selected);
+  const date = useSelector((state) => state.date);
+  const compare = useSelector((state) => state.compare);
   const map = useSelector((state) => state.map);
   const [granulesStartStatus, setGranulesStartStatus] = useState(undefined);
   const [granulesEndStatus, setGranulesEndStatus] = useState(undefined);
   const [olderGranuleDates, setOlderGranuleDates] = useState([]);
   const [newerGranuleDates, setNewerGranuleDates] = useState([]);
   const [page, setPage] = useState(1);
+
+  let selectedDate = date.selected
+
+  if (compare.active && !compare.isCompareA) {
+    selectedDate = date.selectedB;
+  }
 
   const conceptID = layer?.conceptIds?.[0]?.value || layer?.collectionConceptID;
 

--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -28,7 +28,7 @@ export default function ImagerySearch({ layer }) {
   const [newerGranuleDates, setNewerGranuleDates] = useState([]);
   const [page, setPage] = useState(1);
 
-  let selectedDate = date.selected
+  let selectedDate = date.selected;
 
   if (compare.active && !compare.isCompareA) {
     selectedDate = date.selectedB;


### PR DESCRIPTION
## Description

Fixes # .

> When in comparison mode, the "available imagery dates" for HLS imagery doesn't perform as expected.

## How To Test

1. `git checkout WV-2977-comparison-available-imagery`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,HLS_L30_Nadir_BRDF_Adjusted_Reflectance,HLS_S30_Nadir_BRDF_Adjusted_Reflectance,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&l1=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,HLS_L30_Nadir_BRDF_Adjusted_Reflectance,HLS_S30_Nadir_BRDF_Adjusted_Reflectance,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg1=true&ca=false&cv=48&t=2022-12-17-T05%3A00%3A00Z&t1=2023-12-10-T05%3A00%3A00Z)
4. The appropriate dates should load for both A and B sides.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
