### PR TITLE
Fix event-listener leaks in compare Swipe and Spy tools

### DIFF
--- a/web/js/map/compare/spy.js
+++ b/web/js/map/compare/spy.js
@@ -3,7 +3,6 @@ import { getRenderPixel } from 'ol/render';
 import { getCompareDates } from '../../modules/compare/selectors';
 
 let mousePosition = null;
-let spy = null;
 const topLayers = [];
 const bottomLayers = [];
 const DEFAULT_RADIUS = 140;
@@ -135,6 +134,11 @@ export default class Spy {
   constructor(olMap, store) {
     this.mapCase = document.getElementById('wv-map');
     this.map = olMap;
+    // Bind handlers once so addSpy() and destroy() reference the same function
+    // objects — otherwise removeEventListener/un can never remove them.
+    this.updateSpy = this.updateSpy.bind(this);
+    this.hideSpy = this.hideSpy.bind(this);
+    this.showSpy = this.showSpy.bind(this);
     const state = store.getState();
     const isBInside = state.compare.isCompareA;
     this.isBInside = isBInside;
@@ -148,7 +152,7 @@ export default class Spy {
   create(store) {
     const state = store.getState();
     const isBInside = isCompareA(state);
-    spy = this.addSpy(this.map, state);
+    this.addSpy(this.map, state);
     this.isBInside = isBInside;
     this.update(store);
   }
@@ -188,8 +192,10 @@ export default class Spy {
    * Remove all nodes and listeners
    */
   destroy() {
-    spy.removeEventListener('mousemove', this.updateSpy);
+    this.mapCase.removeEventListener('mousemove', this.updateSpy);
     this.map.un('pointerdrag', this.updateSpy);
+    this.mapCase.removeEventListener('mouseleave', this.hideSpy);
+    this.mapCase.removeEventListener('mouseenter', this.showSpy);
     this.mapCase.removeChild(label);
     removeListenersFromLayers(topLayers);
     removeInverseListenersFromLayers(bottomLayers);
@@ -244,10 +250,10 @@ export default class Spy {
     label.innerHTML = getDateText(state);
 
     this.mapCase.appendChild(label);
-    this.mapCase.addEventListener('mousemove', this.updateSpy.bind(this));
-    map.on('pointerdrag', this.updateSpy.bind(this));
-    this.mapCase.addEventListener('mouseleave', this.hideSpy.bind(this));
-    this.mapCase.addEventListener('mouseenter', this.showSpy.bind(this));
+    this.mapCase.addEventListener('mousemove', this.updateSpy);
+    map.on('pointerdrag', this.updateSpy);
+    this.mapCase.addEventListener('mouseleave', this.hideSpy);
+    this.mapCase.addEventListener('mouseenter', this.showSpy);
 
     return this.mapCase;
   }

--- a/web/js/map/compare/spy.test.js
+++ b/web/js/map/compare/spy.test.js
@@ -258,6 +258,40 @@ describe('destroy', () => {
     expect(l1.un).toHaveBeenCalledWith('prerender', expect.any(Function));
     expect(l1.un).toHaveBeenCalledWith('postrender', expect.any(Function));
   });
+
+  // Regression: addSpy() previously registered mapCase/map listeners via inline
+  // `.bind(this)`, so destroy() could never remove them (bind returns a new fn
+  // each call) and mouseleave/mouseenter were not removed at all. Every A/B swap
+  // recreates the Spy, permanently leaking 4 listeners. destroy() must remove the
+  // exact same handler references that addSpy() registered.
+  test('removes every listener it registered using the identical handler references', () => {
+    const mapCase = document.getElementById('wv-map');
+    const addSpy = jest.spyOn(mapCase, 'addEventListener');
+    const removeSpy = jest.spyOn(mapCase, 'removeEventListener');
+
+    const l0 = makeLayer(null);
+    const l1 = makeLayer(null);
+    const map = makeMap(l0, l1);
+    const store = makeStore({ compare: { isCompareA: true } });
+    getCompareDates.mockReturnValue({ dateA: '2020-01-01', dateB: '2021-01-01' });
+    const instance = new Spy(map, store);
+
+    // Capture the exact handler reference registered for each DOM event type...
+    const addedByType = {};
+    addSpy.mock.calls.forEach(([type, handler]) => { addedByType[type] = handler; });
+    // ...and the handler registered for pointerdrag on the OL map.
+    const pointerdragCall = map.on.mock.calls.find(([evt]) => evt === 'pointerdrag');
+    const pointerdragHandler = pointerdragCall && pointerdragCall[1];
+
+    instance.destroy();
+
+    ['mousemove', 'mouseleave', 'mouseenter'].forEach((type) => {
+      expect(addedByType[type]).toBeInstanceOf(Function);
+      expect(removeSpy).toHaveBeenCalledWith(type, addedByType[type]);
+    });
+    expect(pointerdragHandler).toBeInstanceOf(Function);
+    expect(map.un).toHaveBeenCalledWith('pointerdrag', pointerdragHandler);
+  });
 });
 
 describe('updateSpy', () => {

--- a/web/js/map/compare/swipe.js
+++ b/web/js/map/compare/swipe.js
@@ -197,13 +197,16 @@ export default class Swipe {
     this.map = olMap;
     this.getSwipeOffset = getSwipeOffset;
     percentSwipe = valueOverride / 100;
-    this.create(store);
-    window.addEventListener('resize', () => {
+    // Stable handler reference so create()/destroy() add and remove the same
+    // listener — previously this was an anonymous fn that could never be removed,
+    // leaking one window 'resize' listener per destroy()/create() cycle.
+    this.onResize = () => {
       if (document.querySelector('.ab-swipe-line')) {
         this.destroy();
         this.create(store);
       }
-    });
+    };
+    this.create(store);
   }
 
   create(store) {
@@ -212,10 +215,12 @@ export default class Swipe {
     this.dateA = dateA;
     this.dateB = dateB;
     line = addLineOverlay(this.map, this.dateA, this.dateB, this.updateExtents);
+    window.addEventListener('resize', this.onResize);
     this.update(store);
   }
 
   destroy = () => {
+    window.removeEventListener('resize', this.onResize);
     mapCase.removeChild(line);
     lodashEach(layersSideA, (layer) => {
       layer.un('prerender', this.setClipMaskA);

--- a/web/js/map/compare/swipe.test.js
+++ b/web/js/map/compare/swipe.test.js
@@ -600,3 +600,45 @@ describe('window resize handler', () => {
     expect(document.querySelector('.ab-swipe-line')).toBeNull();
   });
 });
+
+// ─────────────────────────────────────────────
+// Regression: window resize listener leak
+// The 'resize' listener was registered with no stored reference and never
+// removed in destroy(). compare.js destroys + recreates the Swipe on every
+// completed drag, so each drag leaked one window 'resize' listener for the
+// rest of the session. destroy() must remove the listener it registered.
+// (registeredResizeListeners is tracked by the window.addEventListener shim
+// defined at the top of this file.)
+// ─────────────────────────────────────────────
+
+describe('window resize listener cleanup (regression: listener leak)', () => {
+  it('removes the window resize listener on destroy', () => {
+    document.body.innerHTML = '';
+    const map = makeMockMap();
+    const store = makeMockStore();
+
+    const before = registeredResizeListeners.length;
+    const swipe = new Swipe(map, store, defaultListenerObj, 50);
+    expect(registeredResizeListeners.length).toBe(before + 1);
+
+    swipe.destroy();
+    expect(registeredResizeListeners.length).toBe(before);
+  });
+
+  it('does not accumulate resize listeners across repeated destroy/create cycles', () => {
+    document.body.innerHTML = '';
+    const map = makeMockMap();
+    const store = makeMockStore();
+
+    const before = registeredResizeListeners.length;
+    const swipe = new Swipe(map, store, defaultListenerObj, 50);
+    // Mirror the destroy()+create() churn compare.js drives on every drag-end.
+    swipe.destroy();
+    swipe.create(store);
+    swipe.destroy();
+    swipe.create(store);
+    swipe.destroy();
+
+    expect(registeredResizeListeners.length).toBe(before);
+  });
+});


### PR DESCRIPTION
## Description

Fixes two event-listener leaks in the A/B comparison map tools. No linked issue — filing alongside this PR; happy to open one if preferred.

Both `Swipe` and `Spy` register event listeners in `create()`/`addSpy()` but `destroy()` fails to remove them. Because `compare.js` tears down and recreates these objects on routine user actions, the listeners accumulate for the rest of the session — a real memory/performance leak, not a hypothetical one.

- [x] **Spy** (`web/js/map/compare/spy.js`): `addSpy()` registered `mousemove`, `pointerdrag`, `mouseleave`, and `mouseenter` handlers using inline `.bind(this)`. Since `Function.prototype.bind` returns a new function object every call, `destroy()`'s `removeEventListener`/`un` calls referenced different functions and silently no-op'd — and `mouseleave`/`mouseenter` were never removed at all. `compare.js` recreates the `Spy` on every A/B side swap, so each swap permanently leaked 4 listeners. Fixed by binding the handlers once in the constructor and removing all four in `destroy()`.
- [x] **Swipe** (`web/js/map/compare/swipe.js`): the `window` `resize` listener was an anonymous arrow function with no stored reference, and `destroy()` never removed it. `compare.js` destroys + recreates the `Swipe` after every completed swipe drag, leaking one `resize` listener per drag. Fixed by storing the handler on the instance, registering it in `create()`, and removing it in `destroy()`.
- [x] Added regression tests that fail on the previous code and pass with the fix.

The fixes are intentionally minimal and follow the lifecycle pattern already used correctly by the sibling `opacity.js` in the same directory (stable handler references, matched add/remove). A larger follow-up worth considering separately: `swipe.js` keeps several pieces of state (`line`, `mapCase`, `layersSideA/B`, etc.) as module-level `let` bindings shared across instances; converting those to instance properties would make the tools fully instance-safe. I kept that out of this PR to keep the change surgical and reviewable.

## How To Test

Automated (recommended):

```bash
npm ci
npx jest web/js/map/compare/spy.test.js web/js/map/compare/swipe.test.js
```

The added tests assert that `destroy()` removes exactly the handler references that were registered, and that repeated `destroy()`/`create()` cycles don't accumulate `window` `resize` listeners. Reverting either source fix makes the corresponding new test fail.

Manual (in the UI):

1. Enable A/B comparison mode.
2. **Swipe:** drag the divider several times. Before this fix, a new `window` `resize` listener was added on each drag-end (observable in DevTools → Elements → Event Listeners on `window`, or via `getEventListeners(window).resize.length` in Chrome). After the fix the count stays flat.
3. **Spy:** switch the spy between the A and B sides repeatedly, then move the mouse over the map. Before this fix, duplicate `mousemove`/`pointerdrag` handlers accumulated on `#wv-map`/the map (redundant `map.render()` calls per mouse move). After the fix, swapping sides leaves a single set of handlers.

## PR Submission Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable) — n/a, internal bugfix
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules (if applicable) — n/a
