### PR TITLE
WV-3534 Consolidate CMR Requests

### DIFF
--- a/web/js/components/layer/settings/imagery-search.js
+++ b/web/js/components/layer/settings/imagery-search.js
@@ -5,6 +5,8 @@ import {
 } from 'reactstrap';
 import PropTypes from 'prop-types';
 import { selectDate as selectDateAction } from '../../../modules/date/actions';
+import { getBaseCmrUrl } from '../../../modules/smart-handoff/selectors';
+import { buildGranulesUrl, cmrFetch } from '../../../util/cmr';
 
 const dateOptions = {
   year: 'numeric',
@@ -14,7 +16,6 @@ const dateOptions = {
 };
 const parseGranuleTimestamp = (granule) => new Date(granule.time_start);
 const maxExtent = [-180, -90, 180, 90];
-const headers = { 'Client-Id': 'Worldview' };
 
 export default function ImagerySearch({ layer }) {
   const listRef = useRef(null);
@@ -25,6 +26,7 @@ export default function ImagerySearch({ layer }) {
   const date = useSelector((state) => state.date);
   const compare = useSelector((state) => state.compare);
   const map = useSelector((state) => state.map);
+  const cmrBaseUrl = useSelector(getBaseCmrUrl);
   const [granulesStartStatus, setGranulesStartStatus] = useState(undefined);
   const [granulesEndStatus, setGranulesEndStatus] = useState(undefined);
   const [olderGranuleDates, setOlderGranuleDates] = useState([]);
@@ -63,8 +65,15 @@ export default function ImagerySearch({ layer }) {
   const getOlderGranules = async (layerArg, refDate = selectedDate, pageNum = 1) => {
     const smallerExtent = getSmallerExtent();
     try {
-      const olderUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=,${refDate.toISOString()}&sort_key=-start_date&pageSize=25&page_num=${pageNum}`;
-      const olderResponse = await fetch(olderUrl, { headers });
+      const olderUrl = buildGranulesUrl(cmrBaseUrl, {
+        conceptId: conceptID,
+        bbox: smallerExtent.join(','),
+        temporal: `,${refDate.toISOString()}`,
+        sortKey: '-start_date',
+        pageSize: 25,
+        pageNum,
+      });
+      const olderResponse = await cmrFetch(olderUrl);
       const olderGranules = await olderResponse.json();
       const olderDates = olderGranules.feed.entry.map(parseGranuleTimestamp);
 
@@ -77,8 +86,15 @@ export default function ImagerySearch({ layer }) {
   const getNewerGranules = async (layerArg, refDate = selectedDate, pageNum = 1) => {
     const smallerExtent = getSmallerExtent();
     try {
-      const newerUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${smallerExtent.join(',')}&temporal=${refDate.toISOString()},&sort_key=start_date&pageSize=25&page_num=${pageNum}`;
-      const newerResponse = await fetch(newerUrl, { headers });
+      const newerUrl = buildGranulesUrl(cmrBaseUrl, {
+        conceptId: conceptID,
+        bbox: smallerExtent.join(','),
+        temporal: `${refDate.toISOString()},`,
+        sortKey: 'start_date',
+        pageSize: 25,
+        pageNum,
+      });
+      const newerResponse = await cmrFetch(newerUrl);
       const newerGranules = await newerResponse.json();
       const newerDates = newerGranules.feed.entry.map(parseGranuleTimestamp);
 

--- a/web/js/components/smart-handoffs/granule-count.js
+++ b/web/js/components/smart-handoffs/granule-count.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { get as lodashGet } from 'lodash';
 import PropTypes from 'prop-types';
+import { cmrFetch } from '../../util/cmr';
 
 export default function GranuleCount (props) {
   const {
@@ -28,7 +29,7 @@ export default function GranuleCount (props) {
   } = state;
 
   const requestGranules = async (url) => {
-    const granulesResponse = await fetch(url, { timeout: 5000 });
+    const granulesResponse = await cmrFetch(url);
     const result = await granulesResponse.json();
     return lodashGet(result, 'feed.entry', []);
   };

--- a/web/js/components/timeline/timeline-axis/timeline-axis.js
+++ b/web/js/components/timeline/timeline-axis/timeline-axis.js
@@ -1434,6 +1434,7 @@ class TimelineAxis extends Component {
     const {
       addGranuleDateRanges,
       describeDomainsUrl,
+      cmrBaseUrl,
     } = this.props;
     const {
       cmrAvailability,
@@ -1448,7 +1449,7 @@ class TimelineAxis extends Component {
         addGranuleDateRanges(def, event.data);
       };
       worker.onerror = () => worker.terminate();
-      worker.postMessage({ operation: 'getLayerGranuleRanges', args: [def] });
+      worker.postMessage({ operation: 'getLayerGranuleRanges', args: [def], cmrBaseUrl });
     }
     // if opted in to DescribeDomains availability, get granule date ranges if needed
     if (dataAvailability === 'dd') {
@@ -1715,6 +1716,7 @@ TimelineAxis.propTypes = {
   updatePositioningOnSimpleDrag: PropTypes.func,
   updateTimelineMoveAndDrag: PropTypes.func,
   describeDomainsUrl: PropTypes.string,
+  cmrBaseUrl: PropTypes.string,
 };
 
 export default TimelineAxis;

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -954,4 +954,5 @@ LayerRow.propTypes = {
   map: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf(['null'])]),
   selectedDate: PropTypes.instanceOf(Date),
   describeDomainsUrl: PropTypes.string,
+  cmrBaseUrl: PropTypes.string,
 };

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -13,6 +13,7 @@ import { faCircleDot, faCircle } from '@fortawesome/free-solid-svg-icons';
 import googleTagManager from 'googleTagManager';
 import PaletteLegend from '../../components/sidebar/paletteLegend';
 import util from '../../util/util';
+import { buildGranulesUrl, cmrFetch } from '../../util/cmr';
 import {
   getPalette as getPaletteSelector,
   getPaletteLegends,
@@ -104,6 +105,7 @@ function LayerRow (props) {
     map,
     selectedDate,
     describeDomainsUrl,
+    cmrBaseUrl,
   } = props;
 
   const encodedLayerId = util.encodeId(layer.id);
@@ -171,10 +173,21 @@ function LayerRow (props) {
           }
           return maxExtent[i];
         });
-        const olderUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${extent.join(',')}&temporal=P0Y0M0DT0H0M/${zeroedDate}&sort_key=-start_date&pageSize=1`;
-        const newerUrl = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${extent.join(',')}&temporal=${zeroedDate}/P0Y0M1DT0H0M&sort_key=-start_date&pageSize=1`;
-        const headers = { 'Client-Id': 'Worldview' };
-        const requests = [fetch(olderUrl, { headers }), fetch(newerUrl, { headers })];
+        const olderUrl = buildGranulesUrl(cmrBaseUrl, {
+          conceptId: conceptID,
+          bbox: extent.join(','),
+          temporal: `P0Y0M0DT0H0M/${zeroedDate}`,
+          sortKey: '-start_date',
+          pageSize: 1,
+        });
+        const newerUrl = buildGranulesUrl(cmrBaseUrl, {
+          conceptId: conceptID,
+          bbox: extent.join(','),
+          temporal: `${zeroedDate}/P0Y0M1DT0H0M`,
+          sortKey: '-start_date',
+          pageSize: 1,
+        });
+        const requests = [cmrFetch(olderUrl), cmrFetch(newerUrl)];
         const responses = await Promise.allSettled(requests);
         const [olderRes, newerRes] = responses.filter(({ status }) => status === 'fulfilled').map(({ value }) => value);
         if (!olderRes.ok || !newerRes.ok) return;
@@ -762,6 +775,7 @@ const makeMapStateToProps = () => {
     const measurementDescriptionPath = getDescriptionPath(state, ownProps);
     const { ddvZoomAlerts, ddvLocationAlerts } = state.alerts;
     const describeDomainsUrl = config?.features?.describeDomains?.url || 'https://gibs.earthdata.nasa.gov';
+    const cmrBaseUrl = config?.features?.cmr?.url;
 
     return {
       compare,
@@ -790,6 +804,7 @@ const makeMapStateToProps = () => {
       selectedDate,
       renderedPalette: renderedPalettes[paletteName],
       describeDomainsUrl,
+      cmrBaseUrl,
     };
   };
 };

--- a/web/js/containers/timeline/timeline.js
+++ b/web/js/containers/timeline/timeline.js
@@ -1225,6 +1225,7 @@ class Timeline extends React.Component {
       toggleActiveCompareState,
       proj,
       describeDomainsUrl,
+      cmrBaseUrl,
     } = this.props;
     const {
       animationEndLocation,
@@ -1390,6 +1391,7 @@ class Timeline extends React.Component {
                           matchingTimelineCoverage={matchingTimelineCoverage}
                           proj={proj}
                           describeDomainsUrl={describeDomainsUrl}
+                          cmrBaseUrl={cmrBaseUrl}
                         />
 
                         <AxisHoverLine
@@ -1659,6 +1661,7 @@ function mapStateToProps(state) {
     appNow,
   );
   const describeDomainsUrl = config?.features?.describeDomains?.url || 'https://gibs.earthdata.nasa.gov';
+  const cmrBaseUrl = config?.features?.cmr?.url;
 
   return {
     appNow,
@@ -1723,6 +1726,7 @@ function mapStateToProps(state) {
     newCustomDelta,
     proj: proj.selected,
     describeDomainsUrl,
+    cmrBaseUrl,
   };
 }
 
@@ -1865,4 +1869,5 @@ Timeline.propTypes = {
   updateAppNow: PropTypes.func,
   proj: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf(['null'])]),
   describeDomainsUrl: PropTypes.string,
+  cmrBaseUrl: PropTypes.string,
 };

--- a/web/js/map/granule/granule-layer-builder.js
+++ b/web/js/map/granule/granule-layer-builder.js
@@ -22,19 +22,15 @@ import {
   transformGranulesForProj,
 } from './util';
 import util from '../../util/util';
+import { cmrFetch } from '../../util/cmr';
 
 const { toISOStringSeconds } = util;
 
+const CMR_ERROR_DIALOG_THROTTLE_MS = 30 * 1000;
+
 export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
-  const getGranuleUrl = getGranulesUrlSelector(store.getState());
-  const baseGranuleUrl = getGranuleUrl();
-  const CMR_AJAX_OPTIONS = {
-    url: baseGranuleUrl,
+  const CMR_FETCH_OPTIONS = {
     cache: 'force-cache',
-    headers: { 'Client-Id': 'Worldview' },
-    traditional: true,
-    dataType: 'json',
-    timeout: 30 * 1000,
   };
 
   function dispathCMRErrorDialog (title) {
@@ -47,7 +43,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
 
   const throttleDispathCMRErrorDialog = lodashThrottle(
     dispathCMRErrorDialog.bind(this),
-    CMR_AJAX_OPTIONS.timeout,
+    CMR_ERROR_DIALOG_THROTTLE_MS,
     { leading: true, trailing: false },
   );
 
@@ -80,7 +76,7 @@ export default function granuleLayerBuilder(cache, store, createLayerWMTS) {
       showLoading();
       const promises = paramsArray.map((params) => {
         const requestUrl = getGranulesUrl(params);
-        return fetch(requestUrl, CMR_AJAX_OPTIONS);
+        return cmrFetch(requestUrl, CMR_FETCH_OPTIONS);
       });
       const responses = await Promise.allSettled(promises);
       const fulfilledResponses = responses.filter(({ status }) => status === 'fulfilled').map(({ value }) => value);

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -24,6 +24,7 @@ import lodashGet from 'lodash/get';
 import lodashCloneDeep from 'lodash/cloneDeep';
 import { applyBackground, applyStyle as olmsApplyStyle } from 'ol-mapbox-style';
 import util from '../util/util';
+import { buildGranulesUrl, cmrSearchAfterFetch } from '../util/cmr';
 import lookupFactory from '../ol/lookupimagetile';
 import granuleLayerBuilder from './granule/granule-layer-builder';
 import {
@@ -954,30 +955,15 @@ export default function mapLayerBuilder(config, cache, store) {
           }
           return cmrMaxExtent[i];
         });
-        const getGranules = () => {
-          const entries = [];
-          return async function requestGranules(searchAfter) {
-            const headers = {
-              'Client-Id': 'Worldview',
-            };
-            headers['cmr-search-after'] = searchAfter ?? '';
-            const url = `https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=${conceptID}&bounding_box=${clampedExtent.join(',')}&temporal=${zeroedDate}/P0Y0M1DT0H0M&pageSize=2000`;
-            const cmrRes = await fetch(url, { headers });
-            const resHeaders = cmrRes.headers;
-            const granules = await cmrRes.json();
-            const resEntries = granules?.feed?.entry || [];
-
-            entries.push(...resEntries);
-
-            if (resHeaders.has('cmr-search-after')) {
-              await requestGranules(resHeaders.get('cmr-search-after'));
-            }
-            return entries;
-          };
-        };
-
-        const granuleGetter = getGranules();
-        const granules = await granuleGetter();
+        const { config: stateConfig } = store.getState();
+        const cmrBaseUrl = stateConfig?.features?.cmr?.url;
+        const granuleUrl = buildGranulesUrl(cmrBaseUrl, {
+          conceptId: conceptID,
+          bbox: clampedExtent.join(','),
+          temporal: `${zeroedDate}/P0Y0M1DT0H0M`,
+          pageSize: 2000,
+        });
+        const { entries: granules } = await cmrSearchAfterFetch(granuleUrl);
 
         const features = granules.map((granule) => {
           const coords = granule.polygons[0][0].split(' ').reduce((acc, coord, i, arr) => {

--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -282,24 +282,3 @@ export function extractDateFromTileErrorURL(url) {
   return null;
 }
 
-/**
- * @method getLayerGranuleRanges
- * @param {object} layer
- * @returns {array} granuleDateRanges
- * @description
- * Get granule date ranges for a given layer
-*/
-export function getLayerGranuleRanges(layer) {
-  const worker = new Worker('js/workers/cmr.worker.js');
-  return new Promise((resolve, reject) => {
-    worker.onmessage = (event) => {
-      resolve(event.data);
-      worker.terminate();
-    };
-    worker.onerror = (error) => {
-      reject(error);
-      worker.terminate();
-    };
-    worker.postMessage({ funcName: 'getLayerGranuleRanges', args: [layer] });
-  });
-}

--- a/web/js/map/util.js
+++ b/web/js/map/util.js
@@ -281,4 +281,3 @@ export function extractDateFromTileErrorURL(url) {
   console.error('Date not found in the URL.');
   return null;
 }
-

--- a/web/js/modules/smart-handoff/actions.js
+++ b/web/js/modules/smart-handoff/actions.js
@@ -5,6 +5,7 @@ import {
   SET_VALID_LAYERS_CONCEPTIDS,
 } from './constants';
 import { getCollectionsUrl, getConceptUrl } from './selectors';
+import { cmrFetch } from '../../util/cmr';
 
 export function selectCollection(conceptId, layerId) {
   return {
@@ -23,7 +24,7 @@ export function fetchAvailableTools() {
       const { smartHandoffs } = state.config.features;
       availableTools = await Promise.all(smartHandoffs.map(async (tool) => {
         const url = getConceptUrl(state)(tool.conceptId);
-        const response = await fetch(url, { timeout: 5000 });
+        const response = await cmrFetch(url);
         const result = await response.json();
         return {
           name: tool.toolName,
@@ -52,7 +53,7 @@ export function validateLayersConceptIds (layers) {
 
     try {
       const conceptIdRequest = async (url) => {
-        const granulesResponse = await fetch(url, { timeout: 5000 });
+        const granulesResponse = await cmrFetch(url);
         const result = await granulesResponse.json();
         return lodashGet(result, 'feed.entry', []);
       };

--- a/web/js/modules/smart-handoff/selectors.js
+++ b/web/js/modules/smart-handoff/selectors.js
@@ -1,44 +1,21 @@
 import { getActiveLayers, memoizedAvailable } from '../layers/selectors';
-import util from '../../util/util';
+import { buildGranulesUrl, buildCollectionsUrl, buildConceptUrl } from '../../util/cmr';
 
-const getBaseCmrUrl = ({ config: { features: { cmr } } }) => cmr.url;
+export const getBaseCmrUrl = ({ config: { features: { cmr } } }) => cmr.url;
 
-// e.g. https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=C2185522599-LANCEMODIS&pageSize=500&temporal=2022-03-28T00%3A00%3A00.000Z%2C2022-03-28T23%3A59%3A59.999Z
 export const getGranulesUrl = (state) => {
   const baseUrl = getBaseCmrUrl(state);
-  return (params = {}) => {
-    const getTemporal = () => {
-      if (params.startDate && params.endDate) {
-        return `${params.startDate},${params.endDate}`;
-      }
-      return undefined;
-    };
-    const newParams = {
-      bounding_box: params.bbox,
-      collection_concept_id: params.conceptId,
-      shortName: params.shortName,
-      day_night_flag: params.dayNight,
-      temporal: getTemporal(),
-      pageSize: params.pageSize,
-    };
-    const queryString = util.toQueryString(newParams);
-    return `${baseUrl}granules.json${queryString}`;
-  };
+  return (params = {}) => buildGranulesUrl(baseUrl, params);
 };
 
-// e.g. https://cmr.earthdata.nasa.gov/search/collections.json?concept_id=C2208779826-LANCEMODIS
 export const getCollectionsUrl = (state) => {
   const baseUrl = getBaseCmrUrl(state);
-  return (id) => {
-    const params = { concept_id: id };
-    return `${baseUrl}collections.json${util.toQueryString(params)}`;
-  };
+  return (id) => buildCollectionsUrl(baseUrl, id);
 };
 
-// e.g. https://cmr.earthdata.nasa.gov/search/concepts/C2208779826-LANCEMODIS.html
 export const getConceptUrl = (state) => {
   const baseUrl = getBaseCmrUrl(state);
-  return (id) => `${baseUrl}concepts/${id}`;
+  return (id) => buildConceptUrl(baseUrl, id);
 };
 
 /**

--- a/web/js/util/cmr.js
+++ b/web/js/util/cmr.js
@@ -1,0 +1,91 @@
+import util from './util';
+
+export const CMR_CLIENT_ID = 'Worldview';
+
+export const CMR_REQUEST_OPTIONS = {
+  headers: { 'Client-Id': CMR_CLIENT_ID },
+};
+
+/**
+ * Fetch wrapper that automatically includes the CMR Client-Id header.
+ * Returns the raw Response object so callers can handle parsing.
+ */
+export async function cmrFetch(url, options = {}) {
+  const { headers: extraHeaders, ...restOptions } = options;
+  const headers = {
+    ...CMR_REQUEST_OPTIONS.headers,
+    ...extraHeaders,
+  };
+  return fetch(url, { ...restOptions, headers });
+}
+
+/**
+ * Fetch all pages of CMR results using Cmr-Search-After pagination.
+ * Returns { entries, hits }.
+ */
+export async function cmrSearchAfterFetch(url, options = {}) {
+  const entries = [];
+  let hits = Infinity;
+  let searchAfter = false;
+
+  do {
+    const headers = searchAfter
+      ? { 'Cmr-Search-After': searchAfter }
+      : {};
+    const res = await cmrFetch(url, { ...options, headers: { ...options.headers, ...headers } });
+    searchAfter = res.headers.get('Cmr-Search-After');
+    hits = parseInt(res.headers.get('Cmr-Hits'), 10);
+    const data = await res.json();
+    entries.push(...(data.feed?.entry || []));
+  } while (searchAfter || hits > entries.length);
+
+  return { entries, hits };
+}
+
+/**
+ * Build a CMR granules search URL.
+ * @param {string} baseUrl - CMR base URL (e.g. from features.cmr.url)
+ * @param {object} params - Query parameters
+ */
+export function buildGranulesUrl(baseUrl, params = {}) {
+  const getTemporal = () => {
+    if (params.startDate && params.endDate) {
+      return `${params.startDate},${params.endDate}`;
+    }
+    if (params.temporal) {
+      return params.temporal;
+    }
+    return undefined;
+  };
+  const queryParams = {
+    bounding_box: params.bbox,
+    collection_concept_id: params.conceptId,
+    shortName: params.shortName,
+    day_night_flag: params.dayNight,
+    temporal: getTemporal(),
+    pageSize: params.pageSize,
+    sort_key: params.sortKey,
+    page_num: params.pageNum,
+  };
+  const queryString = util.toQueryString(queryParams);
+  return `${baseUrl}granules.json${queryString}`;
+}
+
+/**
+ * Build a CMR collections search URL.
+ * @param {string} baseUrl - CMR base URL
+ * @param {string} conceptId - Collection concept ID
+ */
+export function buildCollectionsUrl(baseUrl, conceptId) {
+  const params = { concept_id: conceptId };
+  return `${baseUrl}collections.json${util.toQueryString(params)}`;
+}
+
+/**
+ * Build a CMR concept URL.
+ * @param {string} baseUrl - CMR base URL
+ * @param {string} conceptId - Concept ID
+ */
+export function buildConceptUrl(baseUrl, conceptId) {
+  return `${baseUrl}concepts/${conceptId}`;
+}

--- a/web/js/util/cmr.test.js
+++ b/web/js/util/cmr.test.js
@@ -1,0 +1,158 @@
+import {
+  cmrFetch,
+  cmrSearchAfterFetch,
+  buildGranulesUrl,
+  buildCollectionsUrl,
+  buildConceptUrl,
+  CMR_CLIENT_ID,
+} from './cmr';
+
+beforeEach(() => {
+  fetch.resetMocks();
+  fetch.mockResponse(JSON.stringify({ feed: { entry: [] } }), {
+    headers: { 'Cmr-Hits': '0' },
+  });
+});
+
+describe('cmrFetch', () => {
+  test('includes Client-Id header', async () => {
+    await cmrFetch('https://cmr.earthdata.nasa.gov/search/granules.json');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers['Client-Id']).toBe(CMR_CLIENT_ID);
+  });
+
+  test('merges additional headers', async () => {
+    await cmrFetch('https://cmr.earthdata.nasa.gov/search/granules.json', {
+      headers: { 'Cmr-Search-After': 'abc123' },
+    });
+    const [, options] = fetch.mock.calls[0];
+    expect(options.headers['Client-Id']).toBe(CMR_CLIENT_ID);
+    expect(options.headers['Cmr-Search-After']).toBe('abc123');
+  });
+
+  test('passes through cache option', async () => {
+    await cmrFetch('https://cmr.earthdata.nasa.gov/search/granules.json', {
+      cache: 'force-cache',
+    });
+    const [, options] = fetch.mock.calls[0];
+    expect(options.cache).toBe('force-cache');
+  });
+
+  test('returns the Response object', async () => {
+    const response = await cmrFetch('https://cmr.earthdata.nasa.gov/search/granules.json');
+    expect(response).toBeDefined();
+    const data = await response.json();
+    expect(data.feed.entry).toEqual([]);
+  });
+});
+
+describe('cmrSearchAfterFetch', () => {
+  test('returns entries from single page', async () => {
+    const entries = [{ id: '1', time_start: '2024-01-01' }];
+    fetch.mockResponseOnce(JSON.stringify({ feed: { entry: entries } }), {
+      headers: { 'Cmr-Hits': '1' },
+    });
+
+    const result = await cmrSearchAfterFetch('https://cmr.earthdata.nasa.gov/search/granules.json');
+    expect(result.entries).toEqual(entries);
+    expect(result.hits).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('paginates using Cmr-Search-After header', async () => {
+    const page1 = [{ id: '1' }, { id: '2' }];
+    const page2 = [{ id: '3' }];
+
+    fetch.mockResponseOnce(JSON.stringify({ feed: { entry: page1 } }), {
+      headers: { 'Cmr-Hits': '3', 'Cmr-Search-After': 'token123' },
+    });
+    fetch.mockResponseOnce(JSON.stringify({ feed: { entry: page2 } }), {
+      headers: { 'Cmr-Hits': '3' },
+    });
+
+    const result = await cmrSearchAfterFetch('https://cmr.earthdata.nasa.gov/search/granules.json');
+    expect(result.entries).toEqual([...page1, ...page2]);
+    expect(result.hits).toBe(3);
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    const [, secondCallOptions] = fetch.mock.calls[1];
+    expect(secondCallOptions.headers['Cmr-Search-After']).toBe('token123');
+  });
+
+  test('terminates when no more entries', async () => {
+    fetch.mockResponseOnce(JSON.stringify({ feed: { entry: [] } }), {
+      headers: { 'Cmr-Hits': '0' },
+    });
+
+    const result = await cmrSearchAfterFetch('https://cmr.earthdata.nasa.gov/search/granules.json');
+    expect(result.entries).toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildGranulesUrl', () => {
+  const baseUrl = 'https://cmr.earthdata.nasa.gov/search/';
+
+  test('builds URL with conceptId and pageSize', () => {
+    const url = buildGranulesUrl(baseUrl, {
+      conceptId: 'C123-PROVIDER',
+      pageSize: 500,
+    });
+    expect(url).toContain('granules.json');
+    expect(url).toContain('collection_concept_id=C123-PROVIDER');
+    expect(url).toContain('pageSize=500');
+  });
+
+  test('builds URL with temporal from startDate and endDate', () => {
+    const url = buildGranulesUrl(baseUrl, {
+      startDate: '2024-01-01T00:00:00Z',
+      endDate: '2024-01-02T00:00:00Z',
+    });
+    expect(url).toContain('temporal=2024-01-01T00%3A00%3A00Z%2C2024-01-02T00%3A00%3A00Z');
+  });
+
+  test('builds URL with raw temporal param', () => {
+    const url = buildGranulesUrl(baseUrl, {
+      temporal: 'P0Y0M0DT0H0M/2024-01-01T00:00:00Z',
+    });
+    expect(url).toContain('temporal=P0Y0M0DT0H0M');
+  });
+
+  test('builds URL with bbox', () => {
+    const url = buildGranulesUrl(baseUrl, {
+      bbox: '-180,-90,180,90',
+    });
+    expect(url).toContain('bounding_box=-180%2C-90%2C180%2C90');
+  });
+
+  test('builds URL with sortKey and pageNum', () => {
+    const url = buildGranulesUrl(baseUrl, {
+      sortKey: '-start_date',
+      pageNum: 2,
+    });
+    expect(url).toContain('sort_key=-start_date');
+    expect(url).toContain('page_num=2');
+  });
+
+  test('omits undefined params', () => {
+    const url = buildGranulesUrl(baseUrl, { pageSize: 100 });
+    expect(url).not.toContain('bounding_box');
+    expect(url).not.toContain('shortName');
+    expect(url).not.toContain('temporal');
+  });
+});
+
+describe('buildCollectionsUrl', () => {
+  test('builds collections URL with concept_id', () => {
+    const url = buildCollectionsUrl('https://cmr.earthdata.nasa.gov/search/', 'C123-PROVIDER');
+    expect(url).toBe('https://cmr.earthdata.nasa.gov/search/collections.json?concept_id=C123-PROVIDER');
+  });
+});
+
+describe('buildConceptUrl', () => {
+  test('builds concept URL', () => {
+    const url = buildConceptUrl('https://cmr.earthdata.nasa.gov/search/', 'C123-PROVIDER');
+    expect(url).toBe('https://cmr.earthdata.nasa.gov/search/concepts/C123-PROVIDER');
+  });
+});

--- a/web/js/workers/cmr.worker.js
+++ b/web/js/workers/cmr.worker.js
@@ -1,6 +1,5 @@
 // NOTE: This worker runs as a standalone script (not bundled via webpack),
 // so it cannot import from util/cmr.js. These constants mirror those in util/cmr.js.
-const CMR_BASE_URL = 'https://cmr.earthdata.nasa.gov/search/';
 const CMR_CLIENT_ID = 'Worldview';
 
 /**
@@ -53,7 +52,7 @@ function mergeSortedGranuleDateRanges(granules) {
  * @description
  * Request granules from CMR
 */
-async function requestGranules(params) {
+async function requestGranules(params, cmrBaseUrl) {
   const {
     shortName,
     extent,
@@ -63,8 +62,8 @@ async function requestGranules(params) {
   const granules = [];
   let hits = Infinity;
   let searchAfter = false;
-  const url = `${CMR_BASE_URL}granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
-  do { // run the query at least once
+  const url = `${cmrBaseUrl}granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
+  do {
     const headers = { 'Client-Id': CMR_CLIENT_ID };
     if (searchAfter) headers['Cmr-Search-After'] = searchAfter;
     const res = await fetch(url, { headers });
@@ -72,7 +71,7 @@ async function requestGranules(params) {
     hits = parseInt(res.headers.get('Cmr-Hits'), 10);
     const data = await res.json();
     granules.push(...data.feed.entry);
-  } while (searchAfter || hits > granules.length); // searchAfter will not be present if there are no more results https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after
+  } while (searchAfter || hits > granules.length);
 
   return granules;
 }
@@ -84,7 +83,7 @@ async function requestGranules(params) {
  * @description
  * Get granule date ranges for a given layer
 */
-async function getLayerGranuleRanges(layer) {
+async function getLayerGranuleRanges(layer, cmrBaseUrl) {
   const extent = [-180, -90, 180, 90];
   const startDate = new Date(layer.startDate).toISOString();
   const endDate = layer.endDate ? new Date(layer.endDate).toISOString() : new Date().toISOString();
@@ -95,9 +94,9 @@ async function getLayerGranuleRanges(layer) {
     startDate,
     endDate,
   };
-  const nrtGranules = await requestGranules(nrtParams);
+  const nrtGranules = await requestGranules(nrtParams, cmrBaseUrl);
   let nonNRTGranules = [];
-  if (shortName.includes('_NRT')) { // if NRT, also get non-NRT granules
+  if (shortName.includes('_NRT')) {
     const nonNRTShortName = shortName.replace('_NRT', '');
     const nonNRTParams = {
       shortName: nonNRTShortName,
@@ -105,7 +104,7 @@ async function getLayerGranuleRanges(layer) {
       startDate,
       endDate,
     };
-    nonNRTGranules = await requestGranules(nonNRTParams);
+    nonNRTGranules = await requestGranules(nonNRTParams, cmrBaseUrl);
   }
   const granules = [...nonNRTGranules, ...nrtGranules];
   const granuleDateRanges = granules.map(({
@@ -123,7 +122,7 @@ const functions = {
 };
 
 onmessage = async (event) => {
-  const { data } = event;
-  const result = await functions[data.operation]?.(...data.args);
+  const { operation, args, cmrBaseUrl } = event.data;
+  const result = await functions[operation]?.(args[0], cmrBaseUrl);
   postMessage(result);
 };

--- a/web/js/workers/cmr.worker.js
+++ b/web/js/workers/cmr.worker.js
@@ -1,3 +1,8 @@
+// NOTE: This worker runs as a standalone script (not bundled via webpack),
+// so it cannot import from util/cmr.js. These constants mirror those in util/cmr.js.
+const CMR_BASE_URL = 'https://cmr.earthdata.nasa.gov/search/';
+const CMR_CLIENT_ID = 'Worldview';
+
 /**
  * @method makeTime
  * @param {string} date
@@ -58,9 +63,10 @@ async function requestGranules(params) {
   const granules = [];
   let hits = Infinity;
   let searchAfter = false;
-  const url = `https://cmr.earthdata.nasa.gov/search/granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
+  const url = `${CMR_BASE_URL}granules.json?shortName=${shortName}&bounding_box=${extent.join(',')}&temporal=${startDate}/${endDate}&sort_key=start_date&pageSize=2000`;
   do { // run the query at least once
-    const headers = searchAfter ? { 'Cmr-Search-After': searchAfter, 'Client-Id': 'Worldview' } : { 'Client-Id': 'Worldview' };
+    const headers = { 'Client-Id': CMR_CLIENT_ID };
+    if (searchAfter) headers['Cmr-Search-After'] = searchAfter;
     const res = await fetch(url, { headers });
     searchAfter = res.headers.get('Cmr-Search-After');
     hits = parseInt(res.headers.get('Cmr-Hits'), 10);


### PR DESCRIPTION
## Description

Fixes WV-3534.

Consolidate how we make CMR requests. All CMR request implementations were scattered across the codebase with duplicated fetch logic, hardcoded URLs, and inline header management. This PR creates a shared CMR utility and refactors all consumers to use it, so future changes to CMR request behavior only need to happen in one place.

## How To Test

Run `npm run watch`.

1. Add a VIIRS granule layer (e.g., Granule Corrected Reflectance (True Color) *BETA*) and verify granules render on the map
2. Verify the timeline axis displays correctly with coverage data
3. Open a granule layer's settings panel and use the imagery search — verify granule dates load
