### PR TITLE
WV-4102 - Loading Spinner Delay & Fade-in

### DIFF
--- a/web/js/components/map/loading-spinner.js
+++ b/web/js/components/map/loading-spinner.js
@@ -37,7 +37,7 @@ function LoadingIndicator() {
   };
 
   return shouldSpinnerShow && (
-    <div style={spinnerStyle}>
+    <div className="loading-spinner" style={spinnerStyle}>
       <Spinner color="light" size="sm" style={innerSpinnerStyle} />
     </div>
   );

--- a/web/scss/features/loading-spinner.scss
+++ b/web/scss/features/loading-spinner.scss
@@ -1,0 +1,17 @@
+.loading-spinner {
+  animation: fade-in 1.5s ease-in-out forwards;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  67% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}

--- a/web/scss/index.scss
+++ b/web/scss/index.scss
@@ -34,6 +34,7 @@
 @use 'features/layer-categories';
 @use 'features/layer-coverage-panel';
 @use 'features/layers';
+@use 'features/loading-spinner';
 @use 'features/location-search';
 @use 'features/map';
 @use 'features/measure';


### PR DESCRIPTION
## Description
This change adds a delay to when the loading spinner appears, and has it fade-in over a short period of time.

## How To Test
1. `git checkout wv-4102-loading-spinner-delay`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV
5. Verify the spinner appears as expected, and has a delay and fade-in as expected