### PR TITLE
WV-3298 limit data availability to visible time extent

### DIFF
--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -155,9 +155,7 @@ class TimelineAxis extends Component {
       const draggerTimeStateTime = draggerTimeStateDate.getTime();
       const maxBackDate = draggerTimeStateTime > backDateTime ? (draggerTimeStateDate.setDate(draggerTimeStateDate.getDate() + 1), draggerTimeStateDate.toISOString()) : backDate;
       const minFrontDate = draggerTimeStateTime < startDateTime ? (draggerTimeStateDate.setDate(draggerTimeStateDate.getDate() - 1), draggerTimeStateDate.toISOString()) : frontDate;
-      activeLayers.forEach((layer) => {
-        this.addTimeRanges(layer, proj, [minFrontDate, maxBackDate])
-      });
+      activeLayers.forEach((layer) => this.addTimeRanges(layer, proj, [minFrontDate, maxBackDate]));
     }
 
     const { wheelZoom } = this.state;
@@ -1340,7 +1338,7 @@ class TimelineAxis extends Component {
 
   addTimeRanges = (def, proj, dateRange) => {
     const {
-      addGranuleDateRanges
+      addGranuleDateRanges,
     } = this.props;
     const {
       cmrAvailability,
@@ -1348,15 +1346,13 @@ class TimelineAxis extends Component {
       id,
     } = def;
     // if opted in to CMR availability, get granule date ranges if needed
-    if ((cmrAvailability || dataAvailability === 'cmr')) {
+    if (cmrAvailability || dataAvailability === 'cmr') {
       const worker = new Worker('js/workers/cmr.worker.js');
       worker.onmessage = (event) => {
         worker.terminate();
         addGranuleDateRanges(def, event.data);
       };
-      worker.onerror = () => {
-        worker.terminate();
-      };
+      worker.onerror = () => worker.terminate();
       worker.postMessage({ operation: 'getLayerGranuleRanges', args: [def] });
     }
     // if opted in to DescribeDomains availability, get granule date ranges if needed
@@ -1374,14 +1370,11 @@ class TimelineAxis extends Component {
         if (!domains) worker.terminate();
         worker.postMessage({ operation: 'mergeDomains', args: [domains, 60_000] });
       };
-      worker.onerror = () => {
-        worker.terminate();
-      };
+      worker.onerror = () => worker.terminate();
       let startDate = new Date(def.startDate);
-      let endDate = def.endDate ? new Date(def.endDate).toISOString() : new Date().toISOString()
+      let endDate = def.endDate ? new Date(def.endDate).toISOString() : new Date().toISOString();
       if (dateRange) {
-        startDate = dateRange[0];
-        endDate = dateRange[1];
+        [startDate, endDate] = dateRange;
       }
       const params = {
         startDate,
@@ -1391,7 +1384,7 @@ class TimelineAxis extends Component {
       };
       worker.postMessage({ operation: 'requestDescribeDomains', args: [params] });
     }
-  };  
+  };
 
   /**
   * @desc get matching coverage line dimensions for given date range

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -79,6 +79,7 @@ class TimelineAxis extends Component {
       position,
       dateA,
       dateB,
+      activeLayers,
     } = this.props;
 
     const checkForPropsUpdates = nextProps.axisWidth === axisWidth
@@ -95,6 +96,7 @@ class TimelineAxis extends Component {
       && nextProps.transformX === transformX
       && nextProps.frontDate === frontDate
       && nextProps.backDate === backDate
+      && nextProps.activeLayers.length === activeLayers.length
       && lodashIsEqual(nextProps.matchingTimelineCoverage, matchingTimelineCoverage);
 
     const {

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1708,7 +1708,7 @@ const mapDispatchToProps = (dispatch) => ({
   },
   addGranuleDateRanges: (layer, dateRanges) => {
     dispatch(addGranuleDateRanges(layer, dateRanges));
-  }
+  },
 });
 
 export default connect(

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -54,6 +54,7 @@ import {
   getNextTimeSelection,
 } from '../../modules/date/util';
 import { toggleActiveCompareState } from '../../modules/compare/actions';
+import { addGranuleDateRanges } from '../../modules/layers/actions';
 import {
   onActivate as openAnimation,
   onClose as closeAnimation,
@@ -1138,6 +1139,7 @@ class Timeline extends React.Component {
   render() {
     const {
       activeLayers,
+      addGranuleDateRanges,
       animationDisabled,
       animEndLocationDate,
       animStartLocationDate,
@@ -1170,6 +1172,7 @@ class Timeline extends React.Component {
       timeScale,
       timeScaleChangeUnit,
       toggleActiveCompareState,
+      proj,
     } = this.props;
     const {
       animationEndLocation,
@@ -1281,6 +1284,8 @@ class Timeline extends React.Component {
                     <div id="timeline-footer" className="notranslate">
                       {/* Axis */}
                       <TimelineAxis
+                        activeLayers={activeLayers}
+                        addGranuleDateRanges={addGranuleDateRanges}
                         appNow={appNow}
                         axisWidth={axisWidth}
                         parentOffset={parentOffset}
@@ -1326,6 +1331,7 @@ class Timeline extends React.Component {
                         isDraggerDragging={isDraggerDragging}
                         isTimelineDragging={isTimelineDragging}
                         matchingTimelineCoverage={matchingTimelineCoverage}
+                        proj={proj}
                       />
 
                       <AxisHoverLine
@@ -1640,6 +1646,7 @@ function mapStateToProps(state) {
     isKioskModeActive,
     displayStaticMap,
     newCustomDelta,
+    proj: proj.selected,
   };
 }
 
@@ -1699,6 +1706,9 @@ const mapDispatchToProps = (dispatch) => ({
   onPauseAnimation: () => {
     dispatch(pauseAnimation());
   },
+  addGranuleDateRanges: (layer, dateRanges) => {
+    dispatch(addGranuleDateRanges(layer, dateRanges));
+  }
 });
 
 export default connect(
@@ -1707,6 +1717,7 @@ export default connect(
 )(Timeline);
 
 Timeline.propTypes = {
+  addGranuleDateRanges: PropTypes.func,
   appNow: PropTypes.object,
   activeLayers: PropTypes.array,
   animationDisabled: PropTypes.bool,
@@ -1766,4 +1777,5 @@ Timeline.propTypes = {
   toggleCustomModal: PropTypes.func,
   triggerTodayButton: PropTypes.func,
   updateAppNow: PropTypes.func,
+  proj: PropTypes.object,
 };

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -34,7 +34,6 @@ import {
   getGeographicResolutionWMS,
   mergeBreakpointLayerAttributes,
 } from './util';
-import { addGranuleDateRanges } from '../modules/layers/actions';
 import { datesInDateRanges, prevDateInDateRange } from '../modules/layers/util';
 import { getSelectedDate } from '../modules/date/selectors';
 import {
@@ -1110,53 +1109,6 @@ export default function mapLayerBuilder(config, cache, store) {
     return layer;
   };
 
-  const addTimeRanges = (def) => {
-    const state = store.getState();
-    const proj = state.proj.selected;
-    const {
-      cmrAvailability,
-      dataAvailability,
-      id,
-    } = def;
-    // if opted in to CMR availability, get granule date ranges if needed
-    if ((cmrAvailability || dataAvailability === 'cmr') && !def.granuleDateRanges) {
-      const worker = new Worker('js/workers/cmr.worker.js');
-      worker.onmessage = (event) => {
-        worker.terminate();
-        store.dispatch(addGranuleDateRanges(def, event.data));
-      };
-      worker.onerror = () => {
-        worker.terminate();
-      };
-      worker.postMessage({ operation: 'getLayerGranuleRanges', args: [def] });
-    }
-    // if opted in to DescribeDomains availability, get granule date ranges if needed
-    if (dataAvailability === 'dd' && !def.granuleDateRanges) {
-      const worker = new Worker('js/workers/dd.worker.js');
-      worker.onmessage = (event) => {
-        if (Array.isArray(event.data)) { // our final format is an array
-          worker.terminate(); // terminate the worker
-          return store.dispatch(addGranuleDateRanges(def, event.data)); // dispatch the action
-        }
-        // DOMParser is not available in workers so we parse the xml on the main thread before sending it back to the worker
-        const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(event.data, 'text/xml');
-        const domains = xmlDoc.querySelector('Domain').textContent;
-        worker.postMessage({ operation: 'mergeDomains', args: [domains, 60_000] });
-      };
-      worker.onerror = () => {
-        worker.terminate();
-      };
-      const params = {
-        startDate: new Date(def.startDate).toISOString(),
-        endDate: def.endDate ? new Date(def.endDate).toISOString() : new Date().toISOString(),
-        id,
-        proj: proj.crs,
-      };
-      worker.postMessage({ operation: 'requestDescribeDomains', args: [params] });
-    }
-  };
-
   /**
    * Create a new OpenLayers Layer
    * @param {object} def
@@ -1184,8 +1136,6 @@ export default function mapLayerBuilder(config, cache, store) {
     let { date } = dateOptions;
     let layer = cache.getItem(key);
     const isGranule = type === 'granule';
-
-    addTimeRanges(def);
 
     if (!layer || isGranule || def.type === 'titiler') {
       if (!date) date = options.date || getSelectedDate(state);

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -378,8 +378,7 @@ function UpdateProjection(props) {
   useEffect(() => {
     if (!ui.selected) return;
     const prevL2Layers = selectL2Layers(prevActiveLayers);
-    const activeL2Layers = selectL2Layers(activeLayers);
-    const needsReload = activeL2Layers.some((dateRange, i) => dateRange?.length !== prevL2Layers[i]?.length);
+    const needsReload = prevL2Layers.includes(undefined);
     if (needsReload) {
       reloadLayers(null, true);
     }

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -378,7 +378,7 @@ function UpdateProjection(props) {
   useEffect(() => {
     if (!ui.selected) return;
     const prevL2Layers = selectL2Layers(prevActiveLayers);
-    const needsReload = prevL2Layers.includes(undefined);
+    const needsReload = prevL2Layers.includes(undefined) || prevActiveLayers.length !== activeLayers.length;
     if (needsReload) {
       reloadLayers(null, true);
     }


### PR DESCRIPTION
## Description

> With the goal of resolving long load times for layers with large numbers of temporal ranges (i.e. TEMPO), load only data within the currently visible temporal extent for the data availability bar. This should be completed after we replace CMR with DescribeDomains.

## How To Test

1. `git checkout WV-3298-limit-data-availability`
2. `npm run watch`
3. Open this [link](http://localhost:3000/?v=-181.5652541051307,-4.028503320974131,-16.29922283094197,90.84644055865272&z=4&ics=true&ici=5&icd=6&l=TEMPO_L2_Ozone_Cloud_Fraction_Granule(count=1),TEMPO_L2_Ozone_Column_Amount_Granule(count=1),TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1),TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule(count=1),TEMPO_L2_Formaldehyde_Vertical_Column_Granule(count=1),TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule(count=1),TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule(count=1),Coastlines_15m&lg=true&t=2024-10-15-T17%3A24%3A00Z)
4. Make sure that the data availability date ranges load correctly and that scrolling and dragging performance in the timeline is unaffected.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
