### PR TITLE
WV-3748 - Multiple Layers Alert Styling Fix

### DIFF
--- a/web/scss/features/sidebar.scss
+++ b/web/scss/features/sidebar.scss
@@ -685,6 +685,13 @@ div#group-overlays-checkbox-case {
 .charting-disclaimer {
   line-height: 1.3em;
   text-align: left;
+
+  .wv-alert-icon {
+    color: #d54e21;
+    font-size: 1.4em;
+    margin: 10px 18px 0 8px;
+    position: absolute;
+  }
 }
 
 .charting-disclaimer-pre {
@@ -728,13 +735,6 @@ div#group-overlays-checkbox-case {
       margin-top: 1px;
     }
   }
-}
-
-.wv-alert-icon {
-  color: #d54e21;
-  font-size: 1.4em;
-  margin: 10px 18px 0 8px;
-  position: absolute;
 }
 
 .charting-disclaimer-block {


### PR DESCRIPTION
## Description
This change fixes the styling for the icons in the Multiple Layers Alert window.

## How To Test
1. `git checkout wv-3748-alert-icon-alignment`
2. `npm ci`
3. `npm run watch`
4. Add a bunch of HLS products, then overzoom in to an area until the Multiple Layers Alert warning shows
5. Click the warning to open it, and verify that the icons are correctly aligned and colored, and the text is correctly aligned and spaced