### PR TITLE
WV-3728 - Comparison Mode Place Labels Fix

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -1083,7 +1083,6 @@ export default function mapLayerBuilder(config, cache, store) {
       source,
       extent: shifted ? RIGHT_WING_EXTENT : extent,
       className: id,
-      declutter: true,
       renderMode: 'hybrid',
     });
 


### PR DESCRIPTION
## Description
This change fixes the issue found when entering comparison mode with the Place Labels layer active on both A and B sides.

## How To Test
1. `git checkout wv-3728-comparison-place-labels`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of Worldview
5. Enable the Place Labels layer
6. Enter Comparison mode and verify the Place Labels show on both side A and side B properly