### PR TITLE
WV-3598 Fix Compare Mode Orbit Tracks Behavior

### DIFF
--- a/web/js/containers/sidebar/orbit-track.js
+++ b/web/js/containers/sidebar/orbit-track.js
@@ -18,7 +18,6 @@ function OrbitTrack(props) {
     getPalette,
     renderedPalette,
     requestPalette,
-    isLoading,
     isDistractionFreeModeActive,
     isMobile,
     parentLayer,
@@ -29,7 +28,7 @@ function OrbitTrack(props) {
   const [palette, setPalette] = useState();
 
   useEffect(() => {
-    if (hasPalette && !isLoading && !renderedPalette) {
+    if (hasPalette && !renderedPalette) {
       requestPalette(trackLayer.id);
       return;
     }
@@ -59,7 +58,6 @@ function OrbitTrack(props) {
 OrbitTrack.propTypes = {
   getPalette: PropTypes.func,
   hasPalette: PropTypes.bool,
-  isLoading: PropTypes.bool,
   isDistractionFreeModeActive: PropTypes.bool,
   isMobile: PropTypes.bool,
   paletteLegends: PropTypes.array,
@@ -90,7 +88,6 @@ function mapStateToProps(state, ownProps) {
     trackLayer,
     paletteLegends,
     isCustomPalette,
-    isLoading: palettes.isLoading[paletteName],
     renderedPalette: renderedPalettes[paletteName],
     isMobile: screenSize.isMobileDevice,
     isDistractionFreeModeActive,


### PR DESCRIPTION
## Description
This change fixes the behavior found when enabling an associated orbit track layer while in compare mode.

## How To Test
1. `git checkout wv-3598-compare-orbit-crash`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV, then enter Compare Mode
5. Enable the associated orbit track layer of the default layer Terra / MODIS Corrected Reflectance through opening the layer options menu and adding the associated layer, then verify that the app doesn't error or crash
6. Reset WV to a fresh instance, enter Compare mode, then add the same orbit track layer (`OrbitTracks_Terra_Descending`) and verify the app doesn't error or crash
7. Verify that these changes do not negatively affect other orbit tracks, or negatively impact any orbit tracks when not in Compare Mode either