### PR TITLE
WV-3237 Alert users if snapshot exceeds GRANULE_LIMIT

### DIFF
--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -1,10 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import googleTagManager from 'googleTagManager';
 import {
   imageSizeValid,
   getDimensions,
   getDownloadUrl,
+  getTruncatedGranuleDates,
+  GRANULE_LIMIT,
 } from '../../modules/image-download/util';
 import SelectionList from '../util/selector';
 import ResTable from './grid';
@@ -54,6 +56,16 @@ function ImageDownloadPanel(props) {
   const [currIsWorldfile, setIsWorldfile] = useState(isWorldfile);
   const [currResolution, setResolution] = useState(resolution);
   const [debugUrl, setDebugUrl] = useState('');
+  const [showGranuleWarning, setShowGranuleWarning] = useState(false);
+
+  useEffect(() => {
+    const layerList = getLayers();
+    const granuleDatesMap = new Map(map.getLayers().getArray().map((layer) => [layer.wv.id, layer.wv.granuleDates]));
+    const layerDefs = layerList.map((def) => ({ ...def, granuleDates: granuleDatesMap.get(def.id) }));
+    const isTruncated = getTruncatedGranuleDates(layerDefs, date).truncated;
+
+    setShowGranuleWarning(isTruncated);
+  }, [])
 
   const onDownload = (width, height) => {
     const time = new Date(date.getTime());
@@ -195,6 +207,9 @@ function ImageDownloadPanel(props) {
           proj={projection.id}
           map={map}
         />
+        {showGranuleWarning && (
+          <p>Warning: A snapshot will capture a max. of {GRANULE_LIMIT} granules, additional granules are omitted.</p>
+        )}
         <ResTable
           width={width}
           height={height}

--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -65,7 +65,7 @@ function ImageDownloadPanel(props) {
     const isTruncated = getTruncatedGranuleDates(layerDefs, date).truncated;
 
     setShowGranuleWarning(isTruncated);
-  }, [])
+  }, []);
 
   const onDownload = (width, height) => {
     const time = new Date(date.getTime());
@@ -208,7 +208,7 @@ function ImageDownloadPanel(props) {
           map={map}
         />
         {showGranuleWarning && (
-          <p>Warning: A snapshot will capture a max. of {GRANULE_LIMIT} granules, additional granules are omitted.</p>
+          <p>Warning: A snapshot will capture a max. of {GRANULE_LIMIT} granules, additional granules are omitted.</p> // eslint-disable-line react/jsx-one-expression-per-line
         )}
         <ResTable
           width={width}


### PR DESCRIPTION
## Description

> Alert users if snapshot exceeds GRANULE_LIMIT

## How To Test

1. `git checkout WV-3237-exceed-snapshot`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-353.40938621902797,-198.58423316002302,321.3109507141554,189.14568268178897&z=4&ics=true&ici=5&icd=6&l=VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule,VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule,VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule,VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule,VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule(count=30),VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule(count=30),Coastlines_15m&lg=true&t=2024-08-04-T19%3A21%3A00Z).
4. Open the snapshot modal.
5. Verify that the warning appears in the modal.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
