### PR TITLE
fix: iOS Canvas memory leak on colormap threshold change (#1510)

### DIFF
--- a/web/js/ol/lookupimagetile.js
+++ b/web/js/ol/lookupimagetile.js
@@ -56,6 +56,12 @@ LookupImageTile.prototype.load = async function () {
     let imageProcessed = false;
 
     const onImageLoad = function() {
+      // Clear existing canvas to prevent memory leak (#1510)
+      if (that.canvas_) {
+        that.canvas_.width = 0;
+        that.canvas_.height = 0;
+        that.canvas_ = null;
+      }
       that.canvas_ = document.createElement('canvas');
       that.canvas_.width = that.image_.width;
       that.canvas_.height = that.image_.height;
@@ -91,6 +97,12 @@ LookupImageTile.prototype.load = async function () {
         const decodedPNG = await decodePNG(buffer);
         const { width, height, data } = decodedPNG;
 
+        // Clear existing canvas to prevent memory leak (#1510)
+        if (that.canvas_) {
+          that.canvas_.width = 0;
+          that.canvas_.height = 0;
+          that.canvas_ = null;
+        }
         that.canvas_ = document.createElement('canvas');
         that.canvas_.width = width;
         that.canvas_.height = height;


### PR DESCRIPTION
Fixed an 8-year-old memory leak where each colormap threshold 
change created a new Canvas element without destroying the 
previous one, causing unbounded memory growth on iOS Safari.

## Root Cause
`LookupImageTile.load()` creates a new Canvas on every invocation 
without clearing the previous reference. On iOS, Safari enforces 
a Canvas memory limit (~256MB), causing crashes after repeated 
threshold adjustments.

## Fix
Added explicit Canvas cleanup (setting dimensions to zero and 
nullifying the reference) before creating a new Canvas in both 
the image load callback and the PNG decode path.

## Verification
- Safari dev tools Canvas tab no longer shows accumulation
- Memory usage remains stable after multiple threshold changes
- Desktop Chrome tab memory stays around ~470MB instead of 
  climbing to 1GB+

Closes #1510