### PR TITLE
WV-3873: Update TROPOMI SO2 NRT

### DIFF
--- a/config/default/common/config/metadata/layers/tropomi/TROPOMI_L2_Sulfur_Dioxide_Total_Vertical_Column.md
+++ b/config/default/common/config/metadata/layers/tropomi/TROPOMI_L2_Sulfur_Dioxide_Total_Vertical_Column.md
@@ -4,4 +4,4 @@ The retrieval algorithm for Sentinel-5P TROPOMI SO2 from ultraviolet spectral me
 
 The Sulfur Dioxide (L2, Total Vertical Column) layer is a science parameter of the Sentinel-5P TROPOMI Sulphur Dioxide SO2 1-Orbit L2 5.5km x 3.5km (S5P_L2__SO2____HiR) product. It is available from the TROPOspheric Monitoring Instrument (TROPOMI) instrument aboard the European Space Agency's (ESA) Sentinel-5P satellite. The sensor resolution is ~5.5km at nadir (5.5 x 3.5 km<sup>2</sup>), the imagery resolution is 2 km, and the temporal resolution is daily.
 
-References: S5P_L2__SO2____HiR [doi:10.5270/S5P-74eidii](https://doi.org/10.5270/S5P-74eidii); [S5P_L2__SO2____HiR  description at GES DISC](https://disc.gsfc.nasa.gov/datasets/S5P_L2__SO2____HiR_2/summary)
+References: [S5P_L2__SO2____HiR_NRT](https://disc.gsfc.nasa.gov/datasets/S5P_L2__SO2____HiR_NRT_2/summary); S5P_L2__SO2____HiR [doi:10.5270/S5P-74eidii](https://doi.org/10.5270/S5P-74eidii); [S5P_L2__SO2____HiR  description at GES DISC](https://disc.gsfc.nasa.gov/datasets/S5P_L2__SO2____HiR_2/summary)


### PR DESCRIPTION
## Description

Fixes #WV-3873 .

Add link for NRT product in the TROPOMI SO2 layer description

## How To Test

1. `git checkout wv-3873-tropomi-so2-nrt`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TROPOMI_L2_Sulfur_Dioxide_Total_Vertical_Column,OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=false&t=2026-06-11-T13%3A48%3A44Z)
4. Check that the first link under "References" goes to a NRT dataset landing page for TROPOMI SO2.
5. Verify expected result


@nasa-gibs/worldview
