### PR TITLE
WV-3581 - Improved Charting Error Messages

### DIFF
--- a/web/js/components/charting/chart-component.js
+++ b/web/js/components/charting/chart-component.js
@@ -18,7 +18,7 @@ function ChartComponent (props) {
     numRangeDays,
     isTruncated,
     title,
-    STEP_NUM,
+    numPoints,
   } = liveData;
 
   // Arbitrary array of colors to use
@@ -250,11 +250,11 @@ function ChartComponent (props) {
               </b>
               have been reduced from
               <b>
-                {` ${numRangeDays} days `}
+                {` ${numRangeDays} `}
               </b>
               to
               <b>
-                {` ${STEP_NUM} days`}
+                {` ${numPoints}`}
               </b>
               .
             </i>

--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -411,6 +411,7 @@ function ChartingModeOptions(props) {
       if (timeSpanSelection === 'range') {
         const rechartsData = formatGIBSDataForRecharts(dataToRender);
         const numRangeDays = Math.floor((Date.parse(initialEndDate) - Date.parse(initialStartDate)) / 86400000);
+        const numPoints = STEP_NUM - (data?.body?.errors?.error_count > 0 ? data.body.errors.error_count : 0);
         displayChart({
           title: dataToRender.title,
           subtitle: dataToRender.subtitle,
@@ -420,7 +421,7 @@ function ChartingModeOptions(props) {
           endDate: secondaryDate,
           numRangeDays,
           isTruncated: numRangeDays > STEP_NUM,
-          STEP_NUM,
+          numPoints,
         });
         updateChartRequestStatus(false);
       } else {

--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -41,7 +41,7 @@ const sources = {};
 let init = false;
 const STEP_NUM = 31;
 const SERVER_ERROR_MESSAGE = 'An error has occurred while requesting the charting data. Please try again in a few minutes.';
-const NO_DATA_ERROR_MESSAGE = 'No data was found for this request. Please check the layer, date(s) & location to process & try again.';
+const NO_DATA_ERROR_MESSAGE = 'No data was found for this request. Please check the layer, date(s) & location to process.';
 
 function ChartingModeOptions(props) {
   const {


### PR DESCRIPTION
## Description
This change removes reference to `days` in the "data points reduced" warning message shown on the chart component when trying to chart too large a time period. The change also correctly accounts for error_days in this message, correctly stating how many data points are actual present on the chart. Also removed is the prompting for the user to try again after attempting to generate a chart and receiving a 204 error message.

## How To Test
1. `git checkout wv-3581-charting-error-messages`
2. `npm ci`
3. `npm run watch`
4. _Note: To actually test in localhost, mock data must be used_
5. Add any chartable layer to the layer list, then open Charting Mode.
6. Attempt to create a chart that will return a 204 error and verify the error message has been updated correctly.
7. Generate a chart with too long a time period and verify that 'days' has been removed from the warning message below the chart.
8. Generate a chart with too long a time period and has error_days and verify the warning message includes the actual correct number of points on the chart.