### PR TITLE
WV-3539 Charting Bounding Box Not Set & Inactive Layers Fix

### DIFF
--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -128,13 +128,6 @@ function ChartingModeOptions(props) {
   const [bottomLeftLatLong, setBottomLeftLatLong] = useState(getLatLongFromPixelValue(x, y2));
   const [topRightLatLong, setTopRightLatLong] = useState(getLatLongFromPixelValue(x2, y));
 
-  /**
-   * Filters the layers array & returns those with visible set to 'true'.
-   */
-  function getLiveLayers() {
-    return activeLayers.filter((obj) => obj.visible === true);
-  }
-
   function formatDateString(dateObj) {
     const date = new Date(dateObj);
     const year = date.getUTCFullYear();
@@ -144,8 +137,7 @@ function ChartingModeOptions(props) {
   }
 
   function getActiveChartingLayer() {
-    const liveLayers = getLiveLayers();
-    const filteredLayerList = liveLayers.filter((layer) => layer.id === activeLayer);
+    const filteredLayerList = activeLayers.filter((layer) => layer.id === activeLayer);
     if (filteredLayerList.length > 0) {
       return filteredLayerList[0];
     }
@@ -193,6 +185,9 @@ function ChartingModeOptions(props) {
     isMounted.current = true;
     onUpdateStartDate(initialStartDate);
     onUpdateEndDate(initialEndDate);
+    if (!aoiCoordinates || aoiCoordinates.length === 0) {
+      debouncedUpdateAOICoordinates([...bottomLeftLatLong, ...topRightLatLong]);
+    }
     if (maxExtent) {
       let inLeftWing;
       let inRightWing;
@@ -461,6 +456,7 @@ function ChartingModeOptions(props) {
       const topRight = getLatLongFromPixelValue(x2, y);
       setBottomLeftLatLong(bottomLeft);
       setTopRightLatLong(topRight);
+      debouncedUpdateAOICoordinates([...bottomLeft, ...topRight]);
       if (maxExtent) {
         const inLeftWing = bottomLeft[0] < maxExtent[0] && topRight[0] < maxExtent[0];
         const inRightWing = bottomLeft[0] > maxExtent[2] && topRight[0] > maxExtent[2];


### PR DESCRIPTION
## Description
These changes fix issues with bounding boxes 

## How To Test
1. `git checkout wv-3539-charting-fixes-bb-inactive`
2. `npm ci`
3. `npm run watch`
4. Open a new instance of WV. Add a current chartable layer, then enter Charting mode and click generate chart **without changing the bounding box**. Verify that a chart is correctly created (and verify in the network tab that the request includes the correct coordinates).
5. Open a new instance of WV. Add a current chartable layer, then enter Charting mode, select a bounding box, then click generate chart. Let the chart generate, close the chart, exit Charting Mode. Enter Charting mode again and click generate chart **without changing the bounding box**. Verify that the chart created is generated from the correct bounding box (and verify via the network tab that the request has the correct bounding box as well).
6. Open a new instance of WV. Add current chartable layer, then hide the layer via the eye icon in the side panel. Enter Charting mode, then generate a chart with the hidden layer selected. Verify that a chart can be created correctly.