### PR TITLE
WV-3550 Additional Charting Error Handling

### DIFF
--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -297,8 +297,9 @@ function ChartingModeOptions(props) {
     try {
       const response = await fetch(simpleStatsURI, requestOptions);
       const data = await response.text();
+      const parsedData = JSON.parse(data);
       // This is the response when the imageStat server fails
-      if (data === 'Internal Server Error') {
+      if (data === 'Internal Server Error' || data === null || parsedData.status === 204) {
         return {
           ok: false,
           body: data,

--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -39,6 +39,8 @@ const vectorLayers = {};
 const sources = {};
 let init = false;
 const STEP_NUM = 31;
+const SERVER_ERROR_MESSAGE = 'An error has occurred while requesting the charting data. Please try again in a few minutes.';
+const NO_DATA_ERROR_MESSAGE = 'No data was found for this request. Please check the layer, date(s) & location to process & try again.';
 
 function ChartingModeOptions(props) {
   const {
@@ -299,10 +301,16 @@ function ChartingModeOptions(props) {
       const data = await response.text();
       const parsedData = JSON.parse(data);
       // This is the response when the imageStat server fails
-      if (data === 'Internal Server Error' || data === null || parsedData.status === 204) {
+      if (data === 'Internal Server Error') {
         return {
           ok: false,
-          body: data,
+          error: SERVER_ERROR_MESSAGE,
+        };
+      }
+      if (data === null || parsedData.status === 204) {
+        return {
+          ok: false,
+          error: NO_DATA_ERROR_MESSAGE,
         };
       }
 
@@ -313,7 +321,7 @@ function ChartingModeOptions(props) {
     } catch (error) {
       return {
         ok: false,
-        error,
+        error: SERVER_ERROR_MESSAGE,
       };
     }
   }
@@ -370,7 +378,7 @@ function ChartingModeOptions(props) {
 
       if (!data.ok) {
         updateChartRequestStatus(false);
-        openChartingErrorModal('An error has occurred while requesting the charting data. Please try again in a few minutes.');
+        openChartingErrorModal(data.error);
         return;
       }
 


### PR DESCRIPTION
## Description
This change accounts for other errors when attempting to generate a chart in Charting mode.

## How To Test
1. `git checkout wv-3550-charting-error-handling`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?l=CYGNSS_L3_Wind_Speed_SDR_Daily&lg=true&cha=true&chl=CYGNSS_L3_Wind_Speed_SDR_Daily&chc=-89.9668,-12.4653,-58.4097,19.0918&cht=2025-02-28-T20%3A09%3A52Z&cht2=2025-03-10-T20%3A09%3A52Z&t=2025-02-28-T20%3A09%3A52Z), try to generate a chart, and verify that an error message is displayed correctly (may not work in localhost).
5.  Open [this link](http://localhost:3000/?l=CYGNSS_L3_Wind_Speed_SDR_Daily&lg=true&cha=true&chl=CYGNSS_L3_Wind_Speed_SDR_Daily&chc=-89.9668,-12.4653,-58.4097,19.0918&cht=2025-02-28-T20%3A09%3A52Z&chch=true&t=2019-02-28-T20%3A09%3A52Z), try to generate simple statistics, and verify that an error message is displayed correctly (may not work in localhost).