### PR TITLE
WV-4148

### DIFF
--- a/web/js/containers/map-interactions/ol-vector-interactions.js
+++ b/web/js/containers/map-interactions/ol-vector-interactions.js
@@ -107,12 +107,15 @@ export function VectorInteractions(props) {
     events.on(MAP_SINGLE_CLICK, singleClick);
 
     return () => {
+      mouseMoveThrottled.cancel();
+      mouseOutThrottled.cancel();
+
       events.off(MAP_MOVE_END, moveEnd);
       events.off(MAP_MOUSE_MOVE, mouseMoveThrottled);
       events.off(MAP_MOUSE_OUT, mouseOutThrottled);
       events.off(MAP_SINGLE_CLICK, singleClick);
     };
-  }, []);
+  }, [proj?.id, proj?.selected?.crs]);
 
   useEffect(() => {
     if (granuleDate && prevGranuleFootprints !== granuleFootprints) {

--- a/web/js/map/granule/util.js
+++ b/web/js/map/granule/util.js
@@ -391,7 +391,7 @@ export const areCoordinatesAndPolygonExtentValid = (points, coords, maxExtent) =
   const polygon = new OlGeomPolygon([points]);
 
   const areCoordsWithinPolygon = polygon.intersectsCoordinate(coords);
-  // check is polygon footprint is within max extent, will allow partial corners within max extent
+  // check if polygon footprint is within max extent, will allow partial corners within max extent
   const doesPolygonIntersectMaxExtent = polygon.intersectsExtent(maxExtent);
   // check if polygon is larger than maxExtent - helpful to catch most large polar granules
   const polygonExtent = polygon.getExtent();


### PR DESCRIPTION
## Description

Fixes #WV-4148

Granule hover effects (outline & timestamp) do not appear in polar projections.

To confirm behavior:
- Load [this link](https://worldview.earthdata.nasa.gov/?v=-65.86420083614397,-62.964919771908,93.46392416385603,58.7673581886183&z=4&l=VIIRS_NOAA20_CorrectedReflectance_TrueColor_Granule&lg=false&t=2026-08-13-T13%3A00%3A59Z)
- Confirm hover works in geographic projection
- Switch projection to arctic or antarctic
- Confirm hover does NOT work (note hover WILL work if you reload while in polar projection)

## How To Test
- `git checkout WV-4148`
- `npm ci && npm run watch`
- Repeat steps above
- Confirm granule hover works as intended in all projections

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
