### PR TITLE
WV-3368 backup eic links

### DIFF
--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -24,8 +24,6 @@ export const layersToMeasure = [
   'VIIRS_NOAA20_DayNightBand_AtSensor_M15',
   'VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate',
   'VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean',
-  'VIIRS_NOAA21_Thermal_Anomalies_375m_All',
-  'VIIRS_NOAA20_Thermal_Anomalies_375m_All',
   'VIIRS_NOAA21_CorrectedReflectance_TrueColor',
 ];
 
@@ -56,8 +54,6 @@ export const layerPixelData = {
   VIIRS_NOAA20_DayNightBand_AtSensor_M15: { threshold: 0.10 },
   VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate: { threshold: 0.90 },
   VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean: { threshold: 0.90 },
-  VIIRS_NOAA21_Thermal_Anomalies_375m_All: { threshold: 0.95 },
-  VIIRS_NOAA20_Thermal_Anomalies_375m_All: { threshold: 0.95 },
   VIIRS_NOAA21_CorrectedReflectance_TrueColor: { threshold: 0.65 },
 };
 
@@ -87,8 +83,6 @@ export const bestDates = {
   VIIRS_NOAA20_DayNightBand_AtSensor_M15: { date: '2024-10-01' },
   VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate: { date: '2024-10-01' },
   VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean: { date: '2024-10-01' },
-  VIIRS_NOAA21_Thermal_Anomalies_375m_All: { date: '2024-10-01' },
-  VIIRS_NOAA20_Thermal_Anomalies_375m_All: { date: '2024-10-01' },
   VIIRS_NOAA21_CorrectedReflectance_TrueColor: { date: '2024-10-01' },
 };
 

--- a/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
+++ b/web/js/mapUI/components/kiosk/tile-measurement/utils/layer-data-eic.js
@@ -20,6 +20,13 @@ export const layersToMeasure = [
   'CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly',
   'TEMPO_L3_NO2_Vertical_Column_Troposphere',
   'TEMPO_L3_Ozone_Column_Amount',
+  'VIIRS_NOAA20_DayNightBand_At_Sensor_Radiance',
+  'VIIRS_NOAA20_DayNightBand_AtSensor_M15',
+  'VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate',
+  'VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean',
+  'VIIRS_NOAA21_Thermal_Anomalies_375m_All',
+  'VIIRS_NOAA20_Thermal_Anomalies_375m_All',
+  'VIIRS_NOAA21_CorrectedReflectance_TrueColor',
 ];
 
 // Object that contains the black pixel % threshold for each layer
@@ -45,6 +52,13 @@ export const layerPixelData = {
   CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly: { threshold: 0.01 },
   TEMPO_L3_NO2_Vertical_Column_Troposphere: { threshold: 0.99 },
   TEMPO_L3_Ozone_Column_Amount: { threshold: 0.99 },
+  VIIRS_NOAA20_DayNightBand_At_Sensor_Radiance: { threshold: 0.45 },
+  VIIRS_NOAA20_DayNightBand_AtSensor_M15: { threshold: 0.10 },
+  VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate: { threshold: 0.90 },
+  VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean: { threshold: 0.90 },
+  VIIRS_NOAA21_Thermal_Anomalies_375m_All: { threshold: 0.95 },
+  VIIRS_NOAA20_Thermal_Anomalies_375m_All: { threshold: 0.95 },
+  VIIRS_NOAA21_CorrectedReflectance_TrueColor: { threshold: 0.65 },
 };
 
 // Back-up dates for each layer in case no date is found that satisfies the full imagery threshold
@@ -69,6 +83,13 @@ export const bestDates = {
   CERES_EBAF_TOA_Shortwave_Flux_All_Sky_Monthly: { date: '2023-10-30' },
   TEMPO_L3_NO2_Vertical_Column_Troposphere: { date: '2024-06-03T17:00:00.000Z' },
   TEMPO_L3_Ozone_Column_Amount: { date: '2024-06-03T17:00:00.000Z' },
+  VIIRS_NOAA20_DayNightBand_At_Sensor_Radiance: { date: '2024-10-01' },
+  VIIRS_NOAA20_DayNightBand_AtSensor_M15: { date: '2024-10-01' },
+  VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate: { date: '2024-10-01' },
+  VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean: { date: '2024-10-01' },
+  VIIRS_NOAA21_Thermal_Anomalies_375m_All: { date: '2024-10-01' },
+  VIIRS_NOAA20_Thermal_Anomalies_375m_All: { date: '2024-10-01' },
+  VIIRS_NOAA21_CorrectedReflectance_TrueColor: { date: '2024-10-01' },
 };
 
 export const travelModeData = {
@@ -112,9 +133,21 @@ export const travelModeData = {
     title: 'Aerosol Optical Depth (AOD) by Suomi NPP satellite',
   },
   14: {
-    title: 'TEMPO L3 NO2 Vertical Column Troposphere',
+    title: 'Nitrogen Dioxide Vertical Column Troposphere (L3) by TEMPO satellite',
   },
   15: {
-    title: 'TEMPO L3 Ozone Column Amount',
+    title: 'Ozone Column Amount (L3) by TEMPO satellite',
+  },
+  16: {
+    title: 'Black Marble Nighttime At Sensor Radiance from NOAA-20 satellite',
+  },
+  17: {
+    title: 'Black Marble Nighttime Blue/Yellow Composite from NOAA-20 satellite',
+  },
+  18: {
+    title: 'Aerosol Optical Depth (AOD) by NOAA-20 satellite',
+  },
+  19: {
+    title: 'Active Fires detected by NOAA-21 satellite',
   },
 };


### PR DESCRIPTION
## Description

> Create backup EIC links for NOAA-20 and NOAA-21

## How To Test

1. `git checkout WV-3368-backup-eic-links`
2. `npm run watch`
3. Test these scenarios: [1](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&scenario=16&l=Coastlines_15m,VIIRS_NOAA20_DayNightBand_At_Sensor_Radiance&lg=false
), [2](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&scenario=17&l=Coastlines_15m,VIIRS_NOAA20_DayNightBand_AtSensor_M15&lg=false
), [3](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&scenario=18&l=Coastlines_15m,VIIRS_NOAA20_AOT_Dark_Target_Land_Ocean,VIIRS_NOAA20_AOT_Deep_Blue_Best_Estimate,VIIRS_NOAA20_CorrectedReflectance_TrueColor&lg=false
), [4](http://localhost:3000/?v=-181.74360912131363,-98.53068072538338,182.80846643543055,106.52986177528524&df=true&kiosk=true&eic=si&scenario=19&l=Coastlines_15m,VIIRS_NOAA21_Thermal_Anomalies_375m_All,VIIRS_NOAA21_CorrectedReflectance_TrueColor&lg=false
)

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
