### PR TITLE
WV-3176 Missing Sentinel Tracks Fix

### DIFF
--- a/config/default/common/config/wv.json/measurements/Orbital Track.json
+++ b/config/default/common/config/wv.json/measurements/Orbital Track.json
@@ -284,28 +284,27 @@
                         "OrbitTracks_Sentinel-2B_Ascending",
                         "OrbitTracks_Sentinel-2B_Descending"
                     ]
-                    ,
-                    "Sentinel-3A/Space-Track.org": {
-                        "id": "space-track-org-sentinel-3a",
-                        "title": "Sentinel-3A/Space-Track.org",
-                        "description": "",
-                        "image": "",
-                        "settings": [
-                            "OrbitTracks_Sentinel-3A_Ascending",
-                            "OrbitTracks_Sentinel-3A_Descending"
-                        ]
-                    },
-                    "Sentinel-3B/Space-Track.org": {
-                        "id": "space-track-org-sentinel-3b",
-                        "title": "Sentinel-3B/Space-Track.org",
-                        "description": "",
-                        "image": "",
-                        "settings": [
-                            "OrbitTracks_Sentinel-3B_Ascending",
-                            "OrbitTracks_Sentinel-3B_Descending"
-                        ]
-                    }}
-                ,
+                },
+                "Sentinel-3A/Space-Track.org": {
+                    "id": "space-track-org-sentinel-3a",
+                    "title": "Sentinel-3A/Space-Track.org",
+                    "description": "",
+                    "image": "",
+                    "settings": [
+                        "OrbitTracks_Sentinel-3A_Ascending",
+                        "OrbitTracks_Sentinel-3A_Descending"
+                    ]
+                },
+                "Sentinel-3B/Space-Track.org": {
+                    "id": "space-track-org-sentinel-3b",
+                    "title": "Sentinel-3B/Space-Track.org",
+                    "description": "",
+                    "image": "",
+                    "settings": [
+                        "OrbitTracks_Sentinel-3B_Ascending",
+                        "OrbitTracks_Sentinel-3B_Descending"
+                    ]
+                },
                 "Sentinel-5P/Space-Track.org": {
                     "id": "space-track-org-sentinel-5p",
                     "title": "Sentinel-5P/Space-Track.org",


### PR DESCRIPTION
## Description
This fixes sentinel tracks of 3A and 3B not showing in the [Visualization Product Catalog](https://nasa-gibs.github.io/gibs-api-docs/available-visualizations/#visualization-product-catalog). This fix adds the layers back into the `wv.json` file, which is what is used to generate the list in the viz catalog.

## How To Test
1. `git checkout wv-3176-sentinel-tracks-missing`
2. `npm ci`
3. `npm run build`
4. Open `wv.json` and make sure Sentinel-3A and Sentinel-3B appear under `"measurements" --> "Orbital Track"` as their own entry, and not as a sub-entry inside Sentinel-2B.
