### PR TITLE
Add regression coverage for missing historical date ranges

### DIFF
--- a/web/js/modules/layers/util.test.js
+++ b/web/js/modules/layers/util.test.js
@@ -464,6 +464,20 @@ describe('adjustStartDates', () => {
     expect(layer.startDate).toBeDefined();
     expect(layer.startDate).not.toBe('2000-01-01');
   });
+
+  test('uses historical ranges when GetCapabilities dateRanges are missing [adjust-start-dates-missing-date-ranges]', () => {
+    const config = buildConfig({ dateRanges: undefined });
+    const layer = config.layers['test-layer'];
+    const expectedRanges = [...layer.availability.historicalRanges];
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    adjustStartDates(config.layers);
+
+    expect(warnSpy).toHaveBeenCalledWith('GetCapabilities is missing the time value for test-layer');
+    expect(layer.startDate).toBe(expectedRanges[0].startDate);
+    expect(layer.dateRanges).toEqual(expectedRanges);
+    warnSpy.mockRestore();
+  });
 });
 
 describe('getCacheOptions', () => {


### PR DESCRIPTION
## Summary
- add regression coverage for adjustStartDates when GetCapabilities omits dateRanges
- verify configured historicalRanges restore both the layer start date and date ranges
- preserve the existing missing-time warning

## Context
This is a focused follow-up to #6931 for the scenario reported in #6927. It targets the feature branch so it does not duplicate the active fix.

## Validation
- npm run test:unit -- web/js/modules/layers/util.test.js --runInBand
- full pre-push suite: 388 test suites / 9,478 tests passed in both default and Australia/Sydney time zones
- npm run lint (0 errors; 34 pre-existing warnings)
- confirmed the new test fails on develop and passes with #6931