### PR TITLE
 WV-3395 Prevent Tour Text Box From Resetting Scroll During Animation

### DIFF
--- a/web/js/components/tour/modal-tour-in-progress.js
+++ b/web/js/components/tour/modal-tour-in-progress.js
@@ -7,11 +7,6 @@ import { Close } from '@edsc/earthdata-react-icons/horizon-design-system/hds/ui'
 import Steps from './widget-steps';
 
 class ModalInProgress extends React.Component {
-  componentDidUpdate() {
-    // eslint-disable-next-line react/no-string-refs
-    if (this.refs.stepContent) this.refs.stepContent.parentNode.scrollTop = 0;
-  }
-
   render() {
     const {
       className,


### PR DESCRIPTION
## Description
This change prevents the scroll position of the text box during a tour story from being reset to the top during every animation step while an animation is playing.

## How To Test
1. `git checkout wv-3395-animation-text-scroll`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-94.99760485836387,12.644374670321714,-59.13483308430094,39.482468678872095&z=4&ics=true&ici=5&icd=10&as=2019-09-01-T11%3A00%3A00Z&ae=2019-09-01-T17%3A00%3A00Z&l=Reference_Labels_15m,Reference_Features_15m,Coastlines_15m,GOES-East_ABI_Band2_Red_Visible_1km&lg=false&tr=geostationary&al=true&av=9&ab=on&t=2019-09-01-T11%3A00%3A00Z)
5. Go to step 6 of the tour story, start playing the animation, then verify that you can scroll the tour story text box freely while the animation plays.