### PR TITLE
WV-4033: Convert Sidebar component from class to functional

### DIFF
--- a/web/js/containers/sidebar/sidebar.js
+++ b/web/js/containers/sidebar/sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -39,6 +39,7 @@ import {
 } from '../../modules/sidebar/actions';
 import history from '../../main';
 import safeLocalStorage from '../../util/local-storage';
+import usePrevious from '../../util/customHooks';
 
 const { SIDEBAR_COLLAPSED } = safeLocalStorage.keys;
 
@@ -51,70 +52,54 @@ const getActiveTabs = function(config) {
   };
 };
 
-class Sidebar extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      subComponentHeight: 700,
-      isEventsTabDisabledEmbed: false,
-      sidebarHeight: 0,
-    };
-    this.toggleSidebar = this.toggleSidebar.bind(this);
-    this.renderSidebarLogo = this.renderSidebarLogo.bind(this);
-    this.updateDimensions = this.updateDimensions.bind(this);
-    this.getProductsToRender = this.getProductsToRender.bind(this);
-    this.handleWorldviewLogoClick = this.handleWorldviewLogoClick.bind(this);
-  }
+function Sidebar(props) {
+  const {
+    activeTab,
+    activeString,
+    changeTab,
+    chartingModeAccessible,
+    collapseExpandToggle,
+    config,
+    displayStaticMap,
+    eventsData,
+    eventsSources,
+    hasEventRequestError,
+    isCollapsed,
+    isCompareMode,
+    isChartMode,
+    isDataDisabled,
+    isDistractionFreeModeActive,
+    isEmbedModeActive,
+    isKioskModeActive,
+    isLoadingEvents,
+    isMobile,
+    loadedCustomPalettes,
+    mapIsRendered,
+    numberOfLayers,
+    onTabClick,
+    requestEvents,
+    requestSources,
+    screenHeight,
+    selectedDate,
+    selectedMap,
+    tabTypes,
+  } = props;
 
-  componentDidMount() {
-    const {
-      activeTab,
-      config,
-      isEmbedModeActive,
-      loadedCustomPalettes,
-      requestSources,
-    } = this.props;
-    const customPalettePromise = loadCustomPalette(config);
-    customPalettePromise.then((customs) => {
-      loadedCustomPalettes(customs);
-    });
-    requestSources();
-    this.updateDimensions();
-    // prevent events tab if embed init layers tab
-    if (isEmbedModeActive && activeTab === 'layers') {
-      this.setState({ isEventsTabDisabledEmbed: true });
-    }
-  }
+  const [subComponentHeight, setSubComponentHeight] = useState(700);
+  const [isEventsTabDisabledEmbed, setIsEventsTabDisabledEmbed] = useState(false);
+  const [sidebarHeight, setSidebarHeight] = useState(0);
 
-  componentDidUpdate(prevProps) {
-    const {
-      activeTab, requestEvents, selectedMap, mapIsRendered, eventsData, isLoadingEvents,
-    } = this.props;
-    const {
-      sidebarHeight,
-    } = this.state;
-    const mapChange = mapIsRendered && !lodashEqual(selectedMap, prevProps.selectedMap);
-    const mapRenderedChange = mapIsRendered && mapIsRendered !== prevProps.mapIsRendered;
-    const tabChange = activeTab !== prevProps.activeTab;
-    const firstLoad = tabChange && !isLoadingEvents && (!eventsData || !eventsData.length);
+  const sidebarElementRef = useRef(null);
+  const addLayersElementRef = useRef(null);
+  const footerElementRef = useRef(null);
 
-    if (activeTab === 'events' && (mapRenderedChange || mapChange || firstLoad)) {
-      requestEvents();
-    }
-    this.updateDimensions();
-    const sidebarHeightNew = lodashGet(this, 'sidebarElement.clientHeight');
-    if (sidebarHeightNew !== sidebarHeight) {
-      this.setState({ sidebarHeight: sidebarHeightNew });
-    }
-  }
+  const prevActiveTab = usePrevious(activeTab);
+  const prevSelectedMap = usePrevious(selectedMap);
+  const prevMapIsRendered = usePrevious(mapIsRendered);
 
-  updateDimensions() {
-    const { subComponentHeight } = this.state;
-    const {
-      isMobile, screenHeight, isCompareMode, isChartMode,
-    } = this.props;
-    const footerHeight = lodashGet(this, 'footerElement.clientHeight') || 20;
-    const addLayersHeight = lodashGet(this, 'addLayersElement.clientHeight') || 30;
+  function updateDimensions() {
+    const footerHeight = lodashGet(footerElementRef, 'current.clientHeight') || 20;
+    const addLayersHeight = lodashGet(addLayersElementRef, 'current.clientHeight') || 30;
     const compareModeHeight = isCompareMode ? 80 : 40;
     const tabHeight = isMobile ? compareModeHeight : 32;
     const groupCheckboxHeight = 35;
@@ -139,16 +124,41 @@ class Sidebar extends React.Component {
     // only update when changed by more than a single pixel. This probably
     // needs a refactoring.
     if (Math.abs(subComponentHeight - newHeight) > 1) {
-      this.setState({ subComponentHeight: newHeight });
+      setSubComponentHeight(newHeight);
     }
   }
 
-  toggleSidebar() {
-    const {
-      isCollapsed,
-      collapseExpandToggle,
-      isMobile,
-    } = this.props;
+  // componentDidMount
+  useEffect(() => {
+    const customPalettePromise = loadCustomPalette(config);
+    customPalettePromise.then((customs) => {
+      loadedCustomPalettes(customs);
+    });
+    requestSources();
+    // prevent events tab if embed init layers tab
+    if (isEmbedModeActive && activeTab === 'layers') {
+      setIsEventsTabDisabledEmbed(true);
+    }
+  }, []);
+
+  // componentDidUpdate
+  useEffect(() => {
+    const mapChange = mapIsRendered && !lodashEqual(selectedMap, prevSelectedMap);
+    const mapRenderedChange = mapIsRendered && mapIsRendered !== prevMapIsRendered;
+    const tabChange = activeTab !== prevActiveTab;
+    const firstLoad = tabChange && !isLoadingEvents && (!eventsData || !eventsData.length);
+
+    if (activeTab === 'events' && (mapRenderedChange || mapChange || firstLoad)) {
+      requestEvents();
+    }
+    updateDimensions();
+    const sidebarHeightNew = lodashGet(sidebarElementRef, 'current.clientHeight');
+    if (sidebarHeightNew !== sidebarHeight) {
+      setSidebarHeight(sidebarHeightNew);
+    }
+  });
+
+  function toggleSidebar() {
     const isNowCollapsed = !isCollapsed;
     if (isMobile) {
       return collapseExpandToggle();
@@ -161,31 +171,29 @@ class Sidebar extends React.Component {
     return collapseExpandToggle();
   }
 
-  getProductsToRender(activeTab, isCompareMode, isChartMode) {
-    const { activeString, chartingModeAccessible } = this.props;
-    const { subComponentHeight } = this.state;
-    if (isCompareMode) {
+  function getProductsToRender(activeTabArg, isCompareModeArg, isChartModeArg) {
+    if (isCompareModeArg) {
       return (
         <CompareCase
-          isActive={activeTab === 'layers'}
+          isActive={activeTabArg === 'layers'}
           height={subComponentHeight}
         />
       );
-    } if (isChartMode) {
+    } if (isChartModeArg) {
       return (
         <ChartingLayerMenu
           height={subComponentHeight}
-          isActive={activeTab === 'layers'}
+          isActive={activeTabArg === 'layers'}
           compareState={activeString}
-          chartState={isChartMode}
+          chartState={isChartModeArg}
           chartingModeAccessible={chartingModeAccessible}
         />
       );
-    } if (!isCompareMode && !isChartMode) {
+    } if (!isCompareModeArg && !isChartModeArg) {
       return (
         <LayersContainer
           height={subComponentHeight}
-          isActive={activeTab === 'layers'}
+          isActive={activeTabArg === 'layers'}
           compareState={activeString}
         />
       );
@@ -193,9 +201,8 @@ class Sidebar extends React.Component {
     return undefined;
   }
 
-  handleWorldviewLogoClick(e, permalink) {
+  function handleWorldviewLogoClick(e, permalink) {
     e.preventDefault();
-    const { isEmbedModeActive } = this.props;
     if (window.location.search === '') return; // Nothing to reset
     let msg;
     if (isEmbedModeActive) {
@@ -216,14 +223,7 @@ class Sidebar extends React.Component {
     }
   }
 
-  renderSidebarLogo() {
-    const {
-      isDistractionFreeModeActive,
-      isEmbedModeActive,
-      selectedDate,
-      isMobile,
-      isKioskModeActive,
-    } = this.props;
+  function renderSidebarLogo() {
     const permalink = getPermalink(history.location.search, selectedDate);
     const WVLogoTitle = isEmbedModeActive
       ? 'Click to Open This @NAME@ Map in a New Tab'
@@ -287,7 +287,7 @@ class Sidebar extends React.Component {
             id="wv-logo"
             className={isDistractionFreeModeActive ? 'wv-logo-distraction-free-mode' : ''}
             style={sidebarStyle}
-            onClick={(e) => this.handleWorldviewLogoClick(e, permalink)}
+            onClick={(e) => handleWorldviewLogoClick(e, permalink)}
           >
             {wvName}
           </a>
@@ -295,156 +295,121 @@ class Sidebar extends React.Component {
     );
   }
 
-  render() {
-    const {
-      isEventsTabDisabledEmbed,
-      subComponentHeight,
-      sidebarHeight,
-    } = this.state;
-    const {
-      activeTab,
-      changeTab,
-      config,
-      displayStaticMap,
-      eventsData,
-      eventsSources,
-      hasEventRequestError,
-      isCollapsed,
-      isCompareMode,
-      isChartMode,
-      isDataDisabled,
-      isDistractionFreeModeActive,
-      isEmbedModeActive,
-      isLoadingEvents,
-      isMobile,
-      isKioskModeActive,
-      numberOfLayers,
-      onTabClick,
-      screenHeight,
-      tabTypes,
-      chartingModeAccessible,
-      activeString,
-    } = this.props;
+  if ((isMobile || isEmbedModeActive) && activeTab === 'download') changeTab('layers');
+  const { naturalEvents } = config.features;
+  const { smartHandoffs } = config.features;
 
-    if ((isMobile || isEmbedModeActive) && activeTab === 'download') changeTab('layers');
-    const { naturalEvents } = config.features;
-    const { smartHandoffs } = config.features;
+  const embedModeHeight = isEmbedModeActive
+    ? '95vh'
+    : `${screenHeight}px`;
+  const maxHeight = isCollapsed
+    ? '0'
+    : embedModeHeight;
+  const displayStyle = isDistractionFreeModeActive ? 'none' : 'block';
 
-    const embedModeHeight = isEmbedModeActive
-      ? '95vh'
-      : `${screenHeight}px`;
-    const maxHeight = isCollapsed
-      ? '0'
-      : embedModeHeight;
-    const displayStyle = isDistractionFreeModeActive ? 'none' : 'block';
+  const mobileWVSidebarStyle = !isDistractionFreeModeActive && isMobile
+    ? {
+      position: 'static',
+    }
+    : null;
 
-    const mobileWVSidebarStyle = !isDistractionFreeModeActive && isMobile
-      ? {
-        position: 'static',
-      }
-      : null;
+  const mobileProductHolderStyle = !isDistractionFreeModeActive && isMobile && !isEmbedModeActive
+    ? {
+      cssFloat: 'left',
+      left: '0',
+      minWidth: '238px',
+      width: '100%',
+      height: '100%',
+      position: 'absolute !important',
+      overflow: 'hidden',
+      background: 'rgb(38 43 49)',
+      top: '0',
+      zIndex: 1000,
+      maxHeight: `${maxHeight}`,
+      display: `{${displayStyle}} !important`,
+    }
+    : {
+      maxHeight: `${maxHeight}`,
+    };
+  const productsHolderStyle = isDistractionFreeModeActive && !isMobile
+    ? {
+      display: 'none',
+    }
+    : mobileProductHolderStyle;
 
-    const mobileProductHolderStyle = !isDistractionFreeModeActive && isMobile && !isEmbedModeActive
-      ? {
-        cssFloat: 'left',
-        left: '0',
-        minWidth: '238px',
-        width: '100%',
-        height: '100%',
-        position: 'absolute !important',
-        overflow: 'hidden',
-        background: 'rgb(38 43 49)',
-        top: '0',
-        zIndex: 1000,
-        maxHeight: `${maxHeight}`,
-        display: `{${displayStyle}} !important`,
-      }
-      : {
-        maxHeight: `${maxHeight}`,
-      };
-    const productsHolderStyle = isDistractionFreeModeActive && !isMobile
-      ? {
-        display: 'none',
-      }
-      : mobileProductHolderStyle;
-
-    return (
-      <ErrorBoundary>
-        <section id="wv-sidebar" style={mobileWVSidebarStyle}>
-          {!displayStaticMap && this.renderSidebarLogo()}
-          {!isDistractionFreeModeActive && isCollapsed && (
-            <CollapsedButton
-              isMobile={isMobile}
-              isEmbed={isEmbedModeActive}
-              onclick={this.toggleSidebar}
-              numberOfLayers={numberOfLayers}
-            />
-          )}
-          <div
-            id="products-holder"
-            className="products-holder-case"
-            style={productsHolderStyle}
-            // eslint-disable-next-line react/no-unused-class-component-methods
-            ref={(el) => { this.sidebarElement = el; }}
-          >
-            <NavCase
-              activeTab={activeTab}
-              onTabClick={onTabClick}
-              tabTypes={tabTypes}
-              isMobile={isMobile}
-              toggleSidebar={this.toggleSidebar}
-              isCompareMode={isCompareMode}
-              isChartMode={isChartMode}
-              isDataDisabled={isDataDisabled}
-              isEventsTabDisabledEmbed={isEventsTabDisabledEmbed}
-            />
-            <TabContent activeTab={activeTab}>
-              <TabPane tabId="layers">
-                {this.getProductsToRender(activeTab, isCompareMode, isChartMode)}
-                <AddLayersContent
-                  // eslint-disable-next-line react/no-unused-class-component-methods
-                  ref={(el) => { this.addLayersElement = el; }}
-                  isActive={activeTab === 'layers'}
-                  compareState={activeString}
+  return (
+    <ErrorBoundary>
+      <section id="wv-sidebar" style={mobileWVSidebarStyle}>
+        {!displayStaticMap && renderSidebarLogo()}
+        {!isDistractionFreeModeActive && isCollapsed && (
+          <CollapsedButton
+            isMobile={isMobile}
+            isEmbed={isEmbedModeActive}
+            onclick={toggleSidebar}
+            numberOfLayers={numberOfLayers}
+          />
+        )}
+        <div
+          id="products-holder"
+          className="products-holder-case"
+          style={productsHolderStyle}
+          ref={(el) => { sidebarElementRef.current = el; }}
+        >
+          <NavCase
+            activeTab={activeTab}
+            onTabClick={onTabClick}
+            tabTypes={tabTypes}
+            isMobile={isMobile}
+            toggleSidebar={toggleSidebar}
+            isCompareMode={isCompareMode}
+            isChartMode={isChartMode}
+            isDataDisabled={isDataDisabled}
+            isEventsTabDisabledEmbed={isEventsTabDisabledEmbed}
+          />
+          <TabContent activeTab={activeTab}>
+            <TabPane tabId="layers">
+              {getProductsToRender(activeTab, isCompareMode, isChartMode)}
+              <AddLayersContent
+                ref={(el) => { addLayersElementRef.current = el; }}
+                isActive={activeTab === 'layers'}
+                compareState={activeString}
+              />
+            </TabPane>
+            {naturalEvents && activeTab === 'events' && (
+              <TabPane tabId="events">
+                <Events
+                  height={subComponentHeight}
+                  isLoading={isLoadingEvents}
+                  hasRequestError={hasEventRequestError}
+                  eventsData={eventsData}
+                  sources={eventsSources}
                 />
               </TabPane>
-              {naturalEvents && activeTab === 'events' && (
-                <TabPane tabId="events">
-                  <Events
-                    height={subComponentHeight}
-                    isLoading={isLoadingEvents}
-                    hasRequestError={hasEventRequestError}
-                    eventsData={eventsData}
-                    sources={eventsSources}
-                  />
-                </TabPane>
-              )}
-              {smartHandoffs && activeTab === 'download' && (
-                <TabPane tabId="download">
-                  <SmartHandoff
-                    isActive={activeTab === 'download'}
-                    tabTypes={tabTypes}
-                  />
-                </TabPane>
-              )}
-              {
-                !isKioskModeActive && (
-                  <FooterContent
-                    // eslint-disable-next-line react/no-unused-class-component-methods
-                    ref={(el) => { this.footerElement = el; }}
-                    tabTypes={tabTypes}
-                    activeTab={activeTab}
-                    chartingModeAccessible={chartingModeAccessible}
-                    sidebarHeight={sidebarHeight}
-                  />
-                )
-              }
-            </TabContent>
-          </div>
-        </section>
-      </ErrorBoundary>
-    );
-  }
+            )}
+            {smartHandoffs && activeTab === 'download' && (
+              <TabPane tabId="download">
+                <SmartHandoff
+                  isActive={activeTab === 'download'}
+                  tabTypes={tabTypes}
+                />
+              </TabPane>
+            )}
+            {
+              !isKioskModeActive && (
+                <FooterContent
+                  ref={(el) => { footerElementRef.current = el; }}
+                  tabTypes={tabTypes}
+                  activeTab={activeTab}
+                  chartingModeAccessible={chartingModeAccessible}
+                  sidebarHeight={sidebarHeight}
+                />
+              )
+            }
+          </TabContent>
+        </div>
+      </section>
+    </ErrorBoundary>
+  );
 }
 
 const mapStateToProps = (state) => {


### PR DESCRIPTION
## Summary
- Converted the Sidebar component from a React class component to a functional component
- Replaced lifecycle methods (`componentDidMount`, `componentDidUpdate`) with `useEffect` hooks

## Test plan
- [ ] Sidebar renders with logo, tabs, and layer list on load
- [ ] Tab switching between Layers, Events, and Download works correctly
- [ ] Events load and display when switching to the Events tab
- [ ] Sidebar collapse/expand via chevron button works; state persists on refresh (localStorage)
- [ ] Worldview logo click shows reset confirmation dialog
- [ ] Browser window resize adjusts sidebar layout correctly
- [ ] Mobile view renders correctly with mobile-specific layout
- [ ] Compare mode shows CompareCase component in sidebar
- [ ] Embed mode (`?em=true`) disables Events tab when starting on layers tab
- [ ] Distraction-free mode (`?df=true`) hides sidebar