### PR TITLE
WV-3398: Update TEMPO from BETA to PROVISIONAL

### DIFF
--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule": {
       "id": "TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule",
-      "title": "Clouds (L2, Cloud Fraction Total, Subdaily) (BETA)",
+      "title": "Clouds (L2, Cloud Fraction Total, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule": {
       "id": "TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule",
-      "title": "Clouds (L2, Cloud Pressure Total, Subdaily) (BETA)",
+      "title": "Clouds (L2, Cloud Pressure Total, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Formaldehyde_Vertical_Column_Granule": {
       "id": "TEMPO_L2_Formaldehyde_Vertical_Column_Granule",
-      "title": "Formaldehyde (L2, Vertical Column, Subdaily) (BETA)",
+      "title": "Formaldehyde (L2, Vertical Column, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule": {
       "id": "TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule",
-      "title": "Nitrogen Dioxide (L2, Vertical Column Stratosphere, Subdaily) (BETA)",
+      "title": "Nitrogen Dioxide (L2, Vertical Column Stratosphere, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule": {
       "id": "TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule",
-      "title": "Nitrogen Dioxide (L2, Vertical Column Troposphere, Subdaily) (BETA)",
+      "title": "Nitrogen Dioxide (L2, Vertical Column Troposphere, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Ozone_Cloud_Fraction_Granule": {
       "id": "TEMPO_L2_Ozone_Cloud_Fraction_Granule",
-      "title": "Ozone (L2, Cloud Fraction, Subdaily) (BETA)",
+      "title": "Ozone (L2, Cloud Fraction, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Ozone_Column_Amount_Granule": {
       "id": "TEMPO_L2_Ozone_Column_Amount_Granule",
-      "title": "Ozone (L2, Column Amount O3, Subdaily) (BETA)",
+      "title": "Ozone (L2, Column Amount O3, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Ozone_Column_Amount_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L2_Ozone_UV_Aerosol_Index_Granule": {
       "id": "TEMPO_L2_Ozone_UV_Aerosol_Index_Granule",
-      "title": "Ozone (L2, UV Aerosol Index, Subdaily) (BETA)",
+      "title": "Ozone (L2, UV Aerosol Index, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Cloud_Cloud_Fraction_Total": {
       "id": "TEMPO_L3_Cloud_Cloud_Fraction_Total",
-      "title": "Clouds (L3, Cloud Fraction Total, Subdaily) (BETA)",
+      "title": "Clouds (L3, Cloud Fraction Total, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Cloud_Cloud_Pressure_Total": {
       "id": "TEMPO_L3_Cloud_Cloud_Pressure_Total",
-      "title": "Clouds (L3, Cloud Pressure Total, Subdaily) (BETA)",
+      "title": "Clouds (L3, Cloud Pressure Total, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Formaldehyde_Vertical_Column": {
       "id": "TEMPO_L3_Formaldehyde_Vertical_Column",
-      "title": "Formaldehyde (L3, Vertical Column, Subdaily) (BETA)",
+      "title": "Formaldehyde (L3, Vertical Column, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Formaldehyde_Vertical_Column",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_NO2_Vertical_Column_Stratosphere": {
       "id": "TEMPO_L3_NO2_Vertical_Column_Stratosphere",
-      "title": "Nitrogen Dioxide (L3, Vertical Column Stratosphere, Subdaily) (BETA)",
+      "title": "Nitrogen Dioxide (L3, Vertical Column Stratosphere, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_NO2_Vertical_Column_Troposphere": {
       "id": "TEMPO_L3_NO2_Vertical_Column_Troposphere",
-      "title": "Nitrogen Dioxide (L3, Vertical Column Troposphere, Subdaily) (BETA)",
+      "title": "Nitrogen Dioxide (L3, Vertical Column Troposphere, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Ozone_Cloud_Fraction": {
       "id": "TEMPO_L3_Ozone_Cloud_Fraction",
-      "title": "Ozone (L3, Cloud Fraction, Subdaily) (BETA)",
+      "title": "Ozone (L3, Cloud Fraction, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Ozone_Cloud_Fraction",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Ozone_Column_Amount": {
       "id": "TEMPO_L3_Ozone_Column_Amount",
-      "title": "Ozone (L3, Column Amount O3, Subdaily) (BETA)",
+      "title": "Ozone (L3, Column Amount O3, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Ozone_Column_Amount",
       "tags": "",

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
@@ -2,7 +2,7 @@
   "layers": {
     "TEMPO_L3_Ozone_UV_Aerosol_Index": {
       "id": "TEMPO_L3_Ozone_UV_Aerosol_Index",
-      "title": "Ozone (L3, UV Aerosol Index, Subdaily) (BETA)",
+      "title": "Ozone (L3, UV Aerosol Index, Subdaily) (PROVISIONAL)",
       "subtitle": "TEMPO",
       "description": "tempo/TEMPO_L3_Ozone_UV_Aerosol_Index",
       "tags": "",


### PR DESCRIPTION
## Description

Fixes #WV-3398 .

Updated TEMPO from BETA to PROVISIONAL.

## How To Test

1. `git checkout wv-3398-tempo-to-provisional`
2. `npm run build && npm start`
3. Open Worldview
4. Click on Add Layers and search for "TEMPO"
5. Verify expected result - the 14 layers visible in Worldview should now have the subtitle that says "(PROVISIONAL)" instead of "(BETA)"

@nasa-gibs/worldview
