### PR TITLE
WV-3081: add accessibility link

### DIFF
--- a/config/default/common/brand/about/license.md
+++ b/config/default/common/brand/about/license.md
@@ -8,4 +8,5 @@
 <hr>
 <p>@BUILD_TIMESTAMP@<br> Responsible NASA Official: <a href="mailto:ryan.a.boller@nasa.gov">Ryan
         Boller</a><br>
-<a href="https://www.nasa.gov/privacy/#privacy-policy" target="_blank">Web Privacy Policy</a></p>
+<a href="https://www.nasa.gov/privacy/#privacy-policy" target="_blank">Web Privacy Policy</a>
+<br><a href="https://www.nasa.gov/accessibility/" target="_blank">Accessibility</a></p>


### PR DESCRIPTION
## Description

Fixes #WV-3081 .

Add Accessibility link to About page


## How To Test

1. `git checkout wv-3081-accessibility-link`
2. `npm run build && npm start`
3. Open localhost:3000, click on "i" icon in upper right corner, click on "About", scroll to the bottom of the about section and verify that the accessibility link is there.

@nasa-gibs/worldview
