### PR TITLE
Sanitize Layer Info HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worldview",
-  "version": "5.3.1",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worldview",
-      "version": "5.3.1",
+      "version": "5.3.0",
       "hasInstallScript": true,
       "license": "NASA-1.3",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "coordinate-parser": "^1.0.7",
         "copy-to-clipboard": "^4.0.2",
         "dom-scroll-into-view": "^2.0.1",
+        "dompurify": "^3.4.14",
         "element-resize-detector": "^1.2.4",
         "elm-pep": "^1.0.6",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -5103,6 +5104,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
@@ -8620,6 +8628,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worldview",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worldview",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "hasInstallScript": true,
       "license": "NASA-1.3",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "coordinate-parser": "^1.0.7",
     "copy-to-clipboard": "^4.0.2",
     "dom-scroll-into-view": "^2.0.1",
+    "dompurify": "^3.4.14",
     "element-resize-detector": "^1.2.4",
     "elm-pep": "^1.0.6",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "5.3.1",
+  "version": "5.3.0",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worldview",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Interactive interface for browsing full-resolution, global satellite imagery",
   "keywords": [
     "NASA",

--- a/web/js/components/layer/info/info.js
+++ b/web/js/components/layer/info/info.js
@@ -1,8 +1,14 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import DOMPurify from 'dompurify';
 import { dateOverlap } from '../../../modules/layers/util';
 import DateRanges from './date-ranges';
 import { coverageDateFormatter } from '../../../modules/date/util';
+
+// Keep target attribute for opening links in new tab
+const purifyConfig = {
+  ADD_ATTR: ['target'],
+};
 
 export default function LayerInfo ({ layer, measurementDescriptionPath, describeDomainsUrl }) {
   const {
@@ -28,7 +34,7 @@ export default function LayerInfo ({ layer, measurementDescriptionPath, describe
         const data = await fetch(`config/metadata/layers/${path}.html`, options);
         const metadataHtml = await data.text();
         controller = null;
-        setFn(metadataHtml || 'No description was found for this layer.');
+        setFn(DOMPurify.sanitize(metadataHtml, purifyConfig) || 'No description was found for this layer.');
       } catch (e) {
         if (!controller.signal.aborted) {
           console.error(e);


### PR DESCRIPTION
## Description
This change is a fix for GITC WV and should not affect base-level WV. The change adds the `dompurify` library to normalize HTML input being displayed directly on-screen during display of layer info. This is not typically needed, but fixes a major UI bug in GITC WV.

As such, this change has already been verified to work for GITC WV, so the only testing needed is to confirm nothing changes/breaks with base-level WV.

## How To Test
1. `git checkout gitc-wv-purify-fix`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV
5. Verify that there is no change to the behavior or appearance of our layer info panel/data