### PR TITLE
WV-3530: Update OMPS LP for STD

### DIFF
--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_AerosolHeight.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_AerosolHeight.md
@@ -1,7 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (Aerosol height) layer indicates the retrieved enhanced aerosol height in kilometers (km), as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite. The aerosol height is located at least 1.5 km above the tropopause. The tropopause height is derived from the Goddard Earth Observing System Forward Processing for Instrument Teams (GEOS FP-IT) data product.
 
-The OMPS Aerosol Extinction Vertical Profile (Height) layer is a science parameter of the OMPS-Suomi NPP LP Near-real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Aerosol Extinction Vertical Profile (Height) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_12KM.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_12KM.md
@@ -1,7 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (11.5 - 12.5 km) layer indicates the average retrieved aerosol extinction coefficient at altitudes of 11.5 - 12.5 km above the tropopause in km-1 (or 1/km), as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite. The assumed tropopause height comes from the Goddard Earth Observing System Forward Processing for Instrument Teams (GEOS FP-IT) data product.
 
-The OMPS Aerosol Extinction Vertical Profile (11.5 - 12.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near-real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Aerosol Extinction Vertical Profile (11.5 - 12.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_14KM.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_14KM.md
@@ -1,7 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (13.5 - 14.5km) layer indicates the average retrieved aerosol extinction coefficient at altitudes of 13.5 - 14.5 km above the tropopause in km-1 (or 1/km), as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite. The assumed tropopause height comes from the Goddard Earth Observing System Forward Processing for Instrument Teams (GEOS FP-IT) data product.
 
-The OMPS Aerosol Extinction Vertical Profile (13.5 - 14.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near-real time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Aerosol Extinction Vertical Profile (13.5 - 14.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_16KM.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_16KM.md
@@ -1,6 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (15.5 - 16.5 km) layer indicates the average retrieved aerosol extinction coefficient at altitudes of 15.5 - 16.5 km above the tropopause in km-1 (or 1/km),as  measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite. The assumed tropopause height comes from the Goddard Earth Observing System Forward Processing for Instrument Teams (GEOS FP-IT) data product.
-The OMPS Aerosol Extinction Vertical Profile (15.5 - 16.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near-real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+
+The OMPS Aerosol Extinction Vertical Profile (15.5 - 16.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_18KM.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_18KM.md
@@ -1,7 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (17.5 - 18.5 km) layer indicates the average retrieved aerosol extinction coefficient at altitudes of 17.5 - 18.5 km above the tropopause in km-1 (or 1/km), as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite. The assumed tropopause height comes from the Goddard Earth Observing System Forward Processing for Instrument Teams (GEOS FP-IT) data product.
 
-The OMPS Aerosol Extinction Vertical Profile (17.5 - 18.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near-real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Aerosol Extinction Vertical Profile (17.5 - 18.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_20KM.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_20KM.md
@@ -1,7 +1,7 @@
 The OMPS Aerosol Extinction Vertical Profile (19.5 - 20.5 km) layer indicates the average retrieved aerosol extinction coefficient at altitudes of 19.5 - 20.5 km in km-1 (or 1/km), as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite.
 
-The OMPS Aerosol Extinction Vertical Profile (19.5 - 20.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near-real time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Aerosol Extinction Vertical Profile (19.5 - 20.5 km) layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_OpticalDepth.md
+++ b/config/default/common/config/metadata/layers/omps/OMPS_SNPP_LimbProfiler_Aerosol_OpticalDepth.md
@@ -1,7 +1,7 @@
 The OMPS Stratospheric Aerosol Optical Depth layer indicates the stratospheric aerosol optical depth as measured by the Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi NPP satellite.
 
-The OMPS Stratospheric Aerosol Optical Depth layer is a science parameter of the OMPS-Suomi NPP LP Near-realtime (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product.
+The OMPS Stratospheric Aerosol Optical Depth layer is a science parameter of the OMPS-Suomi NPP LP Near real-time (NRT) Aerosol Extinction Vertical Profile swath multi-wavelength orbital 3slit product and the OMPS-NPP L2 LP Aerosol Extinction Vertical Profile swath daily 3slit (AER) product.
 
 It is available from the OMPS Limb Profiler (LP) sensor on the joint NASA/NOAA Suomi National Polar orbiting Partnership (Suomi NPP) satellite. Spatial coverage is global (-90 to 90 degrees latitude), and there are about 14.5 orbits per day each measuring three limb profiles spaced approximately 250 km in the cross-track direction. The profiles are measured from the ground up to about 80 km with a vertical resolution of the retrieved profiles of approximately 1.8 km. The temporal resolution is daily.
 
-References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html)
+References: [OMPS_NPP_LP_NRT_AER](https://cmr.earthdata.nasa.gov/search/concepts/C3186057053-OMINRT.html); OMPS_NPP_LP_L2_AER_DAILY [doi:10.5067/CX2B9NW6FI27](https://doi.org/10.5067/CX2B9NW6FI27)

--- a/config/default/common/config/wv.json/measurements/Aerosol Extinction.json
+++ b/config/default/common/config/wv.json/measurements/Aerosol Extinction.json
@@ -5,18 +5,18 @@
             "title":    "Aerosol Extinction",
             "subtitle": "Suomi NPP/OMPS LP",
             "sources": {
-                "Suomi NPP/OMPS": {
+                "Suomi NPP/OMPS LP": {
                     "id": "suomi-npp-omps-lp",
                     "title": "Suomi NPP/OMPS LP",
                     "description": "",
                     "image": "",
                     "settings": [
-                      "OMPS_SNPP_LimbProfiler_AerosolHeight",
-		                  "OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_12KM",
-		                  "OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_14KM",
+		                "OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_12KM",
+		                "OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_14KM",
 	                    "OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_16KM",
 	                  	"OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_18KM",
-	                  	"OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_20KM"
+	                  	"OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_20KM",
+                        "OMPS_SNPP_LimbProfiler_AerosolHeight"
                     ]
                 }
             }

--- a/config/default/common/config/wv.json/measurements/Aerosol Optical Depth.json
+++ b/config/default/common/config/wv.json/measurements/Aerosol Optical Depth.json
@@ -103,7 +103,7 @@
                         "OrbitTracks_Suomi_NPP_Ascending"
                       ]
                 },
-                "Suomi NPP/OMPS": {
+                "Suomi NPP/OMPS LP": {
                     "id": "suomi-npp-omps-lp",
                     "title": "Suomi NPP/OMPS LP",
                     "description": "viirs/Aerosol",


### PR DESCRIPTION
## Description

Fixes #WV-3530 .

Updated layer descriptions for 7 OMPS Suomi NPP Limb Profiler Aerosol layers to include standard product DOI in the References section and added text to the description. 

## How To Test

[Provide whatever information a reviewer might need to know in order to verify that the changes made in this PR are working as expected. If there are special build steps that need to be taken in order to get these changes to run (building while on a separate branch, running `npm ci`, etc) include them here.]

- For bugfixes: What steps need to be taken in the UI to verify the bug is fixed?
- For enhancements and features: What is the expected functionality being added/modified? How can a reviewer verify this?

1. Open with [these URL parameters](http://localhost:3000/?v=-266.17339811675646,-127.72387926885179,218.79066998147724,105.81687999694594&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_20KM,OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_18KM,OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_16KM,OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_14KM,OMPS_SNPP_LimbProfiler_Aerosol_ExinctionCoefficient_12KM,OMPS_SNPP_LimbProfiler_AerosolHeight,OMPS_SNPP_LimbProfiler_Aerosol_OpticalDepth,VIIRS_SNPP_SurfaceReflectance_BandsM5-M4-M3,VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2025-04-05-T13%3A20%3A33Z)
2. Check to make sure the layer descriptions read well. Check that when you are on the current day, the imagery badge states it's NRT, and when you are two days prior to the current day, the imagery badge is STD.
3. Verify expected result

@nasa-gibs/worldview
