### PR TITLE
WV-2865 Classification/Palettes Layers Classification Toggle Behavior

### DIFF
--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -381,7 +381,7 @@ class PaletteLegend extends React.Component {
               palletteClass = isInvisible ? `${palletteClass} checkerbox-bg` : palletteClass;
               let legendColor = color;
               const customColor = palette.custom;
-              if (palette.custom !== undefined) {
+              if (palette.custom !== undefined && palette.custom !== '') {
                 [legendColor] = palettes.custom[customColor].colors;
               }
 

--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -846,7 +846,7 @@ export function serializeLayers(layers, state, groupName) {
         value: bandComboString,
       });
     }
-    if (def.palette && (def.custom || def.min || def.max || def.squash || def.disabled)) {
+    if (def.palette && (def.custom || def.min || def.max || def.squash || def.disabled || (palettes[def.id] && palettes[def.id].maps && palettes[def.id].maps.length > 1))) {
       // If layer has palette and palette attributes
       const paletteAttributeArray = getPaletteAttributeArray(
         def.id,
@@ -926,7 +926,15 @@ const getLayerSpec = (attributes) => {
     }
     if (attr.id === 'disabled') {
       const values = util.toArray(attr.value.split(';'));
-      disabled = values;
+      const disabledArray = [];
+      lodashEach(values, (value, index) => {
+        if (value === '') {
+          disabledArray.push(undefined);
+        } else {
+          disabledArray.push(value);
+        }
+      });
+      disabled = disabledArray;
     }
 
     if (attr.id === 'max' && typeof attr.value === 'string') {

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -386,7 +386,7 @@ export function refreshDisabledSelector(
       },
     },
   });
-  return toggleLookup(layerId, newPalettes, state);
+  return updateLookup(layerId, newPalettes, state);
 }
 
 export function initDisabledSelector(
@@ -396,7 +396,7 @@ export function initDisabledSelector(
   palettes,
   state,
 ) {
-  const disabled = disabledStr.split('-');
+  const disabled = disabledStr ? disabledStr.split('-') : [];
   for (let i = 0; i < disabled.length; i += 1) { disabled[i] = +disabled[i]; }
   let newPalettes = prepare(layerId, palettes, state);
   newPalettes = update(newPalettes, {
@@ -441,7 +441,7 @@ export function setDisabledSelector(
       },
     },
   });
-  return toggleLookup(layerId, newPalettes, state);
+  return updateLookup(layerId, newPalettes, state);
 }
 
 export function setRange(layerId, props, index, palettes, state) {

--- a/web/js/modules/palettes/util.js
+++ b/web/js/modules/palettes/util.js
@@ -344,7 +344,7 @@ export function getPaletteAttributeArray(layerId, palettes, state) {
     }
 
     [palObj, minObj, maxObj, squashObj, disabledObj].forEach((obj) => {
-      if (obj.isActive) {
+      if (obj.isActive || (obj.key === 'disabled' && obj.value !== '')) {
         attrArray.push({
           id: obj.key === 'custom' ? 'palette' : obj.key,
           value: obj.value,

--- a/web/js/modules/vector-styles/selectors.js
+++ b/web/js/modules/vector-styles/selectors.js
@@ -12,6 +12,10 @@ import { stylefunction } from 'ol-mapbox-style';
 import {
   getMinValue, getMaxValue, selectedStyleFunction,
 } from './util';
+import {
+  isActive as isPaletteActive,
+  getLookup as getPaletteLookup,
+} from '../palettes/selectors';
 import util from '../../util/util';
 
 
@@ -115,6 +119,25 @@ const updateGlStylePalette = (glStyle, rgbPalette) => {
   return glStyle;
 };
 
+const updateDisabled = (glStyle, lookup) => {
+  for (let i = 0; i < glStyle.layers.length; i += 1) {
+    const thisCircleColor = glStyle.layers[i].paint['circle-color'];
+    thisCircleColor.forEach((color, index) => {
+      const regex = /rgba?\(.*\)/;
+      if (regex.test(color)) {
+        const colors = color.split('(')[1].split(')')[0].split(/,\s?/);
+        if (colors.length < 4) {
+          colors.push('255');
+        }
+        if (lookup[colors.join(',')]) {
+          thisCircleColor[index] = `rgba(${lookup[colors.join(',')].r}, ${lookup[colors.join(',')].g}, ${lookup[colors.join(',')].b}, ${lookup[colors.join(',')].a})`;
+        }
+      }
+    });
+  }
+  return glStyle;
+};
+
 const shouldRenderFeature = (feature, acceptableExtent) => {
   if (!acceptableExtent) return true;
   const midpoint = feature.getFlatCoordinates
@@ -130,10 +153,11 @@ const shouldRenderFeature = (feature, acceptableExtent) => {
  * @param {String} vectorStyleId | ID to lookup the vector style in the state
  * @param {Object} vectorStyles | Contains styles of all vector products
  * @param {Object} layer | OL layer object
+ * @param {Object} options | Layer options object
  * @param {Object} state | The entire state of the application
  * @param {Boolean} styleSelection | Indicates if the request is triggered by user interaction with vector feature
  */
-export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state, styleSelection = false) {
+export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, options, state, styleSelection = false) {
   const map = lodashGet(state, 'map.ui.selected');
   if (!map) return;
   const { proj } = state;
@@ -142,6 +166,7 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state,
   const layerId = def.id;
   const styleId = lodashGet(def, `vectorStyle.${proj.id}.id`) || vectorStyleId || lodashGet(def, 'vectorStyle.id') || layerId;
   const customPalette = def.custom;
+  const disabledPalette = def.disabled;
 
   let glStyle = vectorStyles[styleId];
   if (customPalette && Object.prototype.hasOwnProperty.call(state, 'palettes')) {
@@ -153,6 +178,17 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state,
     if (customDefaultStyle !== undefined) {
       glStyle = customDefaultStyle;
     }
+  }
+
+  // De-reference the glState object prior to applying the palette to the layer
+  glStyle = lodashCloneDeep(glStyle);
+
+  let lookup;
+  if (isPaletteActive(def.id, options.group, state)) {
+    lookup = getPaletteLookup(def.id, options.group, state);
+  }
+  if (disabledPalette) {
+    glStyle = updateDisabled(glStyle, lookup);
   }
 
   if (!layer || layer.isWMS || glStyle === undefined) {
@@ -168,8 +204,6 @@ export function setStyleFunction(def, vectorStyleId, vectorStyles, layer, state,
     ? lodashFind(layer.getLayers().getArray(), 'isVector')
     : layer;
 
-  // De-reference the glState object prior to applying the palette to the layer
-  glStyle = lodashCloneDeep(glStyle);
   const styleFunction = stylefunction(layer, glStyle, layerId, resolutions);
   const selectedFeatures = selected[layerId];
 
@@ -259,8 +293,9 @@ export function clearStyleFunction(def, vectorStyleId, vectorStyles, layer, stat
  * @param {Object} def
  * @param {Object} olVectorLayer
  * @param {Object} state
+ * @param {Object} options
  */
-export const applyStyle = (def, olVectorLayer, state) => {
+export const applyStyle = (def, olVectorLayer, state, options) => {
   const { config } = state;
   const { vectorStyles } = config;
   const vectorStyleId = def.vectorStyle.id;
@@ -269,5 +304,5 @@ export const applyStyle = (def, olVectorLayer, state) => {
     return;
   }
 
-  setStyleFunction(def, vectorStyleId, vectorStyles, olVectorLayer, state);
+  setStyleFunction(def, vectorStyleId, vectorStyles, olVectorLayer, options, state);
 };


### PR DESCRIPTION
## Description
This fixes the issue of layers that have both classifications and a palette not properly updating when a classification is enabled/disabled. It also fixes behavior when adding a min or max to the palette, and then toggling a classification (previous behavior would incorrectly ignore the min/max set when classification is toggled). It also fixes behavior with refreshing the page with all classifications turned on when the default state for the layer includes disabled classifications (previous behavior incorrectly loaded default state rather than retain classification toggle state).

## How To Test
1. `git checkout wv-2865-classification-toggle`
2. `npm ci`
3. `npm run watch`
4. Add any layer that has classification toggles and a palette (like SSMIS_Sea_Ice_Concentration_Snow_Extent).
5. Verify that toggling on/off classifications correctly updates the layer itself.
6. Verify that setting a min or max for the palette and then toggling a classification still displays the correct previous set min/max on the layer itself.
7. Verify that enabling all classifications and reloading the page does not cause the classifications that are disabled by default to re-enable incorrectly.