### PR TITLE
WV-4142 - Disable wrapX on AERONET vector source

### DIFF
--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -648,6 +648,10 @@ export default function mapLayerBuilder(config, cache, store) {
 
     const vectorSource = new OlSourceVector({
       format: new GeoJSON(),
+      // Only render a single world. OpenLayers does not apply the layer extent
+      // clip to the canvas it draws on when opacity is less than 1, which would
+      // otherwise leave adjacent world copies visible outside of layerExtent
+      wrapX: false,
       loader: async () => {
         const allDataKey = `AERONET:${date.getUTCFullYear()}`;
 

--- a/web/js/map/layerbuilder.test.js
+++ b/web/js/map/layerbuilder.test.js
@@ -579,6 +579,22 @@ describe('mapLayerBuilder', () => {
       expect(layer).toBeDefined();
     });
 
+    it('disables wrapX on the AERONET source so points stay within the layer extent', async () => {
+      const OlSourceVector = require('ol/source/Vector');
+      builder = mapLayerBuilder(
+        buildConfig({ AERONET: { url: 'https://aeronet.example.com', matrixSets: {} } }),
+        cache,
+        store,
+      );
+      await builder.createLayer(
+        buildDef({ type: 'vector', source: 'AERONET', projections: { geographic: {} } }),
+        buildOptions(),
+      );
+      expect(OlSourceVector).toHaveBeenCalledWith(
+        expect.objectContaining({ wrapX: false }),
+      );
+    });
+
     it('throws error for AERONET with missing source config', async () => {
       const noAeronetConfig = buildConfig();
       delete noAeronetConfig.sources.AERONET;


### PR DESCRIPTION
## Summary

Reducing the opacity of an AERONET layer caused data points to render outside the map extent, root cause is an OpenLayers 10.10.0 bug 

## How to test

If you have CORS issue with the layer follow this instructions:

Use Chrome DevTools to add the missing response header:

1. Create an empty folder outside the repo, e.g. `~/chrome-devtools-overrides`
2. DevTools → **Sources** → **Overrides** → *Select folder for overrides* → point at it
3. Click the yellow **Allow** banner at the top of the panel — overrides won't persist without it
4. **Network** tab → right-click either `aeronet.gsfc.nasa.gov` request → **Override headers**
5. Add `Access-Control-Allow-Origin: *`
6. Reload

DevTools must stay open for overrides to apply.

Open worldview with the layer and verify:

http://localhost:3000/?v=-365.5740907096697,-306.31947264588257,370.7384092903303,367.55552735411743&l=Coastlines_15m,DAILY_AERONET_AOD_500NM(opacity=0.75,disabled=;),MODIS_Terra_CorrectedReflectance_TrueColor&lg=true&t=2026-07-21-T08%3A42%3A59Z