### PR TITLE
WV-2870 Allow users to create image snapshots of modified classification type imagery in Worldview

### DIFF
--- a/e2e/features/image-download/unsupported-test.spec.js
+++ b/e2e/features/image-download/unsupported-test.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test')
 const createSelectors = require('../../test-utils/global-variables/selectors')
-const { closeImageDownloadPanel, closeModal } = require('../../test-utils/hooks/wvHooks')
+const { closeModal } = require('../../test-utils/hooks/wvHooks')
 const { joinUrl } = require('../../test-utils/hooks/basicHooks')
 
 let page
@@ -26,31 +26,6 @@ test.beforeAll(async ({ browser }) => {
 
 test.afterAll(async () => {
   await page.close()
-})
-
-test('Custom palettes are not supported dialog', async () => {
-  const { snapshotToolbarButton } = selectors
-  const url = await joinUrl(startParams, '&l=MODIS_Terra_Aerosol(palette=red_1)')
-  await page.goto(url)
-  await closeModal(page)
-  await snapshotToolbarButton.click()
-  await expect(notify).toBeVisible()
-})
-
-test('Custom palettes: Cancel button', async () => {
-  await cancelNotify.click()
-  await expect(notify).not.toBeVisible()
-  await expect(toolbarSnapshot).not.toBeVisible()
-})
-
-test('Custom palettes: OK button brings up download panel', async () => {
-  const { snapshotToolbarButton } = selectors
-  await snapshotToolbarButton.click()
-  await expect(notify).toBeVisible()
-  await acceptNotify.click()
-  await expect(notify).not.toBeVisible()
-  await expect(toolbarSnapshot).toBeVisible()
-  await closeImageDownloadPanel(page)
 })
 
 test('Rotation is not supported dialog', async () => {

--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { getActivePalettes } from '../../modules/palettes/selectors';
 import PropTypes from 'prop-types';
 import googleTagManager from 'googleTagManager';
 import {
@@ -57,6 +59,7 @@ function ImageDownloadPanel(props) {
   const [currResolution, setResolution] = useState(resolution);
   const [debugUrl, setDebugUrl] = useState('');
   const [showGranuleWarning, setShowGranuleWarning] = useState(false);
+  const activePalettes = useSelector((state) => getActivePalettes(state, state.compare.activeString));
 
   useEffect(() => {
     const layerList = getLayers();
@@ -83,6 +86,7 @@ function ImageDownloadPanel(props) {
       currFileType,
       currFileType === 'application/vnd.google-earth.kmz' ? false : currIsWorldfile,
       markerCoordinates,
+      activePalettes,
     );
 
     window.open(dlURL, '_blank');

--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { getActivePalettes } from '../../modules/palettes/selectors';
 import PropTypes from 'prop-types';
 import googleTagManager from 'googleTagManager';
+import { getActivePalettes } from '../../modules/palettes/selectors';
 import {
   imageSizeValid,
   getDimensions,

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -136,7 +136,6 @@ class toolbarContainer extends Component {
     const nonDownloadableLayers = hasNonDownloadableLayer ? getNonDownloadableLayers(visibleLayersForProj) : null;
     const paletteStore = lodashCloneDeep(activePalettes);
     toggleDialogVisible(false);
-    await this.getPromise(hasCustomPalette, 'palette', clearCustoms, 'Notice');
     await this.getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
     await this.getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
     await openModal(

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -21,7 +21,7 @@ import {
   requestNotifications,
   setNotifications,
 } from '../modules/notifications/actions';
-import { clearCustoms, refreshPalettes } from '../modules/palettes/actions';
+import { refreshPalettes } from '../modules/palettes/actions';
 import { clearRotate, refreshRotation } from '../modules/map/actions';
 import {
   showLayers, hideLayers,

--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -1,5 +1,4 @@
 import {
-  each as lodashEach,
   get as lodashGet,
 } from 'lodash';
 import { transform } from 'ol/proj';
@@ -189,7 +188,7 @@ export function imageUtilGetLayers(products, proj, activePalettes) {
     } else if (layer.projections[proj].layer) {
       layerId = layer.projections[proj].layer;
     }
-    const disabled = activePalettes[layer.id]?.maps?.[0]?.disabled;
+    const disabled = activePalettes?.[layer.id]?.maps?.[0]?.disabled;
     if (Array.isArray(disabled)) {
       return `${layerId}(disabled=${disabled.join('-')})`;
     }
@@ -333,12 +332,14 @@ export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime,
     `BBOX=${bboxWMS13(bbox, crs)}`,
     `CRS=${crs}`,
     `LAYERS=${layersArray.join(',')}`,
-    `colormaps=${colormaps.join(',')}`,
     `WRAP=${layerWraps.join(',')}`,
     `FORMAT=${imgFormat}`,
     `WIDTH=${width}`,
     `HEIGHT=${height}`,
   ];
+  if (Array.isArray(colormaps) && colormaps.length > 0) {
+    params.push(`colormaps=${colormaps.join(',')}`);
+  }
   if (granuleDates.length > 0) {
     params.push(`granule_dates=${granuleDates}`);
   }

--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -190,7 +190,7 @@ export function imageUtilGetLayers(products, proj, activePalettes) {
     }
     const disabled = activePalettes?.[layer.id]?.maps?.[0]?.disabled;
     if (Array.isArray(disabled)) {
-      return `${layerId}(disabled=${disabled.join('-')})`;
+      return `${layerId}%28disabled=${disabled.join('-')}%29`;
     }
     return layerId;
   });

--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -179,18 +179,21 @@ export function imageUtilCalculateResolution(
  * @returns {array} array of layer ids
  *
  */
-export function imageUtilGetLayers(products, proj) {
-  const layers = [];
-  lodashEach(products, (layer) => {
+export function imageUtilGetLayers(products, proj, activePalettes) {
+  const layers = products.map((layer) => {
+    let layerId = layer.id;
     if (layer.downloadId) {
-      layers.push(layer.downloadId);
+      layerId = layer.downloadId;
     } else if (layer.projections[proj].id) {
-      layers.push(layer.projections[proj].id);
+      layerId = layer.projections[proj].id;
     } else if (layer.projections[proj].layer) {
-      layers.push(layer.projections[proj].layer);
-    } else {
-      layers.push(layer.id);
+      layerId = layer.projections[proj].layer;
     }
+    const disabled = activePalettes[layer.id]?.maps?.[0]?.disabled;
+    if (Array.isArray(disabled)) {
+      return `${layerId}(disabled=${disabled.join('-')})`;
+    }
+    return layerId;
   });
   return layers;
 }
@@ -306,7 +309,7 @@ export function getTruncatedGranuleDates(layerDefs) {
  * @param {Boolean} isWorldfile
  * @param {Array} markerCoordinates
  */
-export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime, fileType, isWorldfile, markerCoordinates) {
+export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime, fileType, isWorldfile, markerCoordinates, activePalettes) {
   const { crs } = proj.selected;
   const {
     layersArray,
@@ -314,7 +317,7 @@ export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime,
     opacities,
   } = imageUtilProcessWrap(
     fileType,
-    imageUtilGetLayers(layerDefs, proj.id),
+    imageUtilGetLayers(layerDefs, proj.id, activePalettes),
     imageUtilGetLayerWrap(layerDefs),
     imageUtilGetLayerOpacities(layerDefs),
   );
@@ -323,12 +326,14 @@ export function getDownloadUrl(url, proj, layerDefs, bbox, dimensions, dateTime,
   const { height, width } = dimensions;
   const snappedDateTime = getLatestIntervalTime(layerDefs, dateTime);
   const granuleDates = getTruncatedGranuleDates(layerDefs).value;
+  const colormaps = layerDefs.map((layer) => layer.palette?.id);
   const params = [
     'REQUEST=GetSnapshot',
     `TIME=${util.toISOStringSeconds(snappedDateTime)}`,
     `BBOX=${bboxWMS13(bbox, crs)}`,
     `CRS=${crs}`,
     `LAYERS=${layersArray.join(',')}`,
+    `colormaps=${colormaps.join(',')}`,
     `WRAP=${layerWraps.join(',')}`,
     `FORMAT=${imgFormat}`,
     `WIDTH=${width}`,

--- a/web/js/modules/image-download/util.test.js
+++ b/web/js/modules/image-download/util.test.js
@@ -218,7 +218,7 @@ test('Download URL [imagedownload-url]', () => {
     { id: 1, longitude: 2.7117, latitude: -19.1609 },
     { id: 2, longitude: 71.173, latitude: -39.0961 },
   ];
-  const dlURL = getDownloadUrl(url, proj, mockLayerDefs, lonlats, dimensions, dateTime, false, false, locationMarkers);
+  const dlURL = getDownloadUrl(url, proj, mockLayerDefs, lonlats, dimensions, dateTime, false, false, locationMarkers, undefined);
   const expectedURL = 'http://localhost:3002/api/v1/snapshot'
     + '?REQUEST=GetSnapshot'
     + '&TIME=2019-06-24T00:00:00Z'
@@ -228,6 +228,7 @@ test('Download URL [imagedownload-url]', () => {
     + '&WRAP=day'
     + '&FORMAT=image/jpeg'
     + '&WIDTH=300&HEIGHT=300'
+    + '&colormaps='
     + '&MARKER=2.7117,-19.1609,71.173,-39.0961';
   expect(dlURL.includes(expectedURL)).toBe(true);
 });

--- a/web/js/modules/palettes/selectors.js
+++ b/web/js/modules/palettes/selectors.js
@@ -504,3 +504,7 @@ export function isPaletteAllowed(layerId, config) {
   }
   return Boolean(config.layers[layerId].palette);
 }
+
+export function getActivePalettes (state, activeString) {
+  return state.palettes[activeString];
+}


### PR DESCRIPTION
## Description

>This ticket is to track work that has to be done on the Worldview side to allow for imagery snapshots of modified imagery. 

> For example, for this Sea Ice layer, some other classifications have been turned on. When you try to take an image snapshot, the notice says the imagery is modified, but when you go to take a snapshot, it looks like it will take a snapshot of the new classifications you turned on, but the resulting snapshot is just sea ice. 

## How To Test

1. `git checkout WV-2870-classification-snapshots`
2. `npm i && npm run watch`
3. Navigate to this [url](http://localhost:3000/?v=-73.22692923722146,40.863982982998294,-69.46498315873002,43.02361869472486&l=OPERA_L3_Dynamic_Surface_Water_Extent-HLS(disabled=5-1),MODIS_Terra_Sea_Ice(hidden,disabled=1-2-3-6-7-8-9-10),Coastlines_15m&lg=false&t=2024-11-17-T00%3A00%3A00Z)
4. Create an image snapshot and verify that the generated image matches the custom palette.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
