### PR TITLE
WV-3449 Prevent crashes during Embed Mode Comparisons

### DIFF
--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -140,7 +140,8 @@ export const getCollections = (layers, dailyDate, subdailyDate, layer, projId) =
 const getActiveLayersEmbed = (state, activeString) => {
   const { compare, layers } = state;
   const activeLayers = layers[activeString || compare.activeString].layers;
-  return activeLayers.filter((layer) => layer.visible);
+  const filteredLayers = activeLayers.filter((layer) => layer.visible);
+  return filteredLayers.length !== activeLayers.length ? filteredLayers : activeLayers;
 };
 
 /**


### PR DESCRIPTION
## Description
This change prevents the app from crashing when manipulating the 'A' side of the comparison during some cases using Embed Mode.

## How To Test
1. `git checkout wv-3449-embed-compare-crash`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-120.45621226714901,32.54570298090037,-115.93546938776443,34.926418270391096&em=true&l=MODIS_Aqua_Thermal_Anomalies_Day,MODIS_Aqua_CorrectedReflectance_TrueColor&lg=true&l1=MODIS_Aqua_CorrectedReflectance_Bands721&lg1=true&ca=false&cv=47&t=2025-01-08-T19%3A25%3A26Z&t1=2025-01-08-T19%3A25%3A26Z), switch to the 'A' side, and decrease/increase the date.
5. Open [this link](http://localhost:3000/?v=139.92739686913416,-38.72451319420445,144.81852283757257,-36.14874662517728&em=true&l=VIIRS_NOAA21_CorrectedReflectance_BandsM11-I2-I1&lg=true&l1=VIIRS_NOAA21_Thermal_Anomalies_375m_Day,VIIRS_NOAA21_CorrectedReflectance_BandsM11-I2-I1&lg1=true&ca=true&cv=52&t=2024-12-25-T00%3A00%3A00Z&t1=2024-12-25-T00%3A00%3A00Z) and decrease/increase the date of the 'A' side.
6. Verify that the app does not crash in either case.