### PR TITLE
WV-3622: Re-enable Land Surface Disturbance Tour story

### DIFF
--- a/config/default/common/config/wv.json/storyOrder.json
+++ b/config/default/common/config/wv.json/storyOrder.json
@@ -1,5 +1,6 @@
 {
     "storyOrder": [
+        "land_disturbance",
         "el_nino",
         "surface_water_extent",
         "atmospheric_rivers",


### PR DESCRIPTION
## Description

Fixes #WV-3622 .

Re-enable Land Surface Disturbance Tour story

## How To Test

1. `git checkout wv-3622-reenable-land-disturbance-story`
2. `npm run build && npm start`
3. Verify expected result - See that the Land Surface Disturbance story appears in the tour story window


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
