### PR TITLE
Optional chaining to safely handle failed CMR requests

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -190,7 +190,7 @@ function LayerRow (props) {
         const requests = [cmrFetch(olderUrl), cmrFetch(newerUrl)];
         const responses = await Promise.allSettled(requests);
         const [olderRes, newerRes] = responses.filter(({ status }) => status === 'fulfilled').map(({ value }) => value);
-        if (!olderRes.ok || !newerRes.ok) return;
+        if (!olderRes?.ok || !newerRes?.ok) return;
         const jsonRequests = [olderRes.json(), newerRes.json()];
         const jsonResponses = await Promise.allSettled(jsonRequests);
         const [olderGranules, newerGranules] = jsonResponses.filter(({ status }) => status === 'fulfilled').map(({ value }) => value);


### PR DESCRIPTION
## Description
A failed request to CMR leads to an error in the console. This handles that situation more gracefully.

## How To Test

- Load production WV
- Start Harmonized Landsat Sentinel-2 Tour story
- Navigate to Step 2
- In Chrome network tab, filter requests by CMR, right click a CMR request, & block requests to simulate failure
- Advance to step 3, note the 'Cannot red properties...' error in the console
- Load this branch, repeat tests steps, confirm no console error.
- In Chrome network tab, filter by cmr, right click a CMR request, & in Block Requests select "Unblock" to restore function

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
