### PR TITLE
Migrate TiTiler-CMR API from v0.x to v1.0

### DIFF
--- a/config/default/release/config/wv.json/sources.json
+++ b/config/default/release/config/wv.json/sources.json
@@ -141,7 +141,7 @@
       }
     },
     "DDV": {
-      "url": "https://staging.openveda.cloud/api/titiler-cmr/",
+      "url": "https://openveda.cloud/api/titiler-cmr/",
       "matrixSets": {
         "31.25m": {
           "id": "31.25m",

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -1019,15 +1019,15 @@ export default function mapLayerBuilder(config, cache, store) {
 
       const assets = [r, g, b, ...def.bandCombo.assets || []].filter((bArg) => bArg);
 
-      const params = assets.map((asset) => `bands=${asset}`);
+      const params = assets.map((asset) => `assets=${asset}`);
       params.push(`expression=${encodeURIComponent(def?.bandCombo?.expression)}`);
       params.push(`rescale=${encodeURIComponent(def?.bandCombo?.rescale)}`);
       params.push(`colormap_name=${def?.bandCombo?.colormap_name}`);
       params.push(`asset_as_band=${def?.bandCombo?.asset_as_band}`);
-      params.push(`bands_regex=${def?.bandCombo?.bands_regex}`);
+      params.push(`assets_regex=${def?.bandCombo?.bands_regex}`);
       params.push(`color_formula=${def?.bandCombo?.color_formula}`);
 
-      const urlParams = `tiles/WGS1984Quad/${z}/${x}/${y}@1x?concept_id=${def.collectionConceptID}&datetime=${zeroedDateTile}/${lastDateTile}&post_process=swir&backend=rasterio&${params.filter((p) => !p.split('=').includes('undefined')).join('&')}`;
+      const urlParams = `rasterio/tiles/WGS1984Quad/${z}/${x}/${y}?collection_concept_id=${def.collectionConceptID}&temporal=${zeroedDateTile}/${lastDateTile}&post_process=swir&${params.filter((p) => !p.split('=').includes('undefined')).join('&')}`;
 
       return source.url + urlParams;
     };


### PR DESCRIPTION
## Description
- Migrate TiTiler-CMR API from v0.x to v1.0 per [migration guide](https://developmentseed.org/titiler-cmr/1.0.0/migration/)
- Switch base URL from staging (`staging.openveda.cloud`) to production (`openveda.cloud`)
- Update tile URL construction to match v1.0 breaking changes

## Test Plan
- [x] Manually verified HLS Customizable Landsat 8 & 9 loads tiles
- [x] Manually verified HLS NDVI Landsat loads tiles 
- [x] Manually verified HLS NDVI Sentinel loads tiles
- [x] Confirmed correct v1.0 URL format in browser Network tab