### PR TITLE
WV-3607 Fix Land Surface Disturbance Tour story Ghosting

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -534,7 +534,7 @@ const mapDispatchToProps = (dispatch) => ({
     ) {
       layers = layersParse12(parameters.l, config);
       if (parameters.l1 && hasCustomTypePalette(parameters.l1)) {
-        layers.push(layersParse12(parameters.l1, config));
+        layers.push(...layersParse12(parameters.l1, config));
       }
       layers = uniqBy(layers, 'id');
 

--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import OlLayerGroup from 'ol/layer/Group';
@@ -53,6 +53,12 @@ function UpdateProjection(props) {
     renderedPalettes,
     requestPalette,
   } = props;
+
+  const layerStateRef = useRef(layerState);
+
+  useEffect(() => {
+    layerStateRef.current = layerState;
+  }, [layerState]);
 
   /**
   * Remove Layers from map
@@ -124,9 +130,9 @@ function UpdateProjection(props) {
         compareMapUi.destroy();
       }
       clearLayers(saveCache);
-      const defs = getLayers(layerState, { reverse: true });
+      const defs = getLayers(layerStateRef.current, { reverse: true });
       const layerPromises = defs.map((def) => {
-        const options = getGranuleOptions(layerState, def, compare.activeString, granuleOptions);
+        const options = getGranuleOptions(layerStateRef.current, def, compare.activeString, granuleOptions);
         return createLayer(def, options);
       });
       const layerResults = await Promise.allSettled(layerPromises);
@@ -138,7 +144,7 @@ function UpdateProjection(props) {
         stateArray.reverse(); // Set Layer order based on active A|B group
       }
       clearLayers(saveCache);
-      const stateArrayGroups = stateArray.map(async (arr) => getCompareLayerGroup(arr, layerState, granuleOptions));
+      const stateArrayGroups = stateArray.map(async (arr) => getCompareLayerGroup(arr, layerStateRef.current, granuleOptions));
       const compareLayerGroups = await Promise.all(stateArrayGroups);
       mapUI?.setLayers(compareLayerGroups);
       compareMapUi.create(mapUI, compare.mode);


### PR DESCRIPTION
## Description
This change fixes the ghosting behavior found in step 9 of the Land Surface Disturbance Tour story.

## How To Test
1. `git checkout wv-3607-tour-story-ghosting`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV, then start the Land Surface Disturbance Tour story
5. Advance the story to step 9, and verify that both A and B side are displaying only the layers in the layer list, and not any reflectance layer
6. Go backwards to step 8, let it load fully, then advance the story again to step 9 and verify the same result holds true