### PR TITLE
Chunk getMetadata requests to address socket pool issues

### DIFF
--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -145,11 +145,20 @@ async function main (url) {
   layerOrder = layerOrder.filter(x => !skipLayers.includes(x))
 
   console.warn(`${prog}: Fetching ${layerOrder.length} layer-metadata files`)
-  const promises = layerOrder.map((layerId) => {
-    if (!layerId.includes('_STD') && !layerId.includes('_NRT')) return getMetadata(layerId, url)
-    return Promise.reject(new Error(`Skipped layer: ${layerId}`))
-  })
-  const results = await Promise.allSettled(promises)
+
+  const BATCH_SIZE = 15
+  const results = []
+
+  for (let i = 0; i < layerOrder.length; i += BATCH_SIZE) {
+    const chunk = layerOrder.slice(i, i + BATCH_SIZE)
+    const chunkPromises = chunk.map((layerId) => {
+      if (!layerId.includes('_STD') && !layerId.includes('_NRT')) return getMetadata(layerId, url)
+      return Promise.reject(new Error(`Skipped layer: ${layerId}`))
+    })
+    const chunkResults = await Promise.allSettled(chunkPromises)
+    results.push(...chunkResults)
+  }
+
   const { fulfilled = [], rejected = [] } = Object.groupBy(results, (item) => item.status)
 
   rejected.forEach(({ reason }) => {


### PR DESCRIPTION
## Description

`/tasks/build-options/getVisMetadata.js` executes an unbounded Promise.allSettled() over every layer ID in layerOrder simultaneously.

On Linux environments, initiating hundreds of concurrent HTTP requests saturates the socket pool queue, leading to timeouts. This results in incomplete layer metadata dictionaries, causing downstream runtime errors.

## How To Test
- `npm run build` on various environment(s).
- Confirm build succeeds 
- Confirm any change in build time is negligible
- Confirm WV works appropriately

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
