### PR TITLE
WV-3210 Distraction Free Timezone Fix

### DIFF
--- a/web/js/components/timeline/kiosk-timestamp.js
+++ b/web/js/components/timeline/kiosk-timestamp.js
@@ -36,6 +36,7 @@ function KioskTimeStamp({ date, subdaily, isKioskModeActive }) {
   const kioskMonth = dateParts.find((part) => part.type === 'month').value.slice(0, 3);
   const kioskDay = dateParts.find((part) => part.type === 'day').value;
   const kioskHour = dateParts.find((part) => part.type === 'hour').value;
+  const kioskTimeZoneLabel = isDaylightSavingsTime ? 'EDT' : 'EST';
 
   const dfYear = date.getUTCFullYear();
   const dfMonth = MONTH_STRING_ARRAY[date.getUTCMonth()];
@@ -48,7 +49,7 @@ function KioskTimeStamp({ date, subdaily, isKioskModeActive }) {
   const hour = updateKioskModeTime ? kioskHour : dfHour;
 
   const minutes = dateParts.find((part) => part.type === 'minute').value;
-  const timeZoneLabel = updateKioskModeTime ? isDaylightSavingsTime ? 'EDT' : 'EST' : 'UTC';
+  const timeZoneLabel = updateKioskModeTime ? kioskTimeZoneLabel : 'UTC';
 
   return (
     <>

--- a/web/js/components/timeline/kiosk-timestamp.js
+++ b/web/js/components/timeline/kiosk-timestamp.js
@@ -48,7 +48,7 @@ function KioskTimeStamp({ date, subdaily, isKioskModeActive }) {
   const hour = updateKioskModeTime ? kioskHour : dfHour;
 
   const minutes = dateParts.find((part) => part.type === 'minute').value;
-  const timeZoneLabel = isDaylightSavingsTime ? 'EDT' : 'EST';
+  const timeZoneLabel = updateKioskModeTime ? isDaylightSavingsTime ? 'EDT' : 'EST' : 'UTC';
 
   return (
     <>


### PR DESCRIPTION
## Description
This change adds logic to the KioskTimeStamp component to correctly list UTC as the timezone when in distraction free mode.

## How To Test
1. `git checkout wv-3210-df-timezone-label`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-263.0855216903962,-171.5672820006298,197.40353620001952,172.94675390257015&z=4&ics=true&ici=5&icd=10&df=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GOES-East_ABI_GeoColor,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-06-06-T09%3A54%3A00Z) (distraction free mode) and verify that the time is correct and lists it as UTC
5. Open [this link](http://localhost:3000/?v=-263.08552169039626,-171.5672820006298,197.40353620001957,172.94675390257015&z=4&ics=true&ici=5&icd=10&df=true&kiosk=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,GOES-East_ABI_GeoColor,VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2024-06-06-T09%3A54%3A00Z) (kiosk mode) and verify that the change does not affect kiosk mode and it still displays in EDT