### PR TITLE
WV-3476: Update MODIS GPP and Net Photosynthesis for gap filled information

### DIFF
--- a/config/default/common/config/metadata/layers/modis/GrossPrimaryProduction.md
+++ b/config/default/common/config/metadata/layers/modis/GrossPrimaryProduction.md
@@ -1,1 +1,0 @@
-NOTE: We are reprocessing the entire MODIS Land imagery archive to collection 6.1 but currently the imagery is a mix of collection 6 and collection 6.1. Most of the imagery from mid-May 2021 onwards is collection 6.1 and older imagery is collection 6.

--- a/config/default/common/config/metadata/layers/modis/NetPhotosynthesis.md
+++ b/config/default/common/config/metadata/layers/modis/NetPhotosynthesis.md
@@ -1,1 +1,0 @@
-NOTE: We are reprocessing the entire MODIS Land imagery archive to collection 6.1 but currently the imagery is a mix of collection 6 and collection 6.1. Most of the imagery from mid-May 2021 onwards is collection 6.1 and older imagery is collection 6.

--- a/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.md
+++ b/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.md
@@ -1,3 +1,7 @@
-The Gross Primary Production (L4, 8-Day) layer is created from the MYD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept that can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation.
+The Gross Primary Production (L4, 8-Day) layer is created from the MYD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept for the current year. It can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation.
 
-References: MYD17A2H [doi:10.5067/MODIS/MYD17A2H.061](https://doi.org/10.5067/MODIS/MYD17A2H.061)
+For previous years, the Gross Primary Production (L4, 8-Day) layer is created from the MYD17A2HGF product. It is generated at the end of each year when the entire yearly 8-day MYD15A2H is available. Hence, the gap-filled MYD17A2HGF is the improved MYD17, which has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not meet the quality screening criteria, its value is determined through linear interpolation.
+
+The sensor and imagery resolution is 500m, and the temporal resolution is 8-day.
+
+References: MYD17A2H [doi:10.5067/MODIS/MYD17A2H.061](https://doi.org/10.5067/MODIS/MYD17A2H.061); MYD17A2HGF [doi:10.5067/MODIS/MYD17A2HGF.061](https://doi.org/10.5067/MODIS/MYD17A2HGF.061)

--- a/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.md
+++ b/config/default/common/config/metadata/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.md
@@ -1,3 +1,7 @@
-The Net Photosynthesis (L4, 8-Day) layer is created from the MYD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept that can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation.  The Net Photosynthesis (PSN) band values are the GPP minus the Maintenance Respiration (MR).
+The Net Photosynthesis (L4, 8-Day) layer is created from the MYD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept for the current year. It can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation. The Net Photosynthesis (PSN) band values are the GPP minus the Maintenance Respiration (MR).
 
-References: MYD17A2H [doi:10.5067/MODIS/MYD17A2H.061](https://doi.org/10.5067/MODIS/MYD17A2H.061)
+For previous years, the Net Photosynthesis (L4, 8-Day) layer is created from the MYD17A2HGF product. It is generated at the end of each year when the entire yearly 8-day MYD15A2H is available. Hence, the gap-filled MYD17A2HGF is the improved MYD17, which has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not meet the quality screening criteria, its value is determined through linear interpolation.
+
+The sensor and imagery resolution is 500m, and the temporal resolution is 8-day.
+
+References: MYD17A2H [doi:10.5067/MODIS/MYD17A2H.061](https://doi.org/10.5067/MODIS/MYD17A2H.061); MYD17A2HGF [doi:10.5067/MODIS/MYD17A2HGF.061](https://doi.org/10.5067/MODIS/MYD17A2HGF.061)

--- a/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.md
+++ b/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.md
@@ -1,3 +1,7 @@
-The Gross Primary Production (L4, 8-Day) layer is created from the MOD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept that can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation.
+The Gross Primary Production (L4, 8-Day) layer is created from the MOD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept for the current year. It can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation.
 
-References: MOD17A2H [doi:10.5067/MODIS/MOD17A2H.061](https://doi.org/10.5067/MODIS/MOD17A2H.061)
+For previous years, the Gross Primary Production (L4, 8-Day) layer is created from the MOD17A2HGF product. It is generated at the end of each year when the entire yearly 8-day MYD15A2H is available. Hence, the gap-filled MOD17A2HGF is the improved MYD17, which has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not meet the quality screening criteria, its value is determined through linear interpolation.
+
+The sensor and imagery resolution is 500m, and the temporal resolution is 8-day.
+
+References: MOD17A2H [doi:10.5067/MODIS/MOD17A2H.061](https://doi.org/10.5067/MODIS/MOD17A2H.061); MOD17A2HGF [doi:10.5067/MODIS/MOD17A2HGF.061](https://doi.org/10.5067/MODIS/MOD17A2HGF.061)

--- a/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.md
+++ b/config/default/common/config/metadata/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.md
@@ -1,3 +1,7 @@
-The Net Photosynthesis (L4, 8-Day) layer is created from the MOD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept that can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation. The Net Photosynthesis (PSN) band values are the GPP less the Maintenance Respiration (MR).
+The Net Photosynthesis (L4, 8-Day) layer is created from the MOD17A2H Gross Primary Productivity (GPP) product which is a cumulative 8-day composite of values with 500 meter (m) pixel size based on the radiation use efficiency concept for the current year. It can be potentially used as inputs to data models to calculate terrestrial energy, carbon, water cycle processes, and biogeochemistry of vegetation. The Net Photosynthesis (PSN) band values are the GPP less the Maintenance Respiration (MR).
 
-References: MOD17A2H [doi:10.5067/MODIS/MOD17A2H.061](https://doi.org/10.5067/MODIS/MOD17A2H.061)
+For previous years, the Net Photosynthesis (L4, 8-Day) layer is created from the MOD17A2HGF product. It is generated at the end of each year when the entire yearly 8-day MYD15A2H is available. Hence, the gap-filled MOD17A2HGF is the improved MYD17, which has cleaned the poor-quality inputs from 8-day Leaf Area Index and Fraction of Photosynthetically Active Radiation (LAI/FPAR) based on the Quality Control (QC) label for every pixel. If any LAI/FPAR pixel did not meet the quality screening criteria, its value is determined through linear interpolation.
+
+The sensor and imagery resolution is 500m, and the temporal resolution is 8-day.
+
+References: MOD17A2H [doi:10.5067/MODIS/MOD17A2H.061](https://doi.org/10.5067/MODIS/MOD17A2H.061); MOD17A2HGF [doi:10.5067/MODIS/MOD17A2HGF.061](https://doi.org/10.5067/MODIS/MOD17A2HGF.061)

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day.json
@@ -3,7 +3,7 @@
     "MODIS_Aqua_L4_Gross_Primary_Productivity_8Day": {
       "id": "MODIS_Aqua_L4_Gross_Primary_Productivity_8Day",
       "description": "modis/aqua/MODIS_Aqua_L4_Gross_Primary_Productivity_8Day",
-      "tags": "gpp",
+      "tags": "gpp gap filled",
       "group": "overlays",
       "layergroup": "Gross Primary Productivity"
     }

--- a/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day.json
@@ -3,7 +3,7 @@
     "MODIS_Aqua_L4_Net_Photosynthesis_8Day": {
       "id": "MODIS_Aqua_L4_Net_Photosynthesis_8Day",
       "description": "modis/aqua/MODIS_Aqua_L4_Net_Photosynthesis_8Day",
-      "tags": "",
+      "tags": "gap filled",
       "group": "overlays",
       "layergroup": "Photosynthesis, Net"
     }

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day.json
@@ -3,7 +3,7 @@
     "MODIS_Terra_L4_Gross_Primary_Productivity_8Day": {
       "id": "MODIS_Terra_L4_Gross_Primary_Productivity_8Day",
       "description": "modis/terra/MODIS_Terra_L4_Gross_Primary_Productivity_8Day",
-      "tags": "gpp",
+      "tags": "gpp gap filled",
       "group": "overlays",
       "layergroup": "Gross Primary Productivity"
     }

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day.json
@@ -3,6 +3,7 @@
     "MODIS_Terra_L4_Net_Photosynthesis_8Day": {
       "id": "MODIS_Terra_L4_Net_Photosynthesis_8Day",
       "description": "modis/terra/MODIS_Terra_L4_Net_Photosynthesis_8Day",
+      "tags": "gap filled",
       "group": "overlays",
       "layergroup": "Photosynthesis, Net"
     }

--- a/config/default/common/config/wv.json/measurements/Gross Primary Productivity.json
+++ b/config/default/common/config/wv.json/measurements/Gross Primary Productivity.json
@@ -8,7 +8,7 @@
                 "Aqua/MODIS": {
                       "id": "aqua-modis",
                       "title": "Aqua/MODIS",
-                      "description": "modis/GrossPrimaryProduction",
+                      "description": "",
                       "image": "",
                       "settings": [
   			                  "MODIS_Aqua_L4_Gross_Primary_Productivity_8Day"
@@ -17,7 +17,7 @@
                 "Terra/MODIS": {
                       "id": "terra-modis",
                       "title": "Terra/MODIS",
-                      "description": "modis/GrossPrimaryProduction",
+                      "description": "",
                       "image": "",
                       "settings": [
       			                "MODIS_Terra_L4_Gross_Primary_Productivity_8Day"

--- a/config/default/common/config/wv.json/measurements/Photosynthesis.json
+++ b/config/default/common/config/wv.json/measurements/Photosynthesis.json
@@ -8,7 +8,7 @@
                 "Aqua/MODIS": {
                     "id": "aqua-modis",
                     "title": "Aqua/MODIS",
-                    "description": "modis/NetPhotosynthesis",
+                    "description": "",
                     "image": "",
                     "settings": [
                         "MODIS_Aqua_L4_Net_Photosynthesis_8Day"
@@ -17,7 +17,7 @@
                 "Terra/MODIS": {
                     "id": "terra-modis",
                     "title": "Terra/MODIS",
-                    "description": "modis/NetPhotosynthesis",
+                    "description": "",
                     "image": "",
                     "settings": [
                         "MODIS_Terra_L4_Net_Photosynthesis_8Day"


### PR DESCRIPTION
## Description

Fixes #WV-3476 .

Updated layer descriptions for MODIS/Terra and MODIS/Aqua for Gross Primary Productivity and New Photosynthesis to reflect that imagery for Terra from 2000 - 2024 and Aqua from 2002-2024 is gap-filled, and imagery for the current year is non gap filled. 

## How To Test

1. `git checkout wv-3476-merged-modis-mxd-layer-updates`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,MODIS_Aqua_L4_Gross_Primary_Productivity_8Day,MODIS_Terra_L4_Gross_Primary_Productivity_8Day,MODIS_Aqua_L4_Net_Photosynthesis_8Day,MODIS_Terra_L4_Net_Photosynthesis_8Day,VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2025-04-14-T17%3A26%3A08Z)
4. Check that imagery is viewable back to 2000 for Terra and 2002 for Aqua. Imagery for the current year (2025) is non gap filled; imagery before 2025 is gap filled. 
5. Verify expected result


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
