### PR TITLE
Update start date and allow image snapshot of L3 layers

### DIFF
--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Fraction_Total_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Cloud_Cloud_Pressure_Total_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Formaldehyde_Vertical_Column_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Stratosphere_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_NO2_Vertical_Column_Troposphere_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Cloud_Fraction_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_Column_Amount_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L2_Ozone_UV_Aerosol_Index_Granule.json
@@ -12,7 +12,7 @@
       "period": "subdaily",
       "count": 1,
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:41:03Z",
+      "startDate": "2023-08-02T15:12:49Z",
       "disableSnapshot": true,
       "shiftadjacentdays": false
     }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Cloud Fraction",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Cloud Fraction",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Cloud Pressure",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Cloud Pressure",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Formaldehyde",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Formaldehyde",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Ozone",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Ozone",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Ozone",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Ozone",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
@@ -9,8 +9,7 @@
       "group": "overlays",
       "layergroup": "Aerosol Index",
       "dataAvailability": "dd",
-      "startDate": "2024-05-13T10:30:00Z",
-      "disableSnapshot": true,
+      "startDate": "2023-08-02T15:12:49Z",
       "shiftadjacentdays": false
     }
   }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
@@ -9,7 +9,7 @@
       "group": "overlays",
       "layergroup": "Aerosol Index",
       "dataAvailability": "dd",
-      "startDate": "2023-08-02T15:12:49Z",
+      "startDate": "2023-08-02T15:00:00Z",
       "shiftadjacentdays": false
     }
   }


### PR DESCRIPTION
## Description

Fixes #WV-3477 .

- [x] Removed disableSnapshots for Level 3 TEMPO layers
- [x] Updated start date for TEMPO layers to 2023-08-02 15:12:49Z for Level 2; 2023-08-02T15:00:00Z for Level 3

## How To Test

1. `git checkout wv-3477-l3-tempo-snapshots`
2. `npm run build && npm start`
3. Load Worldview
4. Add L3 TEMPO layers, ensure you can take an image snapshot of the layers
5. Check the start date for L2 and L3 TEMPO layers and make sure it starts on 2023-08-02

@nasa-gibs/worldview
