### PR TITLE
WV-4150 - Restore flat styling on facet chips

### DIFF
--- a/web/scss/components/facets.scss
+++ b/web/scss/components/facets.scss
@@ -16,6 +16,7 @@
     margin: 4px;
     background: #ccc;
     color: #333;
+    border: none;
     border-radius: 20px;
     position: relative;
     display: inline-block;


### PR DESCRIPTION
## Summary

Fixes WV-4150. The facet chips in the layer picker search UI rendered with a
native button border/bevel instead of the flat gray pill they had previously.

## Test Plan

- [ ] open the layer picker → Search tab, tick a Coverage facet and a Categories facet (e.g. Fires). Chips should be flat gray pills with no border.