### PR TITLE
WV-3073 granule count doesnt update

### DIFF
--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import OlLayerGroup from 'ol/layer/Group';
 import {
-  each as lodashEach,
   get as lodashGet,
 } from 'lodash';
 import {
@@ -62,7 +61,7 @@ function UpdateProjection(props) {
   * @returns {void}
   */
   const clearLayers = function(saveCache) {
-    ui.selected.setLayers([])
+    ui.selected.setLayers([]);
 
     if (saveCache) return;
     ui.cache.clear();

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -62,13 +62,7 @@ function UpdateProjection(props) {
   * @returns {void}
   */
   const clearLayers = function(saveCache) {
-    const activeLayersUI = ui.selected
-      .getLayers()
-      .getArray()
-      .slice(0);
-    lodashEach(activeLayersUI, (mapLayer) => {
-      ui.selected.removeLayer(mapLayer);
-    });
+    ui.selected.setLayers([])
 
     if (saveCache) return;
     ui.cache.clear();
@@ -135,7 +129,7 @@ function UpdateProjection(props) {
         return createLayer(def, options);
       });
       const createdLayers = await Promise.all(layerPromises);
-      lodashEach(createdLayers, (l) => { mapUI.addLayer(l); });
+      mapUI.setLayers(createdLayers);
     } else {
       const stateArray = [['active', 'selected'], ['activeB', 'selectedB']];
       if (compare && !compare.isCompareA && compare.mode === 'spy') {
@@ -144,7 +138,7 @@ function UpdateProjection(props) {
       clearLayers(saveCache);
       const stateArrayGroups = stateArray.map(async (arr) => getCompareLayerGroup(arr, layerState, granuleOptions));
       const compareLayerGroups = await Promise.all(stateArrayGroups);
-      compareLayerGroups.forEach((layerGroup) => mapUI.addLayer(layerGroup));
+      mapUI.setLayers(compareLayerGroups);
       compareMapUi.create(mapUI, compare.mode);
     }
     updateLayerVisibilities();


### PR DESCRIPTION
## Description

> Following the steps below while reviewing TEMPO data in GIBS UAT resulted in this unexpected behavior: when switching the granule view count from 10 to 1 granule, the old granules remain in the viewer. The old granules and then correct granule as you click through the time slider step also appear beneath instead of on top of the land mass layer. Refreshing the browser page resolves this issue. 

## How To Test

1. `git checkout WV-3073-granule-count-doesn't-update`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-145.93397634005998,-129.69262975142345,303.0015264567445,119.45618227527532&z=4&ics=true&ici=3&icd=10&l=VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule(count=24)&lg=true&t=2024-03-14-T12%3A13%3A31Z)
4. Open layer settings
5. Rapidly adjust the Granule Count slider from 30 to 1
6. Only one granule _should_ be displayed
7. If more than one granule is visible, check that the number of granules showing matches the `count` parameter in the URL and that the same number of granules are visible on reloading. (This means that you have encountered a different bug that happens to produces similar behavior. Repeating step 5 should eventually bypass this bug).

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
