### PR TITLE
WV-4116: Fix sidebar icon padding overlap in embed mode

### DIFF
--- a/web/js/containers/sidebar/layer-row.js
+++ b/web/js/containers/sidebar/layer-row.js
@@ -653,7 +653,7 @@ function LayerRow (props) {
           {...attributes}
           {...listeners}
         >
-          <div className="layer-buttons">
+          <div className={showButtons ? 'layer-buttons' : 'layer-buttons hidden'}>
             {showButtons && renderControls()}
           </div>
           <h4 title={names.title}>{names.title}</h4>

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -125,7 +125,7 @@
       }
 
       & .layer-buttons {
-        background: #ccc;
+        // background: #ccc;
         width: 20px;
 
         & .wv-layers-options {

--- a/web/scss/features/embed.scss
+++ b/web/scss/features/embed.scss
@@ -125,7 +125,6 @@
       }
 
       & .layer-buttons {
-        // background: #ccc;
         width: 20px;
 
         & .wv-layers-options {

--- a/web/scss/features/layers.scss
+++ b/web/scss/features/layers.scss
@@ -1099,7 +1099,7 @@ a[rel="noreferrer"]:hover {
   (max-width: variables.$mobile-max-width) {
   .instrument-collection {
     h6 {
-      margin-right: 20px;
+      margin-right: 2px;
     }
   }
 }

--- a/web/scss/features/sidebar-panel.scss
+++ b/web/scss/features/sidebar-panel.scss
@@ -598,7 +598,7 @@ li.item.productsitem.inmotion,
       width: 100px;
 
       & .layer-group-more-options {
-        top: 10px;
+        top: 0;
         position: absolute;
         right: 0;
       }


### PR DESCRIPTION
## Description
https://www.earthdata.nasa.gov/news/worldview-image-archive/gulf-stream-kuroshio-current

There is a weird overlap/extra padding that appears in the layers in the layer list in embedded Worldview. it overlaps the NRT/STD chip even if you aren't hovered over the top right corner to reveal the "i" layer description icon. 

It [doesn't happen](https://www.earthdata.nasa.gov/news/worldview-image-archive/tropical-storm-amanda-forms-pacific) for all of the embedded Worldview instances, but it does for [some](https://www.earthdata.nasa.gov/news/worldview-image-archive/fire-chars-santa-rosa-island). 

Check here for many instances of embedded WV: https://www.earthdata.nasa.gov/news/worldview-image-archive

## Fixes
CSS changes:
- Made background of icon container transparent
- Adjusted padding and absolute positioning to tighten up spacing

React changes:
- Added conditional to use `hidden` CSS className for `layer-buttons` div if `showButtons` state is false

## How To Test
1. `git checkout -b wv-4116-layer-button-padding`
2. `npm run watch`
3. Open [this URL for localhost](http://localhost:3000/?v=-99.85538807115456,20.75738565833473,-60.32082744313173,46.87559940656668&em=true&l=Reference_Labels_15m,Coastlines_15m,GHRSST_L4_MUR_Sea_Surface_Temperature&lg=true&t=2026-06-10-T19%3A25%3A07Z) and compare with embedded PROD version of Worldview [found here](https://www.earthdata.nasa.gov/news/worldview-image-archive/gulf-stream-kuroshio-current)
4. Verify that the localhost version no longer has the grey overlapping the `v4.1 STD` chip.
5. Verify that hover over the Sea Surface Temperature sidebar layer row shows the `(!)` icon on mouse hover and hides when the mouse leaves.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
