### PR TITLE
WV-3588 Add Charting Info to Docs

### DIFF
--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -99,7 +99,7 @@ Example:
 * **disableSnapshot**: Disable Worldview Snapshots (WVS) for layer.
 * **disableSmartHandoff**: Disable data download capability for a layer.
 * **disableCustomPalettes**: Disable the option to change the layer's palette (for vector layers).
-* **disableCharting**: Disable the ability for the layer to be charting using charting mode.
+* **disableCharting**: Disable the ability for the layer to be charted using charting mode.
 * **wrapadjacentdays**: Wrap the layer across the anti-meridian but select the previous day when greater than 180 and the next day when less than -180.
 * **wrapX**: Wrap the layer across the anti-meridian.
 * **palette**: To display a color palette legend, a `palette` object should exist with the following properties:

--- a/doc/config/layers.md
+++ b/doc/config/layers.md
@@ -99,6 +99,7 @@ Example:
 * **disableSnapshot**: Disable Worldview Snapshots (WVS) for layer.
 * **disableSmartHandoff**: Disable data download capability for a layer.
 * **disableCustomPalettes**: Disable the option to change the layer's palette (for vector layers).
+* **disableCharting**: Disable the ability for the layer to be charting using charting mode.
 * **wrapadjacentdays**: Wrap the layer across the anti-meridian but select the previous day when greater than 180 and the next day when less than -180.
 * **wrapX**: Wrap the layer across the anti-meridian.
 * **palette**: To display a color palette legend, a `palette` object should exist with the following properties:

--- a/doc/features.md
+++ b/doc/features.md
@@ -59,3 +59,8 @@ Worldview uses the analytics framework [Google Tag Manager](https://developers.g
 
 to disable this feature, set:
 `"googleTagManager": false`
+
+## Charting Mode
+
+This feature queries GIBS ImageStat to collect data across a time range for a selected layer, then creates a visualization of that data via a line chart. To enable,
+edit `config/default/common/features.json` and set `"charting"` to `true` to enable the 'Start Charting' button on the bottom of the layer list sidebar (enabled by default).

--- a/doc/features.md
+++ b/doc/features.md
@@ -63,4 +63,4 @@ to disable this feature, set:
 ## Charting Mode
 
 This feature queries GIBS ImageStat to collect data across a time range for a selected layer, then creates a visualization of that data via a line chart. To enable,
-edit `config/default/common/features.json` and set `"charting"` to `true` to enable the 'Start Charting' button on the bottom of the layer list sidebar (enabled by default).
+edit `config/default/common/features.json` and set `"charting"` to `true`, which will populate the 'Start Charting' button on the bottom of the layer list sidebar (enabled by default).

--- a/doc/url_parameters.md
+++ b/doc/url_parameters.md
@@ -33,6 +33,12 @@
 | `ca` | boolean | <i>`true`</i> or <i>`false`</i> | Determines if the A or B state is active. If this parameter exists at all, compare mode will be active. If `ca=true`, Compare mode will be active in the A state. |
 | `cm`                 | string      | _`swipe`_ , _`spy`_ or _`opacity`_                     | If comparison mode is active (`ca=true\|false`) the `cm` parameter will determine which comparison mode to use. Default mode is `swipe`.                                                                                                                                                                        |
 | `cv`                 | Number      | **`0`** to **`100`**                                   | If `ca='true\|false'`, The `cv` parameter is used to determine the location of the swiper or the value of opacity depending on the selected mode. Default is `50` which will place the swiper on the middle of any screen. This parameter is irrelevant when the `spy` mode is active (`cm=spy`).                |
+| `cha` | boolean | <i>`true`</i> or <i>`false`</i> | If `true` value is set, charting mode will be active. |
+| `chl` | string | <i>`layer_id`</i> | Currently selected layer for charting mode, where `layer_id` is the identifier of the layer as defined in the configuration file. |
+| `chc` | string | <i>`coordinates`</i> | A pair of coordinates in the format `x1,y1,x2,y2` for where the area of interest selection is placed for charting mode. |
+| `cht` | date | <i>`YYYY-MM-DDThh:mm:ssZ`</i> | The charting mode chart start day & time. |
+| `cht2` | date | <i>`YYYY-MM-DDThh:mm:ssZ`</i> | The charting mode chart end day & time. If not present, but `cht` is present, charting timespan is considered to be a single date span. |
+| `chch` | boolean | <i>`true`</i> or <i>`false`</i> | If `true` value is set, charting mode chart will be requested and shown on page load. |
 | `download` | string | *`product_id`* | If any value is set, the data download tab will be activated. If a product identifier is set, the corresponding will be selected. |
 | `r` | number | <b>`-180.0000`</b> to <b>`180.0000`</b> | The degree of map rotation. Only applies when `arctic` or `antarctic` projection is selected. |
 | `df` | boolean | <i>`true`</i> or <i>`false`</i> | If `true` value is set, distraction free mode will be activated. Distraction free mode is disabled by default and can be toggled from the Information toolbar menu. |

--- a/web/js/location.js
+++ b/web/js/location.js
@@ -468,6 +468,21 @@ const getParameters = function(config, parameters) {
         },
       },
     },
+    cm: {
+      stateKey: 'compare.mode',
+      initialState: 'swipe',
+      options: {
+        parse: (param) => (config.initialIsMobile ? 'swipe' : param),
+      },
+    },
+    cv: {
+      stateKey: 'compare.value',
+      initialState: 50,
+      type: 'number',
+      options: {
+        parse: (param) => (config.initialIsMobile ? 50 : param),
+      },
+    },
     cha: {
       stateKey: 'charting.active',
       initialState: false,
@@ -519,21 +534,6 @@ const getParameters = function(config, parameters) {
       stateKey: 'charting.isChartOpen',
       initialState: false,
       type: 'bool',
-    },
-    cm: {
-      stateKey: 'compare.mode',
-      initialState: 'swipe',
-      options: {
-        parse: (param) => (config.initialIsMobile ? 'swipe' : param),
-      },
-    },
-    cv: {
-      stateKey: 'compare.value',
-      initialState: 50,
-      type: 'number',
-      options: {
-        parse: (param) => (config.initialIsMobile ? 50 : param),
-      },
     },
     tr: {
       stateKey: 'tour.selected',


### PR DESCRIPTION
## Description
This change adds information about charting mode to our docs, shown in `docs/`, with additions to `config/layers.md`, `features.md`, and `url_parameters.md`.