### PR TITLE
Remove NRT references for AMSR2

### DIFF
--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Day.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Cloud_Liquid_Water_Night.md
@@ -4,4 +4,4 @@ The AMSR2 instrument is a conically scanning passive microwave radiometer. This 
 
 The imagery resolution is 2 km and sensor resolution is 6.25 km. The temporal resolution is daily.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Day.md
@@ -2,4 +2,4 @@ The Columnar Water Vapor (Day) layer is a measure of the columnar water vapor in
 
 The AMSR2 instrument is a conically scanning passive microwave radiometer. This instrument senses microwave radiation for twelve channels and six frequencies ranging from 6.9 GHz to 89 GHz on board the Japan Aerospace Exploration Agency (JAXA) Global Change Observation Mission – Water 1 (GCOM-W1) satellite.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)
+References: AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Columnar_Water_Vapor_Night.md
@@ -2,4 +2,4 @@ The Columnar Water Vapor (Night) layer is a measure of the columnar water vapor 
 
 The AMSR2 instrument is a conically scanning passive microwave radiometer. This instrument senses microwave radiation for twelve channels and six frequencies ranging from 6.9 GHz to 89 GHz on board the Japan Aerospace Exploration Agency (JAXA) Global Change Observation Mission – Water 1 (GCOM-W1) satellite.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)
+References: AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Snow_Water_Equivalent_Daily.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Snow_Water_Equivalent_Daily.md
@@ -2,6 +2,6 @@ The Advanced Microwave Scanning Radiometer-E/Advanced Microwave Scanning Radiome
 
 The AMSR2 instrument is a conically scanning passive microwave radiometer. This instrument senses microwave radiation for twelve channels and six frequencies ranging from 6.9 GHz to 89 GHz on board the Japan Aerospace Exploration Agency (JAXA) Global Change Observation Mission – Water 1 (GCOM-W1) satellite.
 
-This product uses the JAXA AMSR2 Level-1R input TBs which are calibrated (unified) across the JAXA AMSR-E and AMSR2 Level-1R products. Source data for this layer provides Southern Hemisphere data that utilizes a different, older algorithm and browse imagery is not currently available. The most recent near real-time images (generated from `AU_DySno_NRT_R02`) are replaced with data from the standard product (`AU_DySno`) as it becomes available.
+This product uses the JAXA AMSR2 Level-1R input TBs which are calibrated (unified) across the JAXA AMSR-E and AMSR2 Level-1R products. Source data for this layer provides Southern Hemisphere data that utilizes a different, older algorithm and browse imagery is not currently available.
 
-References: AU_DySno_NRT_R02 [doi:10.5067/AMSRU/AU_DySno_NRT_R02](https://doi.org/10.5067/AMSRU/AU_DySno_NRT_R02), AU_DySno [doi:10.5067/8AE2ILXB5SM6](https://doi.org/10.5067/8AE2ILXB5SM6)
+References: AU_DySno [doi:10.5067/8AE2ILXB5SM6](https://doi.org/10.5067/8AE2ILXB5SM6)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Day.md
@@ -2,4 +2,4 @@ The Surface Precipitation (Day) layer displays instantaneous surface precipitati
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)
+References: AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Surface_Precipitation_Night.md
@@ -2,4 +2,4 @@ The Surface Precipitation (Night) layer displays instantaneous surface precipita
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_RAIN_NRT [doi:10.5067/AMSRU/AU_RAIN_NRT_R02](https://doi.org/10.5067/AMSRU/AU_RAIN_NRT_R02); AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)
+References: AU_RAIN [doi:10.5067/P5MCTDH7674A](https://doi.org/10.5067/P5MCTDH7674A)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Day.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Day) layer displays precipitable water totals over
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Total_Precipitable_Water_Night.md
@@ -2,4 +2,4 @@ The Total Precipitable Water (Night) layer displays precipitable water totals ov
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Day.md
@@ -2,4 +2,4 @@ The Wind Speed (Day) layer shows wind speed over oceans in meters per second (m/
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)

--- a/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
+++ b/config/default/common/config/metadata/layers/amsr2/AMSRU2_Wind_Speed_Night.md
@@ -2,4 +2,4 @@ The Wind Speed (Night) layer shows wind speed over oceans in meters per second (
 
 The Advanced Microwave Scanning Radiometer 2 (AMSR2) instrument on the Global Change Observation Mission - Water 1 (GCOM-W1) provides global passive microwave measurements of terrestrial, oceanic, and atmospheric parameters for the investigation of global water and energy cycles. The GCOM-W1 NRT AMSR2 Unified Global Swath Surface Precipitation GSFC Profiling Algorithm is a swath product containing global rain rate and type, calculated by the GPROF 2017 V2R rainfall retrieval algorithm using resampled NRT Level-1R data provided by JAXA. This is the same algorithm that generates the corresponding standard science products in the AMSR SIPS.
 
-References: AU_OCEAN_NRT [doi:10.5067/AMSRU/AU_OCEAN_NRT_R01](https://doi.org/10.5067/AMSRU/AU_OCEAN_NRT_R01); AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)
+References: AU_OCEAN [doi:10.5067/9YQRFKKEPUP4](https://doi.org/10.5067/9YQRFKKEPUP4)


### PR DESCRIPTION
## Description

Fixes #wv-3775 .

Remove references to availability of NRT AMSR2 data products as they have now been discontinued. 

 
## How To Test

1. `git checkout wv-3775-amsr2-nrt-removal`
3. `npm run build && npm start`
4. Open with [these URL parameters](http://localhost:3000/?v=-268.4297250829816,-121.51673026538788,216.62371468094574,99.93736782588383&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,AMSRU2_Snow_Water_Equivalent_Daily,AMSRU2_Wind_Speed_Night,AMSRU2_Wind_Speed_Day,AMSRU2_Total_Precipitable_Water_Night,AMSRU2_Total_Precipitable_Water_Day,AMSRU2_Surface_Precipitation_Night,AMSRU2_Surface_Precipitation_Day,AMSRU2_Columnar_Water_Vapor_Night,AMSRU2_Columnar_Water_Vapor_Day,AMSRU2_Cloud_Liquid_Water_Night,AMSRU2_Cloud_Liquid_Water_Day,OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2025-08-17-T18%3A44%3A20Z)
5. Make sure the layer descriptions do not refer to the availability of NRT imagery.
6. Verify expected result


@nasa-gibs/worldview
