### PR TITLE
WV-4082: Simplified radio buttons for palette selection.

### DIFF
--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -47,7 +47,7 @@ function PaletteSelect (props) {
     const color = palette.classes
       ? palette.classes.colors[0]
       : palette.colors[0];
-    const caseDefaultClassName = 'wv-palette-selector-row wv-checkbox wv-checkbox-round gray ';
+    const caseDefaultClassName = 'wv-palette-selector-row wv-radio';
     const checkedClassName = isSelected ? 'checked' : '';
     const isInvisible = color === '00000000';
 
@@ -83,7 +83,7 @@ function PaletteSelect (props) {
    * @param {Boolean} isSelected | is this colormap active
    */
   const renderSelectorItemScale = (palette, id, legend, isSelected) => {
-    const caseDefaultClassName = 'wv-palette-selector-row wv-checkbox wv-checkbox-round gray ';
+    const caseDefaultClassName = 'wv-palette-selector-row wv-radio ';
     const checkedClassName = isSelected ? 'checked' : '';
     const ctx = canvas.getContext('2d');
     drawPaletteOnCanvas(
@@ -102,9 +102,6 @@ function PaletteSelect (props) {
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
         />
-        {isSelected && (
-          <span className="dot" />
-        )}
         <label htmlFor={`wv-palette-radio-${id}-${index}`}>
           <img src={dataURL} />
           <span className="wv-palette-label">{legend.name || 'Default'}</span>

--- a/web/scss/components/radio.scss
+++ b/web/scss/components/radio.scss
@@ -1,0 +1,41 @@
+.wv-radio {
+  & input[type="radio"] {
+    margin: 3px 1px;
+    vertical-align: middle;
+  }
+
+  input {
+    appearance: none !important;
+    width: 16px;
+    height: 16px;
+    border: 1px solid #eee;
+    border-radius: 50%;
+    background: none;
+    position: relative;
+  }
+
+
+  label {
+    color: #fff;
+    cursor: pointer;
+
+    span {
+      line-height: 22px;
+    }
+  }
+}
+
+.wv-radio.checked input {
+  appearance: none !important;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #eee;
+  border-radius: 50%;
+  background: #1d67e3;
+  box-shadow: 0 0 0 1px #1d67e3;
+  position: relative;
+}
+
+.wv-radio.gray label {
+  color: #666;
+}

--- a/web/scss/components/radio.scss
+++ b/web/scss/components/radio.scss
@@ -1,6 +1,6 @@
 .wv-radio {
   & input[type="radio"] {
-    margin: 3px 1px;
+    margin: 3px 0;
     vertical-align: middle;
   }
 
@@ -30,11 +30,12 @@
   appearance: none !important;
   width: 14px;
   height: 14px;
-  border: 1px solid #eee;
+  border: 1.5px solid #eee;
   border-radius: 50%;
   background: #1d67e3;
   box-shadow: 0 0 0 1px #1d67e3;
   position: relative;
+  margin: 3px 1px;
 }
 
 .wv-radio.gray label {

--- a/web/scss/components/radio.scss
+++ b/web/scss/components/radio.scss
@@ -8,10 +8,11 @@
     appearance: none !important;
     width: 16px;
     height: 16px;
-    border: 1px solid #eee;
+    border: 1px solid #b5b5b7;
     border-radius: 50%;
     background: none;
     position: relative;
+    cursor: pointer;
   }
 
 
@@ -27,9 +28,9 @@
 
 .wv-radio.checked input {
   appearance: none !important;
-  width: 16px;
-  height: 16px;
-  border: 2px solid #eee;
+  width: 14px;
+  height: 14px;
+  border: 1px solid #eee;
   border-radius: 50%;
   background: #1d67e3;
   box-shadow: 0 0 0 1px #1d67e3;

--- a/web/scss/features/palettes.scss
+++ b/web/scss/features/palettes.scss
@@ -18,7 +18,7 @@
 }
 
 .wv-palette-selector-row label {
-  margin-left: 7px;
+  margin-left: 12px;
   color: #b5b5b7 !important;
 }
 

--- a/web/scss/index.scss
+++ b/web/scss/index.scss
@@ -15,6 +15,7 @@
 @use 'components/list';
 @use 'components/modal';
 @use 'components/notifications';
+@use 'components/radio';
 @use 'components/switch';
 @use 'components/tooltip';
 @use 'components/range';


### PR DESCRIPTION
Simplified radio buttons for palette selection.  No longer uses <span> tag to create blue 'checked' radio button. Now uses CSS to fill in radio button.  Created new radio.scss file.

## How To Test
1. `npm ci`
2. `npm run watch`
3. Open this [localhost url](http://localhost:3000/?l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA21_AOD_Dark_Target_Land_Ocean(palette=orange_1),VIIRS_SNPP_DayNightBand,GHRSST_L4_MUR_Sea_Surface_Temperature(palette=purple_3),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2026-06-07-T19%3A57%3A33Z)
4. Verify the radio buttons look and function properly.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
