### PR TITLE
feat: implement Service Worker tile caching for GIBS tiles (#289)

### DIFF
--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -1,3 +1,77 @@
-self.addEventListener('fetch', (event) => {
-  // Ignore
+const CACHE_NAME = 'worldview-tiles-v1';
+const MAX_CACHE_AGE = 24 * 60 * 60 * 1000; // 24 hours
+const TILE_URL_PATTERN = /gibs-\w\.earthdata\.nasa\.gov\/wmts\/.*(?:GetTile|GetMap)/;
+const MAX_CACHE_ENTRIES = 500;
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
 });
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // Only cache NASA GIBS tile requests
+  if (!TILE_URL_PATTERN.test(url.href)) {
+    return;
+  }
+
+  // Only cache GET requests
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.match(event.request).then((cachedResponse) => {
+        const fetchPromise = fetch(event.request).then((networkResponse) => {
+          if (networkResponse && networkResponse.status === 200) {
+            const clonedResponse = networkResponse.clone();
+            cache.put(event.request, clonedResponse);
+            limitCacheSize(cache);
+          }
+          return networkResponse;
+        }).catch(() => cachedResponse);
+
+        // Return cached response immediately, update from network in background
+        if (cachedResponse && !isStale(cachedResponse)) {
+          // Background refresh
+          fetchPromise;
+          return cachedResponse;
+        }
+
+        return fetchPromise;
+      })
+    )
+  );
+});
+
+function isStale(response) {
+  const dateHeader = response.headers.get('date');
+  if (!dateHeader) return false;
+  const requestDate = new Date(dateHeader).getTime();
+  return Date.now() - requestDate > MAX_CACHE_AGE;
+}
+
+function limitCacheSize(cache) {
+  cache.keys().then((keys) => {
+    if (keys.length > MAX_CACHE_ENTRIES) {
+      const deleteCount = keys.length - MAX_CACHE_ENTRIES;
+      keys.slice(0, deleteCount).forEach((request) => {
+        cache.delete(request);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Replaced the empty Service Worker with a cache-first strategy for 
NASA GIBS tile requests. This has been an open issue since 2017.

## Problem
The NASA GIBS tile server sends `Cache-Control: no-cache` headers, 
preventing browsers from caching map tiles. Server-side changes 
have been pending for 9 years with no resolution.

## Solution
Client-side Service Worker using the Cache API:
- **Cache-first strategy**: serves cached tiles instantly, refreshes 
  from network in background
- **24-hour max age**: ensures tiles don't go stale
- **500-entry limit**: prevents unbounded storage growth
- **GIBS-only**: only intercepts NASA tile requests, ignores all 
  other traffic

## Impact
- Reduced bandwidth for repeated tile requests
- Faster map loading on revisits
- Enables basic offline access to previously viewed areas
- Works regardless of server Cache-Control headers

## Why Service Worker
The tile server is an external dependency (GIBS/OnEarth) that the 
Worldview team cannot modify. A Service Worker provides client-side 
caching that bypasses this limitation entirely — a standard web 
technology used by Google Maps, Bing Maps, and other mapping platforms.

Closes #289