### PR TITLE
Fixed radio button CSS for vector layer color palette

### DIFF
--- a/web/js/components/layer/settings/palette.js
+++ b/web/js/components/layer/settings/palette.js
@@ -48,7 +48,7 @@ function PaletteSelect (props) {
       ? palette.classes.colors[0]
       : palette.colors[0];
     const caseDefaultClassName = 'wv-palette-selector-row wv-radio';
-    const checkedClassName = isSelected ? 'checked' : '';
+    const checkedClassName = isSelected ? ' checked' : '';
     const isInvisible = color === '00000000';
 
     return (
@@ -59,9 +59,6 @@ function PaletteSelect (props) {
           name="wv-palette-radio"
           onClick={() => onChangePalette(id)}
         />
-        {isSelected && (
-          <span className="dot" />
-        )}
         <label htmlFor={`wv-palette-radio-${id}-${index}`}>
           <span
             className={isInvisible ? 'checkerbox-bg wv-palettes-class' : 'wv-palettes-class'}
@@ -83,8 +80,8 @@ function PaletteSelect (props) {
    * @param {Boolean} isSelected | is this colormap active
    */
   const renderSelectorItemScale = (palette, id, legend, isSelected) => {
-    const caseDefaultClassName = 'wv-palette-selector-row wv-radio ';
-    const checkedClassName = isSelected ? 'checked' : '';
+    const caseDefaultClassName = 'wv-palette-selector-row wv-radio';
+    const checkedClassName = isSelected ? ' checked' : '';
     const ctx = canvas.getContext('2d');
     drawPaletteOnCanvas(
       ctx,


### PR DESCRIPTION
## Description
This PR fixes a CSS spacing issue with vector layer color palette radio button selections.

## How To Test

1. `git checkout WV-4082-radio-button-checked-offcenter`
2. `npm ci`
3. `npm run watch`
4. Open this [localhost URL](http://localhost:3000/?l=MODIS_Combined_Thermal_Anomalies_All,VIIRS_NOAA21_AOD_Dark_Target_Land_Ocean(palette=red_1)&lg=true&t=2026-06-07-T19%3A57%3A33Z) and compare with this [PROD Worldview URL](https://worldview.earthdata.nasa.gov/?l=MODIS_Combined_Thermal_Anomalies_All,VIIRS_NOAA21_AOD_Dark_Target_Land_Ocean(palette=red_1)&lg=true&t=2026-06-07-T19%3A57%3A33Z)
5. Open the layer settings for Fires and Thermal Anomalies for both versions of Worldview.
6. Verify that the localhost version's radio buttons and the rows containing the color palette bars -- selected and unselected -- have no CSS spacing issues.  They should look identical to the production version of Worldview.
7. Repeat Step 6 for the Aerosol Optical Depth layer.

## PR Submission Checklist

This is simply a reminder of what we are going to look for before merging your code.

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- Any dependent changes have been merged and published in downstream modules (if applicable)

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
