### PR TITLE
WV-4075: Fix for static map fallback crashing when using EIC parameters

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -315,7 +315,7 @@ export default function mapLayerBuilder(config, cache, store) {
     const options = optionsObj;
     const state = store.getState();
     const { compare: { activeString } } = state;
-    const { ui: { isKioskModeActive, displayStaticMap } } = state;
+    const { ui: { displayStaticMap } } = state;
     const { tempoCallback } = options;
 
     options.group = options.group || activeString;
@@ -327,7 +327,7 @@ export default function mapLayerBuilder(config, cache, store) {
     }
 
     // if gibs/dns failure, display static image layer
-    if (displayStaticMap && isKioskModeActive) {
+    if (displayStaticMap) {
       const layer = await createStaticImageLayer();
       return layer;
     }


### PR DESCRIPTION
## Description
When using `&eic=` in the URL (with any of the values: `da`, `sa`, `si`, etc.), a TypeError occurs at the end of the animation when the static map tries to load. The error is Cannot read properties of undefined (reading 'id') in layerbuilder.js. 

## Fixes
The issue was caused by `createStaticImageLayer()` not being called due to a condition requiring `isKioskModeActive` to be true.  `isKioskModeActive` was removed from the condition to allow the `createStaticImageLayer()` call to fire regardless if kiosk mode is used.

## How To Test

1. `git checkout wv-4075-eic-crash-fix`
2. `npm run watch`
3. Go to this [localhost URL](http://localhost:3000/?v=-211.5863883297933,-227.2434188408527,223.4359073149236,220.4284612871503&eic=da&l=OMI_Nitrogen_Dioxide_Tropo_Column(hidden)&lg=false&t=2023-10-27-T16%3A00%3A00Z) and wait for about 10 seconds for the retries to complete.
4. After the retries complete, a static image of the Blue Marble imagery should appear.
5. Edit the URL and append the URL parameter `&kiosk=true`.  Wait again for ~10 seconds for the retries to complete.  The static Blue Marble image should appear.
6. Verify the result.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
