### PR TITLE
don't remove _NRT

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -203,7 +203,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
   const getVisibleGranules = (availableGranules, granuleCount, leadingEdgeDate) => {
     const { proj: { selected: { crs } } } = store.getState();
     const granules = [];
-    const availableCount = availableGranules.length;
+    const availableCount = availableGranules?.length;
     if (!availableCount) return granules;
     const count = granuleCount > availableCount ? availableCount : granuleCount;
 

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -175,8 +175,7 @@ export const getParamsForGranuleRequest = (def, date, crs) => {
 
   const getShortName = () => {
     try {
-      let { shortName } = def.conceptIds[0];
-      [shortName] = shortName.split('_');
+      const { shortName } = def.conceptIds[0];
       return shortName;
     } catch (e) {
       console.error(`Could not get shortName for a collection associated with layer ${def.id}`);


### PR DESCRIPTION
## Description

Investigate issue with granule browse on leading edge

## How To Test

1. `git checkout WV-3057-investigate-granule-leading-edge-issue`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?v=-306.362855237433,-190.1488248941364,271.42163234765894,130.50819107467328&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule(count=10),VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule(count=10),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2024-02-27-T20%3A23%3A38Z)
4. Verify that the granule layers behave correctly on the leading edge.
