### PR TITLE
WV-4041: Modernizing ShareToolTips, Tooltip, and VectorMetaTooltip Components

### DIFF
--- a/web/js/components/toolbar/share/tooltips.js
+++ b/web/js/components/toolbar/share/tooltips.js
@@ -1,88 +1,95 @@
-import { PureComponent } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Tooltip,
 } from 'reactstrap';
+import usePrevious from '../../../util/customHooks';
 
-/*
- * @class ShareToolTips
- * @extends React.PureComponent
- */
-class ShareToolTips extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showErrorTooltip: false,
-      showCopiedToolTip: false,
-    };
-  }
+function ShareToolTips(props) {
+  const {
+    tooltipToggleTime,
+    tooltipErrorTime,
+    activeTab,
+  } = props;
 
-  componentDidUpdate(prevProps) {
-    const { activeTab, tooltipToggleTime, tooltipErrorTime } = this.props;
-    const toolTipChange = tooltipToggleTime !== prevProps.tooltipToggleTime;
-    const tooltipErrorChange = tooltipErrorTime !== prevProps.tooltipErrorTime;
-    const activeTabChange = activeTab !== prevProps.activeTab;
+  const [showErrorTooltip, setShowErrorTooltip] = useState(false);
+  const [showCopiedToolTip, setShowCopiedToolTip] = useState(false);
+
+  const prevTooltipToggleTime = usePrevious(tooltipToggleTime);
+  const prevTooltipErrorTime = usePrevious(tooltipErrorTime);
+  const prevActiveTab = usePrevious(activeTab);
+
+  const showErrorTimeout = useRef();
+  const showCopiedToolTipTimeout = useRef();
+
+  function clearPendingTimeouts() {
+    clearTimeout(showCopiedToolTipTimeout.current);
+    clearTimeout(showErrorTimeout.current);
+  };
+
+  function updateToolTipState(toolTipChange, tooltipErrorChange) {
+    setShowErrorTooltip(tooltipErrorChange);
+    setShowCopiedToolTip(toolTipChange);
+  };
+
+  useEffect(() => {
+    const toolTipChange = tooltipToggleTime !== prevTooltipToggleTime;
+    const tooltipErrorChange = tooltipErrorTime !== prevTooltipErrorTime;
+    const activeTabChange = activeTab !== prevActiveTab;
     if (activeTabChange) {
-      this.clearPendingTimeouts();
-      this.updateToolTipState(false, false);
+      clearPendingTimeouts();
+      updateToolTipState(false, false);
     } else if (toolTipChange || tooltipErrorChange) {
-      this.updateToolTipState(toolTipChange, tooltipErrorChange);
+      updateToolTipState(toolTipChange, tooltipErrorChange);
     }
-  }
+  }, [tooltipToggleTime, tooltipErrorTime, activeTab]);
 
-  componentWillUnmount() {
-    this.clearPendingTimeouts();
-  }
+  useEffect(() => {
+    return () => {
+      clearPendingTimeouts();
+    };
+  }, []);
 
-  clearPendingTimeouts = () => {
-    clearTimeout(this.showCopiedToolTipTimeout);
-    clearTimeout(this.showErrorTimeout);
-  };
-
-  updateToolTipState = (toolTipChange, tooltipErrorChange) => {
-    this.setState({
-      showErrorTooltip: tooltipErrorChange,
-      showCopiedToolTip: toolTipChange,
-    });
-  };
-
-  render() {
-    const { showErrorTooltip, showCopiedToolTip } = this.state;
+  useEffect(() => {
     if (showErrorTooltip) {
-      clearTimeout(this.showErrorTimeout);
-      this.showErrorTimeout = setTimeout(() => {
-        this.setState({ showErrorTooltip: false });
+      clearTimeout(showErrorTimeout.current);
+      showErrorTimeout.current = setTimeout(() => {
+        setShowErrorTooltip(false);
       }, 2000);
     }
+  }, [showErrorTooltip, tooltipErrorTime]);
+
+  useEffect(() => {
     if (showCopiedToolTip) {
-      clearTimeout(this.showCopiedToolTipTimeout);
-      this.showCopiedToolTipTimeout = setTimeout(() => {
-        this.setState({ showCopiedToolTip: false });
+      clearTimeout(showCopiedToolTipTimeout.current);
+      showCopiedToolTipTimeout.current = setTimeout(() => {
+        setShowCopiedToolTip(false);
       }, 2000);
     }
-    return (
-      <>
-        <Tooltip
-          id="center-align-tooltip"
-          placement="right"
-          isOpen={showErrorTooltip}
-          target=".share-body"
-          fade={false}
-        >
-          Link cannot be shortened at this time.
-        </Tooltip>
-        <Tooltip
-          id="center-align-tooltip"
-          placement="right"
-          isOpen={showCopiedToolTip}
-          target=".share-body"
-          fade={false}
-        >
-          Copied!
-        </Tooltip>
-      </>
-    );
-  }
+  }, [showCopiedToolTip, tooltipToggleTime]);
+
+  return (
+    <>
+      <Tooltip
+        id="center-align-tooltip"
+        placement="right"
+        isOpen={showErrorTooltip}
+        target=".share-body"
+        fade={false}
+      >
+        Link cannot be shortened at this time.
+      </Tooltip>
+      <Tooltip
+        id="center-align-tooltip"
+        placement="right"
+        isOpen={showCopiedToolTip}
+        target=".share-body"
+        fade={false}
+      >
+        Copied!
+      </Tooltip>
+    </>
+  );
 }
 
 ShareToolTips.propTypes = {

--- a/web/js/components/tooltip/tooltip.js
+++ b/web/js/components/tooltip/tooltip.js
@@ -1,64 +1,49 @@
-import React from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
-class Tooltip extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      hovered: false,
-    };
-    this.mouseOver = this.mouseOver.bind(this);
-    this.mouseOut = this.mouseOut.bind(this);
-    this.onClick = this.onClick.bind(this);
+function Tooltip(props) {
+  const {
+    onClick,
+    text,
+    dataArray,
+  } = props;
+
+  const [hovered, setHovered] = useState(false);
+
+  function mouseOver() {
+    setHovered(true);
   }
 
-  mouseOver() {
-    this.setState({
-      hovered: true,
-    });
+  function mouseOut() {
+    setHovered(false);
   }
 
-  mouseOut() {
-    this.setState({
-      hovered: false,
-    });
-  }
-
-  onClick(str) {
-    const { onClick } = this.props;
-    onClick(str);
-  }
-
-  render() {
-    const { text, dataArray } = this.props;
-    const { hovered } = this.state;
-    return (
+  return (
+    <div
+      onMouseEnter={mouseOver}
+      onMouseLeave={mouseOut}
+      className="wv-tooltip-case"
+    >
+      <span>{text}</span>
       <div
-        onMouseEnter={this.mouseOver}
-        onMouseLeave={this.mouseOut}
-        className="wv-tooltip-case"
+        className="wv-tooltip"
+        style={hovered ? { visibility: 'visible' } : {}}
       >
-        <span>{text}</span>
-        <div
-          className="wv-tooltip"
-          style={hovered ? { visibility: 'visible' } : {}}
-        >
-          <ul>
-            {dataArray.map((dataEl, i) => (
-              <li
-                /* eslint react/no-array-index-key: 1 */
-                key={`tooltip-${dataEl}-${i}`}
-                id={dataEl}
-                onClick={(dataEl) => this.onClick(dataEl)}
-              >
-                {dataEl}
-              </li>
-            ))}
-          </ul>
-        </div>
+        <ul>
+          {dataArray.map((dataEl, i) => (
+            <li
+              /* eslint react/no-array-index-key: 1 */
+              key={`tooltip-${dataEl}-${i}`}
+              id={dataEl}
+              onClick={(dataEl) => onClick(dataEl)}
+            >
+              {dataEl}
+            </li>
+          ))}
+        </ul>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 Tooltip.propTypes = {

--- a/web/js/components/vector-metadata/tooltip.js
+++ b/web/js/components/vector-metadata/tooltip.js
@@ -1,66 +1,49 @@
-import React from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Tooltip } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import util from '../../util/util';
 
-export default class VectorMetaTooltip extends React.Component {
-  constructor(props) {
-    super(props);
+export default function VectorMetaTooltip(props) {
+  const {
+    id,
+    index,
+    description,
+  } = props;
 
-    this.toggle = this.toggle.bind(this);
-    this.mouseEnter = this.mouseEnter.bind(this);
-    this.mouseLeave = this.mouseLeave.bind(this);
-    this.state = {
-      tooltipOpen: false,
-    };
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  function mouseEnter() {
+    setTooltipOpen(true);
   }
 
-  toggle() {
-    this.setState((prevState) => ({
-      tooltipOpen: !prevState.tooltipOpen,
-    }));
+  function mouseLeave() {
+    setTooltipOpen(false);
   }
 
-  mouseEnter() {
-    this.setState({
-      tooltipOpen: true,
-    });
-  }
+  const elId = util.cleanId(String(`tooltip${id}${index}`));
 
-  mouseLeave() {
-    this.setState({
-      tooltipOpen: false,
-    });
-  }
-
-  render() {
-    const { id, index, description } = this.props;
-    const elId = util.cleanId(String(`tooltip${id}${index}`));
-    const { tooltipOpen } = this.state;
-
-    return (
-      <div
-        className="vector-info-tooltip-case"
-        onMouseEnter={this.mouseEnter}
-        onMouseLeave={this.mouseLeave}
-        key={elId}
-      >
-        <div id={elId} className="sub-case">
-          <FontAwesomeIcon icon="info" className="vector-info-icon cursor-pointer" widthAuto />
-        </div>
-        <Tooltip
-          id="center-align-tooltip"
-          dangerouslySetInnerHTML={{ __html: description }}
-          boundariesElement="window"
-          placement="right"
-          isOpen={tooltipOpen}
-          target={elId}
-          fade={false}
-        />
+  return (
+    <div
+      className="vector-info-tooltip-case"
+      onMouseEnter={mouseEnter}
+      onMouseLeave={mouseLeave}
+      key={elId}
+    >
+      <div id={elId} className="sub-case">
+        <FontAwesomeIcon icon="info" className="vector-info-icon cursor-pointer" widthAuto />
       </div>
-    );
-  }
+      <Tooltip
+        id="center-align-tooltip"
+        dangerouslySetInnerHTML={{ __html: description }}
+        boundariesElement="window"
+        placement="right"
+        isOpen={tooltipOpen}
+        target={elId}
+        fade={false}
+      />
+    </div>
+  );
 }
 
 VectorMetaTooltip.propTypes = {


### PR DESCRIPTION
## Description
This converts the ShareToolTips component from a React Class component to a functional component, per best modern practices for React. This process included replacing the class state with `useState`, replacing `componentDidUpdate` and `componentWillUnmount` with`useEffect`, as well as the logic inside the render function, and using `useRef` to keep track of the two timeout timers.

This also converts the Tooltip component from a React Class component to a functional component, per best modern practices for React. This process included replacing the class state with `useState`.

This converts the VectorMetaTooltip component from a React Class component to a functional component, per best modern practices for React. This process included replacing the class state with `useState`.

## How To Test
1. `git checkout wv-4041-modernize-tooltips`
2. `npm ci`
3. `npm run watch`
4. Open the Share interface via the top-right button and verify the tooltips function correctly inside it
5. Add a Vector layer to the map, like any Fires and Thermal Anomalies product, then zoom in to the product and click a point to open the vector data popup
6. Verify the tooltips function correctly inside it