### PR TITLE
WV-3628 - Support EONET query by id instead of title

### DIFF
--- a/e2e/test-utils/global-variables/selectors.js
+++ b/e2e/test-utils/global-variables/selectors.js
@@ -255,7 +255,7 @@ module.exports = (page) => ({
   thermAnomVIIRSnight: page.locator('#active-VIIRS_NOAA20_Thermal_Anomalies_375m_Night'),
   notifyMessage: page.locator('.wv-alert .alert-content'),
   filterIcons: page.locator('.filter-icons > div > .event-icon'),
-  dustHazeIcon: page.locator('.filter-icons > div > #filter-dust-and-haze'),
+  dustHazeIcon: page.locator('.filter-icons > div > #filter-dustHaze'),
   volcanoesIcon: page.locator('.filter-icons > div > #filter-volcanoes'),
   wildfiresIcon: page.locator('.filter-icons > div >#filter-wildfires'),
   filterDates: page.locator('.filter-dates'),

--- a/web/js/components/sidebar/event-icon.js
+++ b/web/js/components/sidebar/event-icon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CustomTooltip from '../util/custom-tooltip';
+import { UncontrolledTooltip } from 'reactstrap';
 
 export default function EventIcon (props) {
   const {
@@ -8,23 +8,25 @@ export default function EventIcon (props) {
     category,
     title,
     hideTooltip,
-    isSelected,
   } = props;
 
-  const slug = category.toLowerCase().split(' ').join('-');
-
   return (
-    <CustomTooltip
-      id={`${slug}-${id}`}
-      text={title || category}
-      hideTooltip={hideTooltip}
-      isSelected={isSelected}
-    >
+    <>
       <i
-        id={id + slug}
-        className={`event-icon event-icon-${slug}`}
+        id={id + category}
+        className={`event-icon event-icon-${category}`}
       />
-    </CustomTooltip>
+      {!hideTooltip && (
+        <UncontrolledTooltip
+          id={`center-align-tooltip ${category}-${id}`}
+          placement="top"
+          target={id + category}
+          fade={false}
+        >
+          {title || category}
+        </UncontrolledTooltip>
+      )}
+    </>
   );
 }
 
@@ -33,5 +35,4 @@ EventIcon.propTypes = {
   category: PropTypes.string,
   hideTooltip: PropTypes.bool,
   title: PropTypes.string,
-  isSelected: PropTypes.bool,
 };

--- a/web/js/components/sidebar/event-icon.js
+++ b/web/js/components/sidebar/event-icon.js
@@ -11,7 +11,7 @@ export default function EventIcon (props) {
   } = props;
 
   return (
-    <>
+    <div>
       <i
         id={id + category}
         className={`event-icon event-icon-${category}`}
@@ -26,7 +26,7 @@ export default function EventIcon (props) {
           {title || category}
         </UncontrolledTooltip>
       )}
-    </>
+    </div>
   );
 }
 

--- a/web/js/components/sidebar/event-icon.js
+++ b/web/js/components/sidebar/event-icon.js
@@ -19,9 +19,11 @@ export default function EventIcon (props) {
       {!hideTooltip && (
         <UncontrolledTooltip
           id={`center-align-tooltip ${category}-${id}`}
+          className="event-icon-tooltip"
           placement="top"
           target={id + category}
           fade={false}
+          autohide={false}
         >
           {title || category}
         </UncontrolledTooltip>

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -195,7 +195,11 @@ function Event (props) {
         onEventHighlight(false);
       }}
     >
-      <EventIcon id={`${event.id}-list`} category={event.categories[0].id} />
+      <EventIcon
+        id={`${event.id}-list`}
+        category={event.categories[0].id}
+        title={event.categories[0].title}
+      />
       <h4
         className="title"
       >

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -63,7 +63,7 @@ function Event (props) {
       googleTagManager.pushEvent({
         event: 'natural_event_selected',
         natural_events: {
-          category: event.categories[0].title,
+          category: event.categories[0].id,
         },
       });
     }
@@ -195,7 +195,7 @@ function Event (props) {
         onEventHighlight(false);
       }}
     >
-      <EventIcon id={`${event.id}-list`} category={event.categories[0].title} />
+      <EventIcon id={`${event.id}-list`} category={event.categories[0].id} />
       <h4
         className="title"
       >

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -78,11 +78,11 @@ function Events(props) {
           {showDates && `${startDate} - ${endDate}`}
         </div>
         <div className="filter-icons">
-          {selectedCategories.map(({ title }) => (
+          {selectedCategories.map(({ title, id }) => (
             <EventIcon
               id="filter-"
-              key={title}
-              category={title}
+              key={id}
+              category={id}
               title={title}
             />
           ))}

--- a/web/js/map/natural-events/event-markers.js
+++ b/web/js/map/natural-events/event-markers.js
@@ -43,7 +43,6 @@ const createPin = function(id, category, isSelected, title, hideTooltip) {
       title,
       id,
       hideTooltip,
-      isSelected,
     }),
   );
   return new OlOverlay({
@@ -262,8 +261,6 @@ class EventMarkers extends React.Component {
         map.removeOverlay(marker.pin);
       }
     });
-    const markerContainer = document.getElementById('marker-container');
-    markerContainer.remove();
     this.setState({ markers: [] });
   }
 

--- a/web/js/map/natural-events/event-markers.js
+++ b/web/js/map/natural-events/event-markers.js
@@ -24,16 +24,14 @@ import { getFilteredEvents } from '../../modules/natural-events/selectors';
 import { CRS } from '../../modules/map/constants';
 
 const icons = [
-  'Dust and Haze',
-  'Icebergs',
-  'Manmade',
-  'Sea and Lake Ice',
-  'Severe Storms',
-  'Snow',
-  'Temperature Extremes',
-  'Volcanoes',
-  'Water Color',
-  'Wildfires',
+  'dustHaze',
+  'manmade',
+  'seaLakeIce',
+  'severeStorms',
+  'snow',
+  'volcanoes',
+  'waterColor',
+  'wildfires',
 ];
 
 const createPin = function(id, category, isSelected, title, hideTooltip) {
@@ -41,7 +39,7 @@ const createPin = function(id, category, isSelected, title, hideTooltip) {
   const root = createRoot(overlayEl);
   root.render(
     React.createElement(EventIcon, {
-      category: category.title,
+      category: category.id,
       title,
       id,
       hideTooltip,
@@ -174,9 +172,9 @@ class EventMarkers extends React.Component {
       const hideTooltips = isMobile || isAnimatingToEvent;
       let category = event.categories[0];
       // Assign a default category if we don't have an icon
-      category = icons.includes(category.title)
+      category = icons.includes(category.id)
         ? category
-        : { title: 'Default', slug: 'default' };
+        : { title: 'Default', slug: 'default', id: 'default' };
 
       marker.pin = createPin(event.id, category, isSelected, event.title, hideTooltips);
       marker.pin.setPosition(coordinates);
@@ -223,7 +221,7 @@ class EventMarkers extends React.Component {
         googleTagManager.pushEvent({
           event: 'natural_event_selected',
           natural_events: {
-            category: category.title,
+            category: category.id,
           },
         });
       }

--- a/web/js/map/natural-events/event-markers.js
+++ b/web/js/map/natural-events/event-markers.js
@@ -261,6 +261,10 @@ class EventMarkers extends React.Component {
         map.removeOverlay(marker.pin);
       }
     });
+    const markerTooltips = document.getElementsByClassName('event-icon-tooltip');
+    Object.values(markerTooltips).forEach((tooltip) => {
+      tooltip.remove();
+    });
     this.setState({ markers: [] });
   }
 

--- a/web/js/map/natural-events/natural-events.js
+++ b/web/js/map/natural-events/natural-events.js
@@ -27,8 +27,8 @@ import EventMarkers from './event-markers';
 import { fly } from '../util';
 
 const zoomLevelReference = {
-  Wildfires: 8,
-  Volcanoes: 6,
+  wildfires: 8,
+  volcanoes: 6,
 };
 
 /* For Wildfires that didn't happen today, move the timeline forward a day
@@ -40,7 +40,7 @@ const getUseDate = (event, date) => {
   const today = toEventDateString(util.now());
   const yesterday = toEventDateString(util.yesterday());
   const recentDate = date === today || date === yesterday;
-  const isWildfireEvent = event.categories[0].title === 'Wildfires';
+  const isWildfireEvent = event.categories[0].id === 'wildfires';
   const parsedDate = util.parseDateUTC(date);
   return isWildfireEvent && !recentDate ? util.dateAdd(parsedDate, 'day', 1) : parsedDate;
 };
@@ -172,7 +172,7 @@ class NaturalEvents extends React.Component {
   zoomToEvent = function(event, date, isSameEventID) {
     const { proj, map, isKioskModeActive } = this.props;
     const { crs } = proj.selected;
-    const category = event.categories[0].title;
+    const category = event.categories[0].id;
     const zoom = isSameEventID ? map.getView().getZoom() : zoomLevelReference[category];
     const geometry = event.geometry.find((geom) => geom.date.split('T')[0] === date);
 

--- a/web/js/modules/natural-events/util.js
+++ b/web/js/modules/natural-events/util.js
@@ -165,10 +165,10 @@ export function getDefaultEventDate({ geometry, categories }) {
   if (geometry.length < 2) {
     return date;
   }
-  const category = categories.title || categories[0].title;
+  const category = categories.id || categories[0].id;
   const today = toEventDateString(util.now());
   // For storms that happened today, get previous date
-  if (date === today && category === 'Severe Storms') {
+  if (date === today && category === 'severeStorms') {
     [date] = geometry[1].date.split('T');
   }
   return date;

--- a/web/scss/features/events.scss
+++ b/web/scss/features/events.scss
@@ -397,7 +397,7 @@
   width: 26px;
 }
 
-.event-icon-dust-and-haze {
+.event-icon-dustHaze {
   background: url("../images/natural-events/icon-dust-and-haze.svg");
 }
 
@@ -409,11 +409,11 @@
   background: url("../images/natural-events/icon-manmade.svg");
 }
 
-.event-icon-sea-and-lake-ice {
+.event-icon-seaLakeIce {
   background: url("../images/natural-events/icon-icebergs.svg");
 }
 
-.event-icon-severe-storms {
+.event-icon-severeStorms {
   background: url("../images/natural-events/icon-severe-storms.svg");
 }
 
@@ -425,7 +425,7 @@
   background: url("../images/natural-events/icon-volcanoes.svg");
 }
 
-.event-icon-water-color {
+.event-icon-waterColor {
   background: url("../images/natural-events/icon-water-color.svg");
 }
 


### PR DESCRIPTION
## Description
This change modifies the way we handle EONET event objects to sort them by `id` instead of `title`. This allows for EONET to change their event category titles, since their ids will stay consistent and can still be used for sorting.

This change also replaced the old CustomToolip with UncontrolledTooltip, as the former seemed to have some issues with the edge of the screen and persistence.

## How To Test
1. `git checkout wv-3628-eonet-id-query`
2. `npm ci`
3. `npm run watch`
4. Open the Events tab on the sidebar
5. Verify that all icons are correctly present for each category (filter by each category individually to verify)
6. Verify that selecting an event of each kind still works correctly, and the icon on the map is still correct
7. Verify that hovering the icons shows the correct titles, both in the list and on the map
8. Verify that special behavior for some events still works correctly (different zoom levels for some categories, etc.)
9. Verify that there are no additional places in the natural events section of the code that need to be changed from title to id