### PR TITLE
WV-3948: Fix issues with Availability Bar for 1D Products

### DIFF
--- a/web/js/workers/describe-domains.worker.js
+++ b/web/js/workers/describe-domains.worker.js
@@ -66,22 +66,29 @@ function periodToTime(period) {
   const oneMinute = 60_000;
   const oneHour = 3_600_000;
   const oneDay = 86_400_000;
-  const lookup = {
-    S: oneSecond,
-    M: oneMinute,
-    H: oneHour,
-    D: oneDay,
-  };
-  const processedPeriod = period.replace('PT', '');
-  const numberMatch = processedPeriod.match(/[0-9]+/g);
-  const unitMatch = processedPeriod.match(/[a-zA-Z]+/g);
-  const time = numberMatch.reduce((acc, val, idx) => {
-    const number = Number(val);
-    const unit = unitMatch[idx];
-    const milliseconds = number * lookup[unit?.toUpperCase?.()];
-    const invalid = Number.isNaN(milliseconds);
-    const valueToAdd = invalid ? (console.warn(`Invalid period: ${period}`), 0) : milliseconds;
-    return acc + valueToAdd;
+  const lookup = [
+    {
+      D: oneDay,
+    },
+    {
+      S: oneSecond,
+      M: oneMinute,
+      H: oneHour,
+    },
+  ];
+  const processedPeriod = period.replace('P', '').split('T');
+  const time = processedPeriod.reduce((accPortion, valPortion, index) => {
+    if (!valPortion.length) return accPortion;
+    const numberMatch = valPortion.match(/[0-9]+/g);
+    const unitMatch = valPortion.match(/[a-zA-Z]+/g);
+    return accPortion + numberMatch.reduce((acc, val, idx) => {
+      const number = Number(val);
+      const unit = unitMatch[idx];
+      const milliseconds = number * lookup[index][unit?.toUpperCase?.()];
+      const invalid = Number.isNaN(milliseconds);
+      const valueToAdd = invalid ? (console.warn(`Invalid period: ${period}`), 0) : milliseconds;
+      return acc + valueToAdd;
+    }, 0);
   }, 0);
 
   return time || 360_000;


### PR DESCRIPTION
## Description
This change fixes an issue with products that have a 1D time period not correctly showing the blue availability bar in the timeline always.

## How To Test
1. `git checkout wv-3948-availability-bar-fix`
2. `npm ci`
4. `npm run watch`
5. Open [this link](http://localhost:3000/?v=-128.103910991454,31.98550786370111,-115.40733143136745,41.06161736855481&l=Coastlines_15m,AJAX_Alpha_Jet_Ozone&lg=true&t=2016-08-09-T00%3A00%3A00Z) and verify that the availability bar in the timeline shows correctly for when there is imagery
6. Open [this link](http://localhost:3000/?v=-112.60514758752527,9.112983337169027,-39.67720583627814,61.245290480637124&l=ACTIVATE_King_Air_Flight_Track,Coastlines_15m,ACTIVATE_HU-25_Falcon_Ozone&lg=true&t=2022-02-19-T02%3A00%3A00Z) and verify that the availability bar in the timeline shows correctly for when there is imagery