### PR TITLE
WV-3301 TEMPO Operations Loading Issues

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -153,7 +153,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
    * @returns {boolean} - true if date is within a range
   */
   const isWithinRanges = (date, ranges) => {
-    if (!ranges) return true;
+    if (!ranges) return false;
 
     return ranges.some(([start, end]) => date >= new Date(start) && date <= new Date(end));
   };

--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -276,107 +276,23 @@ export function extractDateFromTileErrorURL(url) {
 }
 
 /**
- * @method makeTime
- * @param {string} date
- * @returns {number} time
- * @description
- * Convert date to time
-*/
-function makeTime(date) {
-  return new Date(date).getTime();
-}
-
-/**
- * @method mergeSortedGranuleDateRanges
- * @param {array} granules
- * @returns {array} mergedGranuleDateRanges
- * @description
- * Merge overlapping granule date ranges
-*/
-function mergeSortedGranuleDateRanges(granules) {
-  return granules.reduce((acc, [start, end]) => {
-    if (!acc.length) return [[start, end]];
-    // round start time down and end time up by 1 minute to account for small range gaps
-    const startTime = makeTime(start) - 60000;
-    const endTime = makeTime(end) + 60000;
-    const lastRangeEndTime = makeTime(acc.at(-1)[1]);
-    const lastRangeStartTime = makeTime(acc.at(-1)[0]);
-    if ((startTime >= lastRangeStartTime && startTime <= lastRangeEndTime) && (endTime >= lastRangeStartTime && endTime <= lastRangeEndTime)) { // within current range, ignore
-      return acc;
-    }
-    if (startTime > lastRangeEndTime) { // discontinuous, add new range
-      return [...acc, [start, end]];
-    }
-    if (startTime <= lastRangeEndTime && endTime > lastRangeEndTime) { // intersects current range, merge
-      return acc.with(-1, [acc.at(-1)[0], end]);
-    }
-    return acc;
-  }, []);
-}
-
-/**
- * @method requestGranules
- * @param {object} params
- * @returns {array} granules
- * @description
- * Request granules from CMR
-*/
-async function requestGranules(params) {
-  const {
-    shortName,
-    extent,
-    startDate,
-    endDate,
-  } = params;
-  const granules = [];
-  let hits = Infinity;
-  let searchAfter = false;
-  const url = `https://cmr.earthdata.nasa.gov/search/granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
-  /* eslint-disable no-await-in-loop */
-  do { // run the query at least once
-    const headers = searchAfter ? { 'Cmr-Search-After': searchAfter, 'Client-Id': 'Worldview' } : { 'Client-Id': 'Worldview' };
-    const res = await fetch(url, { headers });
-    searchAfter = res.headers.get('Cmr-Search-After');
-    hits = parseInt(res.headers.get('Cmr-Hits'), 10);
-    const data = await res.json();
-    granules.push(...data.feed.entry);
-  } while (searchAfter || hits > granules.length); // searchAfter will not be present if there are no more results https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after
-
-  return granules;
-}
-/**
  * @method getLayerGranuleRanges
  * @param {object} layer
  * @returns {array} granuleDateRanges
  * @description
  * Get granule date ranges for a given layer
 */
-export async function getLayerGranuleRanges(layer) {
-  const extent = [-180, -90, 180, 90];
-  const startDate = new Date(layer.startDate).toISOString();
-  const endDate = layer.endDate ? new Date(layer.endDate).toISOString() : new Date().toISOString();
-  const shortName = layer.conceptIds?.[0]?.shortName;
-  const nrtParams = {
-    shortName,
-    extent,
-    startDate,
-    endDate,
-  };
-  const nrtGranules = await requestGranules(nrtParams);
-  let nonNRTGranules = [];
-  if (shortName.includes('_NRT')) { // if NRT, also get non-NRT granules
-    const nonNRTShortName = shortName.replace('_NRT', '');
-    const nonNRTParams = {
-      shortName: nonNRTShortName,
-      extent,
-      startDate,
-      endDate,
+export function getLayerGranuleRanges(layer) {
+  const worker = new Worker('js/workers/cmr.worker.js');
+  return new Promise((resolve, reject) => {
+    worker.onmessage = (event) => {
+      resolve(event.data);
+      worker.terminate();
     };
-    nonNRTGranules = await requestGranules(nonNRTParams);
-  }
-  const granules = [...nonNRTGranules, ...nrtGranules];
-  const granuleDateRanges = granules.map(({ time_start: timeStart, time_end: timeEnd }) => [timeStart, timeEnd]);
-  const mergedGranuleDateRanges = mergeSortedGranuleDateRanges(granuleDateRanges); // merge overlapping granule ranges to simplify rendering
-
-  return mergedGranuleDateRanges;
+    worker.onerror = (error) => {
+      reject(error);
+      worker.terminate();
+    };
+    worker.postMessage({ funcName: 'getLayerGranuleRanges', args: [layer] });
+  });
 }

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -369,6 +369,22 @@ function UpdateProjection(props) {
     reloadLayers(null, false);
   }, [renderedPalettes]);
 
+  const selectL2Layers = (layers) => layers
+    .filter((layer) => layer.id.includes('L2'))
+    .map((layer) => layer.granuleDateRanges);
+
+  const prevActiveLayers = usePrevious(activeLayers);
+
+  useEffect(() => {
+    if (!ui.selected) return;
+    const prevL2Layers = selectL2Layers(prevActiveLayers);
+    const activeL2Layers = selectL2Layers(activeLayers);
+    const needsReload = activeL2Layers.some((dateRange, i) => dateRange?.length !== prevL2Layers[i]?.length);
+    if (needsReload) {
+      reloadLayers(null, true);
+    }
+  }, [activeLayers]);
+
   return null;
 }
 

--- a/web/js/workers/cmr.worker.js
+++ b/web/js/workers/cmr.worker.js
@@ -1,0 +1,118 @@
+/**
+ * @method makeTime
+ * @param {string} date
+ * @returns {number} time
+ * @description
+ * Convert date to time
+*/
+function makeTime(date) {
+  return new Date(date).getTime();
+}
+
+/**
+ * @method mergeSortedGranuleDateRanges
+ * @param {array} granules
+ * @returns {array} mergedGranuleDateRanges
+ * @description
+ * Merge overlapping granule date ranges
+*/
+function mergeSortedGranuleDateRanges(granules) {
+  return granules.reduce((acc, [start, end]) => {
+    if (!acc.length) return [[start, end]];
+    // round start time down and end time up by 1 minute to account for small range gaps
+    const startTime = makeTime(start) - 60000;
+    const endTime = makeTime(end) + 60000;
+    const lastRangeEndTime = makeTime(acc.at(-1)[1]);
+    const lastRangeStartTime = makeTime(acc.at(-1)[0]);
+    if ((startTime >= lastRangeStartTime && startTime <= lastRangeEndTime) && (endTime >= lastRangeStartTime && endTime <= lastRangeEndTime)) { // within current range, ignore
+      return acc;
+    }
+    if (startTime > lastRangeEndTime) { // discontinuous, add new range
+      return [...acc, [start, end]];
+    }
+    if (startTime <= lastRangeEndTime && endTime > lastRangeEndTime) { // intersects current range, merge
+      return acc.with(-1, [acc.at(-1)[0], end]);
+    }
+    return acc;
+  }, []);
+}
+
+
+/**
+ * @method requestGranules
+ * @param {object} params
+ * @returns {array} granules
+ * @description
+ * Request granules from CMR
+*/
+async function requestGranules(params) {
+  const {
+    shortName,
+    extent,
+    startDate,
+    endDate,
+  } = params;
+  const granules = [];
+  let hits = Infinity;
+  let searchAfter = false;
+  const url = `https://cmr.earthdata.nasa.gov/search/granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
+  /* eslint-disable no-await-in-loop */
+  do { // run the query at least once
+    const headers = searchAfter ? { 'Cmr-Search-After': searchAfter, 'Client-Id': 'Worldview' } : { 'Client-Id': 'Worldview' };
+    const res = await fetch(url, { headers });
+    searchAfter = res.headers.get('Cmr-Search-After');
+    hits = parseInt(res.headers.get('Cmr-Hits'), 10);
+    const data = await res.json();
+    granules.push(...data.feed.entry);
+  } while (searchAfter || hits > granules.length); // searchAfter will not be present if there are no more results https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after
+
+  return granules;
+}
+
+/**
+ * @method getLayerGranuleRanges
+ * @param {object} layer
+ * @returns {array} granuleDateRanges
+ * @description
+ * Get granule date ranges for a given layer
+*/
+async function getLayerGranuleRanges(layer) {
+  const extent = [-180, -90, 180, 90];
+  const startDate = new Date(layer.startDate).toISOString();
+  const endDate = layer.endDate ? new Date(layer.endDate).toISOString() : new Date().toISOString();
+  const shortName = layer.conceptIds?.[0]?.shortName;
+  const nrtParams = {
+    shortName,
+    extent,
+    startDate,
+    endDate,
+  };
+  const nrtGranules = await requestGranules(nrtParams);
+  let nonNRTGranules = [];
+  if (shortName.includes('_NRT')) { // if NRT, also get non-NRT granules
+    const nonNRTShortName = shortName.replace('_NRT', '');
+    const nonNRTParams = {
+      shortName: nonNRTShortName,
+      extent,
+      startDate,
+      endDate,
+    };
+    nonNRTGranules = await requestGranules(nonNRTParams);
+  }
+  const granules = [...nonNRTGranules, ...nrtGranules];
+  const granuleDateRanges = granules.map(({ time_start: timeStart, time_end: timeEnd }) => [timeStart, timeEnd]);
+  const mergedGranuleDateRanges = mergeSortedGranuleDateRanges(granuleDateRanges); // merge overlapping granule ranges to simplify rendering
+
+  return mergedGranuleDateRanges;
+}
+
+
+const functions = {
+  getLayerGranuleRanges,
+};
+
+onmessage = async (event) => {
+  const { data } = event;
+  const result = await functions[data.funcName]?.(...data.args);
+  postMessage(result);
+};


### PR DESCRIPTION
## Description

Improve TEMPO L2 loading performance

## How To Test

1. `git checkout WV-3301-tempo-loading`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?v=-152.28402058244492,-0.7297757124004818,-39.52935771536997,63.99975297054996&z=4&ics=true&ici=5&icd=6&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TEMPO_L2_Ozone_Cloud_Fraction_Granule(count=1),TEMPO_L2_Ozone_Column_Amount_Granule(count=1),TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1),TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule(count=1),TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule(count=1),TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule(count=1),TEMPO_L2_Formaldehyde_Vertical_Column_Granule(count=1),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2024-08-06-T22%3A42%3A00Z)
4. Coastlines layer should load quickly and L2 granules should be available once the CMR requests resolve and the data availability bar updates.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
