### PR TITLE
Added dataavailability:dd blue bars for PREFIRE

### DIFF
--- a/config/default/common/config/wv.json/layers/prefire/PREFIRE_SAT1_Outgoing_Longwave_Radiative_Flux.json
+++ b/config/default/common/config/wv.json/layers/prefire/PREFIRE_SAT1_Outgoing_Longwave_Radiative_Flux.json
@@ -5,7 +5,8 @@
       "description": "prefire/PREFIRE_SAT1_Outgoing_Longwave_Radiative_Flux",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Outgoing Radiation"
+      "layergroup": "Outgoing Radiation",
+      "dataAvailability": "dd"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/prefire/PREFIRE_SAT2_Outgoing_Longwave_Radiative_Flux.json
+++ b/config/default/common/config/wv.json/layers/prefire/PREFIRE_SAT2_Outgoing_Longwave_Radiative_Flux.json
@@ -5,7 +5,8 @@
       "description": "prefire/PREFIRE_SAT2_Outgoing_Longwave_Radiative_Flux",
       "tags": "",
       "group": "overlays",
-      "layergroup": "Outgoing Radiation"
+      "layergroup": "Outgoing Radiation",
+      "dataAvailability": "dd"
     }
   }
 }


### PR DESCRIPTION
## Description

Added dataAvailability: dd for PREFIRE layers so that the specific times show as blue bars on the timeline.

## How To Test

1. `git checkout add-dd-for-prefire`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-268.8831574266977,-121.78270307412367,241.68026827487984,106.95185686466081&z=5&ics=true&ici=5&icd=90&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,PREFIRE_SAT2_Outgoing_Longwave_Radiative_Flux(hidden),PREFIRE_SAT1_Outgoing_Longwave_Radiative_Flux&lg=true&t=2025-08-03-T22%3A03%3A00Z)
4. Check to see that the blue bars represent when there's imagery. 
5. Verify expected result


@nasa-gibs/worldview
