### PR TITLE
WV-4115: Display WMS when zoomed out for STAQS suborbital

### DIFF
--- a/config/default/common/config/wv.json/layers/staqs/STAQS_G-III_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/staqs/STAQS_G-III_Flight_Track.json
@@ -29,6 +29,18 @@
       "renderOrder": {
         "property": "Altitude",
         "order": "descending"
+      },
+      "breakPointLayer": {
+        "id": "STAQS_G-III_Flight_Track",
+        "type": "wms",
+        "format": "image/png",
+        "breakPointType": "max",
+        "projections": {
+          "geographic": {
+            "source": "GIBS:wms",
+            "resolutionBreakPoint": 0.017578125
+          }
+        }
       }
     }
   }

--- a/config/default/common/config/wv.json/layers/staqs/STAQS_G-V_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/staqs/STAQS_G-V_Flight_Track.json
@@ -29,6 +29,18 @@
       "renderOrder": {
         "property": "Altitude",
         "order": "descending"
+      },
+      "breakPointLayer": {
+        "id": "STAQS_G-V_Flight_Track",
+        "type": "wms",
+        "format": "image/png",
+        "breakPointType": "max",
+        "projections": {
+          "geographic": {
+            "source": "GIBS:wms",
+            "resolutionBreakPoint": 0.017578125
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes #WV-4115 .

Display WMS when zoomed out for STAQS suborbital layers

## How To Test

1. `git checkout wv-4115-breakpointlayer-staqs`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-133.3662429533244,25.220983950457267,-100.5141237962263,42.504884164636536&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,DCOTSS_ER-2_UCATS_Ozone(hidden),DCOTSS_ER-2_ROZE_Ozone,STAQS_G-III_Flight_Track,STAQS_G-V_Flight_Track,PACE-PAX_RV-Shearwater_Ship_Track,PACE-PAX_CIRPAS-TO_Flight_Track(hidden),PACE-PAX_ER-2_Flight_Track(hidden),ARCSIX_P-3B_Flight_Track(hidden),ARCSIX_G-III_Flight_Track(hidden),ARCSIX_SPEC-Learjet_Flight_Track(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=false&t=2023-06-27-T00%3A00%3A00Z)
5. Check that the STAQS layers show WMS when zoomed out and vectors when zoomed in.
6. Verify expected result


@nasa-gibs/worldview
