### PR TITLE
WV-3695 - Fix flaky e2e test

### DIFF
--- a/e2e/features/timeline/timeline-test.spec.js
+++ b/e2e/features/timeline/timeline-test.spec.js
@@ -80,6 +80,11 @@ test('Interval state of HOUR restored from permalink', async () => {
 })
 
 test('Interval subdaily default year, month, day, hour, minute, and custom available', async () => {
+  const timelineInterval = await page.locator('#timeline-interval')
+  const istimelineIntervalVisible = await timelineInterval.isVisible()
+  if (!istimelineIntervalVisible) {
+    await page.locator('#timeline-interval-btn-container').click()
+  }
   const yearlyInterval = await page.locator('#interval-years')
   const monthlyInterval = await page.locator('#interval-months')
   const dailyInterval = await page.locator('#interval-days')


### PR DESCRIPTION
## Description
This changes adds an extra check for a flaky e2e test. This is done by checking if a menu is visible after hovering, and if not, clicks the spot again to open it. This is ideally not needed, but seems to be an issue only sometimes and cannot be replicated outside of the test itself.

## How To Test
1. `git checkout wv-3695-e2e-test-fixes`
2. `npm ci`
3. `npm run watch`
4. In a different terminal window, run `npx playwright test timeline/timeline-test.spec.js` multiple times to verify this test is no longer failing sometimes