### PR TITLE
WV-3604 Add option to disable custom palettes for vector layers

### DIFF
--- a/config/default/common/config/wv.json/layers/ajax/AJAX_Alpha_Jet_Ozone.json
+++ b/config/default/common/config/wv.json/layers/ajax/AJAX_Alpha_Jet_Ozone.json
@@ -11,6 +11,7 @@
       "ongoing": false,
       "disableCharting": true,
       "disableSnapshot": true,
+      "disableCustomPalettes": true,
       "layergroup": "Ozone",
       "vectorStyle": {
         "id": "AJAX_Alpha_Jet_Ozone",

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -98,6 +98,7 @@ Example:
 * **description**: Point to a markdown file within the metadata folder to provide a layer description.
 * **disableSnapshot**: Disable Worldview Snapshots (WVS) for layer.
 * **disableSmartHandoff**: Disable data download capability for a layer.
+* **disableCustomPalettes**: Disable the option to change the layer's palette (for vector layers).
 * **wrapadjacentdays**: Wrap the layer across the anti-meridian but select the previous day when greater than 180 and the next day when less than -180.
 * **wrapX**: Wrap the layer across the anti-meridian.
 * **palette**: To display a color palette legend, a `palette` object should exist with the following properties:

--- a/web/js/components/layer/settings/layer-settings.js
+++ b/web/js/components/layer/settings/layer-settings.js
@@ -352,7 +352,7 @@ class LayerSettings extends React.Component {
       renderCustomizations = customPalettesIsActive && palettedAllowed && layer.palette
         ? this.renderCustomPalettes()
         : '';
-    } else if (layerGroup !== 'Orbital Track' && layerGroup !== 'Reference') {
+    } else if (!layer.disableCustomPalettes && layerGroup !== 'Orbital Track' && layerGroup !== 'Reference') {
       // Orbital Tracks palette swap looks bad at WMS zoom levels (white text stamps)
       // Reference (MGRS/HLS Grid) has no need for palettes
       renderCustomizations = this.renderCustomPalettes();


### PR DESCRIPTION
## Description

Investigate and fix AJAX Vector color palette issue

## How To Test

1. `git checkout WV-3604-ajax-custom-palette-issue`
2. `npm i && npm run build && npm run watch`
3. Go to this [link](http://localhost:3000/?v=-124.52959776531941,35.52042423737853,-120.71926663152064,37.70783655492968&l=AJAX_Alpha_Jet_Ozone&lg=false&t=2011-02-22-T04%3A00%3A00Z)
4. Open layer settings.
5. The option to change the palette should not be shown.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
