### PR TITLE
WV-3716: Update to point to v8 doi dataset landing pages

### DIFF
--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Root_Zone_Soil_Moisture.md
@@ -4,5 +4,5 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `sm_rootzone_analysis`
 
-References: SPL4SMAU [doi:10.5067/LWJ6TF5SZRG3](https://doi.org/10.5067/LWJ6TF5SZRG3)
+References: SPL4SMAU [doi:10.5067/02LGW4DGJYRX](https://doi.org/10.5067/02LGW4DGJYRX)
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Analyzed_Surface_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `sm_surface_analysis`
 
-References: SPL4SMAU [doi:10.5067/LWJ6TF5SZRG3](https://doi.org/10.5067/LWJ6TF5SZRG3)
+References: SPL4SMAU [doi:10.5067/02LGW4DGJYRX](https://doi.org/10.5067/02LGW4DGJYRX)

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Emult_Average.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Emult_Average.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `emult_mean`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Frozen_Area.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Frozen_Area.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `frozen_area`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Gross_Primary_Productivity.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `gpp_mean`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Heterotrophic_Respiration.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `rh_mean`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Mean_Net_Ecosystem_Exchange.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `nee_mean`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Snow_Mass.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Snow_Mass.md
@@ -4,6 +4,6 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `snow_mass`
 
-References: SPL4SMGP [doi:10.5067/EVKPQZ4AFC4D](https://doi.org/10.5067/EVKPQZ4AFC4D)
+References: SPL4SMGP [doi:10.5067/T5RUATAQREF8](https://doi.org/10.5067/T5RUATAQREF8)
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Soil_Temperature_Layer_1.md
@@ -4,6 +4,7 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `soil_temp_layer1_analysis`
 
-References: SPL4SMAU [doi:10.5067/LWJ6TF5SZRG3](https://doi.org/10.5067/LWJ6TF5SZRG3)
+References: SPL4SMAU [doi:10.5067/02LGW4DGJYRX](https://doi.org/10.5067/02LGW4DGJYRX)
+
 
 

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture.md
@@ -4,4 +4,5 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `sm_rootzone_analysis_ensstd`
 
-References: SPL4SMAU [doi:10.5067/LWJ6TF5SZRG3](https://doi.org/10.5067/LWJ6TF5SZRG3)
+References: SPL4SMAU [doi:10.5067/02LGW4DGJYRX](https://doi.org/10.5067/02LGW4DGJYRX)
+

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `sm_surface_analysis_ensstd`
 
-References: SPL4SMAU [doi:10.5067/LWJ6TF5SZRG3](https://doi.org/10.5067/LWJ6TF5SZRG3)
+References: SPL4SMAU [doi:10.5067/02LGW4DGJYRX](https://doi.org/10.5067/02LGW4DGJYRX)

--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
@@ -4,4 +4,4 @@ The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (
 
 Data field: `nee_mean`
 
-References: SPL4CMDL [doi:10.5067/3K9F0S1Q5J2U](https://doi.org/10.5067/3K9F0S1Q5J2U)
+References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)


### PR DESCRIPTION
## Description

Fixes #WV-3716 .

Update SMAP L4 layers to point to v8 doi dataset landing pages in the layer descriptions.

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?v=-203.77959072839474,-69.73584907450862,136.19419922736415,82.57383728697368&l=SMAP_L4_Frozen_Area,SMAP_L4_Emult_Average,SMAP_L4_Mean_Heterotrophic_Respiration,SMAP_L4_Mean_Gross_Primary_Productivity,SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange,SMAP_L4_Mean_Net_Ecosystem_Exchange,SMAP_L4_Snow_Mass,SMAP_L4_Soil_Temperature_Layer_1,SMAP_L4_Uncertainty_Analyzed_Surface_Soil_Moisture,SMAP_L4_Analyzed_Surface_Soil_Moisture,SMAP_L4_Uncertainty_Analyzed_Root_Zone_Soil_Moisture,SMAP_L4_Analyzed_Root_Zone_Soil_Moisture&lg=true&t=2025-06-03-T16%3A09%3A49Z)
2. Make sure there references in the layer descriptions point to version 8.
3. Verify expected result



@nasa-gibs/worldview
