### PR TITLE
WV-3624: AMSR-E sea ice version update

### DIFF
--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89H.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89H.md
@@ -4,6 +4,6 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data fields: `SI_06km_NH_89H_DAY`; `SI_06km_SH_89H_DAY`
 
-References: AE_SI6 [doi:10.5067/AMSR-E/AE_SI6.003](https://doi.org/10.5067/AMSR-E/AE_SI6.003)
+References: AE_SI6 [doi:10.5067/SVVXO1WXDSLW](https://doi.org/10.5067/SVVXO1WXDSLW)
 
 

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89V.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Brightness_Temp_89V.md
@@ -4,4 +4,4 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data fields: `SI_06km_NH_89V_DAY`; `SI_06km_SH_89V_DAY`
 
-References: AE_SI6 [doi:10.5067/AMSR-E/AE_SI6.003](https://doi.org/10.5067/AMSR-E/AE_SI6.003)
+References: AE_SI6 [doi:10.5067/SVVXO1WXDSLW](https://doi.org/10.5067/SVVXO1WXDSLW)

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_12km.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_12km.md
@@ -6,6 +6,6 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data fields: `SI_12km_NH_ICECON_DAY`; `SI_12km_SH_ICECON_DAY`
 
-References: AE_SI12 [doi:10.5067/AMSR-E/AE_SI12.003](https://doi.org/10.5067/AMSR-E/AE_SI12.003)
+References: AE_SI12 [doi:10.5067/J00N1DZZHGW9](https://doi.org/10.5067/J00N1DZZHGW9)
 
 

--- a/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_25km.md
+++ b/config/default/common/config/metadata/layers/amsre/AMSRE_Sea_Ice_Concentration_25km.md
@@ -6,6 +6,6 @@ Onboard NASA's Aqua satellite, the AMSR-E radiometer measured terrestrial, ocean
 
 Data fields: `SI_25km_NH_ICECON_DAY`; `SI_25km_SH_ICECON_DAY`
 
-References: AE_SI25 [doi:10.5067/AMSR-E/AE_SI25.003](https://doi.org/10.5067/AMSR-E/AE_SI25.003)
+References: AE_SI25 [doi:10.5067/QD0EB4TQGG6A](https://doi.org/10.5067/QD0EB4TQGG6A)
 
 


### PR DESCRIPTION
## Description

Fixes #WV-3624 .

Update references to dois for AMSR-E Sea Ice layers for version 4. 

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?v=-7798784,-3502080,7798784,3502080&p=arctic&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,AMSRE_Sea_Ice_Brightness_Temp_89H,AMSRE_Sea_Ice_Brightness_Temp_89V,AMSRE_Sea_Ice_Concentration_12km,AMSRE_Sea_Ice_Concentration_25km,VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2011-08-11-T20%3A09%3A39Z)
2. Check that the Reference links in the layer descriptions take you to a data set landing page for version 4. 
3. Verify expected result

@nasa-gibs/worldview
