### PR TITLE
Dependency Updates 01-31-25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@khanisak/temperature-converter": "^2.0.1",
-        "@reduxjs/toolkit": "^2.5.0",
+        "@reduxjs/toolkit": "^2.5.1",
         "axios": "^1.7.9",
         "bluebird": "3.7.2",
         "bootstrap": "^5.3.3",
@@ -62,7 +62,7 @@
         "react-swipe-to-delete-component": "1.0.5",
         "react-visibility-sensor": "^5.1.1",
         "reactstrap": "^9.2.3",
-        "recharts": "^2.15.0",
+        "recharts": "^2.15.1",
         "redux": "^5.0.1",
         "redux-location-state": "^2.8.2",
         "redux-logger": "^3.0.6",
@@ -87,7 +87,6 @@
         "@babel/preset-react": "^7.26.3",
         "@playwright/test": "^1.49.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-        "@webpack-cli/serve": "^3.0.0",
         "ajv": "^8.17.1",
         "autoprefixer": "^10.4.20",
         "babel-loader": "^9.2.1",
@@ -108,7 +107,7 @@
         "eslint-plugin-n": "^17.15.1",
         "eslint-plugin-no-storage": "^1.0.2",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.6.0",
+        "eslint-plugin-promise": "^7.2.1",
         "eslint-plugin-react": "^7.37.4",
         "express": "^4.21.0",
         "glob": "^11.0.1",
@@ -3332,9 +3331,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.0.tgz",
-      "integrity": "sha512-awNe2oTodsZ6LmRqmkFhtb/KH03hUhxOamEQy411m3Njj3BbFvoBovxo4Q1cBWnV1ErprVj9MlF0UPXkng0eyg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
+      "integrity": "sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==",
       "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
@@ -4098,25 +4097,6 @@
       "peerDependencies": {
         "webpack": "5.x.x",
         "webpack-cli": "5.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.0.tgz",
-      "integrity": "sha512-oX0XqXHb0IgD2jfzxM5sOGuwFTrLpOpfyPT0t4QIXHS69eRRliyuKzbavXgDnOENIs9BxbNnAaDFhTpAEPEChQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -7785,11 +7765,16 @@
       }
     },
     "node_modules/eslint-plugin-promise": {
-      "version": "6.6.0",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.2.1.tgz",
+      "integrity": "sha512-SWKjd+EuvWkYaS+uN2csvj0KoP43YTu7+phKQ5v+xw6+A0gutVX2yqCeCkC3uLCJFiPfR2dD8Es5L7yUsmvEaA==",
       "dev": true,
       "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8314,7 +8299,9 @@
       "peer": true
     },
     "node_modules/fast-equals": {
-      "version": "5.0.1",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -15072,7 +15059,9 @@
       }
     },
     "node_modules/react-smooth": {
-      "version": "4.0.0",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
       "license": "MIT",
       "dependencies": {
         "fast-equals": "^5.0.1",
@@ -15080,8 +15069,8 @@
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-swipe-to-delete-component": {
@@ -15331,16 +15320,16 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
-      "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+      "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
         "react-is": "^18.3.1",
-        "react-smooth": "^4.0.0",
+        "react-smooth": "^4.0.4",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"
@@ -17792,7 +17781,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.19.7",
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@babel/preset-react": "^7.26.3",
     "@playwright/test": "^1.49.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
-    "@webpack-cli/serve": "^3.0.0",
     "ajv": "^8.17.1",
     "autoprefixer": "^10.4.20",
     "babel-loader": "^9.2.1",
@@ -106,7 +105,7 @@
     "eslint-plugin-n": "^17.15.1",
     "eslint-plugin-no-storage": "^1.0.2",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.6.0",
+    "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-react": "^7.37.4",
     "express": "^4.21.0",
     "glob": "^11.0.1",
@@ -154,7 +153,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@khanisak/temperature-converter": "^2.0.1",
-    "@reduxjs/toolkit": "^2.5.0",
+    "@reduxjs/toolkit": "^2.5.1",
     "axios": "^1.7.9",
     "bluebird": "3.7.2",
     "bootstrap": "^5.3.3",
@@ -198,7 +197,7 @@
     "react-swipe-to-delete-component": "1.0.5",
     "react-visibility-sensor": "^5.1.1",
     "reactstrap": "^9.2.3",
-    "recharts": "^2.15.0",
+    "recharts": "^2.15.1",
     "redux": "^5.0.1",
     "redux-location-state": "^2.8.2",
     "redux-logger": "^3.0.6",
@@ -224,7 +223,8 @@
       "redux": "^5.0.1"
     },
     "eslint-config-standard": {
-      "eslint-plugin-n": "^17.1.0"
+      "eslint-plugin-n": "^17.1.0",
+      "eslint-plugin-promise": "^7.2.1"
     },
     "fetch-mock-jest": {
       "path-to-regexp": "^8.0.0"


### PR DESCRIPTION
- `eslint-plugin-promise`: v6.6.0 --> 7.2.1
- `@reduxjs/toolkit`: v2.5.0 --> 2.5.1
- `recharts`: v2.15.0 --> 2.15.1

Removed `@webpack-cli/serve` devDependency, since it is a sub-package of `webpack-cli`