### PR TITLE
WV-3517 Fix e2e tests failing from notifications

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -68,12 +68,10 @@ class App extends React.Component {
   componentDidUpdate(prevProps) {
     // Check if the numberUnseen prop has changed
     const {
-      kioskModeEnabled, notifications, numberOutagesUnseen, e2eModeEnabled,
+      kioskModeEnabled, notifications, numberOutagesUnseen, e2eModeEnabled, hideNotificationsPopup,
     } = this.props;
-    const githubActionsRunning = process.env.GITHUB_ACTIONS === 'true';
-    const locallyHosted = /localhost/.test(window.location.href);
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
-      if (numberOutagesUnseen > 0 && !kioskModeEnabled && !e2eModeEnabled && !githubActionsRunning && !locallyHosted) {
+      if (numberOutagesUnseen > 0 && !kioskModeEnabled && !e2eModeEnabled && !hideNotificationsPopup) {
         this.openNotification(notifications, numberOutagesUnseen);
       }
     }
@@ -156,6 +154,7 @@ class App extends React.Component {
       locationKey,
       modalId,
       parameters,
+      hideNotificationsPopup,
     } = this.props;
     const appClass = `wv-content ${isEmbedModeActive ? 'embed-mode' : ''}`;
     return (
@@ -166,7 +165,7 @@ class App extends React.Component {
         <MapInteractions />
         <AlertDropdown isTourActive={isTourActive} />
         <div>
-          {isTourActive && numberOutagesUnseen === 0 && (!isMobile || isEmbedModeActive) ? <Tour /> : null}
+          {isTourActive && (numberOutagesUnseen === 0 || hideNotificationsPopup) && (!isMobile || isEmbedModeActive) ? <Tour /> : null}
         </div>
         <Sidebar />
         <div id="layer-modal" className="layer-modal" />
@@ -195,6 +194,8 @@ function mapStateToProps(state) {
   } = notifications;
   const kioskModeEnabled = (state.ui.eic !== null && state.ui.eic !== '') || state.ui.isKioskModeActive;
   const e2eModeEnabled = state.ui.isE2eModeActive;
+  const githubActionsRunning = process.env.GITHUB_ACTIONS === 'true';
+  const locallyHosted = /localhost/.test(window.location.href);
   return {
     state,
     kioskModeEnabled,
@@ -213,6 +214,7 @@ function mapStateToProps(state) {
     parameters: state.parameters,
     locationKey: state.location.key,
     modalId: state.modal.id,
+    hideNotificationsPopup: githubActionsRunning || locallyHosted,
   };
 }
 const mapDispatchToProps = (dispatch) => ({
@@ -267,6 +269,7 @@ App.propTypes = {
   numberOutagesUnseen: PropTypes.number,
   parameters: PropTypes.object,
   setScreenInfoAction: PropTypes.func,
+  hideNotificationsPopup: PropTypes.bool,
 };
 
 App.defaultProps = {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -70,8 +70,10 @@ class App extends React.Component {
     const {
       kioskModeEnabled, notifications, numberOutagesUnseen, e2eModeEnabled,
     } = this.props;
+    const githubActionsRunning = process.env.GITHUB_ACTIONS === 'true';
+    const locallyHosted = /localhost/.test(window.location.href);
     if (numberOutagesUnseen !== prevProps.numberOutagesUnseen) {
-      if (numberOutagesUnseen > 0 && !kioskModeEnabled && !e2eModeEnabled) {
+      if (numberOutagesUnseen > 0 && !kioskModeEnabled && !e2eModeEnabled && !githubActionsRunning && !locallyHosted) {
         this.openNotification(notifications, numberOutagesUnseen);
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,9 @@ const pluginSystem = [
   new CssUrlRelativePlugin(),
   new MiniCssExtractPlugin({
     filename: 'wv.css'
+  }),
+  new webpack.DefinePlugin({
+    'process.env.GITHUB_ACTIONS': JSON.stringify(process.env.GITHUB_ACTIONS || 'false')
   })
 ]
 


### PR DESCRIPTION
## Description
This change hides the notification modal from automatically appearing on page load when being run in the Github test environment. It also hides it from automatically appearing when locally hosted as well, to streamline development.

## How To Test
1. `git checkout wv-3517-hide-local-notifications`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Open a fresh instance of Worldview and verify that the notification modal doesn't automatically open.
6. Run `npx playwright test` in a second terminal window while still running Worldview locally, and very that the e2e tests no longer fail due to the notification (some tests may fail for other reasons, because they are inconsistent).