### PR TITLE
WV-3174 Provide ability to set default number of granules to display on a per layer basis

### DIFF
--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -111,6 +111,7 @@ Example:
     * endDate - `YYYY-MM-DDTHH:MM:SSZ`
     * dateInterval - Number of days (or minutes for subdaily layers)
 * **temporal**: Used to override the layer temporal availability declared in the capabilities document. Note: Changing the temporal availability can cause missing layer coverage within the interface for layers tiles that aren't available from the source at the revised temporal range. This option can be added as a string with the new availability range. For example, `"1981-10-13/2019-10-11/P1M"`.
+* **count**: Used to override the default number of granules for granule layers.
 
 ## Full Example
 
@@ -161,7 +162,8 @@ Granule layers will require specific configuration options within the `config/wv
       ],
       "ongoing": true,
       "type": "granule",
-      "period": "subdaily"
+      "period": "subdaily",
+      "count": 1
     }
   }
 }

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -111,7 +111,7 @@ Example:
     * endDate - `YYYY-MM-DDTHH:MM:SSZ`
     * dateInterval - Number of days (or minutes for subdaily layers)
 * **temporal**: Used to override the layer temporal availability declared in the capabilities document. Note: Changing the temporal availability can cause missing layer coverage within the interface for layers tiles that aren't available from the source at the revised temporal range. This option can be added as a string with the new availability range. For example, `"1981-10-13/2019-10-11/P1M"`.
-* **count**: Used to override the default number of granules for granule layers.
+* **count**: Used to override the default number of granules displayed on the map and in the granule count slider component for granule layers.
 
 ## Full Example
 

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -243,7 +243,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const { proj: { selected: { crs } } } = state;
     const { granuleCount, date, group } = options;
     const { count: currentCount } = getGranuleLayer(state, def.id) || {};
-    const count = currentCount || granuleCount || DEFAULT_NUM_GRANULES;
+    const count = currentCount || granuleCount || def.count || DEFAULT_NUM_GRANULES;
 
     // get granule dates waiting for CMR query and filtering (if necessary)
     const availableGranules = await getQueriedGranuleDates(def, date, group);

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -41,7 +41,7 @@ export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength,
   def.max = spec.max || undefined;
   def.squash = spec.squash || undefined;
   def.disabled = spec.disabled || undefined;
-  def.count = spec.count || undefined;
+  def.count = spec.count || def.count || undefined;
 
   if (Array.isArray(spec.bandCombo)) {
     def.bandCombo = {


### PR DESCRIPTION
## Description

> Provide ability to set the default/initial number of granules displayed in Worldview on a per-layer basis. 

## How To Test

1. `git checkout WV-3079-default-num-granules`
2. In `worldview/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule.json` add `"count": 1`
3. `npm run build`
4. `npm run watch`
5. Open this [link](http://localhost:3000/?v=-198.64054187798072,-86.10029096370278,120.95455824145515,97.55592108409806&z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule&lg=true&t=2024-05-14-T21%3A10%3A19Z)
6. Only one granule should be visible by default

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
