### PR TITLE
WV-3740: Change rollingWindow to 90 days for Corrected Reflectance granules

### DIFF
--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }

--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }

--- a/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/noaa20/VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_NOAA20_CorrectedReflectance_TrueColor"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/snpp/VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }

--- a/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule.json
+++ b/config/default/common/config/wv.json/layers/viirs/snpp/VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule.json
@@ -5,13 +5,13 @@
           "description": "viirs/snpp/VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule",
           "tags":     "subdaily",
           "group":    "overlays",
-          "layergroup": "Granules",
+          "layergroup": "Corrected Reflectance",
           "type": "granule",
           "dataAvailability": "dd",
           "period": "subdaily",
           "associatedLayers": ["VIIRS_SNPP_CorrectedReflectance_TrueColor"],
           "availability": {
-            "rollingWindow": 30
+            "rollingWindow": 90
           }
       }
   }


### PR DESCRIPTION
## Description

Fixes #WV-3740 .

Change rollingWindow to 90 days for Corrected Reflectance granules.

## How To Test

1. `git checkout wv-3740-cr-granule-to-90days`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-385.29748505147256,-158.3241851938595,326.82072787136735,153.4153278472571&z=4&ics=true&ici=5&icd=6&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_BandsM3-I3-M11_Granule(count=10),VIIRS_NOAA20_CorrectedReflectance_BandsM11-I2-I1_Granule(count=10),VIIRS_SNPP_CorrectedReflectance_BandsM3-I3-M11_Granule(count=10),VIIRS_SNPP_CorrectedReflectance_BandsM11-I2-I1_Granule(count=10),VIIRS_SNPP_CorrectedReflectance_TrueColor_Granule(count=10),VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(count=10),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2025-07-25-T12%3A19%3A45Z)
4. Check to make sure that Corrected reflectance granules now display 90 day of imagery, not just 30 days. 
5. Verify expected result


@nasa-gibs/worldview
