### PR TITLE
Round Time for TEMPO granule requests

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -64,6 +64,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
    * Query CMR to get dates
    * @param {object} def - Layer specs
    * @param {object} selectedDate - current selected date (Note: may not return this date, but this date will be the max returned)
+   * @returns {array} granule dates
   */
   const getQueriedGranuleDates = async (def, selectedDate) => {
     const {
@@ -176,6 +177,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       const { date } = item;
       const dateDate = new Date(date);
       const leadingEdgeDateUTC = new Date(leadingEdgeDate.toUTCString());
+      leadingEdgeDateUTC.setSeconds(59);
       const isWithinRange = isWithinRanges(leadingEdgeDateUTC, granuleDateRanges);
       if (dateDate <= leadingEdgeDateUTC && isWithinRange && isWithinBounds(crs, item)) {
         granules.unshift(item);

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -161,9 +161,9 @@ export const getCMRQueryDates = (crs, selectedDate) => {
  * @param {*} def - layer definition
  * @param {*} date - "current" date from which to base the query
  * @param {*} crs
- * @returns
+ * @returns {Array} - array of objects with parameters for CMR request
  */
-export const getParamsForGranuleRequest = (def, date, crs, nrt) => {
+export const getParamsForGranuleRequest = (def, date, crs) => {
   const dayNightFilter = def.daynight[0];
   const bboxForProj = {
     [CRS.WEB_MERCATOR]: [-180, -65, 180, 65],
@@ -173,7 +173,7 @@ export const getParamsForGranuleRequest = (def, date, crs, nrt) => {
   };
   const { startQueryDate, endQueryDate } = getCMRQueryDates(crs, date);
 
-  const getShortName = () => {
+  const getShortName = (nrt) => {
     try {
       const { shortName } = def.conceptIds[0];
       if (nrt) return shortName;
@@ -184,14 +184,35 @@ export const getParamsForGranuleRequest = (def, date, crs, nrt) => {
     }
   };
 
-  return {
+  if (def.conceptIds[0].type === 'NRT') {
+    return [
+      {
+        shortName: getShortName(false),
+        startDate: startQueryDate.toISOString(),
+        endDate: endQueryDate.toISOString(),
+        dayNight: dayNightFilter,
+        bbox: bboxForProj[crs],
+        pageSize: 500,
+      },
+      {
+        shortName: getShortName(true),
+        startDate: startQueryDate.toISOString(),
+        endDate: endQueryDate.toISOString(),
+        dayNight: dayNightFilter,
+        bbox: bboxForProj[crs],
+        pageSize: 500,
+      },
+    ];
+  }
+
+  return [{
     shortName: getShortName(),
     startDate: startQueryDate.toISOString(),
     endDate: endQueryDate.toISOString(),
     dayNight: dayNightFilter,
     bbox: bboxForProj[crs],
     pageSize: 500,
-  };
+  }];
 };
 
 /**


### PR DESCRIPTION
## Description

> Consider rounding the time up or down for TEMPO granules

## How To Test

1. `git checkout WV-3239-TEMPO-time-rounding`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-180.43495743956862,-17.36848543743674,-7.178159856487014,82.19401456256327&z=4&i=5&l=TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1),Coastlines_15m&lg=true&t=2024-08-07-T15%3A14%3A00Z)
4. The granule timestamps should match less than or equal to the selected datetime within 59 seconds (ie. a granule with time stamp 15:14:34 should show for a selected time of 15:14 but a different granule should show for a selected time of 15:13).

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
