### PR TITLE
WV-3737: Updated Spinner Styling

### DIFF
--- a/web/js/components/map/loading-spinner.js
+++ b/web/js/components/map/loading-spinner.js
@@ -2,7 +2,6 @@ import { Spinner } from 'reactstrap';
 import { useSelector } from 'react-redux';
 
 function LoadingIndicator() {
-  const msg = useSelector((state) => state.loading.msg);
   const isMobile = useSelector((state) => state.screenSize.isMobileDevice);
   const isLoading = useSelector((state) => state.loading.isLoading);
   const isKioskModeActive = useSelector((state) => state.ui.isKioskModeActive);
@@ -14,18 +13,32 @@ function LoadingIndicator() {
       top: 10,
       left: 80,
       zIndex: 999,
+      backgroundColor: 'rgb(40 40 40 / 85%)',
+      padding: 10,
+      borderRadius: 5,
+      display: 'flex',
+      alignItems: 'center',
     }
     : {
       position: 'absolute',
       top: 10,
-      left: 300,
+      left: 310,
       zIndex: 999,
+      backgroundColor: 'rgb(40 40 40 / 85%)',
+      padding: 10,
+      borderRadius: 5,
+      display: 'flex',
+      alignItems: 'center',
     };
+
+  const innerSpinnerStyle = {
+    height: '1.75rem',
+    width: '1.75rem',
+  };
 
   return shouldSpinnerShow && (
     <div style={spinnerStyle}>
-      <Spinner color="light" size="sm" />
-      {msg}
+      <Spinner color="light" size="sm" style={innerSpinnerStyle} />
     </div>
   );
 }


### PR DESCRIPTION
## Description
This change updates the style of the loading spinner to make it more visible and obvious.

## How To Test
1. `git checkout wv-3737-updated-spinner`
2. `npm ci`
4. `npm run watch`
5. Open a fresh instance of Worldview
6. Add layers to the map, change the timeline, and observe the loading spinner that appears next to the layer list
7. Verify the loading spinner has the correct design