### PR TITLE
WV-3644, WV-3640, WV-3643: Update acknowledgments, orbit track info; add NSIDC_CPRD to filter

### DIFF
--- a/config/default/common/brand/about/acknowledgements.md
+++ b/config/default/common/brand/about/acknowledgements.md
@@ -75,6 +75,7 @@
                 target="_blank" rel="noopener noreferrer">Learn more about “Best Available” Layers from GIBS</a>.</p>
 <p>Other layers and information are provided by:</p>
 <ul>
+        <li>Dynamically generated, customizable Harmonized Landsat Sentinel-2 (HLS) imagery are provided through the <a href="https://www.earthdata.nasa.gov/about/impact" target="_blank" rel="noopener noreferrer">NASA Interagency Implementation and Advanced Concepts Team (IMPACT)</a>.</li>
         <li>GeoColor imagery layers from GOES-East and GOES-West are provided by <a
                         href="https://www.star.nesdis.noaa.gov/goes/" target="_blank"
                         rel="noopener noreferrer">NOAA/NESDIS/STAR</a> .</li>

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Aqua_Ascending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Aqua_Ascending.md
@@ -1,3 +1,3 @@
-The Aqua - Orbit Track & Time (Ascending/Day) layer is the path of the Aqua satellite on its ascending/day-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 13:30.
+The Aqua - Orbit Track & Time (Ascending/Day) layer is the path of the Aqua satellite on its ascending/day-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator has drifted to ~14:30 as the satellite has reached end-of-life and is continuing to drift.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Aqua_Descending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Aqua_Descending.md
@@ -1,3 +1,3 @@
-The Aqua Orbital Track & Overpass Time (Descending/Night) layer is the path of the Aqua satellite on its descending/night-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 01:30.
+The Aqua Orbital Track & Overpass Time (Descending/Night) layer is the path of the Aqua satellite on its descending/night-time orbit. Overpass times are shown in Coordinated Universal Time (UTC).  Local overpass time at the equator has drifted to ~00:30 as the satellite has reached end-of-life and is continuing to drift.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Terra_Ascending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Terra_Ascending.md
@@ -1,3 +1,3 @@
-The Terra Orbital Track & Overpass Time (Ascending/Night) layer is the path of the Terra satellite on its ascending/night-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 22:30.
+The Terra Orbital Track & Overpass Time (Ascending/Night) layer is the path of the Terra satellite on its ascending/night-time orbit. Overpass times are shown in Coordinated Universal Time (UTC).  Local overpass time at the equator has drifted to ~21:30 as the satellite has reached end-of-life and is continuing to drift.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Terra_Descending.md
+++ b/config/default/common/config/metadata/layers/reference/orbits/OrbitTracks_Terra_Descending.md
@@ -1,3 +1,3 @@
-The Terra Orbital Track & Overpass Time (Descending/Day) layer is the path of the Terra satellite on its descending/day-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator is normally 10:30.
+The Terra Orbital Track & Overpass Time (Descending/Day) layer is the path of the Terra satellite on its descending/day-time orbit. Overpass times are shown in Coordinated Universal Time (UTC). Local overpass time at the equator has drifted to ~09:30 as the satellite has reached end-of-life and is continuing to drift.
 
 Orbital Track information from <https://www.space-track.org/>.

--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -25,6 +25,7 @@
                 "LPCLOUD":	"LP DAAC",
                 "MOPITT": "MOPITT SIPS",
                 "NSIDC_ECS": "NSIDC DAAC",
+                "NSIDC_CPRD": "NSIDC DAAC",
                 "OB_DAAC": "OB.DAAC",
                 "OB_CLOUD": "OB.DAAC",
                 "OMINRT": "OMI/Ozone SIPS",


### PR DESCRIPTION


## Description

Fixes # WV-3644, WV-3640, WV-3643

[Description of the bug or feature]

- [x] Update Acknowledgements section
- [x] Added information to Terra and Aqua orbit tracks descriptions to reflect drift times
- [x] Added NSIDC_CPRD to DAAC list so those layers appear in the NSIDC DAAC filter.

## How To Test

1. `git checkout wv-3644-wv3640-wv-3643`
2. `npm run build && npm start`
3. Launch localhost
4. Go to the About section, scroll to Acknowledgements and look at "Other layers and information" section and verify first bullet references HLS and IMPACT.
5. Load Terra and Aqua orbit tracks and see that layer descriptions show earlier equatorial crossing times and explain satellite end-of-life and drift.
6. Go to the faceted filter search, see that there are more NSIDC records under NSIDC DAAC than what production has.
7. Verify expected result


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
