### PR TITLE
WV-3283 AERONET Daily Layer Date Limitting

### DIFF
--- a/config/default/common/config/wv.json/layers/aeronet/AERONET_ANGSTROM_440-870NM.json
+++ b/config/default/common/config/wv.json/layers/aeronet/AERONET_ANGSTROM_440-870NM.json
@@ -22,7 +22,7 @@
           "dateInterval": "60"
         }
       ],
-      "wrapX": true,
+      "wrapX": false,
       "projections": {
         "geographic": {
           "source": "AERONET"

--- a/config/default/common/config/wv.json/layers/aeronet/AERONET_AOD_500NM.json
+++ b/config/default/common/config/wv.json/layers/aeronet/AERONET_AOD_500NM.json
@@ -22,7 +22,7 @@
           "dateInterval": "60"
         }
       ],
-      "wrapX": true,
+      "wrapX": false,
       "projections": {
         "geographic": {
           "source": "AERONET"

--- a/config/default/common/config/wv.json/layers/aeronet/DAILY_AERONET_ANGSTROM_440-870NM.json
+++ b/config/default/common/config/wv.json/layers/aeronet/DAILY_AERONET_ANGSTROM_440-870NM.json
@@ -14,7 +14,7 @@
       "vectorStyle": {
         "id": "DAILY_AERONET_ANGSTROM_440-870NM"
       },
-      "wrapX": true,
+      "wrapX": false,
       "projections": {
         "geographic": {
           "source": "AERONET"

--- a/config/default/common/config/wv.json/layers/aeronet/DAILY_AERONET_AOD_500NM.json
+++ b/config/default/common/config/wv.json/layers/aeronet/DAILY_AERONET_AOD_500NM.json
@@ -14,7 +14,7 @@
       "vectorStyle": {
         "id": "DAILY_AERONET_AOD_500NM"
       },
-      "wrapX": true,
+      "wrapX": false,
       "projections": {
         "geographic": {
           "source": "AERONET"

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -576,7 +576,7 @@ export default function mapLayerBuilder(config, cache, store) {
             for (let j = 0; j < split2.length; j += 1) {
               rowObj[key[j]] = split2[j];
             }
-            if (!!rowObj.AERONET_Site_Name && rowObj.AERONET_Site_Name !== '' && !takenNamesActive[rowObj.AERONET_Site_Name]) {
+            if (!!rowObj.AERONET_Site_Name && rowObj.AERONET_Site_Name !== '' && !takenNamesActive[rowObj.AERONET_Site_Name] && parseInt(rowObj['Date(dd:mm:yyyy)'].split(':')[0], 10) === date.getUTCDate()) {
               featuresObj[rowObj.AERONET_Site_Name] = {};
               featuresObj[rowObj.AERONET_Site_Name].type = 'Feature';
               featuresObj[rowObj.AERONET_Site_Name].geometry = { type: 'Point' };


### PR DESCRIPTION
## Description
This change filters the data from the AERONET daily api, which includes data from multiple dates, to only show data on the current day.

## How To Test
1. `git checkout wv-3283-aeronet-daily-today`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of Worldview
5. Add one of the two AERONET daily layers
6. Make sure no data points are being shown as active with a date that is not the currently selected day's date