### PR TITLE
WV GITC Fix for measurement settings layers & handle errors when adjustingStart dates on load

### DIFF
--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -1412,7 +1412,7 @@ export function adjustStartDates(layers) {
     .format('YYYY-MM-DDThh:mm:ss')}Z`;
 
   const applyDateAdjustment = (layer) => {
-    const { availability, dateRanges } = layer;
+    const { availability, dateRanges, endDate } = layer;
     if (!availability) {
       return;
     }
@@ -1420,8 +1420,15 @@ export function adjustStartDates(layers) {
 
     if (Array.isArray(dateRanges) && dateRanges.length) {
       const [firstDateRange] = dateRanges;
-      firstDateRange.startDate = adjustDate(rollingWindow);
-      layer.startDate = adjustDate(rollingWindow);
+      const adjustedDate = adjustDate(rollingWindow);
+
+      // To prevent a startDate greater than endDate for layers with a rollingWindow and specific start and end dates
+      if (endDate && new Date(adjustedDate) > new Date(endDate)) {
+        return;
+      }
+
+      firstDateRange.startDate = adjustedDate;
+      layer.startDate = adjustedDate;
     } else {
       console.warn(`GetCapabilities is missing the time value for ${layer.id}`);
     }

--- a/web/js/modules/product-picker/selectors.js
+++ b/web/js/modules/product-picker/selectors.js
@@ -43,7 +43,7 @@ export const getSourcesForProjection = createSelector(
     const trackGroup = currentMeasurement && currentMeasurement.id === 'orbital-track';
     const sourcesForProj = sources && sources.filter(
       (source) => source.settings.some((layerId) => {
-        if (!config.layers[layerId].projections) return;
+        if (!config.layers[layerId] || !config.layers[layerId].projections) return;
         const { projections, layergroup } = config.layers[layerId];
         const isOrbitTrack = layergroup === 'Orbital Track';
         const inProj = !!projections[projection];


### PR DESCRIPTION
This provides 2 fixes for handling errors related to layer configurations which surfaced from GITC builds.

1. When a layer with a specific start date and end date included a rolling window property, the start date could possibly be updated to a date greater than the end date. This makes the layer completely unusable. I fixed this by adding a check to the function that adjusts start dates that will check if the new adjusted date is greater than the end date.

2. The other problem arose from layer ID's included in measurement sources not existing within the config files. This was fixed by adding an additional conditional check for the layer selector function that the product picker executes. 