### PR TITLE
WV-3763 variable period flag

### DIFF
--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Fraction_Total.json
@@ -10,7 +10,8 @@
       "layergroup": "Cloud Fraction",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Cloud_Cloud_Pressure_Total.json
@@ -10,7 +10,8 @@
       "layergroup": "Cloud Pressure",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Formaldehyde_Vertical_Column.json
@@ -10,7 +10,8 @@
       "layergroup": "Formaldehyde",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Stratosphere.json
@@ -10,7 +10,8 @@
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_NO2_Vertical_Column_Troposphere.json
@@ -10,7 +10,8 @@
       "layergroup": "Nitrogen Dioxide",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Cloud_Fraction.json
@@ -10,7 +10,8 @@
       "layergroup": "Ozone",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_Column_Amount.json
@@ -10,7 +10,8 @@
       "layergroup": "Ozone",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
+++ b/config/default/common/config/wv.json/layers/tempo/TEMPO_L3_Ozone_UV_Aerosol_Index.json
@@ -10,7 +10,8 @@
       "layergroup": "Aerosol Index",
       "dataAvailability": "dd",
       "startDate": "2023-08-02T15:00:00Z",
-      "shiftadjacentdays": false
+      "shiftadjacentdays": false,
+      "hasVariablePeriod": "30M"
     }
   }
 }

--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -122,7 +122,7 @@ export class VectorInteractions extends React.Component {
       map.forEachFeatureAtPixel(pixel, (feature, layer) => {
         if (!layer) return;
         const def = lodashGet(layer, 'wv.def');
-        if (def.layergroup === 'Reference') isReferenceLayer = true;
+        if (def?.layergroup === 'Reference') isReferenceLayer = true;
         const layerExtent = layer.get('extent');
         const pixelCoords = map.getCoordinateFromPixel(pixel);
         const featureOutsideExtent = layerExtent && !olExtent.containsCoordinate(layerExtent, pixelCoords);

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -627,6 +627,7 @@ export function getSmallestIntervalValue(state) {
   let smallestDelta = timeUnitLookup.D; // 1 day in minutes
   if (layers && layers.length) {
     for (let i = 0; i < layers.length; i += 1) {
+      let interval = lodashGet(layers[i], 'dateRanges[0].dateInterval');
       const variablePeriod = layers[i]?.hasVariablePeriod;
       if (variablePeriod) {
         const numberMatch = variablePeriod.match(/[0-9]+/g);
@@ -641,9 +642,8 @@ export function getSmallestIntervalValue(state) {
           return acc + valueToAdd;
         }, 0);
 
-        return time;
+        interval = time;
       }
-      const interval = lodashGet(layers[i], 'dateRanges[0].dateInterval');
       if (layers[i].period === 'subdaily' && interval < smallestDelta) {
         smallestDelta = Number(interval);
       }

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -614,10 +614,35 @@ export const subdailyLayers = createSelector(
  * @param {Object} state
  */
 export function getSmallestIntervalValue(state) {
+  const oneMinute = 1;
+  const oneHour = 60;
+  const oneDay = 1440;
+  const timeUnitLookup = {
+    S: oneMinute / 60,
+    M: oneMinute,
+    H: oneHour,
+    D: oneDay,
+  };
   const layers = getActiveLayers(state);
-  let smallestDelta = 1440; // 1 day in minutes
+  let smallestDelta = timeUnitLookup.D; // 1 day in minutes
   if (layers && layers.length) {
     for (let i = 0; i < layers.length; i += 1) {
+      const variablePeriod = layers[i]?.hasVariablePeriod;
+      if (variablePeriod) {
+        const numberMatch = variablePeriod.match(/[0-9]+/g);
+        const unitMatch = variablePeriod.match(/[a-zA-Z]+/g);
+        const time = numberMatch.reduce((acc, val, idx) => {
+          const number = Number(val);
+          const unit = unitMatch[idx];
+          const minutes = number * timeUnitLookup[unit?.toUpperCase?.()];
+          const invalid = Number.isNaN(minutes);
+          const valueToAdd = invalid ? (console.warn(`Invalid period: ${variablePeriod}`), 0) : minutes; // eslint-disable-line no-console
+
+          return acc + valueToAdd;
+        }, 0);
+
+        return time;
+      }
       const interval = lodashGet(layers[i], 'dateRanges[0].dateInterval');
       if (layers[i].period === 'subdaily' && interval < smallestDelta) {
         smallestDelta = Number(interval);


### PR DESCRIPTION
## Description

> Make TEMPO L3 layers load as a default of 30min in the time selector

## How To Test

1. `git checkout WV-3763-hasVariablePeriod-flag`
2. `npm i && npm run build && npm run watch`
3. [GO](http://localhost:3000/?v=-181.90066152455853,-45.969323343278106,-8.469209911655298,113.03622194322837&z=4&ics=true&ici=5&icd=30&l=TEMPO_L3_Ozone_UV_Aerosol_Index,TEMPO_L3_Ozone_Cloud_Fraction,TEMPO_L3_Ozone_Column_Amount,TEMPO_L3_Cloud_Cloud_Pressure_Total,TEMPO_L3_Cloud_Cloud_Fraction_Total,TEMPO_L3_NO2_Vertical_Column_Troposphere,TEMPO_L3_NO2_Vertical_Column_Stratosphere,TEMPO_L3_Formaldehyde_Vertical_Column,Coastlines_15m&lg=false&t=2025-09-26-T17%3A29%3A04Z)
4. Should default to 30 minutes.


## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
