### PR TITLE
WV-3190 Smallest Subdaily Timeline Interval

### DIFF
--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -33,7 +33,10 @@ import {
   dateRange as getDateRange,
   hasSubDaily,
   subdailyLayersActive,
+  subdailyLayers,
   getActiveLayers,
+  getSubDaily,
+  getSmallestIntervalValue,
 } from '../../modules/layers/selectors';
 import { getSelectedDate, getDeltaIntervalUnit } from '../../modules/date/selectors';
 import {
@@ -278,7 +281,6 @@ class Timeline extends React.Component {
       animEndLocationDate,
       changeCustomInterval,
       customInterval,
-      customSelected,
       dateA,
       dateB,
       interval,
@@ -286,6 +288,8 @@ class Timeline extends React.Component {
       isAnimationWidgetOpen,
       isGifActive,
       hasSubdailyLayers,
+      subDailyLayersList,
+      newCustomDelta,
     } = this.props;
     const { frontDate, draggerTimeState, draggerTimeStateB } = this.state;
 
@@ -309,8 +313,8 @@ class Timeline extends React.Component {
       }
     }
 
-    const subdailyAdded = hasSubdailyLayers && !prevProps.hasSubdailyLayers;
     const subdailyRemoved = !hasSubdailyLayers && prevProps.hasSubdailyLayers;
+    const subDailyCountChanged = subDailyLayersList.length !== prevProps.subDailyLayersList.length;
     const subdailyInterval = customInterval > 3 || interval > 3;
 
     if (subdailyRemoved && subdailyInterval) {
@@ -318,8 +322,8 @@ class Timeline extends React.Component {
       selectInterval(1, TIME_SCALE_TO_NUMBER.day, false);
     }
 
-    if (subdailyAdded && !customSelected) {
-      changeCustomInterval(10, TIME_SCALE_TO_NUMBER.minute);
+    if (subDailyCountChanged) {
+      changeCustomInterval(newCustomDelta, TIME_SCALE_TO_NUMBER.minute);
     }
 
     // if user adds a subdaily layer (and none were active) change the time scale to hourly
@@ -1519,7 +1523,10 @@ function mapStateToProps(state) {
   const hasSubdailyLayers = isCompareModeActive
     ? hasSubDaily(layers.active.layers) || hasSubDaily(layers.activeB.layers)
     : subdailyLayersActive(state);
-
+  const subDailyLayersList = isCompareModeActive
+    ? [...getSubDaily(layers.active.layers), ...getSubDaily(layers.activeB.layers)]
+    : subdailyLayers(state);
+  const newCustomDelta = getSmallestIntervalValue(state);
 
   // if future layers are included, timeline axis end date will extend past appNow
   const hasFutureLayers = checkHasFutureLayers(state);
@@ -1586,6 +1593,7 @@ function mapStateToProps(state) {
     breakpoints,
     draggerSelected: isCompareA ? 'selected' : 'selectedB',
     hasSubdailyLayers,
+    subDailyLayersList,
     customSelected,
     isCompareModeActive,
     isAnimatingToEvent,
@@ -1626,6 +1634,7 @@ function mapStateToProps(state) {
     isEmbedModeActive,
     isKioskModeActive,
     displayStaticMap,
+    newCustomDelta,
   };
 }
 
@@ -1711,6 +1720,7 @@ Timeline.propTypes = {
   draggerSelected: PropTypes.string,
   hasFutureLayers: PropTypes.bool,
   hasSubdailyLayers: PropTypes.bool,
+  subDailyLayersList: PropTypes.object,
   hideTimeline: PropTypes.bool,
   interval: PropTypes.number,
   isAnimationPlaying: PropTypes.bool,

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -322,11 +322,12 @@ class Timeline extends React.Component {
       selectInterval(1, TIME_SCALE_TO_NUMBER.day, false);
     }
 
+    const isSubDaily = newCustomDelta < 1440; // 1440 == 1 day in minutes
     if (subDailyCountChanged) {
-      if (newCustomDelta === 1440) {
-        changeCustomInterval(1, TIME_SCALE_TO_NUMBER.day);
-      } else {
+      if (isSubDaily) {
         changeCustomInterval(newCustomDelta, TIME_SCALE_TO_NUMBER.minute);
+      } else {
+        changeCustomInterval(1, TIME_SCALE_TO_NUMBER.day);
       }
     }
 

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -323,7 +323,11 @@ class Timeline extends React.Component {
     }
 
     if (subDailyCountChanged) {
-      changeCustomInterval(newCustomDelta, TIME_SCALE_TO_NUMBER.minute);
+      if (newCustomDelta === 1440) {
+        changeCustomInterval(1, TIME_SCALE_TO_NUMBER.day);
+      } else {
+        changeCustomInterval(newCustomDelta, TIME_SCALE_TO_NUMBER.minute);
+      }
     }
 
     // if user adds a subdaily layer (and none were active) change the time scale to hourly

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -617,11 +617,12 @@ export const subdailyLayers = createSelector(
  */
 export function getSmallestIntervalValue(state) {
   const layers = getActiveLayers(state);
-  let smallestDelta = 1440;
+  let smallestDelta = 1440; // 1 day in minutes
   if (layers && layers.length) {
     for (let i = 0; i < layers.length; i += 1) {
-      if (layers[i].period === 'subdaily' && lodashGet(layers[i], 'dateRanges[0].dateInterval') < smallestDelta) {
-        smallestDelta = Number(lodashGet(layers[i], 'dateRanges[0].dateInterval'));
+      const interval = lodashGet(layers[i], 'dateRanges[0].dateInterval');
+      if (layers[i].period === 'subdaily' && interval < smallestDelta) {
+        smallestDelta = Number(interval);
       }
     }
   }

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -591,6 +591,44 @@ export const subdailyLayersActive = createSelector(
 );
 
 /**
+ * Get subdaily layers from given layers
+ * @param {Array} layers
+ */
+export function getSubDaily(layers) {
+  const outputLayers = [];
+  if (layers && layers.length) {
+    for (let i = 0; i < layers.length; i += 1) {
+      if (layers[i].period === 'subdaily') {
+        outputLayers.push(layers[i]);
+      }
+    }
+  }
+  return outputLayers;
+}
+
+export const subdailyLayers = createSelector(
+  [getActiveLayers],
+  (layers) => getSubDaily(layers),
+);
+
+/**
+ * Gets smallest interval value of subdaily layers
+ * @param {Object} state
+ */
+export function getSmallestIntervalValue(state) {
+  const layers = getActiveLayers(state);
+  let smallestDelta = 1440;
+  if (layers && layers.length) {
+    for (let i = 0; i < layers.length; i += 1) {
+      if (layers[i].period === 'subdaily' && lodashGet(layers[i], 'dateRanges[0].dateInterval') < smallestDelta) {
+        smallestDelta = Number(lodashGet(layers[i], 'dateRanges[0].dateInterval'));
+      }
+    }
+  }
+  return smallestDelta;
+}
+
+/**
  *
  * @param {*} config
  * @param {*} layerId


### PR DESCRIPTION
## Description
This code change changes the behavior of the timeline interval for subdaily layers. Firstly, it allows for subdaily layers to set a custom interval of something other than 10 minutes, and secondly, if multiple subdaily layers are present and have multiple custom intervals, the smallest interval is chosen.

## How To Test
1. `git checkout wv-3190-smallest-interval-subdaily`
2. `npm ci`
3. `npm run watch`
4. Open a fresh worldview instance and add a subdaily layer with a custom interval of something other than 10 minutes, like `VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule`.
5. Verify that the timeline interval correctly reflects the custom interval.
6. Add another subdaily layer, with a different custom interval than the first subdaily layer added, like `Himawari_AHI_Air_Mass`.
7. Verify that the timeline interval correctly reflects the smaller of the two custom intervals.
8. Repeat the process with the same layers in a new worldview instance, but add the second layer from before first. Verify the behavior is the same.
