### PR TITLE
WV-3220 Smaller Extent BBox For Finding High-Resolution Imagery

### DIFF
--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -46,8 +46,17 @@ export default function ImagerySearch({ layer }) {
       }
       return maxExtent[i];
     });
+    const xDiff = Math.abs(extent[0] - extent[2]);
+    const yDiff = Math.abs(extent[1] - extent[3]);
+    // Reduce width by 40% and height by 20%, to show only centered data
+    const smallerExtent = [
+      extent[0] + (xDiff * 0.2),
+      extent[1] + (yDiff * 0.1),
+      extent[2] - (xDiff * 0.2),
+      extent[3] - (yDiff * 0.1),
+    ];
     try {
-      const olderUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${extent.join(',')}&temporal=,${refDate.toISOString()}&sort_key=-start_date&pageSize=25&page_num=${pageNum}`;
+      const olderUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=,${refDate.toISOString()}&sort_key=-start_date&pageSize=25&page_num=${pageNum}`;
       const olderResponse = await fetch(olderUrl, { headers });
       const olderGranules = await olderResponse.json();
       const olderDates = olderGranules.feed.entry.map(parseGranuleTimestamp);
@@ -67,8 +76,17 @@ export default function ImagerySearch({ layer }) {
       }
       return maxExtent[i];
     });
+    const xDiff = Math.abs(extent[0] - extent[2]);
+    const yDiff = Math.abs(extent[1] - extent[3]);
+    // Reduce width by 40% and height by 20%, to show only centered data
+    const smallerExtent = [
+      extent[0] + (xDiff * 0.2),
+      extent[1] + (yDiff * 0.1),
+      extent[2] - (xDiff * 0.2),
+      extent[3] - (yDiff * 0.1),
+    ];
     try {
-      const newerUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${extent.join(',')}&temporal=${refDate.toISOString()},&sort_key=start_date&pageSize=25&page_num=${pageNum}`;
+      const newerUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=${refDate.toISOString()},&sort_key=start_date&pageSize=25&page_num=${pageNum}`;
       const newerResponse = await fetch(newerUrl, { headers });
       const newerGranules = await newerResponse.json();
       const newerDates = newerGranules.feed.entry.map(parseGranuleTimestamp);

--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -37,7 +37,7 @@ export default function ImagerySearch({ layer }) {
 
   const conceptID = layer?.conceptIds?.[0]?.value || layer?.collectionConceptID;
 
-  const getOlderGranules = async (layer, refDate = selectedDate, pageNum = 1) => {
+  const getSmallerExtent = () => {
     // clamp extent to maximum extent allowed by the CMR api
     const extent = map.extent.map((coord, i) => {
       const condition = i <= 1 ? coord > maxExtent[i] : coord < maxExtent[i];
@@ -55,6 +55,11 @@ export default function ImagerySearch({ layer }) {
       extent[2] - (xDiff * 0.2),
       extent[3] - (yDiff * 0.1),
     ];
+    return smallerExtent;
+  };
+
+  const getOlderGranules = async (layer, refDate = selectedDate, pageNum = 1) => {
+    const smallerExtent = getSmallerExtent();
     try {
       const olderUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=,${refDate.toISOString()}&sort_key=-start_date&pageSize=25&page_num=${pageNum}`;
       const olderResponse = await fetch(olderUrl, { headers });
@@ -68,23 +73,7 @@ export default function ImagerySearch({ layer }) {
   };
 
   const getNewerGranules = async (layer, refDate = selectedDate, pageNum = 1) => {
-    // clamp extent to maximum extent allowed by the CMR api
-    const extent = map.extent.map((coord, i) => {
-      const condition = i <= 1 ? coord > maxExtent[i] : coord < maxExtent[i];
-      if (condition) {
-        return coord;
-      }
-      return maxExtent[i];
-    });
-    const xDiff = Math.abs(extent[0] - extent[2]);
-    const yDiff = Math.abs(extent[1] - extent[3]);
-    // Reduce width by 40% and height by 20%, to show only centered data
-    const smallerExtent = [
-      extent[0] + (xDiff * 0.2),
-      extent[1] + (yDiff * 0.1),
-      extent[2] - (xDiff * 0.2),
-      extent[3] - (yDiff * 0.1),
-    ];
+    const smallerExtent = getSmallerExtent();
     try {
       const newerUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=${refDate.toISOString()},&sort_key=start_date&pageSize=25&page_num=${pageNum}`;
       const newerResponse = await fetch(newerUrl, { headers });


### PR DESCRIPTION
## Description
This change modifies the bounding box used when searching for high-resolution imagery to be smaller than currently. This is to prevent situations where imagery is found, but only exists in the very corner of the extent. The new bounding box is 60% of the window width and 80% of the window height, centered on the middle of the window.

## How To Test
1. `git checkout wv-3220-smaller-extent-bbox`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of Worldview
5. Add a layer that uses the imagery-search feature, like `HLS_S30_Nadir_BRDF_Adjusted_Reflectance`
6. Zoom in and position the screen so that imagery is sometimes in the center of the screen, but sometimes on the edges
7. Open the imagery-search feature and click to various other dates, ensuring that no dates shown in the search have imagery only on the edges of the screen and none towards the center