### PR TITLE
WV-2959 Introduction to Worldview Tour Story Fix

### DIFF
--- a/web/js/components/tour/joyride-wrapper.js
+++ b/web/js/components/tour/joyride-wrapper.js
@@ -51,6 +51,7 @@ export default function JoyrideWrapper ({
   const [elementPositionKey, setElementPositionKey] = useState(key);
   const [stepIndex, setStepIndex] = useState();
   const [run, setRun] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   const incrementKey = () => {
     key += 1;
@@ -144,6 +145,7 @@ export default function JoyrideWrapper ({
         setPlaceholderLocation(placeholderEl, targetCoordinates);
       }
     });
+    setIsInitializing(false);
     // Force a re-render so that Joyride updates the beacon location,
     // otherwise it doesn't know the DOM element position was updated
     incrementKey();
@@ -215,7 +217,7 @@ export default function JoyrideWrapper ({
     }
   });
 
-  return !projMatches ? null : (
+  return !projMatches || isInitializing ? null : (
     <Joyride
       run={run}
       stepIndex={stepIndex}


### PR DESCRIPTION
## Description
This fix prevents the Joyride tooltip from flashing onscreen when the tour story is initially selected. This is done by briefly not adding the Joyride tooltip or spotlight to the screen until after the tour story url finishes initializing.

## How To Test
1. `git checkout wv-2959-intro-tour-fix`
2. `npm ci`
3. `npm run watch`
4. Start with a fresh instance of Worldview and click the Introduction to Worldview tour story.
5. Verify that the tooltip did not pop up briefly while the story was loading in. Repeat this process a few times to ensure consistency.
6. Make sure the tour story still functions as it should otherwise.