### PR TITLE
Block lightning layer from Charting

### DIFF
--- a/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate.json
+++ b/config/default/common/config/wv.json/layers/trmm/LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate.json
@@ -6,7 +6,8 @@
       "tags": "",
       "group": "overlays",
       "layergroup": "Lightning",
-      "wrapadjacentdays": true
+      "wrapadjacentdays": true,
+      "disableCharting": true
     }
   }
 }

--- a/schemas/layer-config.json
+++ b/schemas/layer-config.json
@@ -307,6 +307,9 @@
         "disableSmartHandoff": {
           "type": "boolean"
         },
+        "disableCharting": {
+          "type": "boolean"
+        },
         "temporal": {
           "type": "string"
         }

--- a/web/js/containers/sidebar/charting.js
+++ b/web/js/containers/sidebar/charting.js
@@ -81,7 +81,8 @@ const mapStateToProps = (state, ownProps) => {
     overlays = overlays.filter((layer) => layer.visible && layer.layergroup !== 'Reference');
     overlayGroups = getFilteredOverlayGroups(overlayGroups, overlays);
   }
-  const activeLayersWithPalettes = overlays.map((layer) => ({ ...layer, shouldHide: !(Object.prototype.hasOwnProperty.call(layer, 'palette') && renderedPalettes[layer.palette.id] && renderedPalettes[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily') }));
+  const manuallyBlockedLayers = ['LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate'];
+  const activeLayersWithPalettes = overlays.map((layer) => ({ ...layer, shouldHide: !(Object.prototype.hasOwnProperty.call(layer, 'palette') && renderedPalettes[layer.palette.id] && renderedPalettes[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily') || manuallyBlockedLayers.includes(layer.id) }));
 
   return {
     isAnimating: animation.isPlaying,

--- a/web/js/containers/sidebar/charting.js
+++ b/web/js/containers/sidebar/charting.js
@@ -81,8 +81,7 @@ const mapStateToProps = (state, ownProps) => {
     overlays = overlays.filter((layer) => layer.visible && layer.layergroup !== 'Reference');
     overlayGroups = getFilteredOverlayGroups(overlayGroups, overlays);
   }
-  const manuallyBlockedLayers = ['LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate'];
-  const activeLayersWithPalettes = overlays.map((layer) => ({ ...layer, shouldHide: !(Object.prototype.hasOwnProperty.call(layer, 'palette') && renderedPalettes[layer.palette.id] && renderedPalettes[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily') || manuallyBlockedLayers.includes(layer.id) }));
+  const activeLayersWithPalettes = overlays.map((layer) => ({ ...layer, shouldHide: !(Object.prototype.hasOwnProperty.call(layer, 'palette') && renderedPalettes[layer.palette.id] && renderedPalettes[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily') || layer.disableCharting }));
 
   return {
     isAnimating: animation.isPlaying,

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -452,7 +452,8 @@ const mapStateToProps = (state) => {
     ui,
   } = state;
 
-  const chartingModeAccessible = layers.active.layers.filter((layer) => Object.prototype.hasOwnProperty.call(layer, 'palette') && state.palettes.rendered[layer.palette.id] && state.palettes.rendered[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily').length > 0;
+  const manuallyBlockedLayers = ['LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate'];
+  const chartingModeAccessible = layers.active.layers.filter((layer) => Object.prototype.hasOwnProperty.call(layer, 'palette') && state.palettes.rendered[layer.palette.id] && state.palettes.rendered[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily' && !manuallyBlockedLayers.includes(layer.id)).length > 0;
   const isLoadingEvents = requestedEvents.isLoading
     || requestedEventSources.isLoading;
   const hasEventRequestError = !!(requestedEvents.error

--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -452,8 +452,7 @@ const mapStateToProps = (state) => {
     ui,
   } = state;
 
-  const manuallyBlockedLayers = ['LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate'];
-  const chartingModeAccessible = layers.active.layers.filter((layer) => Object.prototype.hasOwnProperty.call(layer, 'palette') && state.palettes.rendered[layer.palette.id] && state.palettes.rendered[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily' && !manuallyBlockedLayers.includes(layer.id)).length > 0;
+  const chartingModeAccessible = layers.active.layers.filter((layer) => Object.prototype.hasOwnProperty.call(layer, 'palette') && state.palettes.rendered[layer.palette.id] && state.palettes.rendered[layer.palette.id].maps[0].type === 'continuous' && layer.layerPeriod === 'Daily' && !layer.disableCharting).length > 0;
   const isLoadingEvents = requestedEvents.isLoading
     || requestedEventSources.isLoading;
   const hasEventRequestError = !!(requestedEvents.error


### PR DESCRIPTION
## Description
This change blocks the `LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate` layer from being charted.

## How To Test
1. `git checkout charting-block-lightning-layer`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Open a new instance of WV.
6. Add `LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate`, then verify that the Charting button is still greyed-out.
7. Add a second layer that is actually chartable, then enter Charting mode and verify that `LIS_Very_High_Resolution_Lightning_Daily_Climatology_LIS_Mean_Flash_Rate` is not visible in Charting mode as a valid layer to chart.