### PR TITLE
WV-3857: Added Chartable Icon to Categories View

### DIFF
--- a/web/js/components/layer/product-picker/browse/measurement-layer-row.js
+++ b/web/js/components/layer/product-picker/browse/measurement-layer-row.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { ListGroupItem, UncontrolledTooltip } from 'reactstrap';
 import { connect } from 'react-redux';
@@ -29,7 +30,11 @@ function MeasurementLayerRow (props) {
     title,
     selectedDate,
     layerNotices,
+    isChartable,
   } = props;
+
+  const [isHoveringChartingIcon, setIsHoveringChartingIcon] = useState(false);
+
   const layerIsUnavailable = !available(layer.id, selectedDate, [layer]);
   const listItemClass = layerIsUnavailable || layerNotices ? 'unavailable' : '';
   // Replace periods in id since period causes issue with tooltip targeting
@@ -60,7 +65,7 @@ function MeasurementLayerRow (props) {
       >
         {layerIsUnavailable && (<FontAwesomeIcon icon="ban" id="availability-info" widthAuto />)}
         {layerNotices && (<FontAwesomeIcon icon="exclamation-triangle" id="notice-info" widthAuto />)}
-        {(layerNotices || layerIsUnavailable) && (
+        {(layerNotices || layerIsUnavailable || isHoveringChartingIcon) && (
           <UncontrolledTooltip
             id="center-align-tooltip"
             target={itemElementId}
@@ -81,7 +86,26 @@ function MeasurementLayerRow (props) {
               </div>
             )}
             {layerNotices && (<div dangerouslySetInnerHTML={{ __html: layerNotices }} />)}
+            {isHoveringChartingIcon && (
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: 'Create time series charts or get statistics for this layer',
+                }}
+              />
+            )}
           </UncontrolledTooltip>
+        )}
+        {isChartable && (
+          <span
+            className="chartable-icon-wrapper"
+            onMouseEnter={() => setIsHoveringChartingIcon(true)}
+            onMouseLeave={() => setIsHoveringChartingIcon(false)}
+          >
+            <i
+              id={`${layer.id}-chartable-info`}
+              className="layer-notice-icon chartable-icon"
+            />
+          </span>
         )}
       </Checkbox>
     </ListGroupItem>
@@ -90,6 +114,7 @@ function MeasurementLayerRow (props) {
 
 MeasurementLayerRow.propTypes = {
   addLayer: PropTypes.func,
+  isChartable: PropTypes.bool,
   isEnabled: PropTypes.bool,
   isMobile: PropTypes.bool,
   layer: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf(['null'])]),
@@ -103,12 +128,15 @@ MeasurementLayerRow.propTypes = {
 const mapStateToProps = (state, ownProps) => {
   const { notifications, screenSize } = state;
   const activeLayerMap = getActiveLayersMap(state);
-  const { id } = ownProps.layer;
+  const { layer } = ownProps;
+  const { id, colormapType, layerPeriod, disableCharting } = layer;
+  const isChartable = Object.prototype.hasOwnProperty.call(layer, 'palette') && Object.prototype.hasOwnProperty.call(layer, 'colormapType') && colormapType === 'continuous' && layerPeriod === 'Daily' && !disableCharting;
   return {
     isEnabled: !!activeLayerMap[id],
     isMobile: screenSize.isMobile,
     selectedDate: getSelectedDate(state),
     layerNotices: getLayerNoticesForLayer(id, notifications),
+    isChartable,
   };
 };
 

--- a/web/scss/features/layer-categories.scss
+++ b/web/scss/features/layer-categories.scss
@@ -321,6 +321,19 @@
       vertical-align: middle;
       line-height: 14px;
     }
+
+    .chartable-icon-wrapper {
+      margin-left: auto;
+      order: 2;
+    }
+
+    .chartable-icon {
+      display: block;
+      background: url("../images/layers/charting/charting_icon_filled.svg");
+      width: 18px;
+      height: 18px;
+      margin: 4px;
+    }
   }
 
   &.unavailable {


### PR DESCRIPTION
## Description
This change adds the "Chartable" icon (indicating that a product can be charted with Charting Mode) to the Categories view in the Product Picker. The icon is only shown on products that can be charted. Hovering the icon shows some info about charting the product.

## How To Test
1. `git checkout wv-3857-categories-charting-icon`
2. `npm ci`
4. `npm run watch`
5. Open a fresh instance of Worldview
6. Click the Add Layers button, then click into any category (like Aerosol Index)
7. Verify that chartable products have the charting icon present, and that hovering that icon shows the info text correctly
8. Verify that products that are not chartable do not have the icon present