### PR TITLE
WV-3625: Update NOAA-21/VIIRS references to v21

### DIFF
--- a/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_Brightness_Temp_BandI5_Day.md
+++ b/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_Brightness_Temp_BandI5_Day.md
@@ -4,4 +4,4 @@ The VIIRS Brightness Temperature layer is calculated from VIIRS Calibrated Radia
 
 Note: The Corrected Reflectance and the Thermal Band I5 imagery from NOAA-21/VIIRS will occasionally show a checkered pattern, especially over the respective polar areas. This is due to overlapping and superimposition of observations from multiple orbits with widely different cloud/snow coverages. The checkered pattern may also arise from the mixture of partial day and night observations. Though all necessary steps have been taken to mitigate this effect, users may still notice this to some extent over the polar areas, depending on the season.
 
-References: VJ203IMG_NRT [doi:10.5067/VIIRS/VJ203IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.002); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ202IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.002)
+References: VJ203IMG_NRT [doi:10.5067/VIIRS/VJ203IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.021); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ202IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.021)

--- a/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_Brightness_Temp_BandI5_Night.md
+++ b/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_Brightness_Temp_BandI5_Night.md
@@ -4,4 +4,4 @@ The VIIRS Brightness Temperature layer is calculated from VIIRS Calibrated Radia
 
 Note: The Corrected Reflectance and the Thermal Band I5 imagery from NOAA-21/VIIRS will occasionally show a checkered pattern, especially over the respective polar areas. This is due to overlapping and superimposition of observations from multiple orbits with widely different cloud/snow coverages. The checkered pattern may also arise from the mixture of partial day and night observations. Though all necessary steps have been taken to mitigate this effect, users may still notice this to some extent over the polar areas, depending on the season.
 
-References: VJ203IMG_NRT [doi:10.5067/VIIRS/VJ203IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.002); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ202IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.002)
+References: VJ203IMG_NRT [doi:10.5067/VIIRS/VJ203IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.021); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ202IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.021)

--- a/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_BandsM11-I2-I1.md
+++ b/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_BandsM11-I2-I1.md
@@ -17,5 +17,5 @@ Liquid water on the ground appears very dark since it absorbs in the red and the
 
 Note: The Corrected Reflectance and the Thermal Band I5 imagery from NOAA-21/VIIRS will occasionally show a checkered pattern, especially over the respective polar areas. This is due to overlapping and superimposition of observations from multiple orbits with widely different cloud/snow coverages. The checkered pattern may also arise from the mixture of partial day and night observations. Though all necessary steps have been taken to mitigate this effect, users may still notice this to some extent over the polar areas, depending on the season.
 
-References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.002); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.002);
-VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.002); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.002)
+References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.021); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.021);
+VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.021); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.021)

--- a/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_BandsM3-I3-M11.md
+++ b/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_BandsM3-I3-M11.md
@@ -15,5 +15,5 @@ Liquid water on the ground will appear very dark since it absorbs in the red and
 
 Note: The Corrected Reflectance and the Thermal Band I5 imagery from NOAA-21/VIIRS will occasionally show a checkered pattern, especially over the respective polar areas. This is due to overlapping and superimposition of observations from multiple orbits with widely different cloud/snow coverages. The checkered pattern may also arise from the mixture of partial day and night observations. Though all necessary steps have been taken to mitigate this effect, users may still notice this to some extent over the polar areas, depending on the season.
 
-References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.002); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.002);
-VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.002); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.002)
+References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.021); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.021);
+VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.021); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.021)

--- a/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_TrueColor.md
+++ b/config/default/common/config/metadata/layers/viirs/noaa21/VIIRS_NOAA21_CorrectedReflectance_TrueColor.md
@@ -6,5 +6,5 @@ The Visible Infrared Imaging Radiometer Suite (VIIRS) Corrected Reflectance imag
 
 Note: The Corrected Reflectance and the Thermal Band I5 imagery from NOAA-21/VIIRS will occasionally show a checkered pattern, especially over the respective polar areas. This is due to overlapping and superimposition of observations from multiple orbits with widely different cloud/snow coverages. The checkered pattern may also arise from the mixture of partial day and night observations. Though all necessary steps have been taken to mitigate this effect, users may still notice this to some extent over the polar areas, depending on the season.
 
-References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.002); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.002);
-VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.002](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.002); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.002](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.002)
+References: VJ203MOD_NRT [doi:10.5067/VIIRS/VJ103MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ203IMG_NRT.021); VJ203IMG_NRT [doi:10.5067/VIIRS/VJ103IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ203MOD_NRT.021);
+VJ202MOD_NRT [doi:10.5067/VIIRS/VJ102MOD_NRT.021](https://doi.org/10.5067/VIIRS/VJ202MOD_NRT.021); VJ202IMG_NRT [doi:10.5067/VIIRS/VJ102IMG_NRT.021](https://doi.org/10.5067/VIIRS/VJ202IMG_NRT.021)


### PR DESCRIPTION
## Description

Fixes #WV-3625.

Update references for NOAA-21/VIIRS Corrected Reflectance and Brightness Temperature layers to point to v2.1

## How To Test


1. Open with [these URL parameters](http://localhost:3000/?v=-301.0228976144216,-130.32539189331632,299.63127096869255,109.22696841653546&l=VIIRS_NOAA21_Brightness_Temp_BandI5_Night,VIIRS_NOAA21_Brightness_Temp_BandI5_Day,VIIRS_NOAA21_CorrectedReflectance_BandsM11-I2-I1,VIIRS_NOAA21_CorrectedReflectance_BandsM3-I3-M11,VIIRS_NOAA21_CorrectedReflectance_TrueColor&lg=true&t=2025-07-02-T17%3A11%3A59Z)
3. Verify expected result - See that the references section point to v2.1 dois

@nasa-gibs/worldview
