### PR TITLE
WV-4149: Fix Invalid Extent In Permalink Error

### DIFF
--- a/web/js/mapUI/components/update-projection/updateProjection.js
+++ b/web/js/mapUI/components/update-projection/updateProjection.js
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import OlLayerGroup from 'ol/layer/Group';
+import { isEmpty } from 'ol/extent';
 import {
   get as lodashGet,
 } from 'lodash';
@@ -287,7 +288,7 @@ function UpdateProjection(props) {
       const projId = proj.selected.id;
       let extent = null;
       let callback = null;
-      if (models.map.extent) {
+      if (models.map.extent && !isEmpty(models.map.extent)) {
         extent = models.map.extent;
       } else if (!models.map.extent && projId === 'geographic') {
         extent = getLeadingExtent(config.pageLoadTime);


### PR DESCRIPTION
## Description
This change fixes an issue with trying to load a permalink with an invalid extent and the WV page failing to load because of it. The fix here is checking if an extent is a non-empty extent before applying it to the map.

## How To Test
1. `git checkout wv-4149-invalid-extent-fix`
2. `npm ci`
3. `npm run watch`
4. Open [this link](http://localhost:3000/?v=90,-30,-70,30&l=Coastlines_15m,IMERG_Precipitation_Rate&lg=false&t=2026-08-10-T00%3A00%3A00Z)
6. Verify the link loads into WV without crashing and that the invalid extent is reset to a default valid extent