### PR TITLE
Make getVisMetadata skipLayers configurable

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -35,7 +35,8 @@
                 "POCLOUD": "PO.DAAC",
                 "SEDAC": "SEDAC",
                 "AERONET": "AERONET"
-            }
+            },
+            "skipLayers": []
         },
         "cmr": {
             "url": "https://cmr.earthdata.nasa.gov/search/"

--- a/doc/features.md
+++ b/doc/features.md
@@ -8,6 +8,19 @@ CGI files. Next, enable these features in your configuration file.
 
 By default during the build process we try to fetch images of layers from our Snapshots application to show as previews in the layer picker component.  However, this will only work for layers that are present in NASA GIBS (Global Imagery Browse Services).  If you are serving your own layers, you will likely wish to disable this feature by setting `"previewSnapshots": false` in `config/default/common/features.json`.
 
+## Skipping Layer Metadata
+
+During the build process, Worldview fetches imagery layer metadata from the GIBS Layer Metadata API (see `vismetadata.url` in `config/default/common/features.json`) for every layer in the layer order. By default a fixed set of layers that do not exist in GIBS is skipped and won't be fetched. If you are serving your own layers, you can skip additional layers by adding their IDs to the `vismetadata.skipLayers` array:
+
+```
+"vismetadata": {
+    "url": "https://gibs.earthdata.nasa.gov/layer-metadata/v1.0/",
+    "skipLayers": ["your_internal_layer"]
+}
+```
+
+Layers listed here are skipped in addition to the default set, so existing behavior is preserved.
+
 ## Natural Events
 
 This feature provides natural events queried by Earth Observatory Natural Event Tracker (EONET) by default. To enable, edit `config/default/common/features.json` and set:

--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -67,9 +67,10 @@ const outputFile = argv.layerMetadata
 const metadataConfig = features.features.vismetadata
 const url = metadataConfig.url
 const daacMap = metadataConfig.daacMap || {}
+const configuredSkipLayers = metadataConfig.skipLayers || []
 
 // These are alias or otherwise layers that don't exist in GIBS
-const skipLayers = [
+const defaultSkipLayers = [
   'Land_Water_Map',
   'Land_Mask',
   'World_Database_on_Protected_Areas',
@@ -124,6 +125,8 @@ const skipLayers = [
   'NISAR_L2_Geocoded_Polarimetric_Covariance_12Day'
 
 ]
+
+const skipLayers = defaultSkipLayers.concat(configuredSkipLayers)
 
 // NOTE: Only using these properties at this time
 const useKeys = [


### PR DESCRIPTION
Fixes #6687

## Description

The list of layers skipped when fetching GIBS layer metadata during the build process is currently hardcoded in `tasks/build-options/getVisMetadata.js`. Self-hosted deployments serving their own layers have no first-party way to skip their internal layers and resort to patching the script (e.g. via `sed` in a Dockerfile).

This PR makes the skip list configurable: additional layers can be added via `vismetadata.skipLayers` in `config/default/common/features.json`. The existing default list is preserved, so behavior for the default NASA configuration is unchanged.

## Changes

- `tasks/build-options/getVisMetadata.js`: rename the hardcoded list to `defaultSkipLayers` and merge with `configuredSkipLayers` read from the vismetadata config.
- `config/default/common/features.json`: add `vismetadata.skipLayers` (empty by default).
- `doc/features.md`: document the new option.

## How To Test

- Run a build with a layer that does not exist in GIBS added to `vismetadata.skipLayers` and confirm it is no longer fetched / fails the build.
- With an empty `skipLayers` (default config), behavior is identical to before this change.
- `npm run lint` passes.

## PR Submission Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

@nasa-gibs/worldview