### PR TITLE
WV-3006 Node LTS to 20.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf install -y epel-release && \
     xz
 RUN mkdir -p /usr/local/nvm
 ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=20.9.0
+ENV NODE_VERSION=20.11.0
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash && \
     . "$NVM_DIR/nvm.sh" && \
     nvm install v${NODE_VERSION} && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,7 +148,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "node": ">= 18.16.1"
+        "node": ">= 20.11.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "NASA-1.3",
   "repository": "nasa-gibs/worldview",
   "engines": {
-    "node": ">= 18.16.1"
+    "node": ">= 20.11.0"
   },
   "scripts": {
     "analyze": "cross-env ANALYZE_MODE=true NODE_ENV=production webpack",


### PR DESCRIPTION
Updating Node to version 20.11.0.

**How To Test**
- Update your local environment to Node version 20.11.0 
- git checkout wv-3006-node_lts
- npm ci
- npm run watch
- Verify that WV runs properly