### PR TITLE
WV-3938: Change property to Altitude for ACTIVATE layers

### DIFF
--- a/config/default/common/config/wv.json/layers/activate/ACTIVATE_HU-25_Falcon_Ozone.json
+++ b/config/default/common/config/wv.json/layers/activate/ACTIVATE_HU-25_Falcon_Ozone.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Alt_m_",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/activate/ACTIVATE_King_Air_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/activate/ACTIVATE_King_Air_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Alt_m_",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {


### PR DESCRIPTION
## Description

Fixes #WV-3938 .

Change renderOrder property to "Altitude" for ACTIVATE layers.

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?v=-80.683238428326,34.73755224193564,-69.21349179040794,39.98226544816314&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,ACTIVATE_HU-25_Falcon_Ozone,ACTIVATE_King_Air_Flight_Track(hidden),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2022-05-17-T08%3A00%3A00Z) and compare to [this prod URL](https://go.nasa.gov/3PXPA6Z)
2. Check to see that the Altitude property is now in descending order, where smaller points (higher altitude) appears on top of larger dots (lower altitude)
3. Verify expected result


@nasa-gibs/worldview
