### PR TITLE
WV-3147 update collections when projection changes

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -646,7 +646,7 @@ const makeMapStateToProps = () => {
     const dailyDate = formatDailyDate(activeDate);
     const selectedDate = date.selected;
     const subdailyDate = formatSubdailyDate(activeDate);
-    const collections = getCollections(layers, dailyDate, subdailyDate, layer);
+    const collections = getCollections(layers, dailyDate, subdailyDate, layer, proj.id);
     const measurementDescriptionPath = getDescriptionPath(state, ownProps);
     const { ddvZoomAlerts, ddvLocationAlerts } = state.alerts;
 

--- a/web/js/mapUI/components/update-collections/updateCollections.js
+++ b/web/js/mapUI/components/update-collections/updateCollections.js
@@ -50,7 +50,7 @@ function UpdateCollections () {
       if (type !== 'NRT' && type !== 'STD') return undefined;
 
       return {
-        id, date: formattedDate, type, version,
+        id, date: formattedDate, type, version, projection: proj.id
       };
     } catch (error) {
       // errors will clutter console, turn this on for debugging

--- a/web/js/mapUI/components/update-collections/updateCollections.js
+++ b/web/js/mapUI/components/update-collections/updateCollections.js
@@ -50,7 +50,7 @@ function UpdateCollections () {
       if (type !== 'NRT' && type !== 'STD') return undefined;
 
       return {
-        id, date: formattedDate, type, version, projection: proj.id
+        id, date: formattedDate, type, version, projection: proj.id,
       };
     } catch (error) {
       // errors will clutter console, turn this on for debugging

--- a/web/js/modules/layers/reducers.js
+++ b/web/js/modules/layers/reducers.js
@@ -351,14 +351,28 @@ export function layerReducer(state = initialState, action) {
       const updates = {};
       action.payload.forEach((collection) => {
         const {
-          id, date, type, version, projection
+          id, date, type, version, projection,
         } = collection;
         // If the layer doesn't exist, initialize it
         if (!state.collections[id]) {
-          updates[id] = { $set: { dates: [{ version, type, date, projection }] } };
+          updates[id] = {
+            $set: {
+              dates: [{
+                version,
+                type,
+                date,
+                projection,
+              }],
+            },
+          };
         } else {
           // If the layer exists, prepare to push to the dates array
-          const newEntry = { date, type, version, projection };
+          const newEntry = {
+            date,
+            type,
+            version,
+            projection,
+          };
           updates[id] = {
             dates: { $push: [newEntry] },
           };

--- a/web/js/modules/layers/reducers.js
+++ b/web/js/modules/layers/reducers.js
@@ -351,14 +351,14 @@ export function layerReducer(state = initialState, action) {
       const updates = {};
       action.payload.forEach((collection) => {
         const {
-          id, date, type, version,
+          id, date, type, version, projection
         } = collection;
         // If the layer doesn't exist, initialize it
         if (!state.collections[id]) {
-          updates[id] = { $set: { dates: [{ version, type, date }] } };
+          updates[id] = { $set: { dates: [{ version, type, date, projection }] } };
         } else {
           // If the layer exists, prepare to push to the dates array
-          const newEntry = { date, type, version };
+          const newEntry = { date, type, version, projection };
           updates[id] = {
             dates: { $push: [newEntry] },
           };

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -126,11 +126,11 @@ export const getStartingLayers = createSelector([getConfig], (config) => resetLa
 
 export const isGroupingEnabled = ({ compare, layers }) => layers[compare.activeString].groupOverlays;
 
-export const getCollections = (layers, dailyDate, subdailyDate, layer) => {
+export const getCollections = (layers, dailyDate, subdailyDate, layer, projId) => {
   if (!layers.collections[layer.id]) return;
   const dateCollection = layers.collections[layer.id].dates;
   for (let i = 0; i < dateCollection.length; i += 1) {
-    if (dateCollection[i].date === dailyDate || dateCollection[i].date === subdailyDate) {
+    if ((dateCollection[i].date === dailyDate || dateCollection[i].date === subdailyDate) && dateCollection[i].projection === projId) {
       return dateCollection[i];
     }
   }


### PR DESCRIPTION
## Description

> Currently, for MODIS_Aqua_NDSI_Snow_Cover on 2007-FEB-26 we have c6.1 for both the poles but have not received 6.1 for geographic yet.  We only have 6.0 for geographic for that day.

 

> Steps:

> Load Worldview geographic for MODIS_Aqua_NDSI_Snow_Cover.  Change the date to 2007- FEB-26.  The badge shows " v6STD" which is correct for geographic (at the moment).  Now switch to either of the poles.  It still shows " v6 STD" which is incorrect b/c we have v6.1 for both poles.

 

> Now open a new window, switch the projection to one of the poles, add MODIS_Aqua_NDSI_Snow_Cover.  Change the date to 2007- FEB-26.  The badge shows " v6.1 STD" which is correct for the poles.  Now switch the projection to geographic.  Geographic show "v6.1 STD" which is incorrect.  We have not received v6.1 for geographic for that day yet. 

 

> It appears whichever projection is loaded first, caches the version for that product across all projections.


## How To Test

1. `git checkout WV-3147-incorrect-badge-version`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?v=-243,-134.859375,243,134.859375&l=MODIS_Aqua_Brightness_Temp_Band31_Day&lg=true&t=2008-03-31-T12%3A00%3A00Z) (I'll try to keep this link updated)
4. Geographic should show v6, Arctic/Antarctic should show v6.1

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
