### PR TITLE
WV-3720: Add updated HLS VI descriptions

### DIFF
--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
@@ -1,12 +1,10 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Moisture Index (NDMI) (B5-B6)/(B5+B6) imagery layer is an index to determine vegetation water content and monitor drought. It is calculated using near infrared and shortwave infrared (SWIR) wavelengths.
-
-It is calculated using:
+The dynamically generated Normalized Difference Moisture Index (NDMI) (B5-B6)/(B5+B6) imagery layer is an index to determine vegetation water content and monitor drought. NDMI is sensitive to liquid water content in vegetation and can provide an indicator of vegetation stress due to drought. The water content present in healthy vegetation strongly absorbs shortwave infrared light while the structure of leaves strongly reflects near infrared light. NDMI is calculated using the reflectance of the near infrared band (Band 5) and 1.6 µm shortwave infrared band (Band 6) in HLS L30 imagery.
 
 `NDMI = (B5-B6)/(B5+B6)`
 
-The image is applied with a divergent blue to red color palette. Darker blue colors represent high canopy without water stress, and red colors are areas approaching water stress.
+The image is applied with a divergent blue to red color palette. Darker blue colors represent high canopy without water stress, and red colors are areas approaching water stress. NDMI values range from -1 to 1. Decreasing NDMI values for vegetated areas indicate increasingly less water content and increased stress due to drought with the lowest values generally corresponding to completely senesced vegetation or barren areas (rock, sand, exposed soil, built-up areas, etc.). High NDMI values represent healthy, unstressed vegetation (irrigated croplands, wetlands, lush forests, etc.).
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
@@ -1,6 +1,6 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Moisture Index (NDMI) (B5-B6)/(B5+B6) imagery layer is an index to determine vegetation water content and monitor drought. NDMI is sensitive to liquid water content in vegetation and can provide an indicator of vegetation stress due to drought. The water content present in healthy vegetation strongly absorbs shortwave infrared light while the structure of leaves strongly reflects near infrared light. NDMI is calculated using the reflectance of the near infrared band (Band 5) and 1.6 µm shortwave infrared band (Band 6) in HLS L30 imagery.
+The dynamically generated Normalized Difference Moisture Index (NDMI) imagery layer is an index to determine vegetation water content and monitor drought. NDMI is sensitive to liquid water content in vegetation and can provide an indicator of vegetation stress due to drought. The water content present in healthy vegetation strongly absorbs shortwave infrared light while the structure of leaves strongly reflects near infrared light. NDMI is calculated using the reflectance of the near infrared band (Band 5) and 1.6 µm shortwave infrared band (Band 6) in HLS L30 imagery.
 
 `NDMI = (B5-B6)/(B5+B6)`
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Sentinel.md
@@ -1,12 +1,10 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Moisture Index (NDMI) (B8A-B11)/(B8A+B11) imagery layer is an index to determine vegetation water content and monitor drought. It is calculated using near infrared and shortwave infrared (SWIR) wavelengths.
-
-It is calculated using:
+The dynamically generated Normalized Difference Moisture Index (NDMI) imagery layer is an index to determine vegetation water content and monitor drought. NDMI is sensitive to liquid water content in vegetation and can provide an indicator of vegetation stress due to drought. The water content present in healthy vegetation strongly absorbs shortwave infrared light while the structure of leaves strongly reflects near infrared light. NDMI is calculated using the reflectance of the “narrow” near infrared band (Band 8A) and 1.6 µm shortwave infrared band (Band 11) in HLS S30 imagery.
 
 `NDMI = (B8A-B11)/(B8A+B11)`
 
-The image is applied with a divergent blue to red color palette. The image is applied with a divergent blue to red color palette. Darker blue colors represent high canopy without water stress, and red colors are areas approaching water stress.
+The image is applied with a divergent blue to red color palette. The image is applied with a divergent blue to red color palette. Darker blue colors represent high canopy without water stress, and red colors are areas approaching water stress. NDMI values range from -1 to 1. Decreasing NDMI values for vegetated areas indicate increasingly less water content and increased stress due to drought with the lowest values generally corresponding to completely senesced vegetation or barren areas (rock, sand, exposed soil, built-up areas, etc.). High NDMI values represent healthy, unstressed vegetation (irrigated croplands, wetlands, lush forests, etc.).
 
 The Reflectance imagery layer from Sentinel-2/MSI product (S30) is available through the HLS project from the Multi-Spectral Instrument (MSI) aboard the European Union’s Copernicus Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites. The sensor resolution is 10, 20, and 60 m, imagery resolution is resampled to 30 m, and the temporal resolution is daily with a 5 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Landsat 8 and 9 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Landsat.md
@@ -1,8 +1,6 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Burn Ratio 2 (NBR2) imagery layer modifies the Normalized Burn Ratio (NBR) to highlight water sensitivity in vegetation and may be useful in post-fire recovery studies. NBR2 is calculated as a ratio between the SWIR values, substituting the SWIR1 band for the NIR band used in NBR.
-
-It is calculated using:
+The dynamically generated Normalized Burn Ratio 2 (NBR2) imagery layer is a variant of the Normalized Burn Ratio (NBR). It is used to highlight water sensitivity in vegetation and can potentially be used to assess post-fire vegetation conditions. The water content present in healthy vegetation, saturated soils, open water bodies, etc. are strongly absorbed by shortwave infrared light at 1.6 µm and 2.1 µm, relatively more so for the latter. The 1.6 µm band is particularly sensitive to moisture content within vegetation and can aid in discriminating between woody and non-woody vegetation types, while the 2.1 µm band provides additional overall sensitivity to moisture in vegetation and soils. NBR2 is calculated using the reflectance of the 1.6 µm shortwave infrared band (Band 6) and the 2.1 µm shortwave infrared band (Band 7) in HLS L30 imagery.
 
 `NBR2 = (SWIR1 – SWIR2) / (SWIR1 + SWIR2)`
 
@@ -10,7 +8,7 @@ Specifically for Landsat 8 and 9:
 
 `NBR2 = (Band 6 – Band 7) / (Band 6 + Band 7)`
 
-The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange.
+The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange. NBR2 values range from -1 to 1. NBR2 values on this continuum generally provide similar information to the NBR. NBR2 values at 0 and progressively negative indicate increased vegetation damage and soil exposure resulting from fire while increasingly positive NBR2 values after a fire represent lightly damaged to unburned vegetation. NBR2 can aid in identifying small variations in the moisture content, health and stage of recovery for vegetation that has been affected by fire. Additionally, compared to other indices like the NBR, NBR2 can be more ideal for delineating the extent of burned areas and the mosaic of severity within those boundaries for fires occurring in particular biomes where the burn signal may be relatively more subtle. Such examples include grass/shrubland environments where the vegetation outside of the burned areas are senesced or herbaceous wetland areas and coastal marshes characterized by saturated soils.
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Sentinel.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Sentinel.md
@@ -1,16 +1,14 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Burn Ratio 2 (NBR2) imagery layer modifies the Normalized Burn Ratio (NBR) to highlight water sensitivity in vegetation and may be useful in post-fire recovery studies. NBR2 is calculated as a ratio between the SWIR values, substituting the SWIR1 band for the NIR band used in NBR.
-
-It is calculated using:
+The dynamically generated Normalized Burn Ratio 2 (NBR2) imagery layer is a variant of the Normalized Burn Ratio (NBR). It is used to highlight water sensitivity in vegetation and can potentially be used to assess post-fire vegetation conditions. The water content present in healthy vegetation, saturated soils, open water bodies, etc. are strongly absorbed by shortwave infrared light at 1.6 µm and 2.1 µm, relatively more so for the latter. The 1.6 µm band is particularly sensitive to moisture content within vegetation and can aid in discriminating between woody and non-woody vegetation types, while the 2.1 µm band provides additional overall sensitivity to moisture in vegetation and soils. NBR is calculated using the reflectance of the 1.6 µm shortwave infrared band (Band 11) and the 2.1 µm shortwave infrared band (Band 12) in HLS S30 imagery.
 
 `NBR2 = (SWIR1 – SWIR2) / (SWIR1 + SWIR2)`
 
-Specifically for Sentinel-2A and -2B:
+Specifically for Sentinel-2:
 
 `NBR2 = (Band 11 – Band 12) / (Band 11 + Band 12)`
 
-The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange.
+The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange. NBR2 values range from -1 to 1. NBR2 values on this continuum generally provide similar information to the NBR. NBR2 values at 0 and progressively negative indicate increased vegetation damage and soil exposure resulting from fire while increasingly positive NBR2 values after a fire represent lightly damaged to unburned vegetation. NBR2 can aid in identifying small variations in the moisture content, health and stage of recovery for vegetation that has been affected by fire. Additionally, compared to other indices like the NBR, NBR2 can be more ideal for delineating the extent of burned areas and the mosaic of severity within those boundaries for fires occurring in particular biomes where the burn signal may be relatively more subtle. Such examples include grass/shrubland environments where the vegetation outside of the burned areas are senesced or herbaceous wetland areas and coastal marshes characterized by saturated soils.
 
 The Reflectance imagery layer from Sentinel-2/MSI product (S30) is available through the HLS project from the Multi-Spectral Instrument (MSI) aboard the European Union’s Copernicus Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites. The sensor resolution is 10, 20, and 60 m, imagery resolution is resampled to 30 m, and the temporal resolution is daily with a 5 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Landsat 8 and 9 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Landsat.md
@@ -1,8 +1,6 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Burn Ratio (NBR) imagery layer is used to identify burned areas and provide a measure of burn severity. It is calculated as a ratio between the NIR and SWIR values.
-
-It is calculated using:
+The dynamically generated Normalized Burn Ratio (NBR) imagery layer is used to delineate burned areas and measure the degree of fire effects (burn severity) within those areas. The water content present in healthy vegetation, saturated soils, open water bodies, etc. strongly absorbs shortwave infrared light while the structure of healthy vegetation strongly reflects near infrared light. NBR is calculated using the reflectance of the near infrared band (Band 5) and the 2.1 µm shortwave infrared band (Band 7) in HLS L30 imagery. It is calculated as a ratio between the NIR and SWIR values.
 
 `NBR = (NIR - SWIR) / (NIR + SWIR)`
 
@@ -11,6 +9,8 @@ Specifically for Landsat 8 and 9:
 `NBR = (Band 5 – Band 7) / (Band 5 + Band 7)`
 
 The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange.
+
+NBR values range from -1 to 1. Decreasing NBR values within burned areas indicate increasing damage to vegetation density and vigor resulting from fire, increasing presence of ash from burned vegetation, and the increasing exposure of bare, dry soils and rocky areas. Recently burned areas present NBR values that are typically 0 to strongly negative. NBR values increasing from 0 to 1 represent increasingly healthy, undamaged vegetation only lightly burned or not at all affected by fire.
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Sentinel.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Sentinel.md
@@ -1,16 +1,14 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Burn Ratio (NBR) imagery layer is used to identify burned areas and provide a measure of burn severity. It is calculated as a ratio between the NIR and SWIR values.
-
-It is calculated using:
+The dynamically generated Normalized Burn Ratio (NBR) imagery layer is used to delineate burned areas and measure the variability of fire effects (burn severity) within those areas. The water content present in healthy vegetation, saturated soils, open water bodies, etc. strongly absorbs shortwave infrared light while the structure of vegetation biomass strongly reflects near infrared light. NBR is calculated using the reflectance of the “narrow” near infrared band (Band 8A) and the 2.1 µm shortwave infrared band (Band 12) in HLS S30 imagery. It is calculated as a ratio between the NIR and SWIR values.
 
 `NBR = (NIR - SWIR) / (NIR + SWIR)`
 
-Specifically for Sentinel-2A and -2B:
+Specifically for Sentinel-2:
 
 `NBR = (Band 8A – Band 12) / (Band 8A + Band 12)`
 
-The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange.
+The divergent purple to orange color palette depicts vegetated areas in shades of purple and burned areas in shades of orange. NBR values range from -1 to 1. Decreasing NBR values within burned areas indicate increasing damage to vegetation density and vigor resulting from fire, increasing presence of ash from burned vegetation, and the increasing exposure of bare, dry soils and rocky areas. Recently burned areas present NBR values that are typically 0 to strongly negative. NBR values increasing from 0 to 1 represent increasingly healthy, undamaged vegetation only lightly burned or not at all affected by fire.
 
 The Reflectance imagery layer from Sentinel-2/MSI product (S30) is available through the HLS project from the Multi-Spectral Instrument (MSI) aboard the European Union’s Copernicus Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites. The sensor resolution is 10, 20, and 60 m, imagery resolution is resampled to 30 m, and the temporal resolution is daily with a 5 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Landsat 8 and 9 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Landsat.md
@@ -1,12 +1,10 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Vegetation Index (NDVI) (B5-B4)/(B5+B4) imagery layer is an index for quantifying green vegetation. It reflects the state of vegetation health based on how vegetation reflects light at certain wavelengths. It is calculated using near infrared and red wavelengths.
-
-It is calculated using:
+The dynamically generated Normalized Difference Vegetation Index (NDVI) imagery layer is an index for quantifying green vegetation. NDVI is used to quantify vegetation greenness, understand vegetation density and monitor plant health. In healthy vegetation, chlorophyll strongly absorbs visible light while the structure of leaves strongly reflects near infrared light. NDVI is calculated using the reflectance of the red band (Band 4) and near infrared band (Band 5) in HLS L30 imagery.
 
 `NDVI = (B5-B4)/(B5+B4)`
 
-The image is applied with a divergent blue-green to brown color palette. It depicts areas with a lot of green leaf growth, indicating the presence of chlorophyll, in dark green colors. Chlorophyll reflects more infrared light and less visible light. Areas with some green leaf growth are in light yellows, and areas with little to no vegetation growth are shades of brown.
+The image is applied with a divergent blue-green to brown color palette. It depicts areas with a lot of green leaf growth, indicating the presence of chlorophyll, in dark green colors. Chlorophyll reflects more infrared light and less visible light. Areas with some green leaf growth are in light yellows, and areas with little to no vegetation growth are shades of brown. NDVI values range from -1 to 1. Low NDVI values, at or near 0, generally correspond to barren areas (rock, sand, exposed soil, snow, etc.) while high NDVI values (0.8 to 0.9) represent greener, denser vegetation (forests, croplands, wetlands, etc.).
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Sentinel.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Sentinel.md
@@ -1,6 +1,6 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Vegetation Index (NDVI) (B8-B4)/(B8+B4) imagery layer is an index for quantifying green vegetation. NDVI is used to quantify vegetation greenness, understand vegetation density and monitor plant health. In healthy vegetation, chlorophyll strongly absorbs visible light while the structure of leaves strongly reflects near infrared light. NDVI is calculated using the reflectance of the red band (Band 4) and near infrared band (Band 8A) in HLS S30 imagery.
+The dynamically generated Normalized Difference Vegetation Index (NDVI) imagery layer is an index for quantifying green vegetation. NDVI is used to quantify vegetation greenness, understand vegetation density and monitor plant health. In healthy vegetation, chlorophyll strongly absorbs visible light while the structure of leaves strongly reflects near infrared light. NDVI is calculated using the reflectance of the red band (Band 4) and near infrared band (Band 8A) in HLS S30 imagery.
 
 `NDVI = (B8-B4)/(B8+B4)`
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Sentinel.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Sentinel.md
@@ -1,12 +1,10 @@
 **NOTE: This layer is undergoing beta testing.**
 
-The dynamically generated Normalized Difference Vegetation Index (NDVI) (B8-B4)/(B8+B4) imagery layer is an index for quantifying green vegetation. It reflects the state of vegetation health based on how vegetation reflects light at certain wavelengths. It is calculated using near infrared and red wavelengths.
-
-It is calculated using:
+The dynamically generated Normalized Difference Vegetation Index (NDVI) (B8-B4)/(B8+B4) imagery layer is an index for quantifying green vegetation. NDVI is used to quantify vegetation greenness, understand vegetation density and monitor plant health. In healthy vegetation, chlorophyll strongly absorbs visible light while the structure of leaves strongly reflects near infrared light. NDVI is calculated using the reflectance of the red band (Band 4) and near infrared band (Band 8A) in HLS S30 imagery.
 
 `NDVI = (B8-B4)/(B8+B4)`
 
-The image is applied with a divergent blue-green to brown color palette. It depicts areas with a lot of green leaf growth, indicating the presence of chlorophyll, in dark green colors. Chlorophyll reflects more infrared light and less visible light. Areas with some green leaf growth are in light yellows, and areas with little to no vegetation growth are in shades of brown.
+The image is applied with a divergent blue-green to brown color palette. It depicts areas with a lot of green leaf growth, indicating the presence of chlorophyll, in dark green colors. Chlorophyll reflects more infrared light and less visible light. Areas with some green leaf growth are in light yellows, and areas with little to no vegetation growth are in shades of brown. NDVI values range from -1 to 1. Low NDVI values, at or near 0, generally correspond to barren areas (rock, sand, exposed soil, snow, etc.) while high NDVI values (0.8 to 0.9) represent greener, denser vegetation (forests, croplands, wetlands, etc.).
 
 The Reflectance imagery layer from Sentinel-2/MSI product (S30) is available through the HLS project from the Multi-Spectral Instrument (MSI) aboard the European Union’s Copernicus Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites. The sensor resolution is 10, 20, and 60 m, imagery resolution is resampled to 30 m, and the temporal resolution is daily with a 5 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Landsat 8 and 9 imagery layer available.
 


### PR DESCRIPTION
## Description

Fixes #WV-3720.

Updated layer descriptions for HLS Vegetation indices - NDVI, NDMI, NBR, and NBR2 for both satellites. 

## How To Test

1. `git checkout wv-3720-add-hls-vi-descriptions`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,HLS_NBR_Sentinel(bandCombo=%7B%22assets%22%3A%5B%22B05%22;%22B07%22%5D;%22expression%22%3A%22%3CB05-B07%3E%2F%3CB05%2BB07%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22puor%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D),HLS_NBR2_Sentinel(bandCombo=%7B%22assets%22%3A%5B%22B06%22;%22B07%22%5D;%22expression%22%3A%22%3CB06-B07%3E%2F%3CB06%2BB07%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22puor%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D),HLS_NBR_Landsat(bandCombo=%7B%22assets%22%3A%5B%22B05%22;%22B07%22%5D;%22expression%22%3A%22%3CB05-B07%3E%2F%3CB05%2BB07%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22puor%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9%5D%22%7D),HLS_NBR2_Landsat(bandCombo=%7B%22assets%22%3A%5B%22B06%22;%22B07%22%5D;%22expression%22%3A%22%3CB06-B07%3E%2F%3CB06%2BB07%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22puor%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9%5D%22%7D),HLS_Moisture_Index_Sentinel(bandCombo=%7B%22assets%22%3A%5B%22B8A%22;%22B11%22%5D;%22expression%22%3A%22%3CB8A-B11%3E%2F%3CB8A%2BB11%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22bwr_r%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D),HLS_Moisture_Index_Landsat(bandCombo=%7B%22assets%22%3A%5B%22B05%22;%22B06%22%5D;%22expression%22%3A%22%3CB05-B06%3E%2F%3CB05%2BB06%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22bwr_r%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9%5D%22%7D),HLS_NDVI_Sentinel(bandCombo=%7B%22assets%22%3A%5B%22B08%22;%22B04%22%5D;%22expression%22%3A%22%3CB08-B04%3E%2F%3CB08%2BB04%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22brbg%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D),HLS_NDVI_Landsat(bandCombo=%7B%22assets%22%3A%5B%22B05%22;%22B04%22%5D;%22expression%22%3A%22%3CB05-B04%3E%2F%3CB05%2BB04%3E%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22brbg%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9%5D%22%7D),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2025-08-18-T16%3A09%3A59Z)
4. See the updated, more detailed layer descriptions for Landsat and Sentinel NDVI, NDMI, NBR, and NBR2 layers
5. Verify expected result



@nasa-gibs/worldview
