### PR TITLE
WV-3111 Kiosk Mode Logo Reset

### DIFF
--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -179,8 +179,9 @@ class Sidebar extends React.Component {
 
   handleWorldviewLogoClick(e, permalink) {
     e.preventDefault();
-    const { isEmbedModeActive } = this.props;
+    const { isEmbedModeActive, isKioskModeActive } = this.props;
     if (window.location.search === '') return; // Nothing to reset
+    if (isKioskModeActive) return;
     let msg;
     if (isEmbedModeActive) {
       msg = 'Do you want to open full featured @NAME@ in a new tab with current content loaded?';

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -247,13 +247,7 @@ class Sidebar extends React.Component {
       };
 
     return (
-      !isKioskModeActive ? (
-        <span
-          id="wv-logo"
-          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
-          style={sidebarStyle}
-        />
-      ) : (
+      isKioskModeActive ? (
         <a
           href={embedWVLogoLink}
           title={WVLogoTitle}
@@ -261,6 +255,12 @@ class Sidebar extends React.Component {
           className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
           style={sidebarStyle}
           onClick={(e) => this.handleWorldviewLogoClick(e, permalink)}
+        />
+      ) : (
+        <span
+          id="wv-logo"
+          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
+          style={sidebarStyle}
         />
       )
     );

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -179,9 +179,8 @@ class Sidebar extends React.Component {
 
   handleWorldviewLogoClick(e, permalink) {
     e.preventDefault();
-    const { isEmbedModeActive, isKioskModeActive } = this.props;
+    const { isEmbedModeActive } = this.props;
     if (window.location.search === '') return; // Nothing to reset
-    if (isKioskModeActive) return;
     let msg;
     if (isEmbedModeActive) {
       msg = 'Do you want to open full featured @NAME@ in a new tab with current content loaded?';
@@ -207,6 +206,7 @@ class Sidebar extends React.Component {
       isEmbedModeActive,
       selectedDate,
       isMobile,
+      isKioskModeActive,
     } = this.props;
     const permalink = getPermalink(history.location.search, selectedDate);
     const WVLogoTitle = isEmbedModeActive
@@ -247,14 +247,22 @@ class Sidebar extends React.Component {
       };
 
     return (
-      <a
-        href={embedWVLogoLink}
-        title={WVLogoTitle}
-        id="wv-logo"
-        className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
-        style={sidebarStyle}
-        onClick={(e) => this.handleWorldviewLogoClick(e, permalink)}
-      />
+      !isKioskModeActive ? (
+        <span
+          id="wv-logo"
+          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
+          style={sidebarStyle}
+        />
+      ) : (
+        <a
+          href={embedWVLogoLink}
+          title={WVLogoTitle}
+          id="wv-logo"
+          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
+          style={sidebarStyle}
+          onClick={(e) => this.handleWorldviewLogoClick(e, permalink)}
+        />
+      )
     );
   }
 

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -248,6 +248,12 @@ class Sidebar extends React.Component {
 
     return (
       isKioskModeActive ? (
+        <span
+          id="wv-logo"
+          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
+          style={sidebarStyle}
+        />
+      ) : (
         <a
           href={embedWVLogoLink}
           title={WVLogoTitle}
@@ -255,12 +261,6 @@ class Sidebar extends React.Component {
           className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
           style={sidebarStyle}
           onClick={(e) => this.handleWorldviewLogoClick(e, permalink)}
-        />
-      ) : (
-        <span
-          id="wv-logo"
-          className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
-          style={sidebarStyle}
         />
       )
     );


### PR DESCRIPTION
## Description
This disables the ability to click the Worldview logo at the top of the sidebar to reset the worldview instance.

## How To Test
1. `git checkout wv-3111-kiosk-logo-disable`
2. `npm ci`
3. `npm run build`
4. Open [this link](http://localhost:3000/?kiosk=true&t=2024-05-31-T20%3A17%3A01Z) and verify that clicking the Worldview logo does not reset the page.
