### PR TITLE
Fix +INF/-INF colormap bounds being written as null in palette JSON

### DIFF
--- a/tasks/build-options/processColormap.js
+++ b/tasks/build-options/processColormap.js
@@ -4,6 +4,7 @@ const convert = require('xml-js')
 const { promisify } = require('util')
 const yargs = require('yargs')
 const { hideBin } = require('yargs/helpers')
+const { parseColormapValue } = require('./util')
 
 const readFile = promisify(fs.readFile)
 const writeFile = promisify(fs.writeFile)
@@ -211,23 +212,7 @@ async function processEntries (colormap) {
       colors.push(colorString)
 
       if (mapType === 'continuous' || mapType === 'discrete') {
-        const items = entry._attributes.value.replace(/[()[\]]/g, '').split(',')
-        try {
-          const newItems = []
-          for (const item of items) {
-            let v = parseFloat(item)
-            if (v === Number.POSITIVE_INFINITY) {
-              v = Number.MAX_VALUE
-            }
-            if (v === Number.NEGATIVE_INFINITY) {
-              v = Number.MIN_VALUE
-            }
-            newItems.push(v)
-          }
-          values.push(newItems)
-        } catch (error) {
-          throw new Error(`Invalid value: ${entry._attributes.value}`)
-        }
+        values.push(parseColormapValue(entry._attributes.value))
       }
     })
   )

--- a/tasks/build-options/util.js
+++ b/tasks/build-options/util.js
@@ -40,6 +40,45 @@ function dictMerge (target, ...args) {
   return target
 }
 
+/*
+ * parseColormapValue: Parses a GIBS ColorMapEntry value attribute such as
+ * "[0,1.181e+14)", "[350,+INF)", "[-INF,150)" or "[5]" into a list of numbers.
+ *
+ * GIBS spells unbounded intervals with "+INF" / "-INF", which parseFloat does
+ * not understand (it only accepts "Infinity"), so they are matched explicitly.
+ * Infinite bounds are clamped to the largest finite double because JSON has no
+ * representation for Infinity (JSON.stringify would otherwise emit null).
+ *
+ * Parameters:
+ * value [string] Raw value attribute, e.g. "[350,+INF)"
+ *
+ * Returns an array of finite numbers, one per interval bound
+ */
+function parseColormapValue (value) {
+  const items = String(value).replace(/[()[\]]/g, '').split(',')
+  return items.map((item) => {
+    const token = item.trim()
+    if (/^\+?INF(INITY)?$/i.test(token)) {
+      return Number.MAX_VALUE
+    }
+    if (/^-INF(INITY)?$/i.test(token)) {
+      return -Number.MAX_VALUE
+    }
+    const v = parseFloat(token)
+    if (Number.isNaN(v)) {
+      throw new Error(`Invalid value: ${value}`)
+    }
+    if (v === Number.POSITIVE_INFINITY) {
+      return Number.MAX_VALUE
+    }
+    if (v === Number.NEGATIVE_INFINITY) {
+      return -Number.MAX_VALUE
+    }
+    return v
+  })
+}
+
 module.exports = {
-  dictMerge
+  dictMerge,
+  parseColormapValue
 }

--- a/tasks/build-options/util.test.js
+++ b/tasks/build-options/util.test.js
@@ -1,0 +1,48 @@
+const { describe, expect, test } = require('@jest/globals')
+const { parseColormapValue } = require('./util')
+
+describe('parseColormapValue', () => {
+  test('parses closed and half-open numeric intervals', () => {
+    expect(parseColormapValue('[0,1.181e+14)')).toEqual([0, 1.181e14])
+    expect(parseColormapValue('[4.570,5)')).toEqual([4.57, 5])
+    expect(parseColormapValue('[-1,0)')).toEqual([-1, 0])
+    expect(parseColormapValue('[5]')).toEqual([5])
+    expect(parseColormapValue('[0)')).toEqual([0])
+  })
+
+  test('maps +INF to the largest finite number instead of NaN', () => {
+    const [min, max] = parseColormapValue('[15.00,+INF)')
+    expect(min).toBe(15)
+    expect(max).toBe(Number.MAX_VALUE)
+    expect(Number.isFinite(max)).toBe(true)
+  })
+
+  test('maps -INF to the most negative finite number', () => {
+    const [min, max] = parseColormapValue('[-INF,150)')
+    expect(min).toBe(-Number.MAX_VALUE)
+    expect(max).toBe(150)
+    expect(min).toBeLessThan(max)
+  })
+
+  test('survives JSON serialization without null bounds', () => {
+    const values = [
+      parseColormapValue('[-INF,150)'),
+      parseColormapValue('[150,350)'),
+      parseColormapValue('[350,+INF)')
+    ]
+    const json = JSON.stringify(values)
+    expect(json).not.toContain('null')
+    expect(JSON.parse(json)).toEqual(values)
+  })
+
+  test('accepts unsigned and lower-case infinity spellings', () => {
+    expect(parseColormapValue('[1,INF)')).toEqual([1, Number.MAX_VALUE])
+    expect(parseColormapValue('[-inf,1)')).toEqual([-Number.MAX_VALUE, 1])
+    expect(parseColormapValue('[1,Infinity)')).toEqual([1, Number.MAX_VALUE])
+  })
+
+  test('rejects bounds that are not numbers', () => {
+    expect(() => parseColormapValue('[foo,1)')).toThrow('Invalid value: [foo,1)')
+    expect(() => parseColormapValue('[1,)')).toThrow('Invalid value: [1,)')
+  })
+})


### PR DESCRIPTION
## Description

No existing issue; found while reviewing the build scripts. Happy to file one if the team prefers a ticket to track it.

`tasks/build-options/processColormap.js` parses every `ColorMapEntry` bound with `parseFloat`. GIBS writes unbounded intervals as `[350,+INF)` / `[-INF,150)`, and `parseFloat("+INF")` is `NaN` (it only understands `"Infinity"`). The `=== Number.POSITIVE_INFINITY` / `NEGATIVE_INFINITY` branches right below therefore never run, and `JSON.stringify` turns the `NaN` bounds into `null` in the generated `config/palettes/*.json`.

This is visible in production today: https://worldview.earthdata.nasa.gov/config/palettes/AIRS_All_Sky_Outgoing_Longwave_Radiation.json has `values[0] = [null, 150]` and `values[201] = [350, null]`. Running the current script against the GIBS v1.3 colormaps referenced by the live `wv.json`, 262 of 402 palettes contain `null` bounds (436 bounds in total).

The Python build this script replaced (`tasks/python3/processColormap.py`, removed in 5d4ac0f5) used `float()`, which accepts `"+INF"` / `"-INF"`, so the regression dates from the JS port. That version also mapped `-inf` to `sys.float_info.min`, the smallest *positive* double, and the JS port copied that as `Number.MIN_VALUE`, so a `[-INF, x)` interval would have become `[5e-324, x)` even if the parsing had worked.

- Move the bound parsing into `parseColormapValue()` in `tasks/build-options/util.js`, next to the existing shared `dictMerge` helper.
- Match `+INF` / `-INF` (and `Infinity`) explicitly and clamp them to `Number.MAX_VALUE` / `-Number.MAX_VALUE`, so unbounded intervals serialise to finite numbers with the correct sign and ordering (`min < max`).
- Bounds that do not parse as a number now throw `Invalid value: ...`, which is what the existing (unreachable) `try/catch` in `processEntries` intended. The error is still caught per file by `processFile`, as before.
- Add `tasks/build-options/util.test.js` covering numeric ranges, single-value entries like `[0)`, both infinities, JSON round-tripping, and rejection of non-numeric bounds. The test imports from `@jest/globals` because the ESLint `tasks/**` block does not provide Jest globals.

The only front-end consumer that reads both bounds is the AERONET point styling in `web/js/map/layerbuilder.js` (`value >= range[0] && value < range[1]`). With `null` the upper comparison degrades to `value < 0`, so a `[x,+INF)` bin can never match. The AERONET colormaps do not use INF today, so this is latent rather than user-visible, but any vector layer whose colormap uses `+INF` would hit it. Everything else (`getPaletteAttributeArray`, `findIndex`) only reads lower bounds or `.length`, which is why the `null`s have gone unnoticed.

## How To Test

1. `npm ci` and `npx jest tasks/build-options/util.test.js` (Node 24). The suite passes here and fails against the old inline logic (`parseFloat("+INF")` is `NaN`).
2. `npm run build:options` (or `npm run getcapabilities`), then open `build/options/config/palettes/AIRS_All_Sky_Outgoing_Longwave_Radiation.json`. `maps[0].entries.values[0]` should be `[-1.7976931348623157e+308, 150]` and the last entry `[350, 1.7976931348623157e+308]`; there should be no `null` anywhere in `values`. On `develop` the same file contains `[null, 150]` and `[350, null]`.
3. Optional end-to-end check I ran: unpatched vs patched script over the 402 GIBS colormaps referenced by the live `wv.json`. The unpatched output is byte-identical to the deployed palette JSON for 401/402 files (the remaining one changed upstream since the last deploy). The patched output differs only in the 436 previously-`null` bounds; colors, refs, legends, tooltips, ticks and all other values are unchanged.
4. Full `npm test` (jest, TZ jest, lint) passes under Node 24.15.0.

## PR Submission Checklist

- I have read the [CONTRIBUTING](https://github.com/nasa-gibs/worldview/blob/main/.github/CONTRIBUTING.md) doc
- I have added necessary documentation (if applicable): n/a, the helper has a doc comment
- I have added tests that prove my fix is effective or that my feature works
- Any dependent changes have been merged and published in downstream modules (if applicable): n/a

## Merging

Please use the `squash and merge` commit method unless each commit in your branch is vital to the commit history of main.

@nasa-gibs/worldview
