### PR TITLE
WV-3233-date-change-bug

### DIFF
--- a/web/js/mapUI/components/update-date/updateDate.js
+++ b/web/js/mapUI/components/update-date/updateDate.js
@@ -123,7 +123,10 @@ function UpdateDate(props) {
       return updateDate(action.outOfStep);
     }
     if (action.type === layerConstants.TOGGLE_LAYER_VISIBILITY || action.type === layerConstants.TOGGLE_OVERLAY_GROUP_VISIBILITY) {
-      return updateLayerVisibilities();
+      const outOfStep = false;
+      // if date not changing we do not want to recreate titiler layer
+      const skipTitiler = true;
+      return updateDate(outOfStep, skipTitiler);
     }
   };
 


### PR DESCRIPTION
## Description

> When you change the date, Worldview is not loading the imagery for the correct date

## How To Test

1. `git checkout WV-3233-date-change-bug`
2. `npm run watch`
3. go to this [link](http://localhost:3000/)
4. go back one day
5. toggle hidden layers
6. verify that the hidden layers load the correct date.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
