### PR TITLE
WV-3621: Add API Access menu item

### DIFF
--- a/web/js/containers/info.js
+++ b/web/js/containers/info.js
@@ -133,6 +133,13 @@ function InfoList (props) {
         id: 'source_code_info_item',
         href: 'https://github.com/nasa-gibs/worldview',
       },
+      {
+        text: 'API Access',
+        iconClass: 'ui-icon',
+        iconName: 'satellite',
+        id: 'api_access_info_item',
+        href: 'https://nasa-gibs.github.io/gibs-api-docs/',
+      },
     ];
 
     if (feedbackEnabled) {


### PR DESCRIPTION
## Description

Fixes #WV-3621 .

Add API Access menu item under Information menu
## How To Test

1. `git checkout wv-3621-api-menu-item`
2. `npm run build && npm start`
3. Go to the "i" information menu in the top right corner
4. See that there is an API Access menu item that takes you to the GIBS API docs site.
5. Verify expected result


@nasa-gibs/worldview
