### PR TITLE
WV-3631 Add Charting to Google Analaytics

### DIFF
--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -13,6 +13,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect } from 'react-redux';
 import { Vector as OlVectorSource } from 'ol/source';
+import googleTagManager from 'googleTagManager';
 import CustomButton from '../util/button';
 import Crop from '../util/image-crop';
 import util from '../../util/util';
@@ -371,6 +372,13 @@ function ChartingModeOptions(props) {
       openChartingErrorModal('No valid layer detected for request.');
       return;
     }
+    googleTagManager.pushEvent({
+      event: 'chart_generated',
+      charting: {
+        layer_id: layerInfo.id,
+        date_type: timeSpanSelection,
+      },
+    });
     const requestedLayerSource = layerInfo.projections.geographic.source;
     if (requestedLayerSource === 'GIBS:geographic') {
       const uriParameters = getImageStatRequestParameters(layerInfo, timeSpanSelection);


### PR DESCRIPTION
## Description
This change adds a new GA4 event being pushed when a chart is requesting in Charting mode, and includes the layer_id and date_type for the chart being generated.