### PR TITLE
WV-3104 GIBS API Link in Embed Tab

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -349,7 +349,7 @@ class ShareLinkContainer extends Component {
     } = this.state;
 
     return (
-      <div className={`share-body${activeTab === 'embed' ? ' share-body-tall' : ''}`}>
+      <div className={`share-body${activeTab === 'embed' ? '-tall' : ''}`}>
         <ShareToolTips
           activeTab={activeTab}
           tooltipErrorTime={tooltipErrorTime}

--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -305,6 +305,13 @@ class ShareLinkContainer extends Component {
               {' '}
               to enable Worldview embedding on your website.
             </p>
+            <p>
+              View the
+              {' '}
+              <a href="https://nasa-gibs.github.io/gibs-api-docs/" target="_blank" rel="noopener noreferrer" id="api-doc-url">API documentation</a>
+              {' '}
+              to learn how to directly access the imagery via GIBS.
+            </p>
           </>
         )}
       </TabPane>
@@ -342,7 +349,7 @@ class ShareLinkContainer extends Component {
     } = this.state;
 
     return (
-      <div className="share-body">
+      <div className={`share-body${activeTab === 'embed' ? ' share-body-tall' : ''}`}>
         <ShareToolTips
           activeTab={activeTab}
           tooltipErrorTime={tooltipErrorTime}

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -49,6 +49,10 @@
   height: 108px;
 }
 
+.share-body-tall {
+  height: 148px;
+}
+
 .share-nav-container {
   .input-group {
     padding-top: 10px;
@@ -61,7 +65,7 @@
   }
 
   .share-tab-embed {
-    p {
+    p:first-of-type {
       padding: 10px 1px;
     }
   }
@@ -108,13 +112,13 @@
   }
 }
 
-#feedback-url {
+#feedback-url, #api-doc-url {
   cursor: pointer;
   text-decoration: none;
   color: #7bf;
 }
 
-#feedback-url:hover {
+#feedback-url:hover, #api-doc-url:hover {
   text-decoration: underline;
   color: #7bf !important;
 }


### PR DESCRIPTION
## Description
This change adds a link (and surrounding text) in the embed tab at the top-right of WV to the GIBS API docs.

## How To Test
1. `git checkout wv-3104-api-docs-link`
2. `npm ci`
3. `npm run watch`
4. Open the embed tab via the share icon at the top-right of WV
5. Verify the text for the API docs is in the embed tab and looks correct, and links to the correct page