### PR TITLE
WV-3292 Github Release Notes Filtering

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release


### PR DESCRIPTION
## Description
This change adds the `release.yml` file, which will filter out any PRs with the `ignore-for-release` tag when auto-generating the release notes. This is the only thing it filters by currently, but the file can be added to in the future as needed now.

## How To Test
1. Go to the [release page](https://github.com/nasa-gibs/worldview/releases) on Github
2. Draft a new release (DO NOT actually create a new release by clicking 'Publish release')
3. Click the 'Choose a tag' button at the top of the page and assign it to a new tag called Test (or anything else unique)
4. Switch the target in the box next to the tag from `main` to `wv-3292-release-notes-tweaks`
5. Click the 'Generate release notes' button and verify that doing this fills the textarea below with the release notes.
6. Verify that [this PR](https://github.com/nasa-gibs/worldview/pull/5564) does not show up in those release notes, since it has the correct tag assigned to it
7. The browser tab can now be safely closed - do not try to save or publish the release