### PR TITLE
WV-3611 Fix HLS Available Imagery Dates

### DIFF
--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -9,6 +9,7 @@ const dateOptions = {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
+  timeZone: 'UTC',
 };
 const parseGranuleTimestamp = (granule) => new Date(granule.time_start);
 const maxExtent = [-180, -90, 180, 90];


### PR DESCRIPTION
## Description
This change fixes the available imagery dates for HLS layers not showing the correct dates.

## How To Test
1. `git checkout wv-3611-hls-date-utc`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=141.83354412574116,-37.887984194992335,143.33240857301635,-36.77454203415933&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,HLS_L30_Nadir_BRDF_Adjusted_Reflectance,OPERA_L3_DIST-ALERT-HLS_Color_Index(hidden,disabled=9-5-8),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2024-12-25-T05%3A00%3A00Z)
5. Open the Available Imagery Dates of the HLS Landsat layer, or the OPERA disturbance layer, and verify that December 25, 2024 is present in the list