### PR TITLE
WV-3178: Turn CMR date finding on for OPERA Veg Disturbance

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/opera/OPERA_L3_DIST-ALERT-HLS_Color_Index.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/opera/OPERA_L3_DIST-ALERT-HLS_Color_Index.json
@@ -2,6 +2,7 @@
   "layers": {
     "OPERA_L3_DIST-ALERT-HLS_Color_Index": {
       "id": "OPERA_L3_DIST-ALERT-HLS_Color_Index",
+      "enableCMRDataFinder": true,
       "description": "multi-mission/opera/OPERA_L3_DIST-ALERT-HLS_Color_Index",
       "tags": "lpdaac LPDAAC land surface vegetation disturbance opera",
       "group": "overlays",


### PR DESCRIPTION
## Description

Fixes #WV-3178.

Turn CMR date finding on for OPERA Veg Disturbance
## How To Test

1. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,OPERA_L3_DIST-ALERT-HLS_Color_Index(disabled=9),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2024-09-23-T13%3A53%3A33Z)
2. Click on the Options button to get the Options/Settings panel
3. Verify expected result - "available imagery dates" load



@nasa-gibs/worldview
