### PR TITLE
WV3519: Re-enable palette warning for snapshot

### DIFF
--- a/e2e/features/image-download/unsupported-test.spec.js
+++ b/e2e/features/image-download/unsupported-test.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test')
 const createSelectors = require('../../test-utils/global-variables/selectors')
-const { closeModal } = require('../../test-utils/hooks/wvHooks')
+const { closeImageDownloadPanel, closeModal } = require('../../test-utils/hooks/wvHooks')
 const { joinUrl } = require('../../test-utils/hooks/basicHooks')
 
 let page
@@ -26,6 +26,31 @@ test.beforeAll(async ({ browser }) => {
 
 test.afterAll(async () => {
   await page.close()
+})
+
+test('Custom palettes are not supported dialog', async () => {
+  const { snapshotToolbarButton } = selectors
+  const url = await joinUrl(startParams, '&l=MODIS_Terra_Aerosol(palette=red_1)')
+  await page.goto(url)
+  await closeModal(page)
+  await snapshotToolbarButton.click()
+  await expect(notify).toBeVisible()
+})
+
+test('Custom palettes: Cancel button', async () => {
+  await cancelNotify.click()
+  await expect(notify).not.toBeVisible()
+  await expect(toolbarSnapshot).not.toBeVisible()
+})
+
+test('Custom palettes: OK button brings up download panel', async () => {
+  const { snapshotToolbarButton } = selectors
+  await snapshotToolbarButton.click()
+  await expect(notify).toBeVisible()
+  await acceptNotify.click()
+  await expect(notify).not.toBeVisible()
+  await expect(toolbarSnapshot).toBeVisible()
+  await closeImageDownloadPanel(page)
 })
 
 test('Rotation is not supported dialog', async () => {

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -21,7 +21,7 @@ import {
   requestNotifications,
   setNotifications,
 } from '../modules/notifications/actions';
-import { refreshPalettes } from '../modules/palettes/actions';
+import { clearCustomsSnapshot, refreshPalettes } from '../modules/palettes/actions';
 import { clearRotate, refreshRotation } from '../modules/map/actions';
 import {
   showLayers, hideLayers,
@@ -136,6 +136,7 @@ class toolbarContainer extends Component {
     const nonDownloadableLayers = hasNonDownloadableLayer ? getNonDownloadableLayers(visibleLayersForProj) : null;
     const paletteStore = lodashCloneDeep(activePalettes);
     toggleDialogVisible(false);
+    await this.getPromise(hasCustomPalette, 'palette', clearCustomsSnapshot, 'Notice');
     await this.getPromise(isRotated, 'rotate', clearRotate, 'Reset rotation');
     await this.getPromise(hasNonDownloadableLayer, 'layers', hideLayers, 'Remove Layers?');
     await openModal(
@@ -452,6 +453,7 @@ const mapStateToProps = (state) => {
   const { activeTab } = sidebar;
   const isDataDownloadTabActive = activeTab === 'download';
   const { isOpen: modalIsOpen } = modal;
+  const filteredLayers = activeLayersForProj.filter((layer) => !(layer.colormapType === 'classification' && layer.type !== 'vector'));
 
   // Collapse when Image download / GIF /  is open or measure tool active
   const snapshotModalOpen = modalIsOpen && modal.id === 'TOOLBAR_SNAPSHOT';
@@ -475,7 +477,7 @@ const mapStateToProps = (state) => {
     isMobile,
     isRotated: Boolean(map.rotation !== 0),
     hasCustomPalette: hasCustomPaletteInActiveProjection(
-      activeLayersForProj,
+      filteredLayers,
       activePalettes,
     ),
     modalIsOpen,

--- a/web/js/modules/palettes/actions.js
+++ b/web/js/modules/palettes/actions.js
@@ -165,11 +165,9 @@ export function setToggledClassification(layerId, classIndex, index, groupName) 
 /**
  * Action to remove custom palettes
  *
- * @param {String} layerId
- * @param {Number} index | Palette index value for multi-paletted layers
- * @param {String} groupName | layer group string
+ * @param {Boolean} keepDisabledClassification | Optionally keep disabled classification colormaps
  */
-export function clearCustoms() {
+export function clearCustoms(keepDisabledClassification) {
   return (dispatch, getState) => {
     const state = getState();
     const { palettes, compare } = state;
@@ -184,13 +182,22 @@ export function clearCustoms() {
         if (colormap.max || colormap.min || colormap.squash) {
           dispatch(setThresholdRangeAndSquash(key, props, index, groupName));
         }
-        if (colormap.disabled) {
+        if (colormap.disabled && !keepDisabledClassification) {
           dispatch(setToggledClassification(key, undefined, index, groupName));
         }
       });
     });
   };
 }
+
+/**
+ * Helper function for snapshot functionality to prevent removing disabled colormaps
+ *
+ */
+export function clearCustomsSnapshot() {
+  return (dispatch) => dispatch(clearCustoms(true));
+}
+
 /**
  * Action signifying custom palettes have been loaded
  *


### PR DESCRIPTION
## Description
This change re-enables the custom palette warning when taking a snapshot of a layer with a custom palette. This does not apply to classification-type layers with disabled classifications, only custom colormaps.

## How To Test
1. `git checkout wv-3519-snapshot-palette-warning`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?l=GHRSST_L4_MUR_Sea_Surface_Temperature(palette=green_2),VIIRS_SNPP_CorrectedReflectance_TrueColor&lg=true&t=2024-03-08-T22%3A00%3A00Z), attempt to take a snapshot and verify that the custom palette warning appears. Confirm that accepting the warning correctly changes the layer back to the default colormap and that taking the screenshot functions and looks correct. Verify that closing out of snapshot mode resets the layer back to the custom colormap.
5. Open [this link](http://localhost:3000/?v=-11.651587516725861,42.00047195568837,8.063909967064358,56.64627008650396&l=Nuclear_Power_Plant_Locations(palette=green_dark),OPERA_L3_Dynamic_Surface_Water_Extent-HLS(disabled=5-0),Coastlines_15m(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor&lg=true&t=2024-03-08-T22%3A00%3A00Z), attempt to take a snapshot and verify that the custom palette warning appears. Confirm that accepting the warning correctly changes only the Power Plants layer back to the default colormap and keeps the Opera layer's disabled classifications. Verify that taking the screenshot functions and looks correct. Verify that closing out of snapshot mode resets the Power Plants layer back to the custom colormap, and keep the Opera layer's disabled classifications.
6. Verify other layers behave correctly with snapshots and trigger warnings as required.