### PR TITLE
WV-4042 Modernize CompareModeOptions from class to functional component

### DIFF
--- a/web/js/components/sidebar/compare-mode-options.js
+++ b/web/js/components/sidebar/compare-mode-options.js
@@ -1,63 +1,59 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, ButtonGroup } from 'reactstrap';
 
-class CompareModeOptions extends React.Component {
-  render() {
-    const {
-      isActive, isMobile, selected, onclick,
-    } = this.props;
-
-    return (
+function CompareModeOptions({
+  isActive, isMobile, selected, onclick,
+}) {
+  return (
+    <div
+      id="wv-ab-mode-selection-case"
+      className="wv-ab-mode-selection-case"
+      style={{ display: isActive && !isMobile ? 'block' : 'none' }}
+    >
+      <h3
+        className="compare-title"
+      >
+        Comparison Mode
+      </h3>
       <div
-        id="wv-ab-mode-selection-case"
-        className="wv-ab-mode-selection-case"
-        style={{ display: isActive && !isMobile ? 'block' : 'none' }}
+        className="compare-button-row"
       >
         <h3
-          className="compare-title"
+          className="compare-subtitle"
         >
-          Comparison Mode
+          Type:
         </h3>
-        <div
-          className="compare-button-row"
-        >
-          <h3
-            className="compare-subtitle"
+        <ButtonGroup size="sm">
+          <Button
+            id="compare-swipe-button"
+            className="compare-button compare-swipe-button"
+            disabled={selected === 'swipe'}
+            onClick={() => onclick('swipe')}
           >
-            Type:
-          </h3>
-          <ButtonGroup size="sm">
-            <Button
-              id="compare-swipe-button"
-              className="compare-button compare-swipe-button"
-              disabled={selected === 'swipe'}
-              onClick={() => onclick('swipe')}
-            >
-              Swipe
-            </Button>
-            <Button
-              id="compare-opacity-button"
-              className="compare-button compare-opacity-button"
-              disabled={selected === 'opacity'}
-              onClick={() => onclick('opacity')}
-            >
-              Opacity
-            </Button>
-            <Button
-              id="compare-spy-button"
-              className="compare-button compare-spy-button"
-              disabled={selected === 'spy'}
-              onClick={() => onclick('spy')}
-            >
-              Spy
-            </Button>
-          </ButtonGroup>
-        </div>
+            Swipe
+          </Button>
+          <Button
+            id="compare-opacity-button"
+            className="compare-button compare-opacity-button"
+            disabled={selected === 'opacity'}
+            onClick={() => onclick('opacity')}
+          >
+            Opacity
+          </Button>
+          <Button
+            id="compare-spy-button"
+            className="compare-button compare-spy-button"
+            disabled={selected === 'spy'}
+            onClick={() => onclick('spy')}
+          >
+            Spy
+          </Button>
+        </ButtonGroup>
       </div>
-    );
-  }
+    </div>
+  );
 }
+
 CompareModeOptions.propTypes = {
   isActive: PropTypes.bool,
   isMobile: PropTypes.bool,


### PR DESCRIPTION
## Description

Converts `CompareModeOptions` from a class component to a functional component. The other three components in scope (`ModalInProgress`, `ModalStart`, `TourBox`) were already functional.

## Test Plan
- [ ] Enable A|B compare mode in the sidebar — confirm "Comparison Mode" section is visible
- [ ] Click Swipe, Opacity, and Spy buttons — confirm selected button becomes disabled and mode changes
- [ ] Resize to mobile viewport — confirm the section is hidden
- [ ] Deactivate compare mode — confirm the section disappears
