### PR TITLE
WV-3602 and WV-3536: Update WV intro story for charting; add GOES-18 and 18 tags

### DIFF
--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Air_Mass.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_Air_Mass",
       "description": "goes/GOES-East_ABI_Air_Mass",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band13_Clean_Infrared.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_Band13_Clean_Infrared",
       "description": "goes/GOES-East_ABI_Band13_Clean_Infrared",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "palette": {
         "immutable": true

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Band2_Red_Visible_1km.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_Band2_Red_Visible_1km",
       "description": "goes/GOES-East_ABI_Band2_Red_Visible_1km",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Dust.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_Dust.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_Dust",
       "description": "goes/GOES-East_ABI_Dust",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_FireTemp.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_FireTemp.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_FireTemp",
       "description": "goes/GOES-East_ABI_FireTemp",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_GeoColor.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-East_ABI_GeoColor.json
@@ -4,7 +4,7 @@
       "id": "GOES-East_ABI_GeoColor",
       "description": "goes/GOES-East_ABI_GeoColor",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-19",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Air_Mass.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_Air_Mass",
       "description": "goes/GOES-West_ABI_Air_Mass",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band13_Clean_Infrared.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_Band13_Clean_Infrared",
       "description": "goes/GOES-West_ABI_Band13_Clean_Infrared",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "palette": {
         "immutable": true

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Band2_Red_Visible_1km.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_Band2_Red_Visible_1km",
       "description": "goes/GOES-West_ABI_Band2_Red_Visible_1km",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Dust.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_Dust.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_Dust",
       "description": "goes/GOES-West_ABI_Dust",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_FireTemp.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_FireTemp.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_FireTemp",
       "description": "goes/GOES-West_ABI_FireTemp",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_GeoColor.json
+++ b/config/default/common/config/wv.json/layers/goes/GOES-West_ABI_GeoColor.json
@@ -4,7 +4,7 @@
       "id": "GOES-West_ABI_GeoColor",
       "description": "goes/GOES-West_ABI_GeoColor",
       "group": "overlays",
-      "tags": "geostationary geo",
+      "tags": "geostationary geo GOES-18",
       "layergroup": "Geostationary",
       "wrapX": true,
       "availability": {

--- a/config/default/common/config/wv.json/stories/default/worldview_intro.json
+++ b/config/default/common/config/wv.json/stories/default/worldview_intro.json
@@ -68,6 +68,12 @@
                 "placementBeacon": "top"
               },
               {
+                "target": "#chart-toggle-button",
+                "title": "Time-Series Charts and Statistics",
+                "content": "Select a layer with a color palette to create single variable time-series line charts and simple statistics for an area of interest.",
+                "placementBeacon": "bottom"
+              },
+              {
                 "target": "#date-selector-main",
                 "title": "Date Selector",
                 "content": "Change the date (and time of day if you have Geostationary layers loaded) by typing into the date fields, or by clicking on the up and down arrows by each field.",


### PR DESCRIPTION
## Description

Fixes #WV-3602 and WV-3536 .

- [x] Update Introduction to Worldview Tour Story to include charting
- [x] Add tags to GOES-East and GOES-West to include tags as GOES-19 and GOES-18

## How To Test


1. `git checkout wv-3602-wv-3536`
2. ` npm run build && npm start`
3. Go to the Introduction to Worldview tour story, go through the story by clicking on the red pulsing dot and make sure the charting description makes sense.
4. Go to "Add Layers", type in GOES-19 and you should get GOES-East results, type in GOES-18 and you should get GOES-West results
5. Verify expected result


@nasa-gibs/worldview
