### PR TITLE
WV-4123: Update ARCSIX_G-III_Flight_Track colormap

### DIFF
--- a/config/default/common/colormaps/arcsix/ARCSIX_G-III_Flight_Track.xml
+++ b/config/default/common/colormaps/arcsix/ARCSIX_G-III_Flight_Track.xml
@@ -3,14 +3,14 @@
            xsi:noNamespaceSchemaLocation="http://gibs.earthdata.nasa.gov/schemas/ColorMap_v1.3.xsd">
   <ColorMap title="Flight Track (Per Flight, IWG1, NASA LaRC G-III, ARCSIX)">
     <Entries>
-      <ColorMapEntry rgb="146,208,80" sourceValue="200" transparent="false" ref="1" />
-          <ColorMapEntry rgb="0,255,0" transparent="false" value="[1]" ref="2"/>
+      <ColorMapEntry rgb="255,153,31" sourceValue="200" transparent="false" ref="1" />
+          <ColorMapEntry rgb="255,102,0" transparent="false" value="[1]" ref="2"/>
           <ColorMapEntry rgb="255,0,0" transparent="false" value="[2]" ref="3"/>
     </Entries>
     <Legend type="classification">
-      <LegendEntry rgb="146,208,80" id="1" tooltip="Altitude (m)" label="Altitude (m)" showLabel="true" />
-          <LegendEntry rgb="0,255,0" tooltip="Flight 1" id="2" label="Flight 1" showLabel="true" />
-          <LegendEntry rgb="255,0,0" tooltip="Flight 2" id="3" label="Flight 2" showLabel="true" />
+      <LegendEntry rgb="255,153,31" id="1" tooltip="Altitude (m)" label="Altitude (m)" showLabel="true" />
+          <LegendEntry rgb="255,102,0" tooltip="F1" id="2" label="Flight 1" showLabel="true" />
+          <LegendEntry rgb="255,0,0" tooltip="F2" id="3" label="Flight 2" showLabel="true" />
     </Legend>
   </ColorMap>
 </ColorMaps>


### PR DESCRIPTION
## Description

Fixes #WV-4123 .
Update ARCSIX_G-III_Flight_Track colormap

## How To Test

1. `git checkout
2. `npm run build && npm start`
3. Open with [these URL parameters](http://localhost:3000/?v=-758370.9085744844,-852110.6641633188,-646963.6311230931,-802293.9208738491&p=arctic&l=Reference_Labels_15m(hidden),ARCSIX_SPEC-Learjet_Flight_Track(hidden),ARCSIX_G-III_Flight_Track,ARCSIX_P-3B_Flight_Track(hidden),Land_Water_Map(opacity=0.7),OCI_PACE_True_Color(hidden)&lg=true&t=2024-08-07-T08%3A00%3A00Z)
4. Make sure the legend colors match the colors of the flight track
5. Verify expected result

@nasa-gibs/worldview
