### PR TITLE
WV-3013: Fix dois and short names for AMSR-E and AMSR2 NSIDC layers

### DIFF
--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP5)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP5)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Day.md
@@ -2,4 +2,4 @@ The Columnar Water Vapor (Day) layer is a measure of the columnar water vapor in
 
 The AMSR2 instrument is a conically scanning passive microwave radiometer. This instrument senses microwave radiation for twelve channels and six frequencies ranging from 6.9 GHz to 89 GHz on board the Japan Aerospace Exploration Agency (JAXA) Global Change Observation Mission – Water 1 (GCOM-W1) satellite.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02)
+References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Night.md
@@ -2,4 +2,4 @@ The Columnar Water Vapor (Night) layer is a measure of the columnar water vapor 
 
 The AMSR2 instrument is a conically scanning passive microwave radiometer. This instrument senses microwave radiation for twelve channels and six frequencies ranging from 6.9 GHz to 89 GHz on board the Japan Aerospace Exploration Agency (JAXA) Global Change Observation Mission – Water 1 (GCOM-W1) satellite.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02)
+References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Day.md
@@ -2,4 +2,4 @@ The Surface Precipitation (Day) layer displays instantaneous surface precipitati
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_Rain_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02)
+References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Night.md
@@ -2,4 +2,4 @@ The Surface Precipitation (Night) layer displays instantaneous surface precipita
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_Rain_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02)
+References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Day) layer displays precipitable water totals over
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Day) layer displays precipitable water totals over
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Night) layer displays precipitable water totals ov
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Night) layer displays precipitable water totals ov
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
@@ -2,4 +2,4 @@ The Wind Speed (Day) layer shows wind speed over oceans in meters per second (m/
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
@@ -2,4 +2,4 @@ The Wind Speed (Day) layer shows wind speed over oceans in meters per second (m/
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
@@ -2,4 +2,4 @@ The Wind Speed (Night) layer shows wind speed over oceans in meters per second (
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
@@ -2,4 +2,4 @@ The Wind Speed (Night) layer shows wind speed over oceans in meters per second (
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01)
+References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP5](https://doi.org/10.5067/9YQRFKKEPUP)

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Columnar_Water_Vapor_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Columnar_Water_Vapor_Day.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data field: `TotalColWaterVapor`
 
-References: [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)
+References: AE_Rain [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Columnar_Water_Vapor_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Columnar_Water_Vapor_Night.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data field: `TotalColWaterVapor`
 
-References: [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)
+References: AE_Rain [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Day.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Day.md
@@ -6,6 +6,6 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data field: `surfacePrecipitation`
 
-References: [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)
+References: AE_Rain [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)
 
 

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Night.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Surface_Precipitation_Rate_Night.md
@@ -6,4 +6,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data field: `surfacePrecipitation`
 
-References: [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)
+References: AE_Rain [doi:10.5067/IR85TKB5BLM3](https://doi.org/10.5067/IR85TKB5BLM3)

--- a/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_NDSI_Snow_Cover.md
+++ b/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_NDSI_Snow_Cover.md
@@ -2,4 +2,4 @@ The MODIS Snow Cover (Normalized Difference Snow Index (NDSI)) layer shows the p
 
 The MODIS Snow Cover (Normalized Difference Snow Index) layer is available from both the Terra (MOD10) and Aqua (MYD10) satellites. The sensor and imagery resolution is 500 m and the temporal resolution is daily.
 
-References: MYD10_L2 [doi:10.5067/MODIS/MYD11_L2.061](https://doi.org/10.5067/MODIS/MYD11_L2.061); [NASA Earth Observations - Snow Cover](https://neo.gsfc.nasa.gov/view.php?datasetId=MOD10C1_M_SNOW)
+References: MYD10_L2 [doi:10.5067/MODIS/MYD10_L2.061](https://doi.org/10.5067/MODIS/MYD10_L2.061); [NASA Earth Observations - Snow Cover](https://neo.gsfc.nasa.gov/view.php?datasetId=MOD10C1_M_SNOW)

--- a/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L3_Ice_Surface_Temp_Daily_Day.md
+++ b/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L3_Ice_Surface_Temp_Daily_Day.md
@@ -2,4 +2,4 @@ The Ice Surface Temperature (L3, Daily, Day) layer shows daily, daytime ice surf
 
 The Moderate Resolution Imaging Spectroradiometer (MODIS) is a 36-band visible to thermal-infrared sensor onboard the Terra and Aqua satellites. Two of the bands are imaged at a nominal resolution of 250 m at nadir, five bands at 500 m, and the remaining bands at 1000 m.
 
-References: MOD29P1D [doi:110.5067/MODIS/MOD29P1D.061](https://doi.org/10.5067/MODIS/MOD29P1D.061)
+References: MOD29P1D [doi:10.5067/MODIS/MOD29P1D.061](https://doi.org/10.5067/MODIS/MOD29P1D.061)


### PR DESCRIPTION
## Description

Fixes #WV-3013.

For AMSR-E and AMSR2 layer descriptions:
- Added shortname for AE_Rain for AMSR-E Columnar Water Vapor (day and Night); Surface Precipitation Rate (Day and Night)
- Added shortname and doi for AMSR2 standard products. AU_OCEAN for Cloud Liquid Water (day and night), Total Precipitable Water (Day and Night), Wind Speed (Day and Night); AU_RAIN for Surface Precipitation (Day and Night), Columnar Water Vapor (Day and Night)
- Fixed typos for MODIS/Terra Ice Surface Temperature (Day) and MODIS/Aqua Snow Cover

## How To Test

1. `git checkout wv-3013-nsidc-doi-updates`
2. `npm run build && npm start`
3. Compare [prod link](https://worldview.earthdata.nasa.gov/?l=Coastlines_15m,AMSRE_Surface_Precipitation_Rate_Night,AMSRE_Surface_Precipitation_Rate_Day,AMSRE_Columnar_Water_Vapor_Night,AMSRE_Columnar_Water_Vapor_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2010-01-12-T17%3A40%3A19Z) to [localhost link](http://localhost:3000/?l=Coastlines_15m,AMSRE_Surface_Precipitation_Rate_Night,AMSRE_Surface_Precipitation_Rate_Day,AMSRE_Columnar_Water_Vapor_Night,AMSRE_Columnar_Water_Vapor_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2010-01-12-T17%3A40%3A19Z) to see that AE_Rain has been added at the bottom of the layer description
4. Compare [prod link](https://worldview.earthdata.nasa.gov/?v=-144.7881897540506,-38.623127822541576,32.554658872792196,48.65392930598618&l=Coastlines_15m,AMSRU2_Wind_Speed_Night,AMSRU2_Wind_Speed_Day,AMSRU2_Total_Precipitable_Water_Night,AMSRU2_Total_Precipitable_Water_Day,AMSRU2_Cloud_Liquid_Water_Night,AMSRU2_Cloud_Liquid_Water_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T17%3A40%3A19Z) to [localhost link](http://localhost:3000/?v=-144.7881897540506,-38.623127822541576,32.554658872792196,48.65392930598618&l=Coastlines_15m,AMSRU2_Wind_Speed_Night,AMSRU2_Wind_Speed_Day,AMSRU2_Total_Precipitable_Water_Night,AMSRU2_Total_Precipitable_Water_Day,AMSRU2_Cloud_Liquid_Water_Night,AMSRU2_Cloud_Liquid_Water_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T17%3A40%3A19Z) to check if AU_OCEAN and relevant doi has been added to the bottom of the layer description
5. Compare [prod link](https://worldview.earthdata.nasa.gov/?l=Coastlines_15m,AMSRU2_Surface_Precipitation_Night,AMSRU2_Surface_Precipitation_Day,AMSRU2_Columnar_Water_Vapor_Night,AMSRU2_Columnar_Water_Vapor_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T17%3A40%3A19Z) to [localhost link](http://localhost:3000/?l=Coastlines_15m,AMSRU2_Surface_Precipitation_Night,AMSRU2_Surface_Precipitation_Day,AMSRU2_Columnar_Water_Vapor_Night,AMSRU2_Columnar_Water_Vapor_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T17%3A40%3A19Z) to check if AU_RAIN and relevant doi has been added to the bottom of the layer description
6. Check [MODIS/Terra Ice Surface Temperature Day layer description](http://localhost:3000/?l=Coastlines_15m,MODIS_Terra_Ice_Surface_Temp_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T18%3A01%3A19Z) and see that the extra 1 has been removed "DOI text says "doi:110.5067/MODIS/MOD29P1D.061" which has an extra "1" at the start of the DOI listing."
7. Check [MODIS/Aqua Snow Cover layer description](http://localhost:3000/?l=MODIS_Aqua_NDSI_Snow_Cover,Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-01-12-T18%3A01%3A19Z) doi link points to doi:10.5067/MODIS/MYD10_L2.061


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
