### PR TITLE
WV-3939, WV-3942, WV-3942, WV-3943: Update renderOrder property to Altitude

### DIFF
--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_G-III_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_G-III_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "alt",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_P-3B_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_P-3B_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "alt",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_SPEC-Learjet_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_SPEC-Learjet_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "alt",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/asia-aq/ASIA-AQ_DC-8_NO2.json
+++ b/config/default/common/config/wv.json/layers/asia-aq/ASIA-AQ_DC-8_NO2.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "MSL_GPS_AI",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/asia-aq/ASIA-AQ_G-III_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/asia-aq/ASIA-AQ_G-III_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "G_Alt_m_",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/dcotss/DCOTSS_ER-2_ROZE_Ozone.json
+++ b/config/default/common/config/wv.json/layers/dcotss/DCOTSS_ER-2_ROZE_Ozone.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "O3_ROZE",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/dcotss/DCOTSS_ER-2_UCATS_Ozone.json
+++ b/config/default/common/config/wv.json/layers/dcotss/DCOTSS_ER-2_UCATS_Ozone.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "O3_UCATS",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_CIRPAS-TO_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_CIRPAS-TO_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Altitu",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_ER-2_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_ER-2_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Altitu",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_RV-Shearwater_Ship_Track.json
+++ b/config/default/common/config/wv.json/layers/pace-pax/PACE-PAX_RV-Shearwater_Ship_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "Time_Start",
+        "property": "Altitude",
         "order": "descending"
       },
       "breakPointLayer": {

--- a/config/default/common/config/wv.json/layers/staqs/STAQS_G-III_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/staqs/STAQS_G-III_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Alt_m_",
+        "property": "Altitude",
         "order": "descending"
       }
     }

--- a/config/default/common/config/wv.json/layers/staqs/STAQS_G-V_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/staqs/STAQS_G-V_Flight_Track.json
@@ -27,7 +27,7 @@
       "wrapX": false,
       "wrapadjacentdays": false,
       "renderOrder": {
-        "property": "GPS_Alt_m_",
+        "property": "Altitude",
         "order": "descending"
       }
     }


### PR DESCRIPTION
## Description

Fixes #WV-3939, WV-3942, WV-3942, WV-3943

Update renderOrder property to Altitude

## How To Test

1. `git checkout suborbital_attribute_updates`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-426.95184735331566,-196.7323220431535,374.5653686447845,144.40226351182963&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,DCOTSS_ER-2_UCATS_Ozone,DCOTSS_ER-2_ROZE_Ozone,STAQS_G-III_Flight_Track,STAQS_G-V_Flight_Track,PACE-PAX_RV-Shearwater_Ship_Track,PACE-PAX_CIRPAS-TO_Flight_Track,PACE-PAX_ER-2_Flight_Track,ARCSIX_P-3B_Flight_Track,ARCSIX_G-III_Flight_Track,ARCSIX_SPEC-Learjet_Flight_Track,MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2024-08-29-T14%3A00%3A00Z)
4. Check that the points load for each respective flight track and that they are ordered in descending order by Altitude (smaller points will appear on top of larger points)
5. Verify expected result

@nasa-gibs/worldview
