### PR TITLE
WV-5126 - Fix tour alert showing literal Unicode escapes instead of quotes

### DIFF
--- a/web/js/containers/tour.js
+++ b/web/js/containers/tour.js
@@ -368,7 +368,7 @@ function Tour(props) {
         isOpen
         timeout={10000}
         onDismiss={endTourProp}
-        message="To view these tours again, click the 'Explore @NAME@' link in the \u201ci\u201d menu."
+        message="To view these tours again, click the 'Explore @NAME@' link in the 'i' menu."
       />
     );
   }


### PR DESCRIPTION
## Summary
- Fixed tour alert displaying literal `\u201c` and `\u201d` Unicode escape text instead of quote characters

## Test Plan
- [ ] Open tour → check "Do not show until new story" → close → alert should display: "To view these tours again, click the 'Explore Worldview' link in the 'i' menu."