### PR TITLE
WV-3771: Update data field for SMAP NEE uncertainty

### DIFF
--- a/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
+++ b/config/default/common/config/metadata/layers/smap/SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange.md
@@ -2,6 +2,6 @@ The Soil Moisture Active Passive (SMAP) “Net Ecosystem CO2 Exchange Uncertaint
 
 The SMAP spacecraft carries two instruments, a radar (active) and a radiometer (passive), that together make global measurements of land surface soil moisture and freeze/thaw state. It is useful for monitoring and predicting natural hazards such as floods and droughts, understanding the linkages between Earth’s water, energy and carbon cycles, and reducing uncertainties in predicting weather and climate.
 
-Data field: `nee_mean`
+Data field: `nee_rmse_mean`
 
 References: SPL4CMDL [doi:10.5067/U7SN8JDZL0UC](https://doi.org/10.5067/U7SN8JDZL0UC)


### PR DESCRIPTION
## Description

Fixes #WV-3771.

Update data field from `nee_mean` to `nee_rmse_mean` for the the Soil Moisture Active Passive (SMAP) “Net Ecosystem CO2 Exchange Uncertainty (L4, 9 km Grid Cell Mean, Model Value-Added)” layer (SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange).

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,SMAP_L4_Uncertainty_Mean_Net_Ecosystem_Exchange,OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2025-09-06-T16%3A40%3A45Z)
2. Check that in the layer description, the Data Field has been updated to `nee_rmse_mean`
3. Verify expected result

@nasa-gibs/worldview
