### PR TITLE
WV-3591 Fix Safari's Charting Ability

### DIFF
--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -213,11 +213,11 @@ function ChartingModeOptions(props) {
     }
   }, [fromButton]);
 
-  function formatDateForImageStat(dateStr) {
-    const dateParts = dateStr.split(' ');
-    const year = dateParts[0];
-    const month = `0${new Date(Date.parse(dateStr)).getMonth() + 1}`.slice(-2);
-    const day = dateParts[2];
+  function formatDateForImageStat(dateObj) {
+    const date = new Date(dateObj);
+    const year = date.getUTCFullYear();
+    const month = `0${date.getUTCMonth() + 1}`.slice(-2);
+    const day = `0${date.getUTCDate()}`.slice(-2);
     return `${year}-${month}-${day}`;
   }
 
@@ -252,8 +252,8 @@ function ChartingModeOptions(props) {
    * @param {String} timeSpanSelection | 'Date' for single date, 'Range' for date range, 'series' for time series charting
    */
   function getImageStatRequestParameters(layerInfo, timeSpan) {
-    const startDateForImageStat = formatDateForImageStat(primaryDate);
-    const endDateForImageStat = formatDateForImageStat(secondaryDate);
+    const startDateForImageStat = formatDateForImageStat(initialStartDate);
+    const endDateForImageStat = formatDateForImageStat(initialEndDate);
     const AOIForImageStat = convertOLcoordsForImageStat(aoiCoordinates);
     return {
       timestamp: startDateForImageStat, // start date


### PR DESCRIPTION
## Description
This change fixes the behavior found in Safari not being able to generate a chart in Charting mode correctly by removing the use of `Date.parse`.

## How To Test
1. `git checkout wv-3591-safari-charting`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV, then add any chartable layer and enter Charting mode
5. Open the developer console in the browser, navigate to the Network tab, and clear the network history
6. Attempt to generate a chart, and verify that the url in the request shown in the Network tab is formatted correctly for the `timestamp` and `end_timestamp` parameters (and no longer has `aN` for the month)