### PR TITLE
Added widthAuto

### DIFF
--- a/web/js/components/animation-widget/gif-button.js
+++ b/web/js/components/animation-widget/gif-button.js
@@ -103,6 +103,7 @@ function GifButton(props) {
           id="wv-animation-widget-file-video-icon"
           className="wv-animation-widget-icon"
           icon="file-video"
+          widthAuto
         />
         <UncontrolledTooltip
           placement="right"

--- a/web/js/components/animation-widget/gif-panel-grid.js
+++ b/web/js/components/animation-widget/gif-panel-grid.js
@@ -17,7 +17,7 @@ export default class GifPanelGrid extends React.Component {
     if (!valid) {
       return (
         <div id="gif-size" className="gif-size gif-size-invalid grid-child">
-          <FontAwesomeIcon icon="times" fixedWidth />
+          <FontAwesomeIcon icon="times" fixedWidth widthAuto />
           <span>{`${maxGifSize} MB ~${roundedSize} MB`}</span>
         </div>
       );

--- a/web/js/components/animation-widget/loop-button.js
+++ b/web/js/components/animation-widget/loop-button.js
@@ -32,7 +32,7 @@ function LoopButton({ looping, onLoop, isMobile }) {
             {labelText}
           </UncontrolledTooltip>
         )}
-      <FontAwesomeIcon icon="retweet" className="wv-animation-widget-icon" />
+      <FontAwesomeIcon icon="retweet" className="wv-animation-widget-icon" widthAuto />
     </a>
   );
 }

--- a/web/js/components/animation-widget/play-button.js
+++ b/web/js/components/animation-widget/play-button.js
@@ -34,8 +34,8 @@ function PlayButton({
         </UncontrolledTooltip>
       )}
       {playing
-        ? <FontAwesomeIcon icon="pause" className="wv-animation-widget-icon" />
-        : <FontAwesomeIcon icon="play" className="wv-animation-widget-icon" />}
+        ? <FontAwesomeIcon icon="pause" className="wv-animation-widget-icon" widthAuto />
+        : <FontAwesomeIcon icon="play" className="wv-animation-widget-icon" widthAuto />}
     </a>
   );
 }

--- a/web/js/components/charting/chart-component.js
+++ b/web/js/components/charting/chart-component.js
@@ -237,6 +237,7 @@ function ChartComponent (props) {
               icon="exclamation-triangle"
               className="wv-alert-icon"
               size="1x"
+              widthAuto
             />
             <i className="charting-disclaimer-block">
               As part of this beta feature release, the number of data points plotted between

--- a/web/js/components/context-menu/context-menu.js
+++ b/web/js/components/context-menu/context-menu.js
@@ -73,7 +73,7 @@ function RightClickMenu(props) {
     const oppositeUnit = unitOfMeasure === 'km' ? 'mi' : 'km';
     return {
       oppositeUnit,
-      fontAwesomeTag: <FontAwesomeIcon icon={faToggle} />,
+      fontAwesomeTag: <FontAwesomeIcon icon={faToggle} widthAuto />,
     };
   };
 

--- a/web/js/components/global-settings/coordinate-format-buttons.js
+++ b/web/js/components/global-settings/coordinate-format-buttons.js
@@ -13,7 +13,7 @@ function CoordinateFormatButtons ({ changeCoordinateFormat, coordinateFormat }) 
       <h3 className="wv-header">
         Coordinate Format (latitude, longitude)
         {' '}
-        <span><FontAwesomeIcon id="coordinate-format-buttons-info-icon" icon="info-circle" /></span>
+        <span><FontAwesomeIcon id="coordinate-format-buttons-info-icon" icon="info-circle" widthAuto /></span>
         <UncontrolledTooltip
           id="coordinate-setting-tooltip"
           target="coordinate-format-buttons-info-icon"

--- a/web/js/components/global-settings/global-settings.js
+++ b/web/js/components/global-settings/global-settings.js
@@ -39,7 +39,7 @@ function GlobalSettings(props) {
         <h3 className="wv-header">
           Show Antimeridian / Approximate Date Line
           {' '}
-          <span><FontAwesomeIcon id="datelines-toggle" icon="info-circle" /></span>
+          <span><FontAwesomeIcon id="datelines-toggle" icon="info-circle" widthAuto /></span>
           <HoverTooltip
             isMobile={false}
             labelText="For many layers, this line represents the transition of daytime imagery from one day to the next."

--- a/web/js/components/global-settings/temperature-unit-buttons.js
+++ b/web/js/components/global-settings/temperature-unit-buttons.js
@@ -10,7 +10,7 @@ function TemperatureUnitButtons({ changeTemperatureUnit, globalTemperatureUnit }
       <h3 className="wv-header">
         Temperature Unit
         {' '}
-        <span><FontAwesomeIcon id="temperature-unit-buttons-info-icon" icon="info-circle" /></span>
+        <span><FontAwesomeIcon id="temperature-unit-buttons-info-icon" icon="info-circle" widthAuto /></span>
         <UncontrolledTooltip
           id="temperature-setting-tooltip"
           target="temperature-unit-buttons-info-icon"

--- a/web/js/components/image-download/grid.js
+++ b/web/js/components/image-download/grid.js
@@ -19,7 +19,7 @@ export default class ResolutionTable extends React.Component {
           id="wv-image-size"
           className="wv-image-size wv-image-size-invalid grid-child"
         >
-          <FontAwesomeIcon icon="times" fixedWidth />
+          <FontAwesomeIcon icon="times" fixedWidth widthAuto />
           <span>{`~${fileSize}MB`}</span>
         </div>
       );

--- a/web/js/components/image-download/lat-long-inputs.js
+++ b/web/js/components/image-download/lat-long-inputs.js
@@ -104,7 +104,7 @@ function LatLongSelect(props) {
           title="Hide coordinates"
           className="wv-image-collapse-latlong"
         >
-          <FontAwesomeIcon icon="caret-right" size="lg" rotation={showCoordinates ? 90 : 0} />
+          <FontAwesomeIcon icon="caret-right" size="lg" rotation={showCoordinates ? 90 : 0} widthAuto />
         </span>
       </div>
       {showCoordinates && (

--- a/web/js/components/layer/product-picker/browse/browse-layers.js
+++ b/web/js/components/layer/product-picker/browse/browse-layers.js
@@ -109,7 +109,7 @@ function BrowseLayers (props) {
       : 'layer-category-navigation');
     const recentTab = (sortKey) => (
       <NavLink onClick={() => selectTab(sortKey)}>
-        <FontAwesomeIcon icon="clock" />
+        <FontAwesomeIcon icon="clock" widthAuto />
         Recent
       </NavLink>
     );
@@ -156,6 +156,7 @@ function BrowseLayers (props) {
             id="recent-tooltip-target"
             className="recent-tooltip-icon"
             icon="question-circle"
+            widthAuto
           />
           <Button
             id="clear-recent-layers"
@@ -178,7 +179,7 @@ function BrowseLayers (props) {
           className="categories-dropdown"
         >
           <DropdownToggle caret>
-            {categoryType === 'recent' && (<FontAwesomeIcon icon="clock" />)}
+            {categoryType === 'recent' && (<FontAwesomeIcon icon="clock" widthAuto />)}
             {categoryType}
           </DropdownToggle>
           <DropdownMenu className="categories-dropdown-menu">

--- a/web/js/components/layer/product-picker/browse/category-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/category-layer-row.js
@@ -217,8 +217,8 @@ class CategoryLayerRow extends React.Component {
           <h3>{measurement.title}</h3>
           {measurement.subtitle && !isSelected && <h5>{measurement.subtitle}</h5>}
           {isSelected
-            ? <FontAwesomeIcon icon="chevron-circle-down" className="arrow-icon" />
-            : <FontAwesomeIcon icon="chevron-circle-right" className="arrow-icon" />}
+            ? <FontAwesomeIcon icon="chevron-circle-down" className="arrow-icon" widthAuto />
+            : <FontAwesomeIcon icon="chevron-circle-right" className="arrow-icon" widthAuto />}
         </div>
         {isSelected ? this.renderContent() : ''}
       </div>

--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -59,8 +59,8 @@ function MeasurementLayerRow (props) {
         label={title}
         classNames="settings-check"
       >
-        {layerIsUnavailable && (<FontAwesomeIcon icon="ban" id="availability-info" />)}
-        {layerNotices && (<FontAwesomeIcon icon="exclamation-triangle" id="notice-info" />)}
+        {layerIsUnavailable && (<FontAwesomeIcon icon="ban" id="availability-info" widthAuto />)}
+        {layerNotices && (<FontAwesomeIcon icon="exclamation-triangle" id="notice-info" widthAuto />)}
         {(layerNotices || layerIsUnavailable) && (
           <UncontrolledTooltip
             id="center-align-tooltip"

--- a/web/js/components/layer/product-picker/browse/measurement-metadata-detail.js
+++ b/web/js/components/layer/product-picker/browse/measurement-metadata-detail.js
@@ -117,7 +117,7 @@ function MeasurementMetadataDetail (props) {
   if (!isMobile && !source) {
     return (
       <div className="no-results">
-        <FontAwesomeIcon icon="map" />
+        <FontAwesomeIcon icon="map" widthAuto />
         <h3>{categoryTitle}</h3>
         <h5> Select a measurement to view details here!</h5>
       </div>
@@ -128,7 +128,7 @@ function MeasurementMetadataDetail (props) {
   if (!metadataPath && !layers.length) {
     return (
       <div className="no-results">
-        <FontAwesomeIcon icon="meteor" />
+        <FontAwesomeIcon icon="meteor" widthAuto />
         <h3> No metadata found. </h3>
       </div>
     );

--- a/web/js/components/layer/product-picker/browse/recent-layers-info.js
+++ b/web/js/components/layer/product-picker/browse/recent-layers-info.js
@@ -5,7 +5,7 @@ import { recentLayerInfo } from '../../../../modules/product-picker/util';
 export default function RecentLayersInfo (props) {
   return (
     <div className="no-results">
-      <FontAwesomeIcon icon="clock" />
+      <FontAwesomeIcon icon="clock" widthAuto />
       <h3> Recently Used Layers </h3>
       <p>
         {recentLayerInfo}

--- a/web/js/components/layer/product-picker/browse/recent-layers.js
+++ b/web/js/components/layer/product-picker/browse/recent-layers.js
@@ -45,6 +45,7 @@ function RecentLayersList(props) {
           className="tooltip-icon"
           size="lg"
           icon="question-circle"
+          widthAuto
         />
         <Button id="clear-recent-layers" size="sm" onClick={clearRecentLayers}>
           Clear List

--- a/web/js/components/layer/product-picker/header.js
+++ b/web/js/components/layer/product-picker/header.js
@@ -170,7 +170,7 @@ class ProductPickerHeader extends React.Component {
                 >
                   Return to category view
                 </UncontrolledTooltip>
-                <FontAwesomeIcon icon="arrow-left" />
+                <FontAwesomeIcon icon="arrow-left" widthAuto />
               </Button>
               {isBreadCrumb && this.renderBreadCrumb()}
             </>
@@ -199,7 +199,7 @@ class ProductPickerHeader extends React.Component {
               >
                 Filtered layer search
               </UncontrolledTooltip>
-              <FontAwesomeIcon icon="filter" />
+              <FontAwesomeIcon icon="filter" widthAuto />
             </Button>
           )}
 

--- a/web/js/components/layer/product-picker/search/filter-chips.js
+++ b/web/js/components/layer/product-picker/search/filter-chips.js
@@ -32,6 +32,7 @@ export default function FilterChips(props) {
           <FontAwesomeIcon
             icon="times"
             fixedWidth
+            widthAuto
           />
         </div>
       ))}

--- a/web/js/components/layer/product-picker/search/layer-metadata-detail.js
+++ b/web/js/components/layer/product-picker/search/layer-metadata-detail.js
@@ -38,7 +38,7 @@ class LayerMetadataDetail extends React.Component {
       ? (<RecentLayersInfo />)
       : (
         <div className="no-results">
-          <FontAwesomeIcon icon="globe-americas" />
+          <FontAwesomeIcon icon="globe-americas" widthAuto />
           <h3> No layer selected. </h3>
           <h5> Select a layer to view details here!</h5>
         </div>
@@ -71,7 +71,7 @@ class LayerMetadataDetail extends React.Component {
           )}
         <div className="text-center">
           <Button className={btnClass} onClick={this.toggleLayer}>
-            <FontAwesomeIcon icon={btnIconClass} />
+            <FontAwesomeIcon icon={btnIconClass} widthAuto />
             {buttonText}
           </Button>
         </div>

--- a/web/js/components/layer/product-picker/search/product-facet.js
+++ b/web/js/components/layer/product-picker/search/product-facet.js
@@ -41,11 +41,13 @@ function ProductFacet(props) {
         id={`${field}-tooltip-target`}
         className="facet-tooltip"
         icon="info-circle"
+        widthAuto
       />
       <FontAwesomeIcon
         className={`facet-collapse-toggle ${!data.length && 'hidden'}`}
         icon={!collapsed ? 'caret-down' : 'caret-left'}
         onClick={() => toggleCollapse(field)}
+        widthAuto
       />
     </>
   );

--- a/web/js/components/layer/product-picker/search/search-layer-row.js
+++ b/web/js/components/layer/product-picker/search/search-layer-row.js
@@ -170,6 +170,7 @@ class SearchLayerRow extends React.Component {
                   id={`${encodedId}-notice-info`}
                   className="layer-notice-icon"
                   icon="exclamation-triangle"
+                  widthAuto
                 />
                 <UncontrolledTooltip
                   id="center-align-tooltip"
@@ -195,7 +196,7 @@ class SearchLayerRow extends React.Component {
               title="Remove from recent layers list."
               onClick={(e) => clearSingleRecentLayer(e, layer)}
             >
-              <FontAwesomeIcon icon="trash" />
+              <FontAwesomeIcon icon="trash" widthAuto />
             </Button>
           )}
         </div>

--- a/web/js/components/layer/product-picker/search/search-layers-list.js
+++ b/web/js/components/layer/product-picker/search/search-layers-list.js
@@ -128,7 +128,7 @@ class SearchLayerList extends React.Component {
       ? (<RecentLayersInfo />)
       : (
         <div className="no-results">
-          <FontAwesomeIcon icon="meteor" size="5x" />
+          <FontAwesomeIcon icon="meteor" size="5x" widthAuto />
           <h3> No layers found! </h3>
         </div>
       );

--- a/web/js/components/layer/settings/band-selection/band-selection-menu.js
+++ b/web/js/components/layer/settings/band-selection/band-selection-menu.js
@@ -67,7 +67,7 @@ export default function BandSelection({ layer }) {
       <div>
         <div className="band-selection-title-row">
           <h3>Select a band for each channel:</h3>
-          <span><FontAwesomeIcon id="band-selection-title-info-icon" icon="info-circle" /></span>
+          <span><FontAwesomeIcon id="band-selection-title-info-icon" icon="info-circle" widthAuto /></span>
           <UncontrolledTooltip
             id="band-selection-title-tooltip"
             target="band-selection-title-info-icon"

--- a/web/js/components/layer/settings/granule-count-slider.js
+++ b/web/js/components/layer/settings/granule-count-slider.js
@@ -26,7 +26,7 @@ function GranuleCountSlider(props) {
     <div className="layer-granule-count-select settings-component">
       <div className="d-flex">
         <h2 className="wv-header">Granule Count</h2>
-        <FontAwesomeIcon id="bbox-limit-info" icon="info-circle" className="ms-2" />
+        <FontAwesomeIcon id="bbox-limit-info" icon="info-circle" className="ms-2" widthAuto />
         <UncontrolledTooltip
           id="center-align-tooltip"
           placement="right"

--- a/web/js/components/layer/settings/granule-date-list.js
+++ b/web/js/components/layer/settings/granule-date-list.js
@@ -191,7 +191,7 @@ class GranuleDateList extends PureComponent {
         className="granule-date-item-down-button"
         onClick={(e) => this.moveDown(e, index, date)}
       >
-        <FontAwesomeIcon icon={faArrowCircleDown} fixedWidth />
+        <FontAwesomeIcon icon={faArrowCircleDown} fixedWidth widthAuto />
       </button>
     );
     const renderUpBtn = () => index > 0 && (
@@ -200,7 +200,7 @@ class GranuleDateList extends PureComponent {
         className="granule-date-item-up-button"
         onClick={(e) => this.moveUp(e, index, date)}
       >
-        <FontAwesomeIcon icon={faArrowCircleUp} fixedWidth />
+        <FontAwesomeIcon icon={faArrowCircleUp} fixedWidth widthAuto />
       </button>
     );
 

--- a/web/js/components/location-search/coordinates-dialog.js
+++ b/web/js/components/location-search/coordinates-dialog.js
@@ -117,7 +117,7 @@ class CoordinatesDialog extends Component {
               {closeButtonLabelText}
             </UncontrolledTooltip>
           )}
-          <FontAwesomeIcon onClick={this.removeMarker} icon="times" fixedWidth />
+          <FontAwesomeIcon onClick={this.removeMarker} icon="times" fixedWidth widthAuto />
         </span>
         <span
           id={minimizeButtonId}
@@ -136,7 +136,7 @@ class CoordinatesDialog extends Component {
               {minimizeButtonLabelText}
             </UncontrolledTooltip>
           )}
-          <FontAwesomeIcon onClick={this.minimizeDialog} icon="minus" fixedWidth />
+          <FontAwesomeIcon onClick={this.minimizeDialog} icon="minus" fixedWidth widthAuto />
         </span>
       </>
     );
@@ -168,7 +168,7 @@ class CoordinatesDialog extends Component {
             {labelText}
           </UncontrolledTooltip>
         )}
-        <FontAwesomeIcon icon="copy" fixedWidth />
+        <FontAwesomeIcon icon="copy" fixedWidth widthAuto />
       </div>
     );
   };

--- a/web/js/components/location-search/location-search-input.js
+++ b/web/js/components/location-search/location-search-input.js
@@ -128,7 +128,7 @@ class SearchBox extends Component {
             {labelText}
           </UncontrolledTooltip>
           )}
-          <FontAwesomeIcon icon="search-location" size="1x" />
+          <FontAwesomeIcon icon="search-location" size="1x" widthAuto />
         </Button>
       </div>
     );
@@ -143,7 +143,7 @@ class SearchBox extends Component {
     return (
       activeAlert && (
         <div className="location-search-input-group-addon location-search-input-alert-icon">
-          <FontAwesomeIcon icon="exclamation-triangle" size="1x" />
+          <FontAwesomeIcon icon="exclamation-triangle" size="1x" widthAuto />
         </div>
       )
     );
@@ -177,7 +177,7 @@ class SearchBox extends Component {
             {labelText}
           </UncontrolledTooltip>
           )}
-          <FontAwesomeIcon icon="times" size="1x" />
+          <FontAwesomeIcon icon="times" size="1x" widthAuto />
         </Button>
       )
     );

--- a/web/js/components/location-search/location-search-modal.js
+++ b/web/js/components/location-search/location-search-modal.js
@@ -329,7 +329,7 @@ class LocationSearchModal extends Component {
         className={buttonId}
       >
         {this.renderTooltip(buttonId, labelText)}
-        <FontAwesomeIcon icon="map-marker-alt" size="1x" />
+        <FontAwesomeIcon icon="map-marker-alt" size="1x" widthAuto />
       </Button>
     );
   };

--- a/web/js/components/map/rotation.js
+++ b/web/js/components/map/rotation.js
@@ -71,7 +71,7 @@ function Rotation() {
           placement="left"
           target=".wv-map-rotate-left"
         />
-        <FontAwesomeIcon icon="undo" className="cursor-pointer" />
+        <FontAwesomeIcon icon="undo" className="cursor-pointer" widthAuto />
       </button>
 
       <button
@@ -105,7 +105,7 @@ function Rotation() {
           placement="left"
           target=".wv-map-rotate-right"
         />
-        <FontAwesomeIcon icon="redo" className="cursor-pointer" />
+        <FontAwesomeIcon icon="redo" className="cursor-pointer" widthAuto />
       </button>
     </div>
   );

--- a/web/js/components/map/zoom.js
+++ b/web/js/components/map/zoom.js
@@ -31,7 +31,7 @@ function Zoom({
           target=".wv-map-zoom-in"
         />
         )}
-        <FontAwesomeIcon icon="plus" />
+        <FontAwesomeIcon icon="plus" widthAuto />
       </button>
       <button
         type="button"
@@ -48,7 +48,7 @@ function Zoom({
           target=".wv-map-zoom-out"
         />
         )}
-        <FontAwesomeIcon icon="minus" />
+        <FontAwesomeIcon icon="minus" widthAuto />
       </button>
     </div>
   );

--- a/web/js/components/measure-tool/measure-button.js
+++ b/web/js/components/measure-tool/measure-button.js
@@ -88,7 +88,7 @@ const MeasureButton = function () {
         >
           {labelText}
         </UncontrolledTooltip>
-        <FontAwesomeIcon icon="ruler" size={faSize} />
+        <FontAwesomeIcon icon="ruler" size={faSize} widthAuto />
       </Button>
       )}
     </>

--- a/web/js/components/measure-tool/measure-tooltip.js
+++ b/web/js/components/measure-tool/measure-tooltip.js
@@ -126,7 +126,7 @@ export default function MeasureTooltip(props) {
         <span dangerouslySetInnerHTML={{ __html: tooltipValue }} />
         {!active && (
           <span className="close-tooltip" onClick={onRemove} onTouchEnd={onRemove}>
-            <FontAwesomeIcon icon="times" fixedWidth />
+            <FontAwesomeIcon icon="times" fixedWidth widthAuto />
           </span>
         )}
       </div>

--- a/web/js/components/notifications/notification-block.js
+++ b/web/js/components/notifications/notification-block.js
@@ -26,7 +26,7 @@ function NotificationBlock(props) {
         /* eslint react/no-array-index-key: 1 */
           <li key={type + i} className={activeClass}>
             <h2>
-              <FontAwesomeIcon icon={listIcons[type]} />
+              <FontAwesomeIcon icon={listIcons[type]} widthAuto />
               <span>{`Posted ${date}`}</span>
             </h2>
             <p dangerouslySetInnerHTML={{ __html: notification.message }} />

--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -613,6 +613,7 @@ function ChartingModeOptions(props) {
           <FontAwesomeIcon
             icon="info-circle"
             onClick={openChartingInfoModal}
+            widthAuto
           />
           <UncontrolledTooltip
             id="center-align-tooltip"

--- a/web/js/components/sidebar/collapsed-button.js
+++ b/web/js/components/sidebar/collapsed-button.js
@@ -27,7 +27,7 @@ class CollapsedButton extends PureComponent {
           <UncontrolledTooltip id="center-align-tooltip" placement="right" target={buttonId}>
             {labelText}
           </UncontrolledTooltip>
-          <FontAwesomeIcon className="layer-icon" icon="layer-group" />
+          <FontAwesomeIcon className="layer-icon" icon="layer-group" widthAuto />
           {isMobile
             ? (
               <span className="layer-count mobile">
@@ -39,7 +39,7 @@ class CollapsedButton extends PureComponent {
                 {`${numberOfLayers.toString()} Layers`}
               </span>
             )}
-          {!isMobile && <FontAwesomeIcon className="expand-icon" icon="caret-down" />}
+          {!isMobile && <FontAwesomeIcon className="expand-icon" icon="caret-down" widthAuto />}
         </a>
       </div>
     );

--- a/web/js/components/sidebar/event.js
+++ b/web/js/components/sidebar/event.js
@@ -169,7 +169,7 @@ function Event (props) {
                 e.stopPropagation();
               }}
             >
-              <FontAwesomeIcon icon="external-link-alt" />
+              <FontAwesomeIcon icon="external-link-alt" widthAuto />
               {` ${source.title}`}
             </a>
           );

--- a/web/js/components/sidebar/events-filter.js
+++ b/web/js/components/sidebar/events-filter.js
@@ -145,7 +145,7 @@ function EventFilterModalBody (props) {
             onCheck={() => setListAll(!listAll)}
             checked={!listAll}
           />
-          <FontAwesomeIcon id="bbox-limit-info" icon="info-circle" />
+          <FontAwesomeIcon id="bbox-limit-info" icon="info-circle" widthAuto />
           <UncontrolledTooltip
             id="center-align-tooltip"
             placement="right"
@@ -164,7 +164,7 @@ function EventFilterModalBody (props) {
         onCheck={() => toggleShowAllTracks(!showAllTracksData)}
         checked={showAllTracksData}
       />
-      <FontAwesomeIcon id="bbox-show-all-tracks" icon="info-circle" />
+      <FontAwesomeIcon id="bbox-show-all-tracks" icon="info-circle" widthAuto />
       <UncontrolledTooltip
         id="center-align-tooltip"
         placement="right"

--- a/web/js/components/sidebar/nav/nav-case.js
+++ b/web/js/components/sidebar/nav/nav-case.js
@@ -109,6 +109,7 @@ function NavCase (props) {
           icon={fontAwesomeStyle}
           aria-label="Hide sidebar"
           style={collapseIconMobile}
+          widthAuto
         />
         <UncontrolledTooltip id="center-align-tooltip" placement="right" target="toggleIconHolder">
           Hide sidebar

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -122,7 +122,7 @@ export default function GranuleCount (props) {
           <span className="granule-size fade-in">{`(${sizeText})`}</span>
         )}
         <span className="help-link" onClick={showGranuleHelpModal}>
-          <FontAwesomeIcon icon="question-circle" />
+          <FontAwesomeIcon icon="question-circle" widthAuto />
         </span>
       </>
     );

--- a/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
+++ b/web/js/components/timeline/custom-interval-selector/custom-interval-selector.js
@@ -75,7 +75,7 @@ function CustomIntervalSelector(props) {
           changeZoomLevel={changeZoomLevel}
         />
       </div>
-      <FontAwesomeIcon icon="times" className="wv-close" onClick={closeModal} />
+      <FontAwesomeIcon icon="times" className="wv-close" onClick={closeModal} widthAuto />
     </div>
   );
 }

--- a/web/js/components/timeline/timeline-controls/animation-button.js
+++ b/web/js/components/timeline/timeline-controls/animation-button.js
@@ -59,7 +59,7 @@ function AnimationButton(props) {
               {labelText}
             </UncontrolledTooltip>
           )}
-        <FontAwesomeIcon icon="video" className="wv-animate" size="2x" />
+        <FontAwesomeIcon icon="video" className="wv-animate" size="2x" widthAuto />
       </div>
     </div>
   );

--- a/web/js/components/timeline/timeline-coverage/coverage-item-list.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-list.js
@@ -321,7 +321,7 @@ class CoverageItemList extends Component {
   createEmptyLayersDOMEl = () => (
     <div className="layer-coverage-list-empty">
       <div className="layer-coverage-item-empty">
-        <FontAwesomeIcon icon="exclamation-triangle" className="error-icon" />
+        <FontAwesomeIcon icon="exclamation-triangle" className="error-icon" widthAuto />
         <p>No visible layers with defined coverage. Add layers or toggle &quot;Include Hidden Layers&quot; if current layers are hidden.</p>
       </div>
     </div>

--- a/web/js/components/timeline/timeline-coverage/timeline-coverage.js
+++ b/web/js/components/timeline/timeline-coverage/timeline-coverage.js
@@ -318,7 +318,7 @@ class TimelineLayerCoveragePanel extends Component {
         onMouseDown={this.stopPropagation}
         onClick={() => onInfoClick()}
       >
-        <FontAwesomeIcon icon="question-circle" className="layer-coverage-info-button-icon" />
+        <FontAwesomeIcon icon="question-circle" className="layer-coverage-info-button-icon" widthAuto />
       </a>
     );
   };

--- a/web/js/components/tour/widget-steps.js
+++ b/web/js/components/tour/widget-steps.js
@@ -37,7 +37,7 @@ function Steps(props) {
         aria-label="Previous"
         onClick={decreaseStep}
       >
-        <FontAwesomeIcon icon="arrow-circle-left" />
+        <FontAwesomeIcon icon="arrow-circle-left" widthAuto />
       </a>
       <div className="step-counter">
         <p>
@@ -54,8 +54,8 @@ function Steps(props) {
         onClick={incrementStep}
       >
         {currentStep === totalSteps
-          ? <FontAwesomeIcon icon="check-circle" />
-          : <FontAwesomeIcon icon="arrow-circle-right" />}
+          ? <FontAwesomeIcon icon="check-circle" widthAuto />
+          : <FontAwesomeIcon icon="arrow-circle-right" widthAuto />}
       </a>
     </div>
   );

--- a/web/js/components/util/alert.js
+++ b/web/js/components/util/alert.js
@@ -70,6 +70,7 @@ export default class AlertUtil extends React.Component {
             icon={icon || 'exclamation-triangle'}
             className="wv-alert-icon"
             size="1x"
+            widthAuto
           />
           <div className="alert-text">
             <p className="wv-alert-title">
@@ -86,7 +87,7 @@ export default class AlertUtil extends React.Component {
             className="close-alert"
             onClick={() => this.closeAlert()}
           >
-            <FontAwesomeIcon icon="times" className="exit" size="1x" />
+            <FontAwesomeIcon icon="times" className="exit" size="1x" widthAuto />
           </div>
         )}
       </Alert>

--- a/web/js/components/util/icon-list.js
+++ b/web/js/components/util/icon-list.js
@@ -40,7 +40,7 @@ export default function IconList(props) {
             onClick={onClickFn}
             disabled={isDisabled}
           >
-            {iconName ? <FontAwesomeIcon icon={iconName} className={iconClass} fixedWidth /> : ''}
+            {iconName ? <FontAwesomeIcon icon={iconName} className={iconClass} fixedWidth widthAuto /> : ''}
             {text || ''}
             {badge ? <Badge pill>{badge}</Badge> : ''}
           </ListGroupItem>

--- a/web/js/components/util/switch.js
+++ b/web/js/components/util/switch.js
@@ -70,7 +70,7 @@ function Switch(props) {
         {tooltip
           && (
             <>
-              <FontAwesomeIcon icon="info-circle" id={`${id}-switch-tooltip`} tabIndex="-1" />
+              <FontAwesomeIcon icon="info-circle" id={`${id}-switch-tooltip`} tabIndex="-1" widthAuto />
               <Tooltip
                 id="center-align-tooltip"
                 placement="right"

--- a/web/js/components/vector-metadata/tooltip.js
+++ b/web/js/components/vector-metadata/tooltip.js
@@ -47,7 +47,7 @@ export default class VectorMetaTooltip extends React.Component {
         key={elId}
       >
         <div id={elId} className="sub-case">
-          <FontAwesomeIcon icon="info" className="vector-info-icon cursor-pointer" />
+          <FontAwesomeIcon icon="info" className="vector-info-icon cursor-pointer" widthAuto />
         </div>
         <Tooltip
           id="center-align-tooltip"

--- a/web/js/containers/alertDropdown.js
+++ b/web/js/containers/alertDropdown.js
@@ -20,9 +20,10 @@ export default function AlertDropdown(isTourActive) {
           icon="exclamation-triangle"
           className="wv-alert-icon"
           size="1x"
+          widthAuto
         />
         Multiple Layer Alerts
-        {dropdownOpen ? <FontAwesomeIcon icon="fa-solid fa-caret-down" /> : <FontAwesomeIcon icon="fa-solid fa-caret-up" />}
+        {dropdownOpen ? <FontAwesomeIcon icon="fa-solid fa-caret-down" widthAuto /> : <FontAwesomeIcon icon="fa-solid fa-caret-up" widthAuto />}
       </button>
       <div ref={containerRef} hidden={!(dropdownOpen || notifications === 1)} id="wv-alert-container" className="wv-alert-container">
         <FeatureAlert />

--- a/web/js/containers/animation-widget/collapsed-animation-widget.js
+++ b/web/js/containers/animation-widget/collapsed-animation-widget.js
@@ -74,8 +74,8 @@ function CollapsedAnimationWidget (props) {
             isDisabled={playDisabled}
             isMobile={isMobile}
           />
-          {!isMobile && <FontAwesomeIcon icon="chevron-up" className="wv-expand" onClick={toggleCollapse} /> }
-          {!isMobile && <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} /> }
+          {!isMobile && <FontAwesomeIcon icon="chevron-up" className="wv-expand" onClick={toggleCollapse} widthAuto /> }
+          {!isMobile && <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} widthAuto /> }
         </div>
       </div>
     </Draggable>

--- a/web/js/containers/animation-widget/desktop-animation-widget.js
+++ b/web/js/containers/animation-widget/desktop-animation-widget.js
@@ -125,8 +125,8 @@ function DesktopAnimationWidget(props) {
             subDailyMode={subDailyMode}
             isDisabled={isPlaying}
           />
-          <FontAwesomeIcon icon="chevron-down" className="wv-minimize" onClick={toggleCollapse} />
-          <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} />
+          <FontAwesomeIcon icon="chevron-down" className="wv-minimize" onClick={toggleCollapse} widthAuto />
+          <FontAwesomeIcon icon="times" className="wv-close" onClick={onClose} widthAuto />
         </div>
       </div>
     </Draggable>

--- a/web/js/containers/animation-widget/mobile-animation-widget.js
+++ b/web/js/containers/animation-widget/mobile-animation-widget.js
@@ -89,7 +89,7 @@ function MobileAnimationWidget (props) {
           onClick={toggleCollapse}
           id="mobile-animation-close"
         >
-          <FontAwesomeIcon icon="times" className="collapse-icon" style={collapseIconMobile} />
+          <FontAwesomeIcon icon="times" className="collapse-icon" style={collapseIconMobile} widthAuto />
         </span>
       </div>
       <div className="mobile-animation-warning-message-container">

--- a/web/js/containers/embed.js
+++ b/web/js/containers/embed.js
@@ -42,7 +42,7 @@ function Embed ({ isEmbedModeActive, selectedDate, isMobile }) {
           labelText={labelText}
           target={buttonId}
         />
-        <FontAwesomeIcon icon="external-link-alt" size="2x" fixedWidth />
+        <FontAwesomeIcon icon="external-link-alt" size="2x" fixedWidth widthAuto />
       </Button>
     );
   };
@@ -58,7 +58,7 @@ function Embed ({ isEmbedModeActive, selectedDate, isMobile }) {
           <>
             <div onClick={handleOverlayClick} className="embed-overlay-bg" />
             <div className="embed-overlay-btn">
-              <FontAwesomeIcon icon="hand-pointer" size="2x" fixedWidth />
+              <FontAwesomeIcon icon="hand-pointer" size="2x" fixedWidth widthAuto />
               <p>Click anywhere to interact</p>
             </div>
           </>

--- a/web/js/containers/error-boundary.js
+++ b/web/js/containers/error-boundary.js
@@ -9,7 +9,7 @@ function BODY_COMPONENT() {
   return (
     <>
       <div className="error-header">
-        <FontAwesomeIcon icon="exclamation-triangle" className="error-icon" size="3x" />
+        <FontAwesomeIcon icon="exclamation-triangle" className="error-icon" size="3x" widthAuto />
         An unexpected error has occurred!
       </div>
       <div className="error-body">

--- a/web/js/containers/sidebar/events.js
+++ b/web/js/containers/sidebar/events.js
@@ -98,7 +98,7 @@ function Events(props) {
         block
         disabled={isLoading}
       >
-        <FontAwesomeIcon icon="filter" />
+        <FontAwesomeIcon icon="filter" widthAuto />
       </Button>
     </div>
   );
@@ -145,7 +145,7 @@ function Events(props) {
           {isLoading || hasRequestError ? (
             // notranslate included below to prevent Google Translate extension from crashing the page
             <div className="events-loading-text notranslate">
-              {hasRequestError && (<FontAwesomeIcon icon="exclamation-triangle" fixedWidth />)}
+              {hasRequestError && (<FontAwesomeIcon icon="exclamation-triangle" fixedWidth widthAuto />)}
               {errorOrLoadingText}
             </div>
           ) : renderEventList()}

--- a/web/js/containers/sidebar/footer-content.js
+++ b/web/js/containers/sidebar/footer-content.js
@@ -134,7 +134,7 @@ const FooterContent = React.forwardRef((props, ref) => {
             <span>
               {`Showing the first ${numEvents} events`}
             </span>
-            <FontAwesomeIcon id="filter-info-icon" icon="info-circle" />
+            <FontAwesomeIcon id="filter-info-icon" icon="info-circle" widthAuto />
             <UncontrolledTooltip
               placement="right"
               target="filter-info-icon"

--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -126,6 +126,7 @@ function LayerList(props) {
         <FontAwesomeIcon
           className="layer-group-more"
           icon="ellipsis-v"
+          widthAuto
         />
       </DropdownToggle>
       <DropdownMenu>
@@ -160,6 +161,7 @@ function LayerList(props) {
             className="layer-group-collapse"
             icon={!collapsed ? 'caret-down' : 'caret-left'}
             onClick={() => toggleCollapse(groupId, !collapsed)}
+            widthAuto
           />
         )}
       </div>

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -320,6 +320,7 @@ function LayerRow (props) {
         <FontAwesomeIcon
           className="layer-group-more"
           icon="ellipsis-v"
+          widthAuto
         />
       </DropdownToggle>
       <DropdownMenu container="body" className="layer-options-dropdown-menu">
@@ -363,7 +364,7 @@ function LayerRow (props) {
         <UncontrolledTooltip id="center-align-tooltip" placement="top" target={removeLayerBtnId}>
           {removeLayerBtnTitle}
         </UncontrolledTooltip>
-        <FontAwesomeIcon icon="times" fixedWidth />
+        <FontAwesomeIcon icon="times" fixedWidth widthAuto />
       </a>
       )}
       <a
@@ -376,7 +377,7 @@ function LayerRow (props) {
         <UncontrolledTooltip id="center-align-tooltip" placement="top" target={layerOptionsBtnId}>
           {layerOptionsBtnTitle}
         </UncontrolledTooltip>
-        <FontAwesomeIcon icon="sliders-h" className="wv-layers-options-icon" />
+        <FontAwesomeIcon icon="sliders-h" className="wv-layers-options-icon" widthAuto />
       </a>
       <a
         id={layerInfoBtnId}
@@ -388,7 +389,7 @@ function LayerRow (props) {
         <UncontrolledTooltip id="center-align-tooltip" placement="top" target={layerInfoBtnId}>
           {layerInfoBtnTitle}
         </UncontrolledTooltip>
-        <FontAwesomeIcon icon="fa-solid fa-info" className="wv-layers-info-icon" />
+        <FontAwesomeIcon icon="fa-solid fa-info" className="wv-layers-info-icon" widthAuto />
       </a>
     </>
   );
@@ -412,7 +413,7 @@ function LayerRow (props) {
         <UncontrolledTooltip id="center-align-tooltip" placement="top" target={layerVectorBtnId}>
           {title}
         </UncontrolledTooltip>
-        <FontAwesomeIcon icon="hand-pointer" fixedWidth />
+        <FontAwesomeIcon icon="hand-pointer" fixedWidth widthAuto />
       </div>
     );
   };
@@ -513,7 +514,7 @@ function LayerRow (props) {
             {visibilityTitle}
           </UncontrolledTooltip>
           )}
-          <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" />
+          <FontAwesomeIcon icon={visibilityIconClass} className="layer-eye-icon" widthAuto />
         </a>
       )}
       {isChartingActive && (
@@ -536,11 +537,13 @@ function LayerRow (props) {
                 <FontAwesomeIcon
                   icon={faCircleDot}
                   className="charting-indicator"
+                  widthAuto
                 />
               ) : (
                 <FontAwesomeIcon
                   icon={faCircle}
                   className="charting-indicator"
+                  widthAuto
                 />
               )}
             </a>

--- a/web/js/containers/sidebar/orbit-track.js
+++ b/web/js/containers/sidebar/orbit-track.js
@@ -47,7 +47,7 @@ function OrbitTrack(props) {
   return (
     <div className={containerClasses}>
       {palette}
-      <FontAwesomeIcon icon="satellite" />
+      <FontAwesomeIcon icon="satellite" widthAuto />
       <span className="wv-orbit-track-label">
         {getOrbitTrackTitle(trackLayer)}
       </span>

--- a/web/js/containers/sidebar/smart-handoff.js
+++ b/web/js/containers/sidebar/smart-handoff.js
@@ -408,7 +408,7 @@ class SmartHandoff extends Component {
                     />
                     <label id={labelId} htmlFor={inputId}>
                       {label}
-                      <FontAwesomeIcon id={`${util.encodeId(value)}-tooltip`} icon="info-circle" />
+                      <FontAwesomeIcon id={`${util.encodeId(value)}-tooltip`} icon="info-circle" widthAuto />
                     </label>
 
                     {this.renderCollectionTooltip(collection, labelId)}

--- a/web/js/containers/toolbar.js
+++ b/web/js/containers/toolbar.js
@@ -211,7 +211,7 @@ class toolbarContainer extends Component {
         )}
       >
         {this.renderTooltip(buttonId, labelText)}
-        <FontAwesomeIcon icon="share-square" size={faSize} />
+        <FontAwesomeIcon icon="share-square" size={faSize} widthAuto />
       </Button>
     );
   }
@@ -247,7 +247,7 @@ class toolbarContainer extends Component {
         style={mobileWvToolbarButtonStyle}
       >
         {this.renderTooltip(buttonId, labelText)}
-        <FontAwesomeIcon icon="globe-asia" size={faSize} />
+        <FontAwesomeIcon icon="globe-asia" size={faSize} widthAuto />
       </Button>
     );
   }
@@ -295,7 +295,7 @@ class toolbarContainer extends Component {
           style={mobileWvToolbarButtonStyle}
         >
           {this.renderTooltip(buttonId, labelText)}
-          <FontAwesomeIcon icon="search-location" size={faSize} />
+          <FontAwesomeIcon icon="search-location" size={faSize} widthAuto />
         </Button>
       </div>
     );
@@ -334,7 +334,7 @@ class toolbarContainer extends Component {
           onClick={this.openImageDownload}
           style={mobileWVImageButtonStyle}
         >
-          <FontAwesomeIcon icon="camera" size={faSize} />
+          <FontAwesomeIcon icon="camera" size={faSize} widthAuto />
         </Button>
       </div>
 
@@ -372,7 +372,7 @@ class toolbarContainer extends Component {
         style={mobileWvToolbarButtonStyle}
       >
         {this.renderTooltip(buttonId, labelText)}
-        <FontAwesomeIcon icon="info-circle" size={faSize} />
+        <FontAwesomeIcon icon="info-circle" size={faSize} widthAuto />
       </Button>
     );
   }
@@ -398,7 +398,7 @@ class toolbarContainer extends Component {
         style={mobileButtonStyle}
       >
         {this.renderTooltip(buttonId, labelText)}
-        <FontAwesomeIcon icon={['fas', 'eye']} size={faSize} />
+        <FontAwesomeIcon icon={['fas', 'eye']} size={faSize} widthAuto />
       </Button>
     );
   }

--- a/web/js/font-awesome-library.js
+++ b/web/js/font-awesome-library.js
@@ -5,13 +5,13 @@
 
    For example:
       import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-      <FontAwesomeIcon icon="times" fixedWidth />
+      <FontAwesomeIcon icon="times" fixedWidth widthAuto />
 
   Icons that belong to a package other than '@fortawesome/free-solid-svg-icons'
   need to be defined as an array of strings where thee first element is the
   package abbreviation.  For example an icon from '@fortawesome/free-brands-svg-icons'
   becomes:
-      <FontAwesomeIcon icon={['fab', 'facebook-f']} />
+      <FontAwesomeIcon icon={['fab', 'facebook-f']} widthAuto />
 
 */
 

--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -144,7 +144,7 @@ const addLineOverlay = function(map, dateA, dateB) {
   lineCaseEl.appendChild(secondLabel);
   draggerEl.appendChild(draggerCircleEl);
   const root = createRoot(draggerCircleEl);
-  root.render(<FontAwesomeIcon icon="arrows-alt-h" />);
+  root.render(<FontAwesomeIcon icon="arrows-alt-h" widthAuto />);
   lineCaseEl.appendChild(draggerEl);
   mapCase.appendChild(lineCaseEl);
   swipeOffset = percentSwipe

--- a/web/js/mapUI/components/dev-test-mode/dev-console-test.js
+++ b/web/js/mapUI/components/dev-test-mode/dev-console-test.js
@@ -16,7 +16,7 @@ function ConsoleTest () {
     <div className="d-flex flex-column justify-content-center align-items-center w-100 mt-3">
       <div className="d-flex flex-row justify-content-center align-items-center">
         <h5 className="h5 fw-bold d-inline-block me-1">Console Test Mode</h5>
-        <span><FontAwesomeIcon id="console-test-info-icon" icon="info-circle" className="pb-2" /></span>
+        <span><FontAwesomeIcon id="console-test-info-icon" icon="info-circle" className="pb-2" widthAuto /></span>
         <UncontrolledTooltip
           id="console-test-tooltip"
           target="console-test-info-icon"

--- a/web/js/mapUI/components/dev-test-mode/dev-preset-console-commands.js
+++ b/web/js/mapUI/components/dev-test-mode/dev-preset-console-commands.js
@@ -43,7 +43,7 @@ function PresetConsoleCommands () {
     <div className="d-flex flex-column justify-content-center align-items-center w-100 mt-3">
       <div className="d-flex flex-row justify-content-center align-items-center">
         <h5 className="h5 fw-bold d-inline-block me-1">Preset Console Commands</h5>
-        <span><FontAwesomeIcon id="console-test-info-icon" icon="info-circle" className="pb-2" /></span>
+        <span><FontAwesomeIcon id="console-test-info-icon" icon="info-circle" className="pb-2" widthAuto /></span>
         <UncontrolledTooltip
           id="console-test-tooltip"
           target="console-test-info-icon"

--- a/web/js/mapUI/components/dev-test-mode/find-orbit-tracks-mode/dev-find-orbit-tracks-mode.js
+++ b/web/js/mapUI/components/dev-test-mode/find-orbit-tracks-mode/dev-find-orbit-tracks-mode.js
@@ -143,7 +143,7 @@ function FindOrbitTracksMode () {
     <div className="d-flex flex-column justify-content-center align-items-center mt-3">
       <div className="d-flex flex-row justify-content-center align-items-center">
         <h5 className="h5 fw-bold me-1">Orbit Track Test Mode</h5>
-        <span><FontAwesomeIcon id="orbit-track-test-info-icon" icon="info-circle" className="pb-2" /></span>
+        <span><FontAwesomeIcon id="orbit-track-test-info-icon" icon="info-circle" className="pb-2" widthAuto /></span>
         <UncontrolledTooltip
           id="orbit-track-test-tooltip"
           target="orbit-track-test-info-icon"

--- a/web/js/mapUI/components/dev-test-mode/pixel-test-mode/dev-pixel-test.js
+++ b/web/js/mapUI/components/dev-test-mode/pixel-test-mode/dev-pixel-test.js
@@ -73,7 +73,7 @@ function PixelTestMode () {
     <div className="d-flex flex-column justify-content-center align-items-center mt-3">
       <div className="d-flex flex-row justify-content-center align-items-center">
         <h5 className="h5 fw-bold me-1">Pixel Test Mode</h5>
-        <span><FontAwesomeIcon id="pixel-test-info-icon" icon="info-circle" className="pb-2" /></span>
+        <span><FontAwesomeIcon id="pixel-test-info-icon" icon="info-circle" className="pb-2" widthAuto /></span>
         <UncontrolledTooltip
           id="pixel-test-tooltip"
           target="pixel-test-info-icon"


### PR DESCRIPTION
## Description
This change fixes the new width of fortawesome icons by setting `widthAuto`, which returns to the previous behavior.

## How To Test
1. `git checkout fortawesome-icons-widthauto`
2. `npm ci`
3. `npm run watch`
4. Verify that the icon width look correct throughout WV, and specifically that expanding the location search doesn't collide with the other toolbar icons.