### PR TITLE
WV-4147: ARCSIX displays arctic vectors only when zoomed in

### DIFF
--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_G-III_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_G-III_Flight_Track.json
@@ -39,6 +39,10 @@
           "geographic": {
             "source": "GIBS:wms",
             "resolutionBreakPoint": 0.017578125
+          },
+          "arctic": {
+            "source": "GIBS:wms:arctic",
+            "resolutionBreakPoint": 200
           }
         }
       }

--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_P-3B_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_P-3B_Flight_Track.json
@@ -39,6 +39,10 @@
           "geographic": {
             "source": "GIBS:wms",
             "resolutionBreakPoint": 0.017578125
+          },
+          "arctic": {
+            "source": "GIBS:wms:arctic",
+            "resolutionBreakPoint": 200
           }
         }
       }

--- a/config/default/common/config/wv.json/layers/arcsix/ARCSIX_SPEC-Learjet_Flight_Track.json
+++ b/config/default/common/config/wv.json/layers/arcsix/ARCSIX_SPEC-Learjet_Flight_Track.json
@@ -39,6 +39,10 @@
           "geographic": {
             "source": "GIBS:wms",
             "resolutionBreakPoint": 0.017578125
+          },
+          "arctic": {
+            "source": "GIBS:wms:arctic",
+            "resolutionBreakPoint": 200
           }
         }
       }


### PR DESCRIPTION
## Description
When displaying ARCSIX layers in the arctic projection, the clickable vectors loaded immediately at any zoom level.  This PR updates the config files so that ARCSIX layers only display the vectors when zoomed in far enough.

## How To Test
- `git checkout WV-4147-arcsix-wms-arctic`
- `npm run build`
- `npm run watch`
- Open this [url](http://localhost:3000/?v=-3992739.3467778927,-4351635.035399378,5009958.179519392,1955016.5650332172&p=arctic&l=Coastlines_15m,ARCSIX_P-3B_Flight_Track,ARCSIX_SPEC-Learjet_Flight_Track,ARCSIX_G-III_Flight_Track&lg=true&t=2024-08-15-T17%3A45%3A46Z)
- Verify that the 3 ARCSIX layers have unclickable, raster imagery for their flight tracks on page load.
- Zoom in until about 20km altitude.  This should trigger the vectors to appear and they should be clickable.
- Verify the result.
