### PR TITLE
Update Reflectance.md for Sentinel-2A end date

### DIFF
--- a/config/default/common/config/metadata/layers/multi-mission/hls/Reflectance.md
+++ b/config/default/common/config/metadata/layers/multi-mission/hls/Reflectance.md
@@ -5,10 +5,10 @@ The HLS project began with Landsat 8, Sentinel-2A, and Sentinel-2B. Landsat 9 la
 - Landsat 8: April 11, 2013 - Present
 - Landsat 9: May 31, 2022 - Present
 
-On January 21, 2025, the Sentinel-2C satellite replaced Sentinel-2A satellite. In addition, a [temporary one year extension campaign](https://sentinels.copernicus.eu/-/sentinel-2a-extended-campaign-starting-march-13-2025) of Sentinel-2A began on March 13, 2025. This campaign provides increased observations over Europe, and tropical regions of Africa and South America.
+On January 21, 2025, the Sentinel-2C satellite replaced Sentinel-2A satellite. A [temporary one year extension campaign](https://sentinels.copernicus.eu/-/sentinel-2a-extended-campaign-starting-march-13-2025) of Sentinel-2A began on March 13, 2025. This campaign provides increased observations over Europe, and tropical regions of Africa and South America. In addition, it was announced that [the campaign has been extended to the end of 2026](https://sentinels.copernicus.eu/web/sentinel/-/sentinel-2a-extension-campaign-prolonged-until-the-end-of-2026).
 
 This layer contains a mix of imagery from Sentinel-2A, Sentinel-2B, and Sentinel-2C:
-- Sentinel-2A: November 28, 2015 to January 22, 2025; March 14, 2025 to approximately March 2026.
+- Sentinel-2A: November 28, 2015 to January 22, 2025; March 14, 2025 to December 31, 2026.
 - Sentinel-2B: September 18, 2017 to Present
 - Sentinel-2C: January 21, 2025 to Present
 


### PR DESCRIPTION
## Description

Forgot to update this reflectance.md file for HLS for the Sentinel-2A end date. The other ones were updated previously. 

## How To Test

1. `git checkout update-sentinel2a-end-date`
2. `npm run build && npm start`
3. Open localhost, go to Add layers, go to the "Featured" tab
4. Click on HLS, see that the "About HLS" section states that Sentinel-2A will end on 31 December 2026.
5. Verify expected result

@nasa-gibs/worldview
