### PR TITLE
WV-3371 Don't dateline shift TEMPO layers

### DIFF
--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
@@ -13,7 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
@@ -13,8 +13,8 @@
       "count": 1,
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:41:03Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
@@ -10,7 +10,8 @@
       "layergroup": "Cloud Fraction",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
@@ -10,8 +10,8 @@
       "layergroup": "Cloud Pressure",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
@@ -10,8 +10,8 @@
       "layergroup": "Formaldehyde",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
@@ -10,8 +10,8 @@
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
@@ -10,8 +10,8 @@
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
@@ -10,8 +10,8 @@
       "layergroup": "Ozone",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
@@ -10,8 +10,8 @@
       "layergroup": "Ozone",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
@@ -10,8 +10,8 @@
       "layergroup": "Aerosol Index",
       "dataAvailability": "dd",
       "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true
-
+      "disableSnapshot": true,
+      "shiftadjacentdays": false
     }
   }
 }

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -112,8 +112,8 @@ Example:
     * dateInterval - Number of days (or minutes for subdaily layers)
 * **temporal**: Used to override the layer temporal availability declared in the capabilities document. Note: Changing the temporal availability can cause missing layer coverage within the interface for layers tiles that aren't available from the source at the revised temporal range. This option can be added as a string with the new availability range. For example, `"1981-10-13/2019-10-11/P1M"`.
 * **count**: Used to override the default number of granules displayed on the map and in the granule count slider component for granule layers.
-* **cmrAvailability**: Boolean - Whether or not to use the CMR API for data availability.
 * **dataAvailability**: String - `cmr` or `dd`. Get the layer's data availability from either the CMR API or GIBS DescribeDomains request.
+* **shiftadjacentdays**: Boolean - Whether or not to shift granules across the dateline when they're for an adjacent day. Defaults to `true` when `null` or `undefined`.
 
 ## Full Example
 

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -244,7 +244,8 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
 
     const granuleAttributes = await getGranuleAttributes(def, options);
     const { visibleGranules } = granuleAttributes;
-    const granules = datelineShiftGranules(visibleGranules, date, crs);
+    const shouldShift = def.shiftadjacentdays ?? true; // defaults to true
+    const granules = shouldShift ? datelineShiftGranules(visibleGranules, date, crs) : visibleGranules;
     const tileLayers = new OlCollection(createGranuleTileLayers(granules, def, attributes));
     granuleLayer.setLayers(tileLayers);
     granuleLayer.setExtent(crs === CRS.GEOGRAPHIC ? FULL_MAP_EXTENT : maxExtent);


### PR DESCRIPTION
## Description

> TEMPO L2 Imagery Not Appearing Around Midnight in WV UAT and WV Prod

## How To Test

1. `git checkout WV-3371-midnight-tempo`
2. `npm run build && npm run watch`
3. Go to this [link](http://localhost:3000/?v=-507.80521456317877,-237.58487328128587,453.0304132198363,314.0059500756302&z=5&ics=true&ici=5&icd=6&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(hidden),TEMPO_L2_Ozone_Column_Amount_Granule(count=1),Land_Mask&lg=true&t=2024-08-03-T00%3A01%3A00Z).
4. Verify that TEMPO granules do not get shifted across the dateline when for the adjacent day. Other layer granules should get shifted. The easiest way to do this is to set the time to 23:59 and then observe the granule shift when the time is set to 00:01 the next day.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
