### PR TITLE
WV-3747: Update HLS_MSAVI_Sentinel.json

### DIFF
--- a/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_MSAVI_Sentinel.json
+++ b/config/default/common/config/wv.json/layers/multi-mission/hls/HLS_MSAVI_Sentinel.json
@@ -16,8 +16,8 @@
      "orbitTracks": ["OrbitTracks_Sentinel-2A_Descending", "OrbitTracks_Sentinel-2B_Descending", "OrbitTracks_Sentinel-2C_Descending"],
       "orbitDirection": ["descending", "descending", "descending"],
       "bandCombo": {
-        "assets": ["B05", "B04"],
-        "expression": "(2*B05+1-sqrt((2*B05+1)**2-8*(B05-B04)))/2",
+        "assets": ["B8A", "B04"],
+        "expression": "(2*B8A+1-sqrt((2*B8A+1)**2-8*(B8A-B04)))/2",
         "rescale": "-1,1",
         "colormap_name": "brbg",
         "bands_regex": "B[0-9][0-9A-Za-z]"


### PR DESCRIPTION
## Description

Fixes #WV-3747 .

Also updated the MSAVI Sentinel 2 band combinations. 

## How To Test

1. `git checkout wv-3747-additional-indicies`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-116.33113307493596,44.87926451912857,-112.08568007987827,46.83024212500119&l=HLS_MSAVI_Sentinel(hidden,bandCombo=%7B%22assets%22%3A%5B%22B8A%22;%22B04%22%5D;%22expression%22%3A%22%3C2*B8A%2B1-sqrt%3C%3C2*B8A%2B1%3E**2-8*%3CB8A-B04%3E%3E%3E%2F2%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22brbg%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D),HLS_Customizable_Sentinel(bandCombo=%7B%22assets%22%3A%5B%22B8A%22;%22B04%22%5D;%22expression%22%3A%22%3C2*B8A%2B1-sqrt%3C%3C2*B8A%2B1%3E**2-8*%3CB8A-B04%3E%3E%3E%2F2%22;%22rescale%22%3A%22-1;1%22;%22colormap_name%22%3A%22brbg%22;%22bands_regex%22%3A%22B%5B0-9%5D%5B0-9A-Za-z%5D%22%7D)&lg=true&t=2025-08-22-T18%3A07%3A53Z)
4. Make sure the MSAVI individual layer matches the MSAVI option in the Customizable Sentinel-2 layer.
5. Verify expected result


@nasa-gibs/worldview
