### PR TITLE
WV-4221: Fix Historical Date Ranges for Geostationary Products

### DIFF
--- a/web/js/modules/layers/util.js
+++ b/web/js/modules/layers/util.js
@@ -1523,10 +1523,12 @@ export function adjustStartDates(layers) {
       console.warn(`GetCapabilities is missing the time value for ${layer.id}`);
     }
 
-    if (Array.isArray(historicalRanges) && historicalRanges.length &&
-      Array.isArray(dateRanges) && dateRanges.length) {
+    if (Array.isArray(historicalRanges) && historicalRanges.length) {
       layer.startDate = historicalRanges[0].startDate;
       historicalRanges.reverse().forEach((range) => {
+        if (!layer.dateRanges) {
+          layer.dateRanges = [];
+        }
         layer.dateRanges.unshift(range);
       });
     } else {

--- a/web/js/modules/layers/util.test.js
+++ b/web/js/modules/layers/util.test.js
@@ -459,6 +459,17 @@ describe('adjustStartDates', () => {
 
   test('sets layer startDate from adjustDate when no historicalRanges [adjust-start-dates-no-historical-ranges]', () => {
     const config = buildConfig();
+    delete config.layers['test-layer'].availability.historicalRanges;
+    adjustStartDates(config.layers);
+    const layer = config.layers['test-layer'];
+    expect(layer.startDate).toBeDefined();
+    expect(layer.startDate).not.toBe('2000-01-01');
+  });
+
+  test('initializes empty dateRanges when no dateRanges [adjust-start-dates-empty-date-ranges]', () => {
+    const config = buildConfig();
+    delete config.layers['test-layer'].dateRanges;
+    console.warn(config);
     adjustStartDates(config.layers);
     const layer = config.layers['test-layer'];
     expect(layer.startDate).toBeDefined();


### PR DESCRIPTION
## Description
This change fixes an issue with historical dateRanges for geostationary products that were no longer showing imagery.

## How To Test
1. `git checkout wv-4221-historical-dateRanges-fix`
2. `npm ci`
3. `npm run watch`
4. Open a fresh instance of WV
6. Start the "Geostationary Imagery Every 10 Minutes!" Tour Story
7. Verify there is imagery showing on all steps of the story, and that it looks correct
8. Verify imagery and date ranges look correct for all affected layers