### PR TITLE
WV-3244 Projection swapping removes layers fix

### DIFF
--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -22,10 +22,7 @@ const getConfig = ({ config }) => config;
 const getLayerId = (state, { layer }) => layer && layer.id;
 
 export function addLayer(id, spec = {}, layersParam, layerConfig, overlayLength, projection, groupOverlays, bandComboParam, selectedPresetParam) {
-  let layers = lodashCloneDeep(layersParam);
-  if (projection) {
-    layers = layers.filter((layer) => layer.projections[projection]);
-  }
+  const layers = lodashCloneDeep(layersParam);
   if (lodashFind(layers, { id })) {
     return layers;
   }


### PR DESCRIPTION
## Description
This change fixes the behavior of losing layers when swapping between projections

## How To Test
1. `git checkout wv-3244-layer-projection-switching`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-7077888,-3723264,7077888,3723264&l=MODIS_Aqua_Land_Surface_Temp_Day_TES,MODIS_Aqua_Land_Surface_Temp_Night,MODIS_Aqua_Land_Surface_Temp_Day,MODIS_Aqua_Land_Surface_Temp_Night_TES,MODIS_Aqua_NDSI_Snow_Cover&lg=false&t=2002-12-31-T00%3A00%3A00Z)
5. Swap the projection to Arctic and back to Geographic and verify all layers still show
6. Swap the projection to Arctic, reload the page, then swap back to Geographic and verify all layers still show