### PR TITLE
WV-3713 - Prevent Terra and Suomi NPP NDVI and EVI products from Charting

### DIFF
--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_EVI_8Day.json
@@ -4,6 +4,7 @@
       "id": "MODIS_Terra_EVI_8Day",
       "description": "modis/terra/MODIS_Terra_EVI_8Day",
       "group": "overlays",
+      "disableCharting": true,
       "layergroup": "Vegetation Indices"
     }
   }

--- a/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/modis/terra/MODIS_Terra_NDVI_8Day.json
@@ -5,6 +5,7 @@
       "description": "modis/terra/MODIS_Terra_NDVI_8Day",
       "group": "overlays",
       "tags": "ndvi normalized difference vegetation index",
+      "disableCharting": true,
       "layergroup": "Vegetation Indices"
     }
   }

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_EVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_EVI_8Day.json
@@ -4,6 +4,7 @@
       "id": "VIIRS_SNPP_EVI_8Day",
       "description": "viirs/snpp/VIIRS_SNPP_EVI_8Day",
       "group": "overlays",
+      "disableCharting": true,
       "layergroup": "Vegetation Indices"
     }
   }

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_NDVI_8Day.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_NDVI_8Day.json
@@ -5,6 +5,7 @@
       "description": "viirs/snpp/VIIRS_SNPP_NDVI_8Day",
       "group": "overlays",
       "tags": "ndvi normalized difference vegetation index",
+      "disableCharting": true,
       "layergroup": "Vegetation Indices"
     }
   }


### PR DESCRIPTION
## Description
This change prevents 4 layers from being able to be used in Charting Mode: `MODIS_Terra_NDVI_8Day`, `VIIRS_SNPP_NDVI_8Day`, `MODIS_Terra_EVI_8Day`, and `VIIRS_SNPP_EVI_8Day`.

## How To Test
1. `git checkout wv-3713-disablecharting-8day-products`
2. `npm ci`
3. `npm run build`
4. `npm run watch`
5. Open the layer picker and verify that all 4 of the products in question do not have the Chartable icon on them
6. Add all 4 products in question and verify they don't have the Chartable icon in the sidebar. Verify that Charting Mode cannot be enabled yet with only these products added
7. Add any Chartable product, then enter Charting Mode and verify that none of the 4 products in question can be selected in Charting Mode