### PR TITLE
WV-4073: Fix place labels disappearing at fractional zoom levels

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -1158,7 +1158,7 @@ export default function mapLayerBuilder(config, cache, store) {
     });
 
     if (!vectorStyle.url) {
-      applyStyle(def, layer, state, options);
+      applyStyle(def, layer, state, options, tileGrid.getResolutions());
     } else {
       await olmsApplyStyle(layer, vectorStyle.url, {
         resolutions: tileGrid.getResolutions(),

--- a/web/js/modules/vector-styles/selectors.js
+++ b/web/js/modules/vector-styles/selectors.js
@@ -174,7 +174,7 @@ export function setStyleFunction(opts) {
   if (!map) return undefined;
   const { proj } = state;
   const { selected } = state.vectorStyles;
-  const { resolutions } = proj.selected;
+  const resolutions = opts.resolutions || proj.selected.resolutions;
   const layerId = def.id;
   const styleId = lodashGet(def, `vectorStyle.${proj.id}.id`) || vectorStyleId || lodashGet(def, 'vectorStyle.id') || layerId;
   const customPalette = def.custom;
@@ -315,7 +315,7 @@ export function clearStyleFunction(def, vectorStyleId, vectorStyles, layerObj, s
  * @param {Object} state
  * @param {Object} options
  */
-export const applyStyle = (def, olVectorLayer, state, options) => {
+export const applyStyle = (def, olVectorLayer, state, options, resolutions) => {
   const { config } = state;
   const { vectorStyles } = config;
   const vectorStyleId = def.vectorStyle.id;
@@ -333,6 +333,7 @@ export const applyStyle = (def, olVectorLayer, state, options) => {
     state,
     vectorStyleSource,
     styleSelection: false,
+    ...resolutions && { resolutions },
   };
 
   setStyleFunction(opts);


### PR DESCRIPTION
## Summary
- Place labels disappear at certain fractional zoom levels due to a mismatch between the map view resolutions and the vector tile grid resolutions

## Test plan
- [ ] Open `?v=-90.1,20.6,-89.1,21.2&l=Reference_Labels_15m`
- [ ] Verify labels appear immediately without needing to scroll
- [ ] Zoom smoothly through zoom levels 9-11 and confirm labels remain visible throughout
