### PR TITLE
WV-3863: Show animation controls when aa=true outside EIC mode

### DIFF
--- a/web/js/containers/animation-widget/animation-widget.js
+++ b/web/js/containers/animation-widget/animation-widget.js
@@ -269,7 +269,6 @@ function AnimationWidget (props) {
   const renderDesktopAnimationWidget = (
     <DesktopAnimationWidget
       animationCustomModalOpen={animationCustomModalOpen}
-      autoplay={autoplay}
       customModalType={customModalType}
       isDistractionFreeModeActive={isDistractionFreeModeActive}
       endDate={endDate}

--- a/web/js/containers/animation-widget/desktop-animation-widget.js
+++ b/web/js/containers/animation-widget/desktop-animation-widget.js
@@ -13,7 +13,6 @@ function DesktopAnimationWidget(props) {
   const nodeRef = useRef(null);
   const {
     animationCustomModalOpen,
-    autoplay,
     customModalType,
     endDate,
     handleDragStart,
@@ -50,7 +49,7 @@ function DesktopAnimationWidget(props) {
     onSlide(speed);
   };
 
-  const hideWidget = autoplay || isDistractionFreeModeActive ? 'd-none' : '';
+  const hideWidget = isDistractionFreeModeActive ? 'd-none' : '';
 
   return (
     <Draggable
@@ -137,7 +136,6 @@ function DesktopAnimationWidget(props) {
 
 DesktopAnimationWidget.propTypes = {
   animationCustomModalOpen: PropTypes.bool,
-  autoplay: PropTypes.bool,
   customModalType: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf(['null'])]),
   endDate: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf(['null'])]),
   handleDragStart: PropTypes.func,


### PR DESCRIPTION
## Summary
When using `aa=true` in a URL, the animation controls were being hidden because that parameter was originally added for EIC mode. Since EIC already hides controls through distraction-free mode (`df=true`), we just removed the extra autoplay check so the controls show up normally for non-EIC users.

## Test Plan
- [ ] Animation autoplays with controls visible:
  `http://localhost:3000/?aa=true&ab=on&as=2024-01-01&ae=2024-01-10&l=MODIS_Terra_CorrectedReflectance_TrueColor`
- [ ] Controls stay hidden in EIC mode:
  `http://localhost:3000/?aa=true&ab=on&as=2024-01-01&ae=2024-01-10&df=true&kiosk=true&eic=da&l=MODIS_Terra_CorrectedReflectance_TrueColor`
- [ ] Normal animation without `aa` works as before:
  `http://localhost:3000/?ab=on&as=2024-01-01&ae=2024-01-10&l=MODIS_Terra_CorrectedReflectance_TrueColor`