### PR TITLE
WV-4114: Configurable skipLayers in getVisMetadata.js

### DIFF
--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -37,6 +37,7 @@
                 "AERONET": "AERONET"
             }
         },
+        "skipLayers": [],
         "cmr": {
             "url": "https://cmr.earthdata.nasa.gov/search/"
         },

--- a/config/default/common/features.json
+++ b/config/default/common/features.json
@@ -35,9 +35,9 @@
                 "POCLOUD": "PO.DAAC",
                 "SEDAC": "SEDAC",
                 "AERONET": "AERONET"
-            }
+            },
+            "skipLayers": []
         },
-        "skipLayers": [],
         "cmr": {
             "url": "https://cmr.earthdata.nasa.gov/search/"
         },

--- a/doc/features.md
+++ b/doc/features.md
@@ -31,6 +31,19 @@ edit `config/default/common/features.json` and set `"smartHandoffs": true`.
 This feature uses the [ArcGIS World Geocoding Service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm) to find addresses based on input text, coordinates, and by clicking a spot on the map. To enable,
 edit `config/default/common/features.json` and set `"locationSearch"` object `"url"` to use the ArcGIS request URL used by the [ArcGIS World Geocoding Service](https://developers.arcgis.com/rest/geocode/api-reference/overview-world-geocoding-service.htm).
 
+## Skipping Layer Metadata
+
+During the build process, Worldview fetches imagery layer metadata from the GIBS Layer Metadata API (see `vismetadata.url` in `config/default/common/features.json`) for every layer in the layer order. By default a fixed set of layers that do not exist in GIBS is skipped and won't be fetched. If you are serving your own layers, you can skip additional layers by adding their IDs to the `vismetadata.skipLayers` array:
+
+```
+"vismetadata": {
+    "url": "https://gibs.earthdata.nasa.gov/layer-metadata/v1.0/",
+    "skipLayers": ["your_internal_layer"]
+}
+```
+
+Layers listed here are skipped in addition to the default set, so existing behavior is preserved.
+
 ## URL Shortening
 
 This feature uses

--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -67,9 +67,10 @@ const outputFile = argv.layerMetadata
 const metadataConfig = features.features.vismetadata
 const url = metadataConfig.url
 const daacMap = metadataConfig.daacMap || {}
+const configuredSkipLayers = metadataConfig.skipLayers || []
 
-// These are alias or otherwise layers that don't exist in GIBS
-const skipLayers = [
+// These are aliases or otherwise layers that don't exist in GIBS
+const defaultSkipLayers = [
   'Land_Water_Map',
   'Land_Mask',
   'World_Database_on_Protected_Areas',
@@ -122,8 +123,9 @@ const skipLayers = [
   'EUMETSAT_MSG_IDOC_IR108_10min',
   'OPERA_L2_Radiometric_Terrain_Corrected_SAR_Sentinel-1_12Day',
   'NISAR_L2_Geocoded_Polarimetric_Covariance_12Day'
-
 ]
+
+const skipLayers = defaultSkipLayers.concat(configuredSkipLayers)
 
 // NOTE: Only using these properties at this time
 const useKeys = [


### PR DESCRIPTION
## Description
The list of layers skipped when fetching GIBS layer metadata during the build process is currently hardcoded in tasks/build-options/getVisMetadata.js. Self-hosted deployments serving their own layers have no first-party way to skip their internal layers and resort to patching the script (e.g. via sed in a Dockerfile).

This PR makes the skip list configurable: additional layers can be added via vismetadata.skipLayers in config/default/common/features.json. The existing default list is preserved, so behavior for the default NASA configuration is unchanged.

## Changes
- tasks/build-options/getVisMetadata.js: rename the hardcoded list to defaultSkipLayers and merge with configuredSkipLayers read from the vismetadata config.
- config/default/common/features.json: add vismetadata.skipLayers (empty by default).
- doc/features.md: document the new option.

## How To Test

-  Add `"VIIRS_NOAA20_CorrectedReflectance_TrueColor"` to the `skipLayers` array in `config/default/common/features.json`
- `npm run build`
- Once complete, search for `"VIIRS_NOAA20_CorrectedReflectance_TrueColor"` within `build/options-build/layer-metadata/all.json`.  `"VIIRS_NOAA20_CorrectedReflectance_TrueColor"` should not appear in this file. (There may be another entry that ends with `_Granule`.  This entry can be ignored.
- This verifies that custom `skipLayers` field in `config/default/common/features.json` is working.
- Repeat the steps above, but leave `skipLayers` as an empty array.  With an empty skipLayers the default config will build.
- Search for `"VIIRS_NOAA20_CorrectedReflectance_TrueColor"` within `build/options-build/layer-metadata/all.json` file again.  `"VIIRS_NOAA20_CorrectedReflectance_TrueColor"` should appear in this file.
- Verify the result.