### PR TITLE
WV-4111: Fix Canvas Memory Leak

### DIFF
--- a/web/js/mapUI/components/create-map/createMap.test.js
+++ b/web/js/mapUI/components/create-map/createMap.test.js
@@ -24,6 +24,7 @@ jest.mock('../../../util/util', () => ({
     events: {
       trigger: jest.fn(),
       on: jest.fn(),
+      off: jest.fn(),
     },
   },
 }));

--- a/web/js/mapUI/components/granule-hover/granuleHover.js
+++ b/web/js/mapUI/components/granule-hover/granuleHover.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { getActiveGranuleFootPrints } from '../../../modules/layers/selectors';
 import { GRANULE_HOVERED, GRANULE_HOVER_UPDATE } from '../../../util/constants';
@@ -12,6 +13,16 @@ function GranuleHover(props) {
     state,
     ui,
   } = props;
+
+  useEffect(() => {
+    events.on(GRANULE_HOVERED, onGranuleHover);
+    events.on(GRANULE_HOVER_UPDATE, onGranuleHoverUpdate);
+
+    return () => {
+      events.off(GRANULE_HOVERED, onGranuleHover);
+      events.off(GRANULE_HOVER_UPDATE, onGranuleHoverUpdate);
+    };
+  }, []);
 
   const onGranuleHover = (platform, date, update) => {
     const proj = ui.selected.getView().getProjection()
@@ -35,9 +46,6 @@ function GranuleHover(props) {
     if (!geometry) return;
     granuleFootprints[proj].updateFootprint(geometry, date);
   };
-
-  events.on(GRANULE_HOVERED, onGranuleHover);
-  events.on(GRANULE_HOVER_UPDATE, onGranuleHoverUpdate);
 
   return null;
 }

--- a/web/js/mapUI/components/granule-hover/granuleHover.test.js
+++ b/web/js/mapUI/components/granule-hover/granuleHover.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../util/util', () => ({
   default: {
     events: {
       on: jest.fn(),
+      off: jest.fn(),
     },
   },
 }));

--- a/web/js/mapUI/components/mouse-move-events/mouseMoveEvents.js
+++ b/web/js/mapUI/components/mouse-move-events/mouseMoveEvents.js
@@ -48,11 +48,21 @@ function MouseMoveEvents(props) {
     throttledOnMouseMove(mouseMove);
   }, [mouseMove]);
 
-  events.on(MAP_MOUSE_MOVE, setMouseMove);
-  events.on(MAP_MOUSE_OUT, (e) => {
-    throttledOnMouseMove.cancel();
-    ui.runningdata.clearAll();
-  });
+  useEffect(() => {
+    events.on(MAP_MOUSE_MOVE, setMouseMove);
+    events.on(MAP_MOUSE_OUT, (e) => {
+      throttledOnMouseMove.cancel();
+      ui.runningdata.clearAll();
+    });
+
+    return () => {
+      events.off(MAP_MOUSE_MOVE, setMouseMove);
+      events.off(MAP_MOUSE_OUT, (e) => {
+        throttledOnMouseMove.cancel();
+        ui.runningdata.clearAll();
+      });
+    };
+  }, []);
 
   return null;
 }

--- a/web/js/mapUI/components/mouse-move-events/mouseMoveEvents.test.js
+++ b/web/js/mapUI/components/mouse-move-events/mouseMoveEvents.test.js
@@ -12,6 +12,7 @@ jest.mock('../../../util/util', () => ({
   default: {
     events: {
       on: jest.fn(),
+      off: jest.fn(),
     },
   },
 }));


### PR DESCRIPTION
## Description
This change fixes a memory leak with event listeners that could cause issues on lower-memory devices. Multiple event listeners were not un-attached after the component was destroyed, causing a build-up of many listeners. This change moves the listeners to be within the standard component lifecycle in `useEffect`, where they are also properly un-attached on component destruction.

## How To Test
1. `git checkout wv-4111-canvas-memory-fix`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-111.70592878035987,-102.49604212914198,250.39001326950736,88.19105698276726&l=Coastlines_15m,VIIRS_NOAA20_Cloud_Top_Height_Day,MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2025-07-21-T13%3A22%3A31Z) in Google Chrome
5. Open the browser dev tools, navigate to the Memory tab, then take a Heap Snapshot
6. In WV, open the layer options for the Cloud Top Height layer and change the layer thresholds many times in a row (20-30 times). After doing so, take another Heap Snapshot in the Memory tab
7. Repeat step 6 again, creating a third Heap Snapshot at the end
8. For each of the Heap Snapshots, filter them by `WMTS` and verify that the number of them isn't increasing drastically across the three snapshots
<img width="1702" height="472" alt="image" src="https://github.com/user-attachments/assets/734e31bb-c896-4419-b67a-b3de7db72d20" />
