### PR TITLE
WV-3726 - GA script addition on page load

### DIFF
--- a/web/js/components/util/google-tag-manager.js
+++ b/web/js/components/util/google-tag-manager.js
@@ -1,5 +1,13 @@
 /* eslint-disable */
 
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+  event: "virtualPageView",
+  page_location: location.href,
+  page_title: document.title,
+  page_referrer: document.referrer,
+});
+
 export default {
   /*
   * @func dataLayerPush object to GoogleTagManager


### PR DESCRIPTION
## Description
This change adds a GA script to trigger on page load.

## How To Test
1. `git checkout wv-3726-ga-pageload-script`
2. Verify the script runs on page load and is in the correct file location
3. Verify Worldview does not break with the addition of this script