### PR TITLE
WV-3284 Fix Class Conflict in Embed Container

### DIFF
--- a/web/js/containers/share.js
+++ b/web/js/containers/share.js
@@ -335,7 +335,7 @@ class ShareLinkContainer extends Component {
     } = this.state;
 
     return (
-      <div className={`share-body${activeTab === 'embed' ? '-tall' : ''}`}>
+      <div className={`share-body${activeTab === 'embed' ? ' tall' : ''}`}>
         <ShareToolTips
           activeTab={activeTab}
           tooltipErrorTime={tooltipErrorTime}

--- a/web/scss/features/share.scss
+++ b/web/scss/features/share.scss
@@ -1,9 +1,9 @@
 .share-body {
   height: 108px;
-}
 
-.share-body-tall {
-  height: 148px;
+  &.tall {
+    height: 148px;
+  }
 }
 
 .share-nav-container {


### PR DESCRIPTION
## Description
This fixes an overwriting of the class of the embed container when the container height is elongated, which previously broke functionality of the 'Copy' button.

## How To Test
1. `git checkout wv-3284-embed-iframe-copy`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of Worldview
5. Open the 'Share this map' button at the top-right of WV
6. Navigate to the 'Embed' tab
7. Verify that the copy button in this tab works as intended, and that the height of the tab contents still properly fits the text and is taller than the other tabs