### PR TITLE
WV-3344 path-to-regexp Override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5794,7 +5794,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5818,7 +5820,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.22.3",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -8227,7 +8231,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8236,7 +8242,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8380,6 +8386,8 @@
     },
     "node_modules/fetch-mock": {
       "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.0.0",
@@ -8432,8 +8440,13 @@
       }
     },
     "node_modules/fetch-mock/node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "license": "MIT"
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -12162,6 +12175,8 @@
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
     "node_modules/lodash.truncate": {
@@ -14451,6 +14466,9 @@
     },
     "node_modules/querystring": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.x"
@@ -17209,6 +17227,8 @@
     },
     "node_modules/tr46": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -18191,6 +18211,8 @@
     },
     "node_modules/whatwg-url": {
       "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "license": "MIT",
       "dependencies": {
         "lodash.sortby": "^4.7.0",
@@ -18200,6 +18222,8 @@
     },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "license": "BSD-2-Clause"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -226,6 +226,9 @@
     "eslint-config-standard": {
       "eslint-plugin-n": "^17.1.0"
     },
+    "fetch-mock-jest": {
+      "path-to-regexp": "^8.0.0"
+    },
     "ws": "^8.17.1"
   },
   "browserslist": [


### PR DESCRIPTION
This change overrides the `path-to-regexp` dependency for package `fetch-mock-jest`.