### PR TITLE
WV-3576: add PACE Corrected Reflectance as default; WV-3735: Update Landsat 9 launch date

### DIFF
--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Color_Infrared_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Color_Infrared_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 5-4-3, False Color) imagery layer i
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Customizable_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Customizable_Landsat.md
@@ -4,7 +4,7 @@ This Reflectance imagery layer can be customized to display any available Red-Gr
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_EVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_EVI_Landsat.md
@@ -16,7 +16,7 @@ The image is applied with a divergent blue-green to brown color palette. It depi
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 5-4-3, Color Infrared) imagery laye
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Urban_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 7-6-4, Urban False Color) imagery l
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_False_Color_Vegetation_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 6-5-4, Vegetative Analysis False Co
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_L30_Nadir_BRDF_Adjusted_Reflectance.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_L30_Nadir_BRDF_Adjusted_Reflectance.md
@@ -2,7 +2,7 @@ The Reflectance (Nadir BRDF Adjusted) imagery layer from Landsat 8 and 9/OLI is 
 
 The Reflectance (Nadir BRDF Adjusted) imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_MSAVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_MSAVI_Landsat.md
@@ -14,7 +14,7 @@ The image is applied with a divergent blue-green to brown color palette. It depi
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Moisture_Index_Landsat.md
@@ -8,7 +8,7 @@ The image is applied with a divergent blue to red color palette. Darker blue col
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR2_Landsat.md
@@ -12,7 +12,7 @@ The divergent purple to orange color palette depicts vegetated areas in shades o
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NBR_Landsat.md
@@ -14,7 +14,7 @@ NBR values range from -1 to 1. Decreasing NBR values within burned areas indicat
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDSI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDSI_Landsat.md
@@ -8,7 +8,7 @@ It is calculated using:
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDVI_Landsat.md
@@ -8,7 +8,7 @@ The image is applied with a divergent blue-green to brown color palette. It depi
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDWI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_NDWI_Landsat.md
@@ -10,7 +10,7 @@ The index can overestimate water bodies as it is sensitive to built-up areas. Te
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_SAVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_SAVI_Landsat.md
@@ -14,7 +14,7 @@ The image is applied with a divergent blue-green to brown color palette. It depi
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_Shortwave_Infrared_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 7-5-4, Shortwave Infrared) imagery 
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_TVI_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_TVI_Landsat.md
@@ -14,7 +14,7 @@ The image is applied with a divergent blue-green to brown color palette. It depi
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with an 8 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/HLS_True_Color_Landsat.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/HLS_True_Color_Landsat.md
@@ -4,7 +4,7 @@ The dynamically generated Reflectance (Bands 4-3-2, True Color) imagery layer is
 
 The Reflectance imagery layer from Landsat 8 and 9/OLI product (L30) is available through the HLS project from the Operational Land Imager (OLI) aboard the Landsat 8 and 9 satellites. The sensor resolution is 30 m, imagery resolution is 30 m, and the temporal resolution is daily with a 16 day revisit time. The imagery is available in Worldview/GIBS approximately 2 - 4 days after satellite overpass. There is a separate combined Sentinel-2 imagery layer available.
 
-Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/metadata/layers/multi-mission/hls/Reflectance.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/Reflectance.md
@@ -1,7 +1,7 @@
 ### About HLS
 The Harmonized Landsat and Sentinel-2 (HLS) project provides consistent surface reflectance data from the Operational Land Imager (OLI) aboard the joint NASA/USGS Landsat 8 and 9 satellites and the Multi-Spectral Instrument (MSI) aboard the European Union’s Copernicus Sentinel-2A, Sentinel-2B, and Sentinel-2C satellites. The combined measurements between Landsat 8, Landsat 9, Sentinel-2A, Sentinel-2B, and Sentinel-2C enable global observations of the land every 2-3 days at 30 meter (m) spatial resolution. The HLS project uses a set of algorithms to obtain seamless products from OLI and MSI that include atmospheric correction, cloud and cloud-shadow masking, spatial co-registration and common gridding, illumination and view angle normalization, and spectral bandpass adjustment.
 
-The HLS project began with Landsat 8, Sentinel-2A, and Sentinel-2B. Landsat 9 launched on September 21, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
+The HLS project began with Landsat 8, Sentinel-2A, and Sentinel-2B. Landsat 9 launched on September 27, 2021 and was subsequently added to the HLS product, availability of imagery from Landsat 8 and Landsat 9 is as follows:
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 

--- a/config/default/common/config/wv.json/defaults.json
+++ b/config/default/common/config/wv.json/defaults.json
@@ -21,6 +21,10 @@
                 "id": "VIIRS_NOAA21_CorrectedReflectance_TrueColor",
                 "hidden": "true"
             },
+             {
+                "id": "OCI_PACE_True_Color",
+                "hidden": "true"
+            },
             {
                 "id": "Coastlines_15m"
             },


### PR DESCRIPTION
## Description

Fixes WV-3576: add PACE Corrected Reflectance as default
Fixes WV-3735: Update Landsat 9 launch date

## How To Test

1. `git checkout wv-3576-pace-default-wv-3735-landsat-9`
2. `npm run build &7 npm start`
3. Launch localhost
4. Check that PACE Corrected Reflectance is a default Base layer
5. Check that the launch date in the Landsat HLS descriptions state that it launched September 27 (not September 21)
6. Verify expected result


@nasa-gibs/worldview
