### PR TITLE
WV-3182-Tempo L3 CMR availability

### DIFF
--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
@@ -8,6 +8,7 @@
       "group": "overlays",
       "layergroup": "Granules",
       "type": "granule",
+      "cmrAvailability": true,
       "period": "subdaily"
     }
   }

--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1"],
           "availability": {

--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11"],
           "availability": {

--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_TrueColor"],
           "availability": {

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1"],
           "availability": {

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11"],
           "availability": {

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule.json
@@ -7,6 +7,7 @@
           "group":    "overlays",
           "layergroup": "Granules",
           "type": "granule",
+          "cmrAvailability": true,
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_TrueColor"],
           "availability": {

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -112,7 +112,7 @@ Example:
     * dateInterval - Number of days (or minutes for subdaily layers)
 * **temporal**: Used to override the layer temporal availability declared in the capabilities document. Note: Changing the temporal availability can cause missing layer coverage within the interface for layers tiles that aren't available from the source at the revised temporal range. This option can be added as a string with the new availability range. For example, `"1981-10-13/2019-10-11/P1M"`.
 * **count**: Used to override the default number of granules displayed on the map and in the granule count slider component for granule layers.
-* **cmrAvailability**: Boolean - Whether of not to use the CMR API for data availability.
+* **cmrAvailability**: Boolean - Whether or not to use the CMR API for data availability.
 
 ## Full Example
 

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -112,6 +112,7 @@ Example:
     * dateInterval - Number of days (or minutes for subdaily layers)
 * **temporal**: Used to override the layer temporal availability declared in the capabilities document. Note: Changing the temporal availability can cause missing layer coverage within the interface for layers tiles that aren't available from the source at the revised temporal range. This option can be added as a string with the new availability range. For example, `"1981-10-13/2019-10-11/P1M"`.
 * **count**: Used to override the default number of granules displayed on the map and in the granule count slider component for granule layers.
+* **cmrAvailability**: Boolean - Whether of not to use the CMR API for data availability.
 
 ## Full Example
 
@@ -134,7 +135,8 @@ Example:
       "palette": {
         "id": "AIRS_RH400_A"
       },
-      "temporal": "1981-10-13/2019-10-11/P1M"
+      "temporal": "1981-10-13/2019-10-11/P1M",
+      "cmrAvailability": false
     }
   }
 }
@@ -162,6 +164,7 @@ Granule layers will require specific configuration options within the `config/wv
       ],
       "ongoing": true,
       "type": "granule",
+      "cmrAvailability": true,
       "period": "subdaily",
       "count": 1
     }

--- a/web/js/components/timeline/timeline-coverage/timeline-coverage.js
+++ b/web/js/components/timeline/timeline-coverage/timeline-coverage.js
@@ -99,7 +99,7 @@ async function getLayerGranuleRanges(layer) {
 
 async function mapGranulesToLayers(layers) {
   const promises = layers.map(async (layer) => {
-    if (layer.type !== 'granule') return layer;
+    if (!layer.cmrAvailability) return layer;
 
     const ranges = await getLayerGranuleRanges(layer);
 


### PR DESCRIPTION
## Description

This PR changes the requirement for implementing the CMR data availability functionality from `type: 'granule'` to `cmrAvailability: true` as this is more explicit and without side effects.

## How To Test

1. `git checkout WV-3182-TEMPO-L3`
2. `npm run build`
3. `npm run watch`
4. Open this [link](http://localhost:3000/?v=-243,-139.640625,243,139.640625&z=4&ics=true&ici=5&icd=10&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(count=10)&lg=true&t=2024-05-20-T11%3A54%3A00Z)
5. Ensure that there is a multipart coverage bar (when it loads)

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
