### PR TITLE
WV-3143: Adding Client Side Timeout to EIC Request

### DIFF
--- a/web/js/mapUI/components/eic/eic.js
+++ b/web/js/mapUI/components/eic/eic.js
@@ -17,7 +17,7 @@ function EIC() {
   const requestBestDate = async () => {
     try {
       const url = `https://uhkookzof2.execute-api.us-west-2.amazonaws.com/dev/scenarios?item_type=scenario&item_id=${scenario}`;
-      const response = await fetch(url);
+      const response = await fetch(url, { timeout: 10000 });
       if (!response.ok) {
         throw new Error('Network response was not ok.');
       }


### PR DESCRIPTION
## Description

Adding a 10 second client side timeout to the EIC request to handle API GW and other DNS issues. 

## How To Test

1. `git checkout wv-3143`
2. `npm run watch`
3. Open the `eic.js` file.
4. Delete a few characters from the hostname on line 19 of the URL
5. Open this EIC [URL](http://localhost:3000/?v=-231.3381494355704,-98.53068072538338,232.4030067496873,106.52986177528524&df=true&kiosk=true&eic=si&scenario=1&l=OrbitTracks_Terra_Descending(opacity=0.9),Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2024-04-09-T00%3A00%3A00Z)
6. Verify that it still moves the date via the legacy mode by opening up the console and viewing the print statements. It should have various statements like "Entering EIC mode". These statements do not appear outside of legacy mode. 


@nasa-gibs/worldview
