### PR TITLE
WV-4111 (2): Fix Granule Footprints not appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10903,9 +10903,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/js/mapUI/components/granule-hover/granuleHover.js
+++ b/web/js/mapUI/components/granule-hover/granuleHover.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useEffect } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 import { connect } from 'react-redux';
 import { getActiveGranuleFootPrints } from '../../../modules/layers/selectors';
 import { GRANULE_HOVERED, GRANULE_HOVER_UPDATE } from '../../../util/constants';
@@ -24,7 +24,7 @@ function GranuleHover(props) {
     };
   }, []);
 
-  const onGranuleHover = (platform, date, update) => {
+  const onGranuleHover = useEffectEvent((platform, date, update) => {
     const proj = ui.selected.getView().getProjection()
       .getCode();
     if (!granuleFootprints[proj]) return;
@@ -33,9 +33,9 @@ function GranuleHover(props) {
       geometry = getActiveGranuleFootPrints(state)[date];
     }
     granuleFootprints[proj].addFootprint(geometry, date);
-  };
+  });
 
-  const onGranuleHoverUpdate = (platform, date) => {
+  const onGranuleHoverUpdate = useEffectEvent((platform, date) => {
     const proj = ui.selected.getView().getProjection()
       .getCode();
     if (!granuleFootprints[proj]) return;
@@ -45,7 +45,7 @@ function GranuleHover(props) {
     }
     if (!geometry) return;
     granuleFootprints[proj].updateFootprint(geometry, date);
-  };
+  });
 
   return null;
 }


### PR DESCRIPTION
## Description
This change fixes an issue with granule footprints no longer showing on-hover of a granule. This was caused by outdated props being present in the event listener callback, and is fixed via the implementation of `useEffectEvent`.

## How To Test
1. `git checkout wv-4111-2-fix`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-107.38535003674954,-119.6816354661561,185.19626726985175,99.09344403179556&z=4&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule(count=10),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2026-08-02-T12%3A25%3A59Z)
5. Verify that hovering the granules correctly shows a granule footprint
6. Do the same with [this link](http://localhost:3000/?v=-179.2766687577207,-22.793244897012073,-19.948543757720685,96.34282227636508&z=4&ias=true&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,TEMPO_L2_Formaldehyde_Vertical_Column_Granule(count=1),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2026-08-02-T19%3A42%3A59Z)
