### PR TITLE
WV-4068

### DIFF
--- a/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_EarthCARE_Ascending.json
+++ b/config/default/common/config/wv.json/layers/reference/orbits/OrbitTracks_EarthCARE_Ascending.json
@@ -6,7 +6,6 @@
       "group": "overlays",
       "type": "vector",
       "period": "daily",
-      "wrapadjacentdays": true,
       "layergroup": "Orbital Track",
       "track": "ascending",
       "associatedLayers": ["OrbitTracks_EarthCARE_Descending"],


### PR DESCRIPTION
## Description

Fixes # WV-4068

Don't wrap EarthCare Ascending Orbit Tracks

## How To Test

1. Check [production](https://worldview.earthdata.nasa.gov/?v=-388.585550116727,-246.82021614346547,248.83997388543645,184.9359786298749&l=OrbitTracks_EarthCARE_Descending(hidden),OrbitTracks_EarthCARE_Ascending,Land_Water_Map&lg=false&t=2026-05-04-T19%3A32%3A30Z) & notice that EarthCare Orbit Tracks Ascending/Night wrap around the meridians.
2. Run this branch with `git fetch --all && git checkout WV-4068 && npm ci && npm run build && npm run watch`
3. Load the same link at your [localhost](http://localhost:3000/?v=-388.585550116727,-246.82021614346547,248.83997388543645,184.9359786298749&l=OrbitTracks_EarthCARE_Descending(hidden),OrbitTracks_EarthCARE_Ascending,Land_Water_Map&lg=false&t=2026-05-04-T19%3A32%3A30Z).
4. Confirm that EarthCare Orbit Tracks Ascending/Night no longer wrap at the meridians.

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
