### PR TITLE
WV-3413: Re-enable HLS tour story

### DIFF
--- a/config/default/common/config/wv.json/storyOrder.json
+++ b/config/default/common/config/wv.json/storyOrder.json
@@ -3,6 +3,7 @@
         "el_nino",
         "surface_water_extent",
         "atmospheric_rivers",
+        "hls_intro",
         "flood-product",
         "black_marble_night_lights",
         "geostationary",


### PR DESCRIPTION
## Description

Fixes #WV-3413

Re-enabled HLS tour story

## How To Test

1. `git checkout wv-3413-reenable-hls-story`
2. `npm run build && npm start`
3. Check to make sure the imagery in the HLS tour story looks good!

@nasa-gibs/worldview
