### PR TITLE
WV-4010: Update dois for TRMM v8

### DIFF
--- a/config/default/common/config/metadata/layers/trmm/TRMM_Brightness_Temp_Asc.md
+++ b/config/default/common/config/metadata/layers/trmm/TRMM_Brightness_Temp_Asc.md
@@ -6,4 +6,4 @@ Brightness Temperature is a descriptive measure of radiation in terms of the tem
 
 The spatial resolution is 13 km x 5 km, the imagery resolution is 2 km and temporal availability is daily.
 
-References: GPM_1CTRMMTMI [doi:10.5067/GPM/TMI/TRMM/1C/07](https://doi.org/10.5067/GPM/TMI/TRMM/1C/07)
+References: GPM_1CTRMMTMI [doi:10.5067/GPM/TMI/TRMM/1C/08](https://doi.org/10.5067/GPM/TMI/TRMM/1C/08)

--- a/config/default/common/config/metadata/layers/trmm/TRMM_Brightness_Temp_Dsc.md
+++ b/config/default/common/config/metadata/layers/trmm/TRMM_Brightness_Temp_Dsc.md
@@ -6,4 +6,4 @@ Brightness Temperature is a descriptive measure of radiation in terms of the tem
 
 The spatial resolution is 13 km x 5 km, the imagery resolution is 2 km and temporal availability is daily.
 
-References: GPM_1CTRMMTMI [doi:10.5067/GPM/TMI/TRMM/1C/07](https://doi.org/10.5067/GPM/TMI/TRMM/1C/07)
+References: GPM_1CTRMMTMI [doi:10.5067/GPM/TMI/TRMM/1C/08](https://doi.org/10.5067/GPM/TMI/TRMM/1C/08)

--- a/config/default/common/config/metadata/layers/trmm/TRMM_Precipitation_Rate_Asc.md
+++ b/config/default/common/config/metadata/layers/trmm/TRMM_Precipitation_Rate_Asc.md
@@ -1,7 +1,5 @@
 The Precipitation Rate (Ascending) layer displays rain rate and snow rate measured in millimeters per hour (mm/hr). The layer shows both the Rain Rate and Snow Rate with two different legends. This layer provides snapshots of individual storms, including tropical cyclones and flood-producing systems.
 
-This layer is created from the new (GPM-formatted) TRMM product and replaces the old TRMM_2A12. Version 07 is the current version of the data set. The 2AGPROF (Goddard Profiling) algorithm is developed on GPM/GMI data, then modified to retrieve consistent precipitation and related science fields from other passive microwave sensors. This dataset features 2AGPROF retrievals from TRMM/TMI.
-
 The spatial resolution is 13 km x 5 km, the imagery resolution is 2 km and temporal availability is daily.
 
-References: GPM_2AGPROFTRMMTMI_CLIM [doi:10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/07](https://doi.org/10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/07)
+References: GPM_2AGPROFTRMMTMI_CLIM [doi:10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/08](https://doi.org/10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/08)

--- a/config/default/common/config/metadata/layers/trmm/TRMM_Precipitation_Rate_Dsc.md
+++ b/config/default/common/config/metadata/layers/trmm/TRMM_Precipitation_Rate_Dsc.md
@@ -1,7 +1,5 @@
 The Precipitation Rate (Descending) layer displays rain rate and snow rate measured in millimeters per hour (mm/hr). The layer shows both the Rain Rate and Snow Rate with two different legends. This layer provides snapshots of individual storms, including tropical cyclones and flood-producing systems.
 
-This layer is created from the new (GPM-formatted) TRMM product and replaces the old TRMM_2A12. Version 07 is the current version of the data set. The 2AGPROF (Goddard Profiling) algorithm is developed on GPM/GMI data, then modified to retrieve consistent precipitation and related science fields from other passive microwave sensors. This dataset features 2AGPROF retrievals from TRMM/TMI.
-
 The spatial resolution is 13 km x 5 km, the imagery resolution is 2 km and temporal availability is daily.
 
-References: GPM_2AGPROFTRMMTMI_CLIM [doi:10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/07](https://doi.org/10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/07)
+References: GPM_2AGPROFTRMMTMI_CLIM [doi:10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/08](https://doi.org/10.5067/GPM/TMI/TRMM/GPROFCLIM/2A/08)


### PR DESCRIPTION
## Description

Fixes # WV-4010.

Updated DOIs in layer descriptions for TRMM v8

## How To Test

1. `git checkout wv-4010-trmm-v8`
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TRMM_Precipitation_Rate_Asc,TRMM_Precipitation_Rate_Dsc,TRMM_Brightness_Temp_Asc,TRMM_Brightness_Temp_Dsc,OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2007-03-25-T15%3A17%3A50Z)
4. Check layer descriptions are pointing to v8 dois. Imagery is currently being updated to v8, so may still be showing v7.
5. Verify expected result


@nasa-gibs/worldview
