### PR TITLE
WV-3069: Update AIRS STD L2 to v7

### DIFF
--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.md
@@ -5,8 +5,8 @@ The Carbon Monoxide (L2, 500hPa, Day) layer displays carbon monoxide in units of
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `COVMRLevStd`; pressure level is at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Night.md
@@ -5,8 +5,8 @@ The Carbon Monoxide (L2, 500hPa, Night) layer displays carbon monoxide in units 
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `COVMRLevStd`; pressure level is at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Cloud_Top_Height_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Cloud_Top_Height_Day.md
@@ -5,8 +5,8 @@ The Cloud Top Height (L2, Day) layer is the log-pressure altitude calculated fro
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `PCldTopStd`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Cloud_Top_Height_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Cloud_Top_Height_Night.md
@@ -5,8 +5,8 @@ The Cloud Top Height (L2, Night) layer is the log-pressure altitude calculated f
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `PCldTopStd`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Day.md
@@ -5,9 +5,10 @@ Dust score is determined from multiple tests that compare radiances in select AI
 2 km/pixel (AIRS Level 2 `dust_score` is nominally 13.5 km/pixel, the data has been resampled into a 32 km/pixel visualization.)
 
 #### Data Product
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2SUP_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2SUP` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `dust_score`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -17,4 +18,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/APJ6EEN0PD0Z](https://doi.org/10.5067/APJ6EEN0PD0Z)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Day.md
@@ -5,7 +5,6 @@ Dust score is determined from multiple tests that compare radiances in select AI
 2 km/pixel (AIRS Level 2 `dust_score` is nominally 13.5 km/pixel, the data has been resampled into a 32 km/pixel visualization.)
 
 #### Data Product
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
 Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Night.md
@@ -5,9 +5,10 @@ Dust score is determined from multiple tests that compare radiances in select AI
 2 km/pixel (AIRS Level 2 `dust_score` is nominally 13.5 km/pixel, the data has been resampled into a 32 km/pixel visualization.)
 
 #### Data Product
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2SUP_NRT` (AIRS-Only Level 2 Near Real-Time Product) Version 7<br>
-Science Quality Product: `AIRS2SUP` (AIRS-Only Level 2 Standard Product) Version 6<br>
+Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `dust_score`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -17,4 +18,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/APJ6EEN0PD0Z](https://doi.org/10.5067/APJ6EEN0PD0Z)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Dust_Score_Night.md
@@ -5,7 +5,6 @@ Dust score is determined from multiple tests that compare radiances in select AI
 2 km/pixel (AIRS Level 2 `dust_score` is nominally 13.5 km/pixel, the data has been resampled into a 32 km/pixel visualization.)
 
 #### Data Product
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
 Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.md
@@ -5,8 +5,8 @@ The Methane (L2, 400 hPa, Day) layer displays atmospheric methane in units of pa
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `CH4VMRLevStd`; pressure level at element 8<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Night.md
@@ -5,8 +5,8 @@ The Methane (L2, 400 hPa, Night) layer displays atmospheric methane in units of 
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `CH4VMRLevStd`; pressure level at element 8<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,6 +16,6 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Day.md
@@ -5,8 +5,8 @@ The Relative Humidity (L2, 500 hPa, Day) layer displays relative humidity of the
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHum`; pressure level at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Night.md
@@ -5,8 +5,8 @@ The Relative Humidity (L2, 500 hPa, Night) layer displays relative humidity of t
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 6)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHum`; pressure level at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Day.md
@@ -5,8 +5,8 @@ The Relative Humidity (L2, 700 hPa, Day) layer displays relative humidity of the
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHum`; pressure level at element 5<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,5 +16,5 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Night.md
@@ -5,8 +5,8 @@ The Relative Humidity (L2, 700 hPa, Night) layer displays relative humidity of t
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHum`; pressure level at element 5<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,5 +16,5 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Day.md
@@ -5,8 +5,8 @@ The Relative Humidity (L2, 800 hPa, Day) layer displays relative humidity in uni
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHum`; pressure level at element 4<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,5 +16,5 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Night.md
@@ -16,5 +16,5 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day.md
@@ -5,8 +5,8 @@ Sulfur dioxide (SO2) brightness temperature difference is calculated by subtract
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2SUP_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2SUP` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field Name: `BT_diff_SO2b`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/APJ6EEN0PD0Z](https://doi.org/10.5067/APJ6EEN0PD0Z)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Night.md
@@ -5,8 +5,8 @@ Sulfur dioxide (SO2) brightness temperature difference is calculated by subtract
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2SUP_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2SUP` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2SUP_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2SUP` (qua/AIRS L2 Support Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field Name: `BT_diff_SO2b`<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,5 +16,5 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/Aqua/AIRS/DATA208](https://doi.org/10.5067/Aqua/AIRS/DATA208)
+Data Product: AIRS2SUP_NRT [doi:10.5067/MOQOVNHNERGG](https://doi.org/10.5067/MOQOVNHNERGG); AIRS2SUP [doi:10.5067/APJ6EEN0PD0Z](https://doi.org/10.5067/APJ6EEN0PD0Z)
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Air_Temperature_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Air_Temperature_Day.md
@@ -6,8 +6,8 @@ Temperature of the air in units of Kelvin (K) two meters above sea level. Near-s
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TSurfAir`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Air_Temperature_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Air_Temperature_Night.md
@@ -6,8 +6,8 @@ Temperature of the air in units of Kelvin (K) two meters above sea level. Near-s
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TSurfAir`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Relative_Humidity_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Relative_Humidity_Day.md
@@ -5,8 +5,8 @@ The Surface Relative Humidity (L2, Day) layer displays relative humidity of air 
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHumSurf`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -15,6 +15,6 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)
 
 

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Relative_Humidity_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Relative_Humidity_Night.md
@@ -5,8 +5,8 @@ The Surface Relative Humidity (L2, Night) layer displays relative humidity of ai
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `RelHumSurf`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -15,4 +15,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Skin_Temperature_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Skin_Temperature_Day.md
@@ -6,8 +6,8 @@ Temperature of the solid or liquid surface of the Earth in units of Kelvin (K). 
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TSurfStd`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Skin_Temperature_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Surface_Skin_Temperature_Night.md
@@ -6,8 +6,8 @@ Temperature of the solid or liquid surface of the Earth in units of Kelvin (K). 
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TSurfStd`<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_500hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_500hPa_Day.md
@@ -5,8 +5,8 @@ Air temperature in units of Kelvin (K) at the 500 hPa pressure level, approximat
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_500hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_500hPa_Night.md
@@ -6,8 +6,8 @@ Air temperature in units of Kelvin (K) at the 500 hPa pressure level, approximat
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 7<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_700hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_700hPa_Day.md
@@ -6,8 +6,8 @@ Air temperature in units of Kelvin (K) at the 700 hPa pressure level, approximat
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 5<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_700hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_700hPa_Night.md
@@ -6,8 +6,8 @@ Air temperature in units of Kelvin (K) at the 700 hPa pressure level, approximat
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 5<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_850hPa_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_850hPa_Day.md
@@ -6,8 +6,8 @@ Air temperature in units of Kelvin (K) at the 850 hPa pressure, approximately 15
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 4<br>
 Resolution: 45 km/pixel at nadir
 
@@ -17,4 +17,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_850hPa_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Temperature_850hPa_Night.md
@@ -7,8 +7,8 @@ Air temperature in units of Kelvin (K) at the 850 hPa pressure, approximately 15
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `TAirStd`; pressure level at element 4<br>
 Resolution: 45 km/pixel at nadir
 
@@ -18,4 +18,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Total_Cloud_Fraction_Day.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Total_Cloud_Fraction_Day.md
@@ -5,8 +5,8 @@ The Total Cloud Fraction (Day) layer is the product of cloud fractional coverage
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `CldFrcStd` (sum of 2 cloud decks)<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/metadata/layers/airs/AIRS_L2_Total_Cloud_Fraction_Night.md
+++ b/config/default/common/config/metadata/layers/airs/AIRS_L2_Total_Cloud_Fraction_Night.md
@@ -5,8 +5,8 @@ The Total Cloud Fraction (Night) layer is the product of cloud fractional covera
 
 #### Data Product
 Image initially produced with NRT data. Science quality image replaces NRT when available.<br>
-Near Real-Time Product: `AIRS2RET_NRT` (AIRS-Only Level 2 Near Real-Time Product Version 7)<br>
-Science Quality Product: `AIRS2RET` (AIRS-Only Level 2 Standard Product Version 6)<br>
+Near Real-Time Product: `AIRS2RET_NRT` (Aqua/AIRS L2 Near Real Time (NRT) Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
+Science Quality Product: `AIRS2RET` (Aqua/AIRS L2 Standard Physical Retrieval (AIRS-only) V7.0 at GES DISC)<br>
 Field name: `CldFrcStd` (sum of 2 cloud decks)<br>
 Resolution: 13.5 km/pixel at nadir
 
@@ -16,4 +16,4 @@ Overpasses: Twice daily (day and night)<br>
 Orbit: Sun-synchronous polar; Equatorial crossing local time: Daytime 1:30 pm, Nighttime 1:30 am
 
 #### References
-Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5); AIRS2RET [doi:10.5067/Aqua/AIRS/DATA202](https://doi.org/10.5067/Aqua/AIRS/DATA202)
+Data Product: AIRS2RET_NRT [doi:10.5067/RAEHAOH4VZM5](https://doi.org/10.5067/RAEHAOH4VZM5);  AIRS2RET [doi:10.5067/VP1M6OG1X7M1](https://doi.org/10.5067/VP1M6OG1X7M1)

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day",
       "tags": "CO",
       "group": "overlays",
-      "layergroup": "Carbon Monoxide"
+      "layergroup": "Carbon Monoxide",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Cloud_Top_Height_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Cloud_Top_Height_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Cloud_Top_Height_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Cloud Top Height"
+      "layergroup": "Cloud Top Height",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Dust_Score_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Dust_Score_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Dust_Score_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Dust"
+      "layergroup": "Dust",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day",
       "tags": "CH4",
       "group": "overlays",
-      "layergroup": "Methane"
+      "layergroup": "Methane",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_500hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_RelativeHumidity_500hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Relative Humidity"
+      "layergroup": "Relative Humidity",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_700hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_RelativeHumidity_700hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Relative Humidity"
+      "layergroup": "Relative Humidity",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_RelativeHumidity_850hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_RelativeHumidity_850hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Relative Humidity"
+      "layergroup": "Relative Humidity",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day",
       "tags": "SO2 Bt sulphur dioxide",
       "group": "overlays",
-      "layergroup": "Sulfur Dioxide"
+      "layergroup": "Sulfur Dioxide",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Air_Temperature_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Air_Temperature_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Surface_Air_Temperature_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Temperature"
+      "layergroup": "Temperature",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Relative_Humidity_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Relative_Humidity_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Surface_Relative_Humidity_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Relative Humidity"
+      "layergroup": "Relative Humidity",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Skin_Temperature_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Surface_Skin_Temperature_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Surface_Skin_Temperature_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Temperature"
+      "layergroup": "Temperature",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_500hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_500hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Temperature_500hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Temperature"
+      "layergroup": "Temperature",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_700hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_700hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Temperature_700hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Temperature"
+      "layergroup": "Temperature",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_850hPa_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Temperature_850hPa_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Temperature_850hPa_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Temperature"
+      "layergroup": "Temperature",
+      "wrapadjacentdays": true
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/airs/AIRS_L2_Total_Cloud_Fraction_Day.json
+++ b/config/default/common/config/wv.json/layers/airs/AIRS_L2_Total_Cloud_Fraction_Day.json
@@ -5,7 +5,8 @@
       "description": "airs/AIRS_L2_Total_Cloud_Fraction_Day",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Cloud Fraction"
+      "layergroup": "Cloud Fraction",
+      "wrapadjacentdays": true
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #WV-3069 .

Update AIRS Level 2 Standard layers to version 7

- [x] Updated layer descriptions to point to version 7 instead of 6
- [x] The daytime layers are now continuous at the antimeridian, set `wrapadjacentdays: true`

## How To Test

1. `git checkout WV-3069-update-AIRS-L2-v7`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-368.6247189150679,-176.45040105295806,311.466215993784,121.21145558147334&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,AIRS_L2_Total_Cloud_Fraction_Day,AIRS_L2_Sulfur_Dioxide_Brightness_Temperature_Difference_Day,AIRS_L2_RelativeHumidity_850hPa_Day,AIRS_L2_RelativeHumidity_700hPa_Day,AIRS_L2_RelativeHumidity_500hPa_Day,AIRS_L2_Surface_Relative_Humidity_Day,AIRS_L2_Temperature_850hPa_Day,AIRS_L2_Temperature_700hPa_Day,AIRS_L2_Temperature_500hPa_Day,AIRS_L2_Surface_Skin_Temperature_Day,AIRS_L2_Surface_Air_Temperature_Day,AIRS_L2_Methane_400hPa_Volume_Mixing_Ratio_Day,AIRS_L2_Dust_Score_Day,AIRS_L2_Cloud_Top_Height_Day,AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day,VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2016-06-29-T19%3A52%3A51Z)
4. Check to make sure that the badge is showing v7 STD when looking at older dates; ensure layer descriptions have been updated to point to version 7.0; ensure that day time layers wrap at the wings; ensure image download works
5. Verify expected result

@nasa-gibs/worldview
