### PR TITLE
WV-3065 GITC WV Build layer-metadata Filtering

### DIFF
--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -108,7 +108,9 @@ async function main (url) {
 
   console.warn(`${prog}: Fetching ${layerOrder.length} layer-metadata files`)
   for (const layerId of layerOrder) {
-    await getMetadata(layerId, url)
+    if (!layerId.includes('_STD') && !layerId.includes('_NRT')) {
+      await getMetadata(layerId, url)
+    }
   }
 
   const layers = Object.keys(layerMetadata).sort().reduce(


### PR DESCRIPTION
## Description
This change adds a check in the build process to prevent `STD` and `NRT` layers (non-BEST layers) from attempting to fetch layer-metadata files (which don't exist). This should only affect builds done using GITC's build options.

## How To Test
1. `git checkout wv-3065-gitc-best-build`
2. Set up the environment to use GITC's build options (loosely documented [here](https://git.earthdata.nasa.gov/projects/GIBS/repos/worldview-options-gibs/browse/README.md))
3. Run the build using the GITC build options (`IGNORE_ERRORS=true npm run build`)
4. Verify via the terminal console that STD and NRT layer-metadata files are not trying to be fetched and failing