### PR TITLE
WV-3003 In-Browser Translation Crashing Fix

### DIFF
--- a/web/js/components/layer/info/date-ranges.js
+++ b/web/js/components/layer/info/date-ranges.js
@@ -20,7 +20,8 @@ export default class DateRanges extends React.Component {
       const ListItemEndDate = () => coverageDateFormatter('END-DATE', l.endDate, layer.period);
 
       return (
-        <ListGroupItem key={`${l.startDate} - ${l.endDate}`}>
+        // notranslate included below to prevent Google Translate extension from crashing the page
+        <ListGroupItem key={`${l.startDate} - ${l.endDate}`} className="notranslate">
           <ListItemStartDate />
           {' - '}
           <ListItemEndDate />


### PR DESCRIPTION
## Description
This fix adds the `notranslate` tag to the specific problem element to prevent it from being translated by the Google Translate browser extension.

## How To Test
1. `git checkout wv-3003-translation-extension-fix`
2. `npm ci`
3. `npm run watch`
4. Go to Worldview using Chrome and install Google Translate
5. Click on "translate this page" and change to another language
6. Click on "Add Layers", under Fires, Click on "Aerosol Optical Depth" and add the first layer (MODIS Combined Value-Added Aerosol Optical Depth)
7. Verify that no error occurs and that the app doesn't crash
