### PR TITLE
WV-4095: POC OL Layer Reprojection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4138,9 +4138,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4162,9 +4159,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4186,9 +4180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4210,9 +4201,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4234,9 +4222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4258,9 +4243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5489,9 +5471,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5506,9 +5485,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5523,9 +5499,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5540,9 +5513,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5557,9 +5527,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5574,9 +5541,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5591,9 +5555,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5608,9 +5569,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5625,9 +5583,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5642,9 +5597,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/tasks/build-options/getVisMetadata.js
+++ b/tasks/build-options/getVisMetadata.js
@@ -145,11 +145,20 @@ async function main (url) {
   layerOrder = layerOrder.filter(x => !skipLayers.includes(x))
 
   console.warn(`${prog}: Fetching ${layerOrder.length} layer-metadata files`)
-  const promises = layerOrder.map((layerId) => {
-    if (!layerId.includes('_STD') && !layerId.includes('_NRT')) return getMetadata(layerId, url)
-    return Promise.reject(new Error(`Skipped layer: ${layerId}`))
-  })
-  const results = await Promise.allSettled(promises)
+
+  const BATCH_SIZE = 15
+  const results = []
+
+  for (let i = 0; i < layerOrder.length; i += BATCH_SIZE) {
+    const chunk = layerOrder.slice(i, i + BATCH_SIZE)
+    const chunkPromises = chunk.map((layerId) => {
+      if (!layerId.includes('_STD') && !layerId.includes('_NRT')) return getMetadata(layerId, url)
+      return Promise.reject(new Error(`Skipped layer: ${layerId}`))
+    })
+    const chunkResults = await Promise.allSettled(chunkPromises)
+    results.push(...chunkResults)
+  }
+
   const { fulfilled = [], rejected = [] } = Object.groupBy(results, (item) => item.status)
 
   rejected.forEach(({ reason }) => {

--- a/web/js/map/layerbuilder.js
+++ b/web/js/map/layerbuilder.js
@@ -435,7 +435,7 @@ export default function mapLayerBuilder(config, cache, store) {
     const { proj } = state;
     const {
       id, layer, format, matrixIds, matrixSet, matrixSetLimits,
-      period, source, style, wrapadjacentdays, type,
+      period, source, style, wrapadjacentdays, type, projections,
     } = def;
     const configSource = config.sources[source];
     const { date, shifted } = options;
@@ -472,14 +472,25 @@ export default function mapLayerBuilder(config, cache, store) {
       : tileMatrices.map(({ matrixWidth, matrixHeight }) => [matrixWidth, matrixHeight]);
     const calcMatrixIds = matrixIds || resolutions.map((set, index) => index);
 
+    // POC HACK: Check if the layer definition natively supports the current map projection.
+    const hasNativeProj = projections && !!projections[proj.id];
+    const isPolar = proj.selected.id === 'arctic' || proj.selected.id === 'antarctic';
+    const isReprojecting = !hasNativeProj && isPolar;
+
+    // Standard geographic bounds and top-left origin for EPSG:4326
+    const GEOGRAPHIC_EXTENT = [-180, -90, 180, 90];
+    const GEOGRAPHIC_ORIGIN = [-180, 90];
+
     // Also need to shift this if granule is shifted
     const tileGridOptions = {
-      origin: shifted ? RIGHT_WING_ORIGIN : origin,
-      extent: shifted ? RIGHT_WING_EXTENT : extent,
-      sizes,
+      // Override origin and extent when reprojecting to avoid polar meter contamination
+      origin: isReprojecting ? GEOGRAPHIC_ORIGIN : (shifted ? RIGHT_WING_ORIGIN : origin),
+      extent: isReprojecting ? GEOGRAPHIC_EXTENT : (shifted ? RIGHT_WING_EXTENT : extent),
       resolutions,
       matrixIds: calcMatrixIds,
       tileSize: tileSize[0],
+      // Clear sizes when reprojecting so OpenLayers relies on full global geographic tile ranges
+      ...(isReprojecting ? {} : { sizes }),
     };
 
     // force currently selected time to be 59 seconds.
@@ -489,6 +500,7 @@ export default function mapLayerBuilder(config, cache, store) {
     const tileGrid = new OlTileGridWMTS(tileGridOptions);
     const urlParameters = `?TIME=${util.toISOStringSeconds(layerDate, !isSubdaily)}`;
     const sourceURL = def.sourceOverride || configSource.url;
+    const sourceProjection = hasNativeProj ? undefined : 'EPSG:4326';
     const sourceOptions = {
       interpolate: false,
       url: `${sourceURL}${urlParameters}`,
@@ -499,8 +511,10 @@ export default function mapLayerBuilder(config, cache, store) {
       transition: isGranule ? 350 : 0,
       matrixSet: configMatrixSet.id,
       tileGrid,
-      wrapX: false,
+      wrapX: !isReprojecting,
       style: typeof style === 'undefined' ? 'default' : style,
+      // Only override projection when reprojecting geographic-only layers
+      ...(sourceProjection && { projection: sourceProjection }),
     };
     if (isPaletteActive(id, options.group, state)) {
       const lookup = getPaletteLookup(id, options.group, state);
@@ -512,11 +526,16 @@ export default function mapLayerBuilder(config, cache, store) {
       className: `wv-layer-${id}`,
       preload: 0,
       source: tileSource,
+      // POC HACK: Prevent OpenLayers from hiding reprojected layers due to scale mismatch
+      ...(isReprojecting && {
+        minResolution: 0,
+        maxResolution: Infinity,
+      }),
     });
 
     // Because granule footprints from CMR are imprecise, setting an extent on granule
     // layers can crop valid imagery. So extents are only applied to non-granule layers.
-    if (!isGranule) {
+    if (!isGranule && !isReprojecting) {
       layerTile.setExtent(extent);
     }
     return layerTile;
@@ -1406,7 +1425,11 @@ export default function mapLayerBuilder(config, cache, store) {
           { cmrRebuildAttempts: options.cmrRebuildAttempts }),
       };
       def = lodashCloneDeep(def);
-      lodashMerge(def, projections[proj.id]);
+      // lodashMerge(def, projections[proj.id]);
+      // POC HACK: Fall back to geographic projection if target polar projection is missing
+      const targetProjConfig = projections[proj.id] || projections['geographic'] || projections['epsg4326'];
+      lodashMerge(def, targetProjConfig);
+
       if (breakPointLayer) def = mergeBreakpointLayerAttributes(def, proj.id);
       const isDataDownloadTabActive = activeTab === 'download';
       const wrapDefined = wrapadjacentdays === true || wrapX;

--- a/web/js/modules/layers/selectors.js
+++ b/web/js/modules/layers/selectors.js
@@ -439,7 +439,10 @@ function forGroup(group, activeLayers, state, spec = {}) {
   let results = [];
   const defs = lodashFilter(activeLayers, { group });
   lodashEach(defs, (def) => {
-    const notInProj = !def.projections[projId];
+    // const notInProj = !def.projections[projId];
+    // To this (POC HACK):
+    const hasProj = def.projections[projId] || def.projections['geographic'] || def.projections['epsg4326'];
+    const notInProj = !hasProj;
 
     const notRenderable = spec.renderable && !isRenderable(
       def.id,
@@ -532,7 +535,8 @@ export const getActiveVisibleLayersAtDate = (state, date, activeString) => {
   const layers = getActiveLayers(state, activeString);
   const baseLayers = layers.filter(({ group }) => group === 'baselayers');
   return layers.filter(
-    (l) => !!l.projections[proj.id] && isRenderable(l.id, layers, date, baseLayers, {}),
+    // (l) => !!l.projections[proj.id] && isRenderable(l.id, layers, date, baseLayers, {}),
+    (l) => !!(l.projections[proj.id] || l.projections['geographic'] || l.projections['epsg4326']) && isRenderable(l.id, layers, date, baseLayers, {}),
   );
 };
 


### PR DESCRIPTION
## Description

Fixes #WV-4095

Evaluate the feasibility of reprojecting a GIBS geographic layer into polar stereographic using Open Layers built-in capability.

## How To Test
`git checkout wv-4095`
`npm run watch`
Load [this link](http://localhost:3000/?v=-11664175.071575867,-6840105.836534127,9553104.928424133,6512854.163465873&p=arctic&l=Reference_Features_15m,OPERA_L2_Radiometric_Terrain_Corrected_SAR_Sentinel-1_12Day,MERRA2_Dust_Surface_Mass_Concentration_Monthly(hidden),Coastlines_15m(hidden)&lg=false&t=2026-06-23-T13%3A00%3A30Z) to see Opera Radiometric Terrain corrected SAR Backscatter (12-day) in the Artic

NOTE: This POC is not limited to this layer. However, some UI issues remain unaddressed, specifically the layer picker & layer menu. To change layer(s), return to the geographic projection. Once your desired layers are added, you can return to the polar projection to see the result.

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
