### PR TITLE
WV-4118: Fix spy listener cleanup when switching compare modes

### DIFF
--- a/web/js/map/compare/spy.js
+++ b/web/js/map/compare/spy.js
@@ -95,7 +95,7 @@ const removeListenersFromLayers = function(layers) {
  */
 const removeInverseListenersFromLayers = function(layers) {
   lodashEach(layers, (layer) => {
-    layer.un('prerender', inverseClip);
+    layer.un('postrender', inverseClip);
     layer.un('postrender', restore);
   });
 };
@@ -170,6 +170,10 @@ export default class Spy {
       this.destroy();
       this.create(store);
     } else {
+      removeListenersFromLayers(topLayers);
+      removeInverseListenersFromLayers(bottomLayers);
+      topLayers.length = 0;
+      bottomLayers.length = 0;
       const mapLayers = this.map.getLayers().getArray();
       applyEventsToBaseLayers(
         mapLayers[0],
@@ -189,6 +193,9 @@ export default class Spy {
     this.mapCase.removeChild(label);
     removeListenersFromLayers(topLayers);
     removeInverseListenersFromLayers(bottomLayers);
+    topLayers.length = 0;
+    bottomLayers.length = 0;
+    mousePosition = null;
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes an issue where switching from Spy to Opacity compare mode after changing the date causes the opacity slider to stop working, showing only one image.

## Test Plan
- [ ] Start Comparison mode
- [ ] Click on Spy
- [ ] Change the A date to a date before the B date using the pick in the timeline or the date selectors
- [ ] Change to Opacity
- [ ] Verify the opacity slider works and fades between the two images