### PR TITLE
WV-3036 TiTiler Fixes

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Landsat.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Customizable_Sentinel.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Landsat.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Sentinel.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Urban_Sentinel.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_False_Color_Vegetation_Sentinel.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Land Surface Reflectance",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Land Surface Reflectance",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Landsat.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Snow Indices",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDSI_Sentinel.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Snow Indices",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Landsat.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Vegetation Indices",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDVI_Sentinel.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Vegetation Indices",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Landsat.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Land Surface Reflectance",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_NDWI_Sentinel.json
@@ -11,7 +11,7 @@
         "group": "overlays",
         "layergroup": "Land Surface Reflectance",
         "format": "image/png",
-        "type": "ttiler",
+        "type": "titiler",
         "period": "daily",
         "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
         "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Landsat-8_Descending", "OrbitTracks_Landsat-9_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_Shortwave_Infrared_Sentinel.json
@@ -11,7 +11,7 @@
       "group": "overlays",
       "layergroup": "Land Surface Reflectance",
       "format": "image/png",
-      "type": "ttiler",
+      "type": "titiler",
       "period": "daily",
       "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending"],
       "orbitDirection": ["descending", "descending"],

--- a/e2e/features/layers/layer-picker-test.spec.js
+++ b/e2e/features/layers/layer-picker-test.spec.js
@@ -155,8 +155,8 @@ test('Disabling coverage filter updates list', async () => {
   } = selectors
   await availableFilterCheckbox.click()
   await expect(availableFilterCheckboxInput).not.toBeChecked()
-  await expect(layersSearchRow).toHaveCount(13)
-  await expect(layerResultsCountText).toContainText('Showing 13 out of')
+  await expect(layersSearchRow).toHaveCount(14)
+  await expect(layerResultsCountText).toContainText('Showing 14 out of')
 })
 
 test('Finding layer by ID with search', async () => {

--- a/schemas/layer-config.json
+++ b/schemas/layer-config.json
@@ -355,7 +355,7 @@
         "wmts",
         "vector",
         "granule",
-        "ttiler"
+        "titiler"
       ]
     },
     "format": {

--- a/web/js/components/layer/settings/layer-settings.js
+++ b/web/js/components/layer/settings/layer-settings.js
@@ -344,7 +344,7 @@ class LayerSettings extends React.Component {
     } = this.props;
     const hasAssociatedLayers = layer.associatedLayers && layer.associatedLayers.length;
     const hasTracks = layer.orbitTracks && layer.orbitTracks.length;
-    const ttilerLayer = layer.id === 'HLS_Customizable_Sentinel' || layer.id === 'HLS_Customizable_Landsat';
+    const titilerLayer = layer.id === 'HLS_Customizable_Sentinel' || layer.id === 'HLS_Customizable_Landsat';
     const granuleMetadata = layer?.enableCMRDataFinder && !(zot?.underZoomValue > 0);
     const layerGroup = layer.layergroup;
 
@@ -368,7 +368,7 @@ class LayerSettings extends React.Component {
         />
         {this.renderGranuleSettings()}
         {renderCustomizations}
-        {ttilerLayer && <BandSelection layer={layer} />}
+        {titilerLayer && <BandSelection layer={layer} />}
         {granuleMetadata && <ImagerySearch layer={layer} /> }
         {(hasAssociatedLayers || hasTracks) && <AssociatedLayers layer={layer} />}
       </>

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -129,7 +129,7 @@ function LayerRow (props) {
   const ddvLayerZoomNoticeActive = ddvZoomAlerts.includes(layer.title);
   const ddvLayerLocationNoticeActive = ddvLocationAlerts.includes(layer.title);
   // All DDV layer notices are dismissable + Reflectance (Nadir BRDF-Adjusted) + DSWx-HLS
-  const isLayerNotificationDismissable = layer.type === 'ttiler' || layer.title === 'Reflectance (Nadir BRDF-Adjusted)' || layer.subtitle === 'DSWx-HLS';
+  const isLayerNotificationDismissable = layer.type === 'titiler' || layer.title === 'Reflectance (Nadir BRDF-Adjusted)' || layer.subtitle === 'DSWx-HLS';
 
   useEffect(() => {
     const asyncFunc = async () => {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -679,7 +679,7 @@ export default function mapLayerBuilder(config, cache, store) {
     return name;
   };
 
-  const createTtilerLayer = async (def, options, day, state) => {
+  const createTitilerLayer = async (def, options, day, state) => {
     const { proj: { selected }, date } = state;
     const { maxExtent, crs } = selected;
     const { r, g, b } = def.bandCombo;
@@ -793,7 +793,7 @@ export default function mapLayerBuilder(config, cache, store) {
     let layer = cache.getItem(key);
     const isGranule = type === 'granule';
 
-    if (!layer || isGranule || def.type === 'ttiler') {
+    if (!layer || isGranule || def.type === 'titiler') {
       if (!date) date = options.date || getSelectedDate(state);
       const cacheOptions = getCacheOptions(period, date);
       const attributes = {
@@ -824,8 +824,8 @@ export default function mapLayerBuilder(config, cache, store) {
           case 'wms':
             layer = getLayer(createLayerWMS, def, options, attributes, wrapLayer);
             break;
-          case 'ttiler':
-            layer = await getLayer(createTtilerLayer, def, options, attributes, wrapLayer);
+          case 'titiler':
+            layer = await getLayer(createTitilerLayer, def, options, attributes, wrapLayer);
             break;
           case 'xyz':
             layer = getLayer(createXYZLayer, def, options, attributes, wrapLayer);
@@ -835,7 +835,7 @@ export default function mapLayerBuilder(config, cache, store) {
         }
         layer.wv = attributes;
         cache.setItem(key, layer, cacheOptions);
-        if (def.type !== 'ttiler') layer.setVisible(false);
+        if (def.type !== 'titiler') layer.setVisible(false);
       } else {
         layer = await getGranuleLayer(def, attributes, options);
       }

--- a/web/js/mapUI/components/update-date/updateDate.js
+++ b/web/js/mapUI/components/update-date/updateDate.js
@@ -71,7 +71,7 @@ function UpdateDate(props) {
     compareMapUi.update(activeString);
   }
 
-  async function updateDate(outOfStepChange, skipTtiler) {
+  async function updateDate(outOfStepChange, skipTitiler) {
     const { createLayer } = ui;
 
     const layerGroup = getActiveLayerGroup(layerState);
@@ -92,7 +92,7 @@ function UpdateDate(props) {
       const index = findLayerIndex(def);
       const hasVectorStyles = config.vectorStyles && lodashGet(def, 'vectorStyle.id');
       if (isCompareActive && layers.length) {
-        await updateCompareLayer(def, index, mapLayerCollection, layers, skipTtiler);
+        await updateCompareLayer(def, index, mapLayerCollection, layers, skipTitiler);
       } else if (temporalLayer) {
         if (index !== undefined && index !== -1) {
           const layerValue = layers[index];
@@ -127,9 +127,9 @@ function UpdateDate(props) {
       return updateDate(action.outOfStep);
     } if (action.type === layerConstants.TOGGLE_LAYER_VISIBILITY || action.type === layerConstants.TOGGLE_OVERLAY_GROUP_VISIBILITY) {
       const outOfStep = false;
-      // if date not changing we do not want to recreate ttiler layer
-      const skipTtiler = true;
-      return updateDate(outOfStep, skipTtiler);
+      // if date not changing we do not want to recreate titiler layer
+      const skipTitiler = true;
+      return updateDate(outOfStep, skipTitiler);
     }
   };
 

--- a/web/js/modules/map/util.js
+++ b/web/js/modules/map/util.js
@@ -295,7 +295,7 @@ export async function promiseImageryForTime(state, date, activeString) {
   } = map.ui;
   const layers = getActiveVisibleLayersAtDate(state, date, activeString);
   await Promise.all(layers.map(async (layer) => {
-    if (layer.type === 'granule' || layer.type === 'ttiler') {
+    if (layer.type === 'granule' || layer.type === 'titiler') {
       return Promise.resolve();
     }
     const options = { date, group: activeString };
@@ -320,7 +320,7 @@ export async function promiseImageryForTour(state, layers, dateString, activeStr
   const appNow = lodashGet(state, 'date.appNow');
   const date = tryCatchDate(dateString, appNow);
   await Promise.all(layers.map(async (layer) => {
-    if (layer.type === 'granule' || layer.type === 'ttiler') {
+    if (layer.type === 'granule' || layer.type === 'titiler') {
       return Promise.resolve();
     }
     const options = { date, group: activeString || 'active' };

--- a/web/js/modules/product-picker/format-config.js
+++ b/web/js/modules/product-picker/format-config.js
@@ -81,12 +81,15 @@ function setCoverageFacetProp(layer, selectedDate) {
 
 function setTypeProp(layer) {
   const { type } = layer;
-  const rasterTypes = ['wms', 'wmts'];
+  const rasterTypes = ['wms', 'wmts', 'xyz'];
   if (rasterTypes.includes(type)) {
     layer.type = 'Raster (Mosaicked)';
   }
   if (layer.type === 'granule') {
     layer.type = 'Raster (Granule)';
+  }
+  if (layer.type === 'titiler') {
+    layer.type = 'Dynamically-rendered';
   }
   layer.type = capitalizeFirstLetter(layer.type);
   return layer;


### PR DESCRIPTION
## Description
This updates Redux to Redux 5.0.1, as well as updating related packages and adding Redux Toolkit.

## How To Test
1. `git checkout wv-3036-titiler-fixes`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Open the Add Layers window, open the filtered list of all layers, and verify the Imagery Type at the bottom of the filters shows `Dynamically-rendered` instead of `Ttiler`, and that any layers classified before as `xyz` are correctly categorized as `Raster (Mosaicked)` now.
6. Verify that no other behavior is changed since before this update.