### PR TITLE
WV-3179 and the case of the disappearing badge

### DIFF
--- a/web/js/mapUI/components/update-collections/updateCollections.js
+++ b/web/js/mapUI/components/update-collections/updateCollections.js
@@ -68,7 +68,7 @@ function UpdateCollections () {
       const layerInCollections = collections[layer.id];
       if (!layerInCollections) return true; // Layer not in collections, needs to be updated
 
-      const collectionDate = layerInCollections.dates.some((d) => d.date === date);
+      const collectionDate = layerInCollections.dates.some((d) => d.date === date && d.projection === proj.id);
 
       return !collectionDate || forceUpdate; // If date exists in layer collection, don't query layer
     });


### PR DESCRIPTION
## Description

> Worldview badge disappears when changing projections

## How To Test

1. `git checkout WV-3179-badge-bug`
2. `npm ci && npm run build && npm run watch`
3. Go to this [link](http://localhost:3000/?v=-243,-139.640625,243,139.640625&l=VIIRS_NOAA20_Ice_Surface_Temp_Night,VIIRS_NOAA20_Ice_Surface_Temp_Day,VIIRS_NOAA20_Sea_Ice,VIIRS_NOAA20_NDSI_Snow_Cover&lg=false&t=2019-01-01-T19%3A30%3A26Z)
4. Change the date
5. Change the projection to arctic
6. Change the date again
7. Barring network issues, verify that the version badges are showing up for all layers.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
