### PR TITLE
WV-3380 show no-data granules outside of data availability ranges

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -169,12 +169,14 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
   */
   const getVisibleGranules = (availableGranules, granuleCount, leadingEdgeDate, granuleDateRanges) => {
     const { proj: { selected: { crs } } } = store.getState();
-    const granules = [];
+    const visibleGranules = [];
+    const invisibleGranules = [];
     const availableCount = availableGranules?.length;
-    if (!availableCount) return granules;
+    if (!availableCount) return { visibleGranules, invisibleGranules };
     const count = granuleCount > availableCount ? availableCount : granuleCount;
     const sortedAvailableGranules = availableGranules.sort((a, b) => new Date(b.date) - new Date(a.date));
-    for (let i = 0; granules.length < count; i += 1) {
+    let totalLength = visibleGranules.length + invisibleGranules.length;
+    for (let i = 0; totalLength < count; i += 1) {
       const item = sortedAvailableGranules[i];
       if (!item) break;
       const { date } = item;
@@ -183,14 +185,17 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       leadingEdgeDateUTC.setSeconds(59);
       const isWithinRange = isWithinRanges(leadingEdgeDateUTC, granuleDateRanges);
       if (dateDate <= leadingEdgeDateUTC && isWithinRange && isWithinBounds(crs, item)) {
-        granules.unshift(item);
+        visibleGranules.unshift(item);
+      } else if (dateDate <= leadingEdgeDateUTC && isWithinBounds(crs, item)) {
+        invisibleGranules.unshift(item);
       }
+      totalLength = visibleGranules.length + invisibleGranules.length;
     }
 
-    if (granules.length < granuleCount) {
-      console.warn('Could not find enough matching granules', `${granules.length}/${granuleCount}`);
+    if (totalLength < granuleCount) {
+      console.warn('Could not find enough matching granules', `${totalLength}/${granuleCount}`);
     }
-    return granules;
+    return { visibleGranules, invisibleGranules };
   };
 
   /**
@@ -209,13 +214,15 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
 
     // get granule dates waiting for CMR query and filtering (if necessary)
     const availableGranules = await getQueriedGranuleDates(def, date, group);
-    const visibleGranules = getVisibleGranules(availableGranules, count, date, granuleDateRanges);
-    const transformedGranules = transformGranulesForProj(visibleGranules, crs);
+    const { visibleGranules, invisibleGranules } = getVisibleGranules(availableGranules, count, date, granuleDateRanges);
+    const transformedVisibleGranules = transformGranulesForProj(visibleGranules, crs);
+    const transformedInvisibleGranules = transformGranulesForProj(invisibleGranules, crs);
 
     return {
       count,
-      granuleDates: transformedGranules.map((g) => g.date),
-      visibleGranules: transformedGranules,
+      granuleDates: [...transformedVisibleGranules.map((g) => g.date), ...transformedInvisibleGranules.map((g) => g.date)],
+      visibleGranules: transformedVisibleGranules,
+      invisibleGranules: transformedInvisibleGranules,
       granuleDateRanges,
     };
   };
@@ -243,10 +250,11 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     }
 
     const granuleAttributes = await getGranuleAttributes(def, options);
-    const { visibleGranules } = granuleAttributes;
+    const { visibleGranules, invisibleGranules } = granuleAttributes;
     const shouldShift = def.shiftadjacentdays ?? true; // defaults to true
-    const granules = shouldShift ? datelineShiftGranules(visibleGranules, date, crs) : visibleGranules;
-    const tileLayers = new OlCollection(createGranuleTileLayers(granules, def, attributes));
+    const shiftedVisibleGranules = shouldShift ? datelineShiftGranules(visibleGranules, date, crs) : visibleGranules;
+    const shiftedInvisibleGranules = shouldShift ? datelineShiftGranules(invisibleGranules, date, crs) : invisibleGranules;
+    const tileLayers = new OlCollection(createGranuleTileLayers(shiftedVisibleGranules, def, attributes));
     granuleLayer.setLayers(tileLayers);
     granuleLayer.setExtent(crs === CRS.GEOGRAPHIC ? FULL_MAP_EXTENT : maxExtent);
     granuleLayer.set('granuleGroup', true);
@@ -254,7 +262,8 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     granuleLayer.wv = {
       ...attributes,
       ...granuleAttributes,
-      visibleGranules: granules,
+      visibleGranules: shiftedVisibleGranules,
+      invisibleGranules: shiftedInvisibleGranules,
     };
 
     // Don't update during animation due to the performance hit

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -167,7 +167,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
     if (!ranges) return [];
     const MAX_TIME = 8.64e15;
 
-    const gaps = ranges.reduce((acc, [start, end], i) => {
+    const gaps = ranges.reduce((acc, [start, end]) => {
       acc.at(-1)[1] = new Date(start);
 
       return [...acc, [new Date(end), new Date(MAX_TIME)]];

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -115,19 +115,23 @@ export const isWithinBounds = (crs, granule) => {
 
 export const getGranuleFootprints = (layer) => {
   const {
-    def, visibleGranules, granuleDates,
+    def, visibleGranules, invisibleGranules, granuleDates,
   } = layer.wv;
   const { endDate, startDate } = def;
   const mostRecentGranuleDate = granuleDates[0];
   const isMostRecentDateOutOfRange = new Date(mostRecentGranuleDate) > new Date(endDate);
-
-  return visibleGranules.reduce((dates, { date, polygon }) => {
+  const reduceFunc = (dates, { date, polygon }) => {
     const granuleDate = new Date(date);
     if (!isMostRecentDateOutOfRange && isWithinDateRange(granuleDate, startDate, endDate)) {
       dates[date] = polygon;
     }
     return dates;
-  }, {});
+  };
+
+  const visibleGranuleFootprints = visibleGranules.reduce(reduceFunc, {});
+  const invisibleGranuleFootprints = invisibleGranules.reduce(reduceFunc, {});
+
+  return { ...invisibleGranuleFootprints, ...visibleGranuleFootprints };
 };
 
 /**

--- a/web/js/workers/dd.worker.js
+++ b/web/js/workers/dd.worker.js
@@ -19,9 +19,13 @@ async function requestDescribeDomains(params) {
     proj,
   } = params;
 
-  const describeDomainsUrl = `https://gibs.earthdata.nasa.gov/wmts/${projDict[proj]}/best/1.0.0/${id}/default/250m/all/${startDate.split('T')[0]}--${endDate.split('T')[0]}.xml`;
+  const start = new Date(startDate).toISOString().replace('.000', '');
+  const end = new Date(endDate).toISOString().replace('.000', '');
+
+  const describeDomainsUrl = `https://gibs.earthdata.nasa.gov/wmts/${projDict[proj]}/best/1.0.0/${id}/default/250m/all/${start}--${end}.xml`;
   const describeDomainsResponse = await fetch(describeDomainsUrl);
   const describeDomainsText = await describeDomainsResponse.text();
+
   return describeDomainsText;
 }
 


### PR DESCRIPTION
## Description

> There is a ~15 minute period on October 15, 2024 12:14-12:38, where there is no L2 data in WV prod (which I believe is expected because the bad imagery was filtered out so there was no imagery sent to WV). But I do not see any blue footprint boundaries like used to show up. I was wondering if the change in how WV was hosting the L2 meant that there would no longer be footprint boundaries for granules that don't have imagery. https://go.nasa.gov/48hE8YO

## How To Test

1. `git checkout WV-3380-footprints-with-no-granule`
2. `npm run watch`
3. Go to this [link](http://localhost:3000/?v=-233.8741347860138,-49.14368062321206,55.527906999980104,116.99452855022888&z=5&ics=true&ici=5&icd=6&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TEMPO_L2_Ozone_Cloud_Fraction_Granule(count=1),TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1),TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule(count=1),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2024-10-15-T12%3A15%3A15Z)
4. There should be a granule footprint visible on hover over North America that doesn't have any imagery available. Granule footprints should be available outside of data availability ranges.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
