### PR TITLE
WV-3369 Fix layer coverage panel at minute resolution

### DIFF
--- a/web/js/components/timeline/timeline-coverage/coverage-item-container.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-container.js
@@ -72,7 +72,7 @@ class CoverageItemContainer extends Component {
       dateIntervalStartDates.forEach((dateIntStartDate) => {
         const dateIntTime = new Date(dateIntStartDate).getTime();
         // allow overwriting of subsequent date ranges
-        if (dateIntTime >= startDateTime && dateIntTime < endDateTime) {
+        if (dateIntTime >= startDateTime && dateIntTime <= endDateTime) {
           const dateIntFormatted = dateIntStartDate.toISOString();
           multiCoverageDates[dateIntFormatted] = {
             date: dateIntFormatted,

--- a/web/js/components/timeline/timeline-coverage/coverage-item-list.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-list.js
@@ -262,9 +262,7 @@ class CoverageItemList extends Component {
     const endGreaterThanOrEqualToStartDateLimit = new Date(rangeEnd).getTime() >= startDateLimit.getTime();
     if (startLessThanOrEqualToEndDateLimit && endGreaterThanOrEqualToStartDateLimit) {
       // check layer date array cache and use caches date array if available, if not add date array
-      if (!this.layerDateArrayCache[id]) {
-        this.layerDateArrayCache[id] = {};
-      }
+      this.layerDateArrayCache[id] ??= {};
 
       const layerIdDates = `${appNow.toISOString()}-${frontDate}-${backDate}`;
       if (this.layerDateArrayCache[id][layerIdDates] === undefined) {


### PR DESCRIPTION
## Description

> When you have a subdaily layer (TEMPO, Geostationary) loaded, open the Layer Availability Panel (double up arrow chevrons by the timeline) and change the timeline zoom to "Minute", it doesn't show any availability. Fix this issue so that there are blue bars on the layer availability panel.

## How To Test

1. `git checkout WV-3369-minute-layer-coverage`
2. `npm i && npm run watch`
3. Navigate to this [url](http://localhost:3000/?v=-178.86037695072633,-16.23362518707944,-11.96400101395544,79.5772572951409&z=5&ics=true&ici=5&icd=6&l=MODIS_Combined_L4_LAI_4Day,AMSRU2_Snow_Water_Equivalent_5Day,TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule(count=1),VIIRS_SNPP_DayNightBand_AtSensor_M15,Land_Mask&lg=true&t=2024-10-14-T12%3A39%3A20Z)
4. Confirm that the Layer Coverage panel shows bars for each layer and that the bars are correct.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
