### PR TITLE
Default numberOutagesUnseen to 0

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -263,3 +263,7 @@ App.propTypes = {
   parameters: PropTypes.object,
   setScreenInfoAction: PropTypes.func,
 };
+
+App.defaultProps = {
+  numberOutagesUnseen: 0
+};


### PR DESCRIPTION
## Description

When the application is loaded it it possible for `numberOutagesUnseen` to be `undefined`. In this situation (where `numberOutagesUnseen` is undefined), the tour modal will not open on application load because of the condition on this line: https://github.com/nasa-gibs/worldview/blob/52d5028627710692d37746fc62c17a278a09371d/web/js/app.js#L167

Suggested fix is to default the `numberOutagesUnseen` property on the `App` to 0 so that it is not possible for it to be `undefined` on application load. Alternatively, the condition referenced above could be altered to handle the `undefined` case but using a default seemed to make more sense.

Fixes https://github.com/podaac/worldview/issues/38

## How To Test

This was a hard one to reproduce but the most reliable way to reproduce seems to be:

1. Run `npm dist` to generate a worldview.tar.gz distribution
2. Unpack the distribution to a location on your file system
3. Change directories into the unpacked location
4. Run `npx http-server`
5. Open browser and navigate to URL provided by http-server
6. Notice the tour story modal does not appear

Following these same steps after this fix is applied should result in the story modal showing up after navigating to the application served by http-server.

I haven't had luck reproducing this in a test case.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
