### PR TITLE
WV-4081: Fix mobile sidebar dropdown menu clicks and responsive kebab…

### DIFF
--- a/web/js/containers/sidebar/layer-list.js
+++ b/web/js/containers/sidebar/layer-list.js
@@ -185,6 +185,7 @@ function LayerList(props) {
   const renderHeader = () => (
     <div
       className="layer-group-header"
+      style={{ touchAction: 'none' }}
       onMouseEnter={mouseEnter}
       onMouseLeave={mouseLeave}
       {...dragHandleProps}

--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -54,6 +54,7 @@ const getItemStyle = (isDragging, sortableStyle) => ({
   top: null,
   left: null,
   zIndex: isDragging ? 1 : undefined,
+  touchAction: 'none',
 });
 
 function LayerRow (props) {
@@ -257,6 +258,10 @@ function LayerRow (props) {
     setDisabled(isDisabled);
   }, [isDisabled]);
 
+  useEffect(() => {
+    toggleShowButtons(isMobile);
+  }, [isMobile]);
+
   const toggleDropdownMenuVisible = () => {
     if (showDropdownMenu) {
       setDropdownBtnVisible(false);
@@ -381,6 +386,8 @@ function LayerRow (props) {
           id={layerInfoBtnId}
           aria-label={layerInfoBtnTitle}
           className="button wv-layers-info layer-options-dropdown-item"
+          onPointerDown={stopDndActivation}
+          onMouseDown={stopDndActivation}
           onClick={() => onInfoClick(layer, title, measurementDescriptionPath, describeDomainsUrl)}
         >
           {layerInfoBtnTitle}
@@ -389,12 +396,16 @@ function LayerRow (props) {
           id={layerOptionsBtnId}
           aria-label={layerOptionsBtnTitle}
           className="button wv-layers-options layer-options-dropdown-item"
+          onPointerDown={stopDndActivation}
+          onMouseDown={stopDndActivation}
           onClick={() => onOptionsClick(layer, title, zot)}
         >
           {layerOptionsBtnTitle}
         </DropdownItem>
         <DropdownItem
           id={removeLayerBtnId}
+          onPointerDown={stopDndActivation}
+          onMouseDown={stopDndActivation}
           onClick={() => removeLayer()}
           className="button wv-layers-options layer-options-dropdown-item"
         >
@@ -501,13 +512,13 @@ function LayerRow (props) {
   };
 
   const mouseOver = () => {
-    if (isMobile) return;
+    if (isMobile || isDragging) return;
     events.trigger(SIDEBAR_LAYER_HOVER, layer.id, true);
     toggleShowButtons(true);
   };
 
   const mouseLeave = () => {
-    if (isMobile) return;
+    if (isMobile || isDragging) return;
     events.trigger(SIDEBAR_LAYER_HOVER, layer.id, false);
     toggleShowButtons(false);
   };

--- a/web/js/containers/sidebar/layers-container.js
+++ b/web/js/containers/sidebar/layers-container.js
@@ -48,6 +48,7 @@ function SortableOverlayGroup(props) {
   } = useSortable({
     id: groupName,
     disabled: isEmbedModeActive || isAnimating,
+    animateLayoutChanges: () => false,
   });
 
   const style = {

--- a/web/scss/features/sidebar-panel.scss
+++ b/web/scss/features/sidebar-panel.scss
@@ -719,9 +719,11 @@ li.item.productsitem.inmotion,
       min-height: 44px;
 
       .layer-buttons {
-        height: 26px;
-        width: 26px;
-        background: #ccc;
+        width: auto;
+        min-width: 36px;
+        min-height: 36px;
+        background: transparent;
+        overflow: visible;
 
         .wv-layers-close {
           height: 25px;
@@ -744,6 +746,7 @@ li.item.productsitem.inmotion,
       margin-top: -13px;
     }
 
+    button.visibility,
     a.visibility {
       width: 45px;
     }


### PR DESCRIPTION
## Summary

Fixes mobile sidebar issues after replacing `react-beautiful-dnd` (deprecated) with `@dnd-kit/sortable`.

## Test Plan

- [ ] On mobile or narrow viewport: tap three-dot kebab menu on a layer row
- [ ] Tap "View Description" — modal should open
- [ ] Tap "View Options" — options panel should open
- [ ] Tap "Remove Layer" — layer should be removed
- [ ] Resize browser from desktop to mobile width — kebab icons should appear without refresh
- [ ] Resize browser from mobile back to desktop — hover behavior should resume
- [ ] Drag-and-drop layer reordering still works on both desktop and mobile