### PR TITLE
WV-3234-L2 TEMPO imagery not showing at the correct time

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -153,9 +153,10 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     const availableCount = availableGranules?.length;
     if (!availableCount) return granules;
     const count = granuleCount > availableCount ? availableCount : granuleCount;
+    const sortedAvailableGranules = availableGranules.sort((a, b) => new Date(b.date) - new Date(a.date));
 
     for (let i = 0; granules.length < count; i += 1) {
-      const item = availableGranules[i];
+      const item = sortedAvailableGranules[i];
       if (!item) break;
       const { date } = item;
       if (new Date(date) <= leadingEdgeDate && isWithinBounds(crs, item)) {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -197,7 +197,7 @@ export default function mapLayerBuilder(config, cache, store) {
     }
 
     if (def.period === 'subdaily') {
-      closestDate = nearestInterval(def, closestDate);
+      closestDate = def.id.includes('TEMPO_L2') ? closestDate : nearestInterval(def, closestDate);
     } else if (previousDateFromRange) {
       closestDate = util.clearTimeUTC(previousDateFromRange);
     } else {


### PR DESCRIPTION
## Description

> Worldview is not displaying the correct imagery for the correct time for L2 TEMPO products. 

## How To Test

1. `git checkout WV-3234-tempo-time`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-294.6534092430343,-97.41426940088749,159.41572020995577,163.51781714241062&z=4&ics=true&ici=5&icd=6&l=TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1)&lg=true&t=2024-06-17-T13%3A50%3A00Z)
4. Verify that granules and imagery load throughout the entire block of available time at 6 minute intervals.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
