### PR TITLE
WV-3504 Refine label placement

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/Reference_Labels_15m.json
+++ b/config/default/common/config/wv.json/layers/reference/Reference_Labels_15m.json
@@ -25,7 +25,7 @@
       },
       "vectorStyle": {
         "id": "Reference_Labels_15m",
-        "url": "https://nasa.maps.arcgis.com/sharing/rest/content/items/b611632010304f9a9358e1eec064cd25/resources/styles/root.json?f=pjson"
+        "url": "https://nasa.maps.arcgis.com/sharing/rest/content/items/8a79d68248f4415fb191077549d982e1/resources/styles/root.json?f=pjson"
       }
     }
   }


### PR DESCRIPTION
## Description
The latest release (v4.58.0) introduced vector tile-based reference labels using Esri vector tiles and a custom style.  This PR links to a slightly updated style which refines label placement.

## How To Test
- `git checkout WV-3504-updated-label-placement`
- `npm i && npm run build:verbose`
- Validate that labels in the the reference labels layer are properly placed 

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
