### PR TITLE
WV-3044 Screensize Tab Sizing Fix

### DIFF
--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -28,26 +28,6 @@
     border-right: 1px solid #333;
     border-left: 1px solid #333;
 
-    @media screen and (max-width: $desktop-min-width) and (max-height: $mobile-max-width) and (orientation: landscape),
-      (max-width: $mobile-max-width) {
-      &.nav-tabs {
-        height: $wv-mob-sb-tabs-height;
-
-        .nav-item {
-          width: 120px;
-          margin-right: 15px;
-          font-size: 12px;
-
-          a.nav-link {
-            height: $wv-mob-sb-tabs-height - 2;
-            font-size: 18px;
-            padding: 16px 10px 8px;
-            text-align: center;
-          }
-        }
-      }
-    }
-
     &.nav-tabs {
       border-bottom: 3px solid #00457b;
 


### PR DESCRIPTION
## Description
This changes the styling of the main nav tabs (Layers, Events, Data) on certain screen sizes to fit the space better and not overflow.

## How To Test
1. `git checkout wv-3044-screensize-tabs`
2. `npm ci`
3. `npm run watch`
4. Adjust the sizing of the screen using the mobile view of the browser devtools in responsive mode until a screensize of 1026 by 768 is reached. Then slowly make the width more and more narrow and verify that the tabs do not increase in font size nor overflow their boxes.