### PR TITLE
Update NISAR_L2_Geocoded_Polarimetric_Covariance_12Day.json

### DIFF
--- a/config/default/common/config/wv.json/layers/nisar/NISAR_L2_Geocoded_Polarimetric_Covariance_12Day.json
+++ b/config/default/common/config/wv.json/layers/nisar/NISAR_L2_Geocoded_Polarimetric_Covariance_12Day.json
@@ -16,7 +16,7 @@
       "type": "wmts",
       "format": "image/png",
       "period": "daily",
-      "startDate": "2026-06-17T00:00:00Z",
+      "startDate": "2025-10-29T00:00:00Z",
       "daynight": ["day", "night"],
       "conceptIds": [
         {


### PR DESCRIPTION
## Description
Update NISAR start date to 2025-10-29 for rolling 12-day layer.

## How To Test

1. Open with [these URL parameters](http://localhost:3000/?v=-247.11577044555673,-74.32677300109708,215.51420517532233,124.7767214989029&l=Reference_Labels_15m(hidden),Reference_Features_15m(hidden),Coastlines_15m,NISAR_L2_Geocoded_Polarimetric_Covariance_12Day,NISAR_L2_Geocoded_Polarimetric_Covariance(hidden),OCI_PACE_True_Color(hidden),VIIRS_NOAA21_CorrectedReflectance_TrueColor(hidden),VIIRS_NOAA20_CorrectedReflectance_TrueColor(hidden),VIIRS_SNPP_CorrectedReflectance_TrueColor(hidden),MODIS_Aqua_CorrectedReflectance_TrueColor(hidden),MODIS_Terra_CorrectedReflectance_TrueColor(hidden)&lg=true&t=2025-10-29-T16%3A02%3A07Z)
2. Check that the rolling 12-day layer loads imagery on 2025-10-29. Also check that the regular layer also starts on that date.
3. Verify expected result
@nasa-gibs/worldview
