### PR TITLE
WV-4126 - Fix alerts not displaying by removing hidden attribute from AlertDrop…

### DIFF
--- a/web/js/containers/alertDropdown.js
+++ b/web/js/containers/alertDropdown.js
@@ -1,19 +1,32 @@
-import { useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import {
+  useState, useRef, useEffect, useCallback,
+} from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Alerts from './alerts';
 
 export default function AlertDropdown(isTourActive) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [notifications, setNotifications] = useState(0);
   const containerRef = useRef(null);
-  const notifications = containerRef?.current?.children.length;
+  const observerRef = useRef(null);
+
+  const updateNotifications = useCallback(() => {
+    setNotifications(containerRef.current?.children.length || 0);
+  }, []);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    updateNotifications();
+    observerRef.current = new MutationObserver(updateNotifications);
+    observerRef.current.observe(node, { childList: true });
+    return () => observerRef.current?.disconnect();
+  }, []);
+
   const toggle = () => setDropdownOpen((prevState) => !prevState);
-  const { isTourActive: tourActive } = isTourActive;
-  const isDistractionFreeModeActive = useSelector((state) => state.ui.isDistractionFreeModeActive);
-  const isMobile = useSelector((state) => state.screenSize.isMobileDevice);
 
   return (
-    <div className="wv-alert-dropdown" hidden={isDistractionFreeModeActive || tourActive || isMobile}>
+    <div className="wv-alert-dropdown">
       <button type="button" hidden={notifications <= 1} onClick={toggle}>
         <FontAwesomeIcon
           icon="exclamation-triangle"

--- a/web/js/containers/alertDropdown.test.js
+++ b/web/js/containers/alertDropdown.test.js
@@ -39,21 +39,21 @@ describe('AlertDropdown', () => {
     expect(wrapper).not.toHaveAttribute('hidden');
   });
 
-  it('hides the wrapper when distraction free mode is active', () => {
+  it('does not hide the wrapper when distraction free mode is active', () => {
     mockState = makeState({ ui: { isDistractionFreeModeActive: true } });
     const { container } = render(<AlertDropdown isTourActive={false} />);
-    expect(container.querySelector('.wv-alert-dropdown')).toHaveAttribute('hidden');
+    expect(container.querySelector('.wv-alert-dropdown')).not.toHaveAttribute('hidden');
   });
 
-  it('hides the wrapper when the tour is active', () => {
+  it('does not hide the wrapper when the tour is active', () => {
     const { container } = render(<AlertDropdown isTourActive />);
-    expect(container.querySelector('.wv-alert-dropdown')).toHaveAttribute('hidden');
+    expect(container.querySelector('.wv-alert-dropdown')).not.toHaveAttribute('hidden');
   });
 
-  it('hides the wrapper on mobile devices', () => {
+  it('does not hide the wrapper on mobile devices', () => {
     mockState = makeState({ screenSize: { isMobileDevice: true } });
     const { container } = render(<AlertDropdown isTourActive={false} />);
-    expect(container.querySelector('.wv-alert-dropdown')).toHaveAttribute('hidden');
+    expect(container.querySelector('.wv-alert-dropdown')).not.toHaveAttribute('hidden');
   });
 
   it('renders Alerts inside the alert container', () => {


### PR DESCRIPTION
## Summary
- Fixed multiple alerts (measure tool, distraction free mode, tour stories) not displaying due to the `AlertDropdown` wrapper hiding the `#wv-alert-container` portal target
- Removed `hidden` attribute from the `AlertDropdown` outer wrapper so portaled alerts are always reachable

## Test Plan
- [ ] Open measure tool → select Measure Distance → alert appears in top-right
- [ ] Press Shift+D → distraction free mode alert appears
- [ ] Navigate to URL with invalid story ID (`?tr=invalid-story-id`) → "no longer supported" alert appears
- [ ] Open tour → check "Do not show until new story" → close → re-enable alert appears
- [ ] Trigger 2+ alerts simultaneously → "Multiple Layer Alerts" dropdown button appears and functions correctly
- [ ] Existing alerts (events, compare, vector zoom, DDV) still display correctly