### PR TITLE
WV-4097

### DIFF
--- a/web/js/components/sidebar/charting-mode-options.js
+++ b/web/js/components/sidebar/charting-mode-options.js
@@ -188,11 +188,6 @@ function ChartingModeOptions(props) {
     setTopRightLatLong(topRight);
     debouncedUpdateAOICoordinates([...bottomLeft, ...topRight]);
     setMapViewChecked(false);
-    if (maxExtent) {
-      const inLeftWing = bottomLeft[0] < maxExtent[0] && topRight[0] < maxExtent[0];
-      const inRightWing = bottomLeft[0] > maxExtent[2] && topRight[0] > maxExtent[2];
-      setIsWithinWings(inLeftWing || inRightWing);
-    }
   };
 
   const { initialStartDate, initialEndDate } = initializeDates(timeSpanStartDate, timeSpanEndDate);
@@ -250,20 +245,10 @@ function ChartingModeOptions(props) {
     if (!aoiCoordinates || aoiCoordinates.length === 0) {
       debouncedUpdateAOICoordinates([...bottomLeftLatLong, ...topRightLatLong]);
     }
-    if (maxExtent) {
-      let inLeftWing;
-      let inRightWing;
-      if (aoiCoordinates && aoiCoordinates.length > 0) {
-        inLeftWing = aoiCoordinates[0] < maxExtent[0] && aoiCoordinates[2] < maxExtent[0];
-        inRightWing = aoiCoordinates[0] > maxExtent[2] && aoiCoordinates[2] > maxExtent[2];
-      } else {
-        inLeftWing = bottomLeftLatLong[0] < maxExtent[0] && topRightLatLong[0] < maxExtent[0];
-        inRightWing = bottomLeftLatLong[0] > maxExtent[2] && topRightLatLong[0] > maxExtent[2];
-      }
-      setIsWithinWings(inLeftWing || inRightWing);
-    }
     return () => {
       isMounted.current = false;
+      updateAOICoordinates([]);
+      setIsWithinWings(null);
     };
   }, []);
 
@@ -272,6 +257,22 @@ function ChartingModeOptions(props) {
       setIsPostRender(true);
     }
   }, [fromButton]);
+
+  // Track whether the bounding box is within the wings of the map
+  useEffect(() => {
+    if (!maxExtent) return;
+
+    let inLeftWing, inRightWing;
+
+    if (aoiCoordinates && aoiCoordinates.length > 0) {
+      inLeftWing = aoiCoordinates[0] < maxExtent[0];
+      inRightWing = aoiCoordinates[2] > maxExtent[2];
+    } else {
+      inLeftWing = bottomLeftLatLong[0] < maxExtent[0];
+      inRightWing = topRightLatLong[0] > maxExtent[2];
+    }
+    setIsWithinWings(inLeftWing || inRightWing);
+  }, [maxExtent, aoiCoordinates, bottomLeftLatLong, topRightLatLong]);
 
   function formatDateForImageStat(dateObj) {
     const dateString = new Date(dateObj);
@@ -695,17 +696,13 @@ function ChartingModeOptions(props) {
       onUpdateStartDate(startDate);
       onUpdateEndDate(endDate);
     }
+
     if (!aoiCoordinates || aoiCoordinates.length === 0) {
       const bottomLeft = getLatLongFromPixelValue(x, y2);
       const topRight = getLatLongFromPixelValue(x2, y);
       setBottomLeftLatLong(bottomLeft);
       setTopRightLatLong(topRight);
       debouncedUpdateAOICoordinates([...bottomLeft, ...topRight]);
-      if (maxExtent) {
-        const inLeftWing = bottomLeft[0] < maxExtent[0] && topRight[0] < maxExtent[0];
-        const inRightWing = bottomLeft[0] > maxExtent[2] && topRight[0] > maxExtent[2];
-        setIsWithinWings(inLeftWing || inRightWing);
-      }
       return;
     }
     if (viewExtent.every((val, index) => val === aoiCoordinates[index])) {
@@ -722,11 +719,6 @@ function ChartingModeOptions(props) {
     setBoundaries(newBoundaries);
     setBottomLeftLatLong([aoiCoordinates[0], aoiCoordinates[1]]);
     setTopRightLatLong([aoiCoordinates[2], aoiCoordinates[3]]);
-    if (maxExtent) {
-      const inLeftWing = aoiCoordinates[0] < maxExtent[0] && aoiCoordinates[2] < maxExtent[0];
-      const inRightWing = aoiCoordinates[0] > maxExtent[2] && aoiCoordinates[2] > maxExtent[2];
-      setIsWithinWings(inLeftWing || inRightWing);
-    }
   });
 
   const onLatLongChange = (coordsArray) => {
@@ -745,16 +737,21 @@ function ChartingModeOptions(props) {
     setTopRightLatLong(topRight);
     debouncedUpdateAOICoordinates([...bottomLeft, ...topRight]);
     setMapViewChecked(false);
-    if (maxExtent) {
-      const inLeftWing = bottomLeft[0] < maxExtent[0] && topRight[0] < maxExtent[0];
-      const inRightWing = bottomLeft[0] > maxExtent[2] && topRight[0] > maxExtent[2];
-      setIsWithinWings(inLeftWing || inRightWing);
-    }
   };
 
   const toggleMapView = () => {
     if (!mapViewChecked) {
-      onLatLongChange(viewExtent);
+      // Clamp extent values to the visible map area
+      const clampedViewExtent = viewExtent.map((val, index) => {
+        if (!maxExtent) return val;
+        if (index % 2 === 0) {
+          // Longitude value (x)
+          return Math.min(Math.max(val, maxExtent[0]), maxExtent[2]);
+        }
+        // Latitude value (y)
+        return Math.min(Math.max(val, maxExtent[1]), maxExtent[3]);
+      });
+      onLatLongChange(clampedViewExtent);
     } else {
       const boundariesObj = {
         x: screenWidth / 2 - 100,
@@ -880,6 +877,21 @@ function ChartingModeOptions(props) {
           valid={!chartRequestInProgress && !isWithinWings}
           text={requestBtnText}
         />
+        <style>{`
+          #charting-create-button:disabled {
+            pointer-events: auto !important;
+            cursor: not-allowed;
+          }
+        `}</style>
+        {isWithinWings && (
+          <UncontrolledTooltip
+            id="charting-create-button"
+            target="charting-create-button"
+            placement="right"
+          >
+            Please adjust your AOI to be within the current day's extent to generate a chart.
+          </UncontrolledTooltip>
+        )}
       </div>
       {chartRequestInProgress && (
         <WaitOverlay

--- a/web/js/modules/charting/reducers.js
+++ b/web/js/modules/charting/reducers.js
@@ -61,7 +61,10 @@ export function chartingReducer(state = initialChartingState, action) {
         isChartOpen: action.status,
       });
     case UPDATE_AOI_COORDINATES:
-      // action.extent = the geometry from the drawn AOI box
+      // Don't update the coordinates if charting mode isn't active
+      if (!state.active) {
+        return state;
+      }
       return lodashAssign({}, state, {
         aoiCoordinates: action.extent,
       });

--- a/web/js/modules/charting/reducers.test.js
+++ b/web/js/modules/charting/reducers.test.js
@@ -114,9 +114,10 @@ describe('chartingReducer', () => {
   });
 
   describe('UPDATE_AOI_COORDINATES', () => {
-    it('updates aoiCoordinates with the provided extent', () => {
+    it('updates aoiCoordinates with the provided extent when', () => {
+      const activeState = { ...initialChartingState, active: true };
       const extent = [10, 20, 30, 40];
-      const state = chartingReducer(initialChartingState, { type: UPDATE_AOI_COORDINATES, extent });
+      const state = chartingReducer(activeState, { type: UPDATE_AOI_COORDINATES, extent });
       expect(state.aoiCoordinates).toEqual(extent);
     });
   });


### PR DESCRIPTION
## Description

Fixes #4097

Investigation of charting across the meridians exposed a bug/race condition with the meridian computation in the charting component. This consolidates numerous setIsWithinWings calculations into a single useEffect.
Add text on hover when Generate Chart button is grayed out.
Clamp "full screen selected" checkbox to the map extents (no wings)
Disallow charting if any portion of the AOI selection box is in the wings.

## How To Test
To see the bug described:

- Go to [this link](https://worldview.earthdata.nasa.gov/?v=-425.4359186489095,-106.08361032654409,-74.5640813510905,112.15626098240861&l=AIRS_L2_Carbon_Monoxide_500hPa_Volume_Mixing_Ratio_Day,Coastlines_15m,MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2022-07-03-T13%3A00%3A30Z) in production.
- Confirm the imagery is missing/incomplete in the center of the screen (where the AOI box will be generated). If not, adjust to make this the case.
- Click start charting. Notice 'Generate chart' is grayed out.
- Exit charting. 
- Move the map to the left so the selected date imagery is available in the center of the screen.
- Click start charting. Notice 'Generate chart' is no longer grayed out.
- Exit charting. 
- Move the map as far to the right as possible, leaving empty imagery in the screen center. It should be back in (roughly) the original position.
- Click start charting. Notice 'Generate chart' is NOT grayed out even though the bounding box is at the same coordinates as the initial test.

To confirm this inconsistency has been addressed:

- Load this branch
- npm run watch
- Repeat the steps above & confirm when you revert to the initial position & Start Charting the Generate Charting button is properly grayed out.
- Confirm manually changing coordinates in the layer menu works as expected
- Confirm resizing the AOI box works as expected
- Confirm moving the AOI box around the map works as expected
- Confirm text on hover when Generate Chart button is grayed out.
- Confirm clicking "full screen selected" checkbox selects the visible map but nothing beyond the map extents (no wings, nothing south/north)
- Disallow charting if **any** portion of the AOI selection box is in the wings.

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
