### PR TITLE
WV-4062: Fix Granule Layers Slowing Ability to Show/Hide Other Layers

### DIFF
--- a/web/js/mapUI/components/update-date/updateDate.js
+++ b/web/js/mapUI/components/update-date/updateDate.js
@@ -221,11 +221,11 @@ function UpdateDate(props) {
       }
     };
     const layerPromises = visibleLayers.filter(
-      (def) => def.type !== 'granule').map(async (def) => {
+      (def) => outOfStepChange || def.type !== 'granule').map(async (def) => {
       await createLayerPromise(def);
     });
     // Seperate granule-type layers to be loaded asynchronously
-    visibleLayers.filter((def) => def.type === 'granule').forEach((def) => {
+    !outOfStepChange && visibleLayers.filter((def) => def.type === 'granule').forEach((def) => {
       createLayerPromise(def);
     });
     await Promise.allSettled(layerPromises);

--- a/web/js/mapUI/components/update-date/updateDate.js
+++ b/web/js/mapUI/components/update-date/updateDate.js
@@ -189,7 +189,8 @@ function UpdateDate(props) {
     const visibleLayers = activeLayersArray.filter(({ id, visible }) => layers
       .findIndex(({ wv }) => wv?.def?.id === id) !== -1 && visible);
 
-    const layerPromises = visibleLayers.map(async (def) => {
+    // Helper function for loading updated layer from def
+    const createLayerPromise = async (def) => {
       const { id, type } = def;
       const temporalLayer = ['subdaily', 'daily', 'monthly', 'yearly']
         .includes(def.period);
@@ -218,6 +219,14 @@ function UpdateDate(props) {
       if (hasVectorStyles && temporalLayer) {
         updateVectorStyles(def);
       }
+    };
+    const layerPromises = visibleLayers.filter(
+      (def) => def.type !== 'granule').map(async (def) => {
+      await createLayerPromise(def);
+    });
+    // Seperate granule-type layers to be loaded asynchronously
+    visibleLayers.filter((def) => def.type === 'granule').forEach((def) => {
+      createLayerPromise(def);
     });
     await Promise.allSettled(layerPromises);
     if (isStale()) return;


### PR DESCRIPTION
## Description
This change fixes an issue with non-granule layers being slow to show/hide when a granule layer is present. This is done by loading any granule layers asynchronously.

## How To Test
1. `git checkout wv-4062-granule-hideshow-slowdown-fix`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?z=4&ics=true&ici=5&icd=6&l=Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(count=10)&lg=true&t=2026-05-05-T15%3A21%3A59Z)
6. Verify that the Coastlines layer appears/disappears quickly when toggling show/hide on the layer, while a granule layer is present on the map. If granule layers is loading instantly, you can throttle the granule source to make it easier to see the fix if needed