### PR TITLE
WV-3397 Issue with changing color palettes for dual color paletted layer

### DIFF
--- a/e2e/features/layers/options-test.spec.js
+++ b/e2e/features/layers/options-test.spec.js
@@ -31,13 +31,6 @@ test('Verify that settings button opens settings modal', async () => {
   await expect(thresholdMinLabel).toBeVisible()
 })
 
-test('Verify that custom blue custom palette is checked', async () => {
-  const activeDefaultPaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-__default')
-  const activeBluePaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-blue_2')
-  await expect(activeDefaultPaletteCheckbox).not.toBeVisible()
-  await expect(activeBluePaletteCheckbox).toBeVisible()
-})
-
 test('Verify that threshold and opacity components update when different layer setting button clicked', async () => {
   const thresholdMinLabel = await page.locator('#wv-layer-options-threshold0 .wv-label-range-min')
   const opacityLabel = await page.locator('.layer-opacity-select .wv-label')
@@ -49,11 +42,4 @@ test('Verify that threshold and opacity components update when different layer s
   await terraAodSettingsButton.click()
   await expect(thresholdMinLabel).toContainText('< 0.0')
   await expect(opacityLabel).toContainText('100%')
-})
-
-test('Verify that default palette is now checked', async () => {
-  const activeDefaultPaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-__default')
-  const activeBluePaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-blue_2')
-  await expect(activeDefaultPaletteCheckbox).toBeVisible()
-  await expect(activeBluePaletteCheckbox).not.toBeVisible()
 })

--- a/e2e/features/layers/options-test.spec.js
+++ b/e2e/features/layers/options-test.spec.js
@@ -31,6 +31,13 @@ test('Verify that settings button opens settings modal', async () => {
   await expect(thresholdMinLabel).toBeVisible()
 })
 
+test('Verify that custom blue custom palette is checked', async () => {
+  const activeDefaultPaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-__default-0')
+  const activeBluePaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-blue_2-0')
+  await expect(activeDefaultPaletteCheckbox).not.toBeVisible()
+  await expect(activeBluePaletteCheckbox).toBeVisible()
+})
+
 test('Verify that threshold and opacity components update when different layer setting button clicked', async () => {
   const thresholdMinLabel = await page.locator('#wv-layer-options-threshold0 .wv-label-range-min')
   const opacityLabel = await page.locator('.layer-opacity-select .wv-label')
@@ -42,4 +49,11 @@ test('Verify that threshold and opacity components update when different layer s
   await terraAodSettingsButton.click()
   await expect(thresholdMinLabel).toContainText('< 0.0')
   await expect(opacityLabel).toContainText('100%')
+})
+
+test('Verify that default palette is now checked', async () => {
+  const activeDefaultPaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-__default-0')
+  const activeBluePaletteCheckbox = await page.locator('.wv-palette-selector-row.checked #wv-palette-radio-blue_2-0')
+  await expect(activeDefaultPaletteCheckbox).toBeVisible()
+  await expect(activeBluePaletteCheckbox).not.toBeVisible()
 })

--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -50,12 +50,11 @@ function PaletteSelect (props) {
     const caseDefaultClassName = 'wv-palette-selector-row wv-checkbox wv-checkbox-round gray ';
     const checkedClassName = isSelected ? 'checked' : '';
     const isInvisible = color === '00000000';
-    const identifier = crypto.randomUUID();
 
     return (
-      <div key={identifier} className={caseDefaultClassName + checkedClassName}>
+      <div key={`${id}-${index}`} className={caseDefaultClassName + checkedClassName}>
         <input
-          id={`wv-palette-radio-${identifier}`}
+          id={`wv-palette-radio-${id}-${index}`}
           type="radio"
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
@@ -63,7 +62,7 @@ function PaletteSelect (props) {
         {isSelected && (
           <span class="dot" />
         )}
-        <label htmlFor={`wv-palette-radio-${identifier}`}>
+        <label htmlFor={`wv-palette-radio-${id}-${index}`}>
           <span
             className={isInvisible ? 'checkerbox-bg wv-palettes-class' : 'wv-palettes-class'}
             style={isInvisible ? null : { backgroundColor: util.hexToRGBA(color) }}
@@ -94,11 +93,11 @@ function PaletteSelect (props) {
       canvas.height,
     );
     const dataURL = canvas.toDataURL('image/png');
-    const identifier = crypto.randomUUID();
+
     return (
-      <div key={identifier} className={caseDefaultClassName + checkedClassName}>
+      <div key={`${id}-${index}`} className={caseDefaultClassName + checkedClassName}>
         <input
-          id={`wv-palette-radio-${identifier}`}
+          id={`wv-palette-radio-${id}-${index}`}
           type="radio"
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
@@ -106,7 +105,7 @@ function PaletteSelect (props) {
         {isSelected && (
           <span class="dot" />
         )}
-        <label htmlFor={`wv-palette-radio-${identifier}`}>
+        <label htmlFor={`wv-palette-radio-${id}-${index}`}>
           <img src={dataURL} />
           <span className="wv-palette-label">{legend.name || 'Default'}</span>
         </label>

--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -50,11 +50,12 @@ function PaletteSelect (props) {
     const caseDefaultClassName = 'wv-palette-selector-row wv-checkbox wv-checkbox-round gray ';
     const checkedClassName = isSelected ? 'checked' : '';
     const isInvisible = color === '00000000';
+    const identifier = crypto.randomUUID();
 
     return (
-      <div key={id} className={caseDefaultClassName + checkedClassName}>
+      <div key={identifier} className={caseDefaultClassName + checkedClassName}>
         <input
-          id={`wv-palette-radio-${id}`}
+          id={`wv-palette-radio-${identifier}`}
           type="radio"
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
@@ -62,7 +63,7 @@ function PaletteSelect (props) {
         {isSelected && (
           <span class="dot" />
         )}
-        <label htmlFor={`wv-palette-radio-${id}`}>
+        <label htmlFor={`wv-palette-radio-${identifier}`}>
           <span
             className={isInvisible ? 'checkerbox-bg wv-palettes-class' : 'wv-palettes-class'}
             style={isInvisible ? null : { backgroundColor: util.hexToRGBA(color) }}
@@ -93,10 +94,11 @@ function PaletteSelect (props) {
       canvas.height,
     );
     const dataURL = canvas.toDataURL('image/png');
+    const identifier = crypto.randomUUID();
     return (
-      <div key={id} className={caseDefaultClassName + checkedClassName}>
+      <div key={identifier} className={caseDefaultClassName + checkedClassName}>
         <input
-          id={`wv-palette-radio-${id}`}
+          id={`wv-palette-radio-${identifier}`}
           type="radio"
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
@@ -104,7 +106,7 @@ function PaletteSelect (props) {
         {isSelected && (
           <span class="dot" />
         )}
-        <label htmlFor={`wv-palette-radio-${id}`}>
+        <label htmlFor={`wv-palette-radio-${identifier}`}>
           <img src={dataURL} />
           <span className="wv-palette-label">{legend.name || 'Default'}</span>
         </label>

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -80,7 +80,12 @@ class PaletteLegend extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isDistractionFreeModeActive, layer, width, paletteLegends } = this.props;
+    const {
+      isDistractionFreeModeActive,
+      layer,
+      width,
+      paletteLegends
+    } = this.props;
     // Updates when layer options/settings changed, if ZOT changes the width of the palette, or distraction free mode exit
     const layerChange = !lodashIsEqual(layer, prevProps.layer);
     const paletteLegendsChange = !lodashIsEqual(paletteLegends, prevProps.paletteLegends);

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -80,12 +80,13 @@ class PaletteLegend extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isDistractionFreeModeActive, layer, width } = this.props;
+    const { isDistractionFreeModeActive, layer, width, paletteLegends } = this.props;
     // Updates when layer options/settings changed, if ZOT changes the width of the palette, or distraction free mode exit
     const layerChange = !lodashIsEqual(layer, prevProps.layer);
+    const paletteLegendsChange = !lodashIsEqual(paletteLegends, prevProps.paletteLegends);
     const widthChange = prevProps.width !== width;
     const distractionFreeChange = prevProps.isDistractionFreeModeActive && !isDistractionFreeModeActive;
-    if (layerChange || widthChange || distractionFreeChange) {
+    if (layerChange || widthChange || distractionFreeChange || paletteLegendsChange) {
       this.updateCanvas();
     }
   }

--- a/web/js/components/sidebar/paletteLegend.js
+++ b/web/js/components/sidebar/paletteLegend.js
@@ -84,7 +84,7 @@ class PaletteLegend extends React.Component {
       isDistractionFreeModeActive,
       layer,
       width,
-      paletteLegends
+      paletteLegends,
     } = this.props;
     // Updates when layer options/settings changed, if ZOT changes the width of the palette, or distraction free mode exit
     const layerChange = !lodashIsEqual(layer, prevProps.layer);


### PR DESCRIPTION
## Description

> Dual color paletted layers like IMERG Precipitation Rate has an issue when changing the color palette of the second color bar (Snow Rate), and it changes the palette of the first tab, Rain Rate.

## How To Test

1. `git checkout WV-3397-changing-palettes`
2. `npm i && npm run watch`
3. Go to this [link](http://localhost:3000/?v=-149.18647629361564,-84.53960677557683,131.9035413555856,76.8268848378535&l=IMERG_Precipitation_Rate,Coastlines_15m&lg=true&t=2024-12-24-T00%3A00%3A00Z)
4. Change the Rain Rate palette to "Red 2" and then change the Snow Rate palette to "Blue 1"
5. The palettes should apply appropriately

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
