### PR TITLE
WV-3171: Added companion orbit track as associated layer

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Aqua_Descending"],
       "palette": {
         "id": "OrbitTracks_Aqua_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aqua_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Aqua_Ascending"],
       "palette": {
         "id": "OrbitTracks_Aqua_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Aura_Descending"],
       "palette": {
         "id": "OrbitTracks_Aura_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Aura_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Aura_Ascending"],
       "palette": {
         "id": "OrbitTracks_Aura_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CYGNSS_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CYGNSS_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_CYGNSS_Descending"],
       "palette": {
         "id": "OrbitTracks_CYGNSS_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CYGNSS_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CYGNSS_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_CYGNSS_Ascending"],
       "palette": {
         "id": "OrbitTracks_CYGNSS_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Calipso_Descending"],
       "palette": {
         "id": "OrbitTracks_Calipso_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Calipso_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Calipso_Ascending"],
       "palette": {
         "id": "OrbitTracks_Calipso_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_CloudSat_Descending"],
       "palette": {
         "id": "OrbitTracks_CloudSat_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_CloudSat_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_CloudSat_Ascending"],
       "palette": {
         "id": "OrbitTracks_CloudSat_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-C_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-C_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_GCOM-C_Descending"],
       "palette": {
         "id": "OrbitTracks_GCOM-C_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-C_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-C_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_GCOM-C_Ascending"],
       "palette": {
         "id": "OrbitTracks_GCOM-C_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-W1_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-W1_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_GCOM-W1_Descending"],
       "palette": {
         "id": "OrbitTracks_GCOM-W1_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-W1_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GCOM-W1_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_GCOM-W1_Ascending"],
       "palette": {
         "id": "OrbitTracks_GCOM-W1_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT-2_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_GOSAT-2_Descending"],
       "palette": {
         "id": "OrbitTracks_GOSAT-2_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT-2_Descending.json
@@ -9,6 +9,7 @@
       "layergroup": "Orbital Track",
       "wrapadjacentdays": true,
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_GOSAT-2_Ascending"],
       "palette": {
         "id": "OrbitTracks_GOSAT-2_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_GOSAT_Descending"],
       "palette": {
         "id": "OrbitTracks_GOSAT_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GOSAT_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_GOSAT_Ascending"],
       "palette": {
         "id": "OrbitTracks_GOSAT_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_GPM_Descending"],
       "palette": {
         "id": "OrbitTracks_GPM_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_GPM_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_GPM_Ascending"],
       "palette": {
         "id": "OrbitTracks_GPM_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_ICESAT-2_Descending"],
       "palette": {
         "id": "OrbitTracks_ICESAT-2_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ICESAT-2_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_ICESAT-2_Ascending"],
       "palette": {
         "id": "OrbitTracks_ICESAT-2_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_ISS_Descending"],
       "palette": {
         "id": "OrbitTracks_ISS_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_ISS_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_ISS_Ascending"],
       "palette": {
         "id": "OrbitTracks_ISS_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Landsat-7_Descending"],
       "palette": {
         "id": "OrbitTracks_Landsat-7_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-7_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Landsat-7_Ascending"],
       "palette": {
         "id": "OrbitTracks_Landsat-7_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Landsat-8_Descending"],
       "palette": {
         "id": "OrbitTracks_Landsat-8_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-8_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Landsat-8_Ascending"],
       "palette": {
         "id": "OrbitTracks_Landsat-8_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-9_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-9_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Landsat-9_Descending"],
       "palette": {
         "id": "OrbitTracks_Landsat-9_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-9_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Landsat-9_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Landsat-9_Ascending"],
       "palette": {
         "id": "OrbitTracks_Landsat-9_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-A_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_METOP-A_Descending"],
       "palette": {
         "id": "OrbitTracks_METOP-A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-A_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_METOP-A_Ascending"],
       "palette": {
         "id": "OrbitTracks_METOP-A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-B_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_METOP-B_Descending"],
       "palette": {
         "id": "OrbitTracks_METOP-B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-B_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_METOP-B_Ascending"],
       "palette": {
         "id": "OrbitTracks_METOP-B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_METOP-C_Descending"],
       "palette": {
         "id": "OrbitTracks_METOP-C_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_METOP-C_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_METOP-C_Ascending"],
       "palette": {
         "id": "OrbitTracks_METOP-C_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-20_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-20_Ascending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_NOAA-20_Descending"],
       "palette": {
         "id": "OrbitTracks_NOAA-20_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-20_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-20_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_NOAA-20_Ascending"],
       "palette": {
         "id": "OrbitTracks_NOAA-20_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-21_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-21_Ascending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_NOAA-21_Descending"],
       "palette": {
         "id": "OrbitTracks_NOAA-21_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-21_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_NOAA-21_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_NOAA-21_Ascending"],
       "palette": {
         "id": "OrbitTracks_NOAA-21_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_OCO-2_Descending"],
       "palette": {
         "id": "OrbitTracks_OCO-2_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_OCO-2_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_OCO-2_Ascending"],
       "palette": {
         "id": "OrbitTracks_OCO-2_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_PACE_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_PACE_Ascending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_PACE_Descending"],
       "palette": {
         "id": "OrbitTracks_PACE_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_PACE_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_PACE_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_PACE_Ascending"],
       "palette": {
         "id": "OrbitTracks_PACE_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_SAOCOM1-A_Descending"],
       "palette": {
         "id": "OrbitTracks_SAOCOM1-A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SAOCOM1-A_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_SAOCOM1-A_Ascending"],
       "palette": {
         "id": "OrbitTracks_SAOCOM1-A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_SMAP_Descending"],
       "palette": {
         "id": "OrbitTracks_SMAP_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_SMAP_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_SMAP_Ascending"],
       "palette": {
         "id": "OrbitTracks_SMAP_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-1A_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-1A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1A_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-1A_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-1A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-1B_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-1B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-1B_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-1B_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-1B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-2A_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-2A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2A_Descending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-2A_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-2A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-2B_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-2B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-2B_Descending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-2B_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-2B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3A_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3A_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-3A_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-3A_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3A_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3A_Descending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-3A_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-3A_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3B_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3B_Ascending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-3B_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-3B_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3B_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-3B_Descending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-3B_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-3B_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Ascending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Sentinel-5P_Descending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-5P_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Sentinel-5P_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Sentinel-5P_Ascending"],
       "palette": {
         "id": "OrbitTracks_Sentinel-5P_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Ascending.json
@@ -10,6 +10,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Suomi_NPP_Descending"],
       "palette": {
         "id": "OrbitTracks_Suomi_NPP_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Suomi_NPP_Descending.json
@@ -9,6 +9,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Suomi_NPP_Ascending"],
       "palette": {
         "id": "OrbitTracks_Suomi_NPP_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_TRMM_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_TRMM_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_TRMM_Descending"],
       "palette": {
         "id": "OrbitTracks_TRMM_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_TRMM_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_TRMM_Descending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_TRMM_Ascending"],
       "palette": {
         "id": "OrbitTracks_TRMM_Descending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Ascending.json
@@ -8,6 +8,7 @@
       "period": "daily",
       "layergroup": "Orbital Track",
       "track": "ascending",
+      "associatedLayers": ["OrbitTracks_Terra_Descending"],
       "palette": {
         "id": "OrbitTracks_Terra_Ascending",
         "immutable": true

--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Descending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_Terra_Descending.json
@@ -9,6 +9,7 @@
       "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "descending",
+      "associatedLayers": ["OrbitTracks_Terra_Ascending"],
       "palette": {
         "id": "OrbitTracks_Terra_Descending",
         "immutable": true


### PR DESCRIPTION
## Description

Fixes #WV-3171 .

Added companion orbit track as associated layer.

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,OrbitTracks_GCOM-W1_Ascending,OrbitTracks_Sentinel-3A_Ascending(hidden),OrbitTracks_Sentinel-2B_Ascending(hidden),OrbitTracks_TRMM_Ascending(hidden),OrbitTracks_Terra_Ascending(hidden),OrbitTracks_Suomi_NPP_Ascending(hidden),OrbitTracks_Sentinel-5P_Ascending(hidden),OrbitTracks_Sentinel-3B_Ascending(hidden),OrbitTracks_Sentinel-2A_Ascending(hidden),OrbitTracks_Sentinel-1B_Ascending(hidden),OrbitTracks_Sentinel-1A_Ascending(hidden),OrbitTracks_SMAP_Ascending(hidden),OrbitTracks_SAOCOM1-A_Ascending(hidden),OrbitTracks_PACE_Ascending(hidden),OrbitTracks_OCO-2_Ascending(hidden),OrbitTracks_NOAA-21_Ascending(hidden),OrbitTracks_NOAA-20_Ascending(hidden),OrbitTracks_METOP-C_Ascending(hidden),OrbitTracks_METOP-B_Ascending(hidden),OrbitTracks_METOP-A_Ascending(hidden),OrbitTracks_Landsat-9_Ascending(hidden),OrbitTracks_Landsat-8_Ascending(hidden),OrbitTracks_Landsat-7_Ascending(hidden),OrbitTracks_ISS_Ascending(hidden),OrbitTracks_ICESAT-2_Ascending(hidden),OrbitTracks_GPM_Ascending(hidden),OrbitTracks_GOSAT_Ascending(hidden),OrbitTracks_GOSAT-2_Ascending(hidden),OrbitTracks_GCOM-C_Ascending(hidden),OrbitTracks_CloudSat_Ascending(hidden),OrbitTracks_Calipso_Ascending(hidden),OrbitTracks_CYGNSS_Ascending(hidden),OrbitTracks_Aura_Ascending(hidden),OrbitTracks_Aqua_Ascending(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2024-06-04-T14%3A29%3A25Z)
2. Click on the Settings icon, and see if the associated orbit track is listed and displays properly on the map.
3. Verify expected result

@nasa-gibs/worldview
