### PR TITLE
WV-3172-Granule imagery not always loading when it should

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -111,6 +111,15 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     return startIsCovered && endIsCovered;
   };
 
+  const getGranulesFromStore = (shortName, nrtShortName) => {
+    const state = store.getState();
+    const { proj: { selected: { crs } } } = state;
+    const existingGranules = CMRDataStore[crs][shortName] || [];
+    const existingNRTGranules = CMRDataStore[crs][nrtShortName] || [];
+
+    return [...existingGranules, ...existingNRTGranules];
+  };
+
   /**
    * Query CMR to get dates
    * @param {object} def - Layer specs
@@ -129,9 +138,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const { shortName: nrtShortName } = nrtParams;
     let data = [];
     let nrtData = [];
-    const existingGranules = CMRDataStore[crs][shortName] || [];
-    const existingNRTGranules = CMRDataStore[crs][nrtShortName] || [];
-    const mergedExistingGranules = existingGranules.concat(existingNRTGranules);
+    const mergedExistingGranules = getGranulesFromStore(shortName, nrtShortName);
     const datesQueried = datesHaveBeenQueried(params.startDate, date, mergedExistingGranules);
 
     if (mergedExistingGranules.length && datesQueried) {
@@ -163,7 +170,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       hideLoading();
     }
 
-    return [...existingNRTGranules, ...existingGranules];
+    return getGranulesFromStore(shortName, nrtShortName);
   };
 
   /**


### PR DESCRIPTION
## Description

> Granule imagery isn't always displayed when it should be.  I believe I found this issue when initially loading a granule layer (or perhaps rearranging layer order), but it can also be reproduced when loading the app from a permalink ([example](https://worldview.earthdata.nasa.gov/?v=-393.18045373749464,-191.69893753238023,308.81954626250536,311.7385624676198&z=4&ics=true&ici=5&icd=10&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule(count=10),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden),Land_Water_Map&lg=false&t=2024-05-14-T19%3A33%3A00Z)). Granule imagery should be displayed when loading that link but only appears once you move the time slider around.

## How To Test

1. `git checkout WV-3172-get-granules`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-98.78100910491418,-120.13131565098205,325.8604666785327,123.89008796763066&z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(count=30)&lg=true&t=2024-05-16-T09%3A45%3A00Z)
4. Imagery and granules should be visible once it loads
5. Imagery and granules should be visible when the page is refreshed

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
