### PR TITLE
WV-3386 Granule footprints do not behave as expected when you have a mix of granules with and without imagery for TEMPO L2 layers 

### DIFF
--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -204,11 +204,11 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       const granuleIsWithinRange = isWithinRanges(dateDate, granuleDateRanges) ?? true; // check if the current granule is within a date range, defaults to true
       const gaps = identifyGaps(granuleDateRanges); // identify gaps between date ranges
       const currentlySelectedGap = !isWithinRange ? gaps.find(([start, end]) => leadingEdgeDate >= start && leadingEdgeDate <= end) : null; // get the gap that the currently selected time is within
-      const granuleIsWithinSelectedGap = currentlySelectedGap ? dateDate >= currentlySelectedGap[0] && dateDate <= currentlySelectedGap[1] : false; // check if the current granule is within the currently selected gap
+      const granuleIsWithinSelectedGap = currentlySelectedGap ? dateDate >= currentlySelectedGap[0] && dateDate <= currentlySelectedGap[1] : true; // check if the current granule is within the currently selected gap
 
       if (dateDate <= leadingEdgeDate && isWithinRange && granuleIsWithinRange && isWithinBounds(crs, item)) {
         visibleGranules.unshift(item);
-      } else if (dateDate <= leadingEdgeDate && !isWithinRange && !granuleIsWithinRange && isWithinBounds(crs, item) && granuleIsWithinSelectedGap) {
+      } else if (dateDate <= leadingEdgeDate && !granuleIsWithinRange && isWithinBounds(crs, item) && granuleIsWithinSelectedGap) {
         invisibleGranules.unshift(item);
       }
 


### PR DESCRIPTION
## Description

> When I increase the granule count to more (e.g., 5), I think what WV is doing, is that it shows the past 5 granules, with the last granule being the one that matches the current time step. If this is the case, I'm not sure the viewer is acting as expected...it seems like when there is a mix of missing imagery (i.e., there is a granule but not an image so there is a blue polygon) and imagery.
https://worldview.uat.earthdata.nasa.gov/?v=-235.8508278866956,-41.26803179477153,73.48244727446703,100.30833046974496&z=5&ics=true&ici=5&icd=6&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TEMPO_L2_Ozone_Cloud_Fraction_Granule(hidden,count=5),TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(hidden,count=5),TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule(count=5),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2024-10-15-T12%3A33%3A40Z

## How To Test

1. `git checkout WV-3386-mixed-granules`
2. `npm i && npm run watch`
3.  Navigate to this [url](http://localhost:3000/?v=-235.8508278866956,-59.269957421735896,73.48244727446703,118.31025609670932&z=4&ics=true&ici=5&icd=6&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TEMPO_L2_Ozone_Cloud_Fraction_Granule(hidden,count=5),TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(hidden,count=5),TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule(count=5),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2024-10-15-T12%3A37%3A40Z)
4. There should be two granule footprints with imagery and three granule footprints without imagery.
5. Granules should behave as expected otherwise.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
