### PR TITLE
WV-4119 & WV-4120: Fix Auto Animation Issues

### DIFF
--- a/web/js/components/timeline/timeline-coverage/coverage-item-container.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-container.js
@@ -24,8 +24,7 @@ class CoverageItemContainer extends Component {
     const { dateRanges } = layer;
     // handle date range query/array building
     if (needDateRangeBuilt) {
-      const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
-      this.updateDateRangeState(dateRangesToDisplay);
+      this.callDateRangeHelper(dateRanges);
     }
   }
 
@@ -43,21 +42,25 @@ class CoverageItemContainer extends Component {
 
     if (frontDateChanged || backDateChanged) {
       if (needDateRangeBuilt) {
-        const dateRangesToDisplay = this.getDateRangeToDisplay(dateRanges);
-        this.updateDateRangeState(dateRangesToDisplay);
+        this.callDateRangeHelper(dateRanges);
       }
     }
+  }
+
+  async callDateRangeHelper(dateRanges) {
+    const dateRangesToDisplay = await this.getDateRangeToDisplay(dateRanges);
+    this.updateDateRangeState(dateRangesToDisplay);
   }
 
   /**
   * @desc getDateRangeToDisplay
   * @param {Array} dateRanges
-  * @returns {ArrayBuffer} multiDateToDisplay
+  * @returns {Promise() <ArrayBuffer>} multiDateToDisplay
   */
-  getDateRangeToDisplay = (dateRanges) => {
+  getDateRangeToDisplay = async (dateRanges) => {
     const { getMaxEndDate, getDatesInDateRange, layer } = this.props;
 
-    const multiDateToDisplay = dateRanges.reduce((dates, range, innerIndex) => {
+    const multiDateToDisplay = await dateRanges.reduce(async (dates, range, innerIndex) => {
       const multiCoverageDates = { ...dates };
       const { dateInterval, startDate, endDate } = range;
       const isLastInRange = innerIndex === dateRanges.length - 1;
@@ -67,7 +70,8 @@ class CoverageItemContainer extends Component {
       // get dates based on date ranges
       const startDateTime = new Date(startDate).getTime();
       const endDateTime = new Date(endDate).getTime();
-      const dateIntervalStartDates = getDatesInDateRange(layer, range, endDateLimit, isLastInRange);
+      const dateIntervalStartDates = await getDatesInDateRange(
+        layer, range, endDateLimit, isLastInRange);
 
       // add date intervals to multiCoverageDates object to catch repeats
       dateIntervalStartDates.forEach((dateIntStartDate) => {

--- a/web/js/components/timeline/timeline-coverage/coverage-item-container.test.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-item-container.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('./coverage-line', () => function MockCoverageLine({
@@ -176,13 +176,15 @@ describe('CoverageItemContainer', () => {
       expect(getMaxEndDate).toHaveBeenCalledWith(layer, true);
     });
 
-    it('renders MULTI CoverageLines for dates within range', () => {
+    it('renders MULTI CoverageLines for dates within range', async () => {
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const layer = { ...defaultLayer, dateRanges: singleRange };
       const { getByTestId } = renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange,
       });
-      expect(getByTestId('coverage-line-layer-abc-0').dataset.lineType).toBe('MULTI');
+      await waitFor(() => {
+        expect(getByTestId('coverage-line-layer-abc-0').dataset.lineType).toBe('MULTI');
+      });
     });
 
     it('renders no MULTI CoverageLines when all dates fall outside range', () => {
@@ -213,33 +215,37 @@ describe('CoverageItemContainer', () => {
       expect(getMaxEndDate).toHaveBeenCalledWith(layer, true);
     });
 
-    it('passes MULTI start date from itemRange.date', () => {
+    it('passes MULTI start date from itemRange.date', async () => {
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const layer = { ...defaultLayer, dateRanges: singleRange };
       const { getByTestId } = renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange,
       });
-      expect(getByTestId('coverage-line-layer-abc-0').dataset.start).toBe(dateInRange.toISOString());
+      await waitFor(() => {
+        expect(getByTestId('coverage-line-layer-abc-0').dataset.start).toBe(dateInRange.toISOString());
+      });
     });
 
-    it('calls getRangeDateEndWithAddedInterval for each range item', () => {
+    it('calls getRangeDateEndWithAddedInterval for each range item', async () => {
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const getRangeDateEndWithAddedInterval = jest.fn(() => new Date('2020-07-01'));
       const layer = { ...defaultLayer, dateRanges: singleRange };
       renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange, getRangeDateEndWithAddedInterval,
       });
-      expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledTimes(1);
-      expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledWith(
-        layer,
-        new Date(dateInRange.toISOString()),
-        'day',
-        1,
-        undefined,
-      );
+      await waitFor(() => {
+        expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledTimes(1);
+        expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledWith(
+          layer,
+          new Date(dateInRange.toISOString()),
+          'day',
+          1,
+          undefined,
+        );
+      });
     });
 
-    it('uses dateInterval as numeric interval in getRangeDateEndWithAddedInterval', () => {
+    it('uses dateInterval as numeric interval in getRangeDateEndWithAddedInterval', async () => {
       const rangeWith5Interval = [{ startDate: '2020-01-01', endDate: '2020-12-31', dateInterval: '5' }];
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const getRangeDateEndWithAddedInterval = jest.fn(() => new Date('2020-06-20'));
@@ -247,16 +253,18 @@ describe('CoverageItemContainer', () => {
       renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange, getRangeDateEndWithAddedInterval,
       });
-      expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledWith(
-        layer,
-        expect.any(Date),
-        'day',
-        5,
-        undefined,
-      );
+      await waitFor(() => {
+        expect(getRangeDateEndWithAddedInterval).toHaveBeenCalledWith(
+          layer,
+          expect.any(Date),
+          'day',
+          5,
+          undefined,
+        );
+      });
     });
 
-    it('calls getMatchingCoverageLineDimensions per MULTI range item', () => {
+    it('calls getMatchingCoverageLineDimensions per MULTI range item', async () => {
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const getMatchingCoverageLineDimensions = jest.fn(() => [{ visible: true }]);
       const layer = { ...defaultLayer, dateRanges: singleRange };
@@ -267,14 +275,16 @@ describe('CoverageItemContainer', () => {
         getMatchingCoverageLineDimensions,
       });
       // once for the single MULTI item
-      expect(getMatchingCoverageLineDimensions).toHaveBeenCalledWith(
-        layer,
-        expect.any(Date),
-        expect.any(Date),
-      );
+      await waitFor(() => {
+        expect(getMatchingCoverageLineDimensions).toHaveBeenCalledWith(
+          layer,
+          expect.any(Date),
+          expect.any(Date),
+        );
+      });
     });
 
-    it('filters invisible dimensions for MULTI range items', () => {
+    it('filters invisible dimensions for MULTI range items', async () => {
       const getDatesInDateRange = jest.fn(() => [dateInRange]);
       const getMatchingCoverageLineDimensions = jest.fn(() => [
         { visible: true },
@@ -284,10 +294,12 @@ describe('CoverageItemContainer', () => {
       const { getByTestId } = renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange, getMatchingCoverageLineDimensions,
       });
-      expect(getByTestId('coverage-line-layer-abc-0').dataset.optionsCount).toBe('1');
+      await waitFor(() => {
+        expect(getByTestId('coverage-line-layer-abc-0').dataset.optionsCount).toBe('1');
+      });
     });
 
-    it('deduplicates dates from overlapping ranges via object key overwrite', () => {
+    it('deduplicates dates from overlapping ranges via object key overwrite', async () => {
       const duplicateDate = new Date('2020-06-15');
       const twoRanges = [
         { startDate: '2020-01-01', endDate: '2020-12-31', dateInterval: '1' },
@@ -299,7 +311,9 @@ describe('CoverageItemContainer', () => {
       const { container } = renderComponent({
         needDateRangeBuilt: true, layer, getDatesInDateRange,
       });
-      expect(container.querySelectorAll('[data-line-type="MULTI"]')).toHaveLength(1);
+      await waitFor(() => {
+        expect(container.querySelectorAll('[data-line-type="MULTI"]')).toHaveLength(1);
+      });
     });
   });
 
@@ -398,7 +412,7 @@ describe('CoverageItemContainer', () => {
       expect(getDatesInDateRange).not.toHaveBeenCalled();
     });
 
-    it('reflects updated layerDateRanges in render after frontDate change', () => {
+    it('reflects updated layerDateRanges in render after frontDate change', async () => {
       const getDatesInDateRange = jest.fn(() => []);
       const layer = { ...defaultLayer, dateRanges: singleRange };
       const { rerender, container } = renderComponent({
@@ -416,7 +430,9 @@ describe('CoverageItemContainer', () => {
           frontDate="2020-03-01"
         />,
       );
-      expect(container.querySelectorAll('[data-line-type="MULTI"]')).toHaveLength(1);
+      await waitFor(() => {
+        expect(container.querySelectorAll('[data-line-type="MULTI"]')).toHaveLength(1);
+      });
     });
   });
 });

--- a/web/js/components/timeline/timeline-coverage/coverage-line.js
+++ b/web/js/components/timeline/timeline-coverage/coverage-line.js
@@ -154,8 +154,8 @@ class CoverageLine extends PureComponent {
       layerPeriod,
       index,
     } = this.props;
-    return options.map((option) => (
-      <g clipPath="url(#coverageLineBoundary)">
+    return options.map((option, i) => (
+      <g clipPath="url(#coverageLineBoundary)" key={`${id}-${i}`}>
         {this.createMatchingCoverageLineDOMEl(
           id,
           option,

--- a/web/js/modules/date/util.js
+++ b/web/js/modules/date/util.js
@@ -593,11 +593,12 @@ function getDateRanges(layer) {
 export function getValidDateRanges(layers, dateA, dateB) {
   for (let i = 0; i < layers.length; i += 1) {
     const dateRanges = getDateRanges(layers[i]);
-    if (dateRanges && layers[i].visible) {
+    if (dateRanges && dateRanges.length && layers[i].visible) {
       return dateRanges.filter((element) => new Date(element.startDate) <= dateB &&
         new Date(element.endDate) >= dateA);
     }
   }
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Description
This change fixes an issue with opening the layer coverage panel with a subdaily and non-subdaily layer present. It also fixes an issue with some Auto interval animations not playing in certain circumstances.

## How To Test
1. `git checkout wv-4119-4120-auto-anim-fixes`
2. `npm ci`
4. `npm run watch`
5. Open a fresh Worldview instance
6. Add TEMPO L3 Formaldehyde layer to the map
7. Verify that opening the layer coverage panel (via the double-chevron above the timeline) doesn't cause a crash and correctly displays the blue availability bars
8. Close the layer coverage panel, hide the Terra/MODIS Corrected Reflectance layer, then open the Animation interface and set up an animation with the Auto interval
9. Verify that clicking the play button on the animation interface correctly plays the animation