### PR TITLE
WV-4139: Fix Higher Resolution Snapshots Returning Black Screenshot

### DIFF
--- a/web/js/components/image-download/image-download-panel.js
+++ b/web/js/components/image-download/image-download-panel.js
@@ -76,6 +76,7 @@ function ImageDownloadPanel(props) {
   const [isSnapshotInProgress, setIsSnapshotInProgress] = useState(false);
   const [snapshotStatus, setSnapshotStatus] = useState('');
   const abortControllerRef = useRef(null);
+  const dimensionsRef = useRef(null);
 
   const onCancelSnapshot = () => {
     abortControllerRef.current?.abort();
@@ -155,6 +156,7 @@ function ImageDownloadPanel(props) {
 
     const timeout = setTimeout(onCancelSnapshot, 180_000);
     try {
+      dimensionsRef.current = getDimensions(map, lonlats, currResolution);
       setSnapshotStatus('Creating snapshot...');
       const startTime = Date.now();
       await snapshot(snapshotOptions);
@@ -192,6 +194,7 @@ function ImageDownloadPanel(props) {
       onProgressChange(false);
       abortControllerRef.current = null;
       changeResolution(currResolution);
+      dimensionsRef.current = null;
     }
   };
 
@@ -271,7 +274,7 @@ function ImageDownloadPanel(props) {
   };
 
   const { crs } = projection.selected;
-  const dimensions = getDimensions(map, lonlats, currResolution);
+  const dimensions = dimensionsRef.current || getDimensions(map, lonlats, currResolution);
   const { height } = dimensions;
   const { width } = dimensions;
   const filetypeSelect = renderFileTypeSelect();

--- a/web/js/modules/image-download/util.js
+++ b/web/js/modules/image-download/util.js
@@ -737,6 +737,7 @@ function createMapRestore(map, extent, abortSignal, tileMatrixID, onerror) {
   const originalStyleHeight = mapElement.style.height;
 
   const restoreLayers = toggleHighResTileGrids(map, abortSignal, tileMatrixID, onerror);
+  restoreLayers();
 
   return () => {
     // Restore original map size


### PR DESCRIPTION
## Description
This change fixes an issue with trying to take a higher resolution snapshot of imagery and the resulting snapshot not showing the correct result, instead showing only black.

This change also fixes an issue with the shown output file dimensions changing as the snapshot is being generated.

## How To Test
1. `git checkout wv-4139-snapshot-highres-fix`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=-3902282.270216844,-1383472.4044973506,-1582024.859992004,-161577.58777014888&p=arctic&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA21_Brightness_Temp_BandI5_Night(hidden),VIIRS_NOAA21_DayNightBand,OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2026-01-04-T12%3A33%3A40Z), take a snapshot with resolution set to 250m, and verify the resulting image file shows the correct imagery
6. Open [this link](http://localhost:3000/?v=-25.375289623972698,59.298940972074064,-7.583816397391708,68.66829319209067&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,VIIRS_NOAA21_Brightness_Temp_BandI5_Night,VIIRS_NOAA21_DayNightBand(hidden),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2026-01-04-T12%3A33%3A40Z), take a snapshot with resolution set to 125m, and verify the resulting image file shows the correct imagery
7. Take a few snapshots of any imagery varying the size and shape of the bounding box between each, and verify that the width and height of the output file shown in the sidebar don't change during snapshot generation